### PR TITLE
🚨 (repo): Make eslint not fail on warnings

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,7 +26,7 @@ jobs:
         run: pnpm typecheck
 
       - name: Test
-        run: pnpm test:coverage
+        run: pnpm test:coverage -- --max-warnings=0
 
       - uses: sonarsource/sonarqube-scan-action@master
         env:

--- a/apps/sample/package.json
+++ b/apps/sample/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint --max-warnings=0",
+    "lint": "next lint",
     "lint:fix": "next lint --fix",
     "prettier": "prettier . --check",
     "prettier:fix": "prettier . --write",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "rimraf lib && tsc -p tsconfig.prod.json && tsc-alias -p tsconfig.prod.json",
     "dev": "tsc && (concurrently \"tsc -w -p tsconfig.prod.json\" \"tsc-alias -w -p tsconfig.prod.json\")",
-    "lint": "eslint --cache --ext .ts \"src\" --max-warnings=0",
+    "lint": "eslint --cache --ext .ts \"src\"",
     "lint:fix": "eslint --cache --fix --ext .ts \"src\"",
     "prettier": "prettier . --check",
     "prettier:fix": "prettier . --write",

--- a/packages/signer/package.json
+++ b/packages/signer/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "rimraf lib && tsc",
     "dev": "tsc --watch",
-    "lint": "eslint --cache --ext .ts \"src\" --max-warnings=0",
+    "lint": "eslint --cache --ext .ts \"src\"",
     "lint:fix": "eslint --cache --fix --ext .ts \"src\"",
     "prettier": "prettier . --check",
     "prettier:fix": "prettier . --write",

--- a/packages/trusted-apps/package.json
+++ b/packages/trusted-apps/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "build": "rimraf lib && tsc",
-    "lint": "eslint --cache --ext .ts \"src\" --max-warnings=0",
+    "lint": "eslint --cache --ext .ts \"src\"",
     "lint:fix": "eslint --cache --fix --ext .ts \"src\"",
     "prettier": "prettier . --check",
     "prettier:fix": "prettier . --write",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "rimraf lib && tsc",
     "dev": "tsc --watch",
-    "lint": "eslint --cache --ext .ts \"src\" --max-warnings=0",
+    "lint": "eslint --cache --ext .ts \"src\"",
     "lint:fix": "eslint --cache --fix --ext .ts \"src\"",
     "prettier": "prettier . --check",
     "prettier:fix": "prettier . --write",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Remove --max-warnings=0 from the default lint scripts.
Add it back into the CI run.

This way we can still push to github with warnings BUT our CI will fail, making sure we don't merge it in this state 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - lint will not fail on warnings locally
  - ci lint will fail on warnings

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
