### PR TITLE
♻️ (core) [NO-ISSUE]: ConnectUseCase now returns a promise

### DIFF
--- a/apps/sample/src/components/MainView/index.tsx
+++ b/apps/sample/src/components/MainView/index.tsx
@@ -70,16 +70,16 @@ export const MainView: React.FC = () => {
 
   useEffect(() => {
     if (discoveredDevice) {
-      sdk.connect({ deviceId: discoveredDevice.id }).subscribe({
-        next: (connectedDevice) => {
+      sdk
+        .connect({ deviceId: discoveredDevice.id })
+        .then((connectedDevice) => {
           console.log(
             `🦖 Response from connect: ${JSON.stringify(connectedDevice)} 🎉`,
           );
-        },
-        error: (error) => {
+        })
+        .catch((error) => {
           console.error(`Error from connection or get-version`, error);
-        },
-      });
+        });
     }
   }, [sdk, discoveredDevice]);
 

--- a/packages/core/src/internal/discovery/use-case/ConnectUseCase.test.ts
+++ b/packages/core/src/internal/discovery/use-case/ConnectUseCase.test.ts
@@ -24,41 +24,26 @@ describe("ConnectUseCase", () => {
     jest.restoreAllMocks();
   });
 
-  test("If connect use case encounter an error, return it", (done) => {
-    jest.spyOn(transport, "connect").mockImplementation(() => {
-      return Promise.resolve(Left(new UnknownDeviceError()));
-    });
+  test("If connect use case encounter an error, return it", async () => {
+    jest
+      .spyOn(transport, "connect")
+      .mockResolvedValue(Left(new UnknownDeviceError()));
+
     const usecase = new ConnectUseCase(transport);
 
-    const connect = usecase.execute({ deviceId: "" });
-
-    connect.subscribe({
-      next: (connectedDevice) => {
-        done(connectedDevice);
-      },
-      error: (error) => {
-        expect(error).toBeInstanceOf(UnknownDeviceError);
-        done();
-      },
-    });
+    await expect(usecase.execute({ deviceId: "" })).rejects.toBeInstanceOf(
+      UnknownDeviceError,
+    );
   });
 
-  test("If connect is in success, return an observable connected device object", (done) => {
-    jest.spyOn(transport, "connect").mockImplementation(() => {
-      return Promise.resolve(Right(stubConnectedDevice));
-    });
+  test("If connect is in success, return an observable connected device object", async () => {
+    jest
+      .spyOn(transport, "connect")
+      .mockResolvedValue(Promise.resolve(Right(stubConnectedDevice)));
+
     const usecase = new ConnectUseCase(transport);
 
-    const connect = usecase.execute({ deviceId: "" });
-
-    connect.subscribe({
-      next: (connectedDevice) => {
-        expect(connectedDevice).toBe(stubConnectedDevice);
-        done();
-      },
-      error: (error) => {
-        done(error);
-      },
-    });
+    const connectedDevice = await usecase.execute({ deviceId: "" });
+    expect(connectedDevice).toBe(stubConnectedDevice);
   });
 });

--- a/packages/core/src/internal/discovery/use-case/ConnectUseCase.ts
+++ b/packages/core/src/internal/discovery/use-case/ConnectUseCase.ts
@@ -1,5 +1,4 @@
 import { inject, injectable } from "inversify";
-import { from, Observable, of, switchMap } from "rxjs";
 
 import { DeviceId } from "@internal/device-model/model/DeviceModel";
 import { usbDiTypes } from "@internal/usb/di/usbDiTypes";
@@ -21,18 +20,13 @@ export class ConnectUseCase {
     // Later: @inject(usbDiTypes.BleTransport) private bleTransport: BleTransport,
   ) {}
 
-  execute({ deviceId }: ConnectUseCaseArgs): Observable<ConnectedDevice> {
-    return from(this.usbHidTransport.connect({ deviceId })).pipe(
-      switchMap((either) => {
-        return either.caseOf({
-          Left: (error) => {
-            throw error;
-          },
-          Right: (connectedDevice) => {
-            return of(connectedDevice);
-          },
-        });
-      }),
-    );
+  async execute({ deviceId }: ConnectUseCaseArgs): Promise<ConnectedDevice> {
+    const either = await this.usbHidTransport.connect({ deviceId });
+    return either.caseOf({
+      Left: (error) => {
+        throw error;
+      },
+      Right: (connectedDevice) => connectedDevice,
+    });
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

As discussed with Mathieu, usecases that return only one value should return a promise instead of an Observable.
That is why we have decided to work the ConnectUseCase.

Not logic change here, only some return types rework.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ConnectUseCase rework + tests
  - Sample App fixes

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
