### PR TITLE
🚨 (othr): Remove eslint cache

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "build": "rimraf lib && tsc -p tsconfig.prod.json && tsc-alias -p tsconfig.prod.json",
     "dev": "tsc && (concurrently \"tsc -w -p tsconfig.prod.json\" \"tsc-alias -w -p tsconfig.prod.json\")",
-    "lint": "eslint --cache --ext .ts \"src\" --max-warnings=0",
-    "lint:fix": "eslint --cache --fix --ext .ts \"src\"",
+    "lint": "eslint --ext .ts \"src\" --max-warnings=0",
+    "lint:fix": "eslint --fix --ext .ts \"src\"",
     "prettier": "prettier . --check",
     "prettier:fix": "prettier . --write",
     "test": "jest src",

--- a/packages/signer/package.json
+++ b/packages/signer/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "build": "rimraf lib && tsc",
     "dev": "tsc --watch",
-    "lint": "eslint --cache --ext .ts \"src\" --max-warnings=0",
-    "lint:fix": "eslint --cache --fix --ext .ts \"src\"",
+    "lint": "eslint --ext .ts \"src\" --max-warnings=0",
+    "lint:fix": "eslint --fix --ext .ts \"src\"",
     "prettier": "prettier . --check",
     "prettier:fix": "prettier . --write",
     "typecheck": "tsc --noEmit",

--- a/packages/trusted-apps/package.json
+++ b/packages/trusted-apps/package.json
@@ -9,8 +9,8 @@
   ],
   "scripts": {
     "build": "rimraf lib && tsc",
-    "lint": "eslint --cache --ext .ts \"src\" --max-warnings=0",
-    "lint:fix": "eslint --cache --fix --ext .ts \"src\"",
+    "lint": "eslint --ext .ts \"src\" --max-warnings=0",
+    "lint:fix": "eslint --fix --ext .ts \"src\"",
     "prettier": "prettier . --check",
     "prettier:fix": "prettier . --write",
     "typecheck": "tsc --noEmit",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "build": "rimraf lib && tsc",
     "dev": "tsc --watch",
-    "lint": "eslint --cache --ext .ts \"src\" --max-warnings=0",
-    "lint:fix": "eslint --cache --fix --ext .ts \"src\"",
+    "lint": "eslint --ext .ts \"src\" --max-warnings=0",
+    "lint:fix": "eslint --fix --ext .ts \"src\"",
     "prettier": "prettier . --check",
     "prettier:fix": "prettier . --write",
     "typecheck": "tsc --noEmit",

--- a/turbo.json
+++ b/turbo.json
@@ -7,10 +7,12 @@
       "inputs": ["src/**/*.ts"]
     },
     "lint": {
-      "dependsOn": ["^lint"]
+      "dependsOn": ["^lint"],
+      "cache": false
     },
     "lint:fix": {
-      "dependsOn": ["^lint:fix"]
+      "dependsOn": ["^lint:fix"],
+      "cache": false
     },
     "prettier": {
       "dependsOn": ["^prettier"]


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

It appears we have some local issues with turbo + eslint caching, which may not catch some new issues. 
Removing Eslint + Turbo cache for lint processes.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - remove cache from `lint` scripts

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
