### PR TITLE
:recycle: (core) [DSDK-292]: Use custom errors SdkError everywhere

### DIFF
--- a/packages/core/src/api/command/Errors.ts
+++ b/packages/core/src/api/command/Errors.ts
@@ -1,0 +1,46 @@
+import { SdkError } from "@api/Error";
+
+export class InvalidStatusWordError implements SdkError {
+  readonly _tag = "InvalidStatusWordError";
+  originalError?: Error;
+
+  constructor(message?: string) {
+    this.originalError = new Error(message ?? "Invalid status word.");
+  }
+}
+
+export class InvalidBatteryStatusTypeError implements SdkError {
+  readonly _tag = "InvalidBatteryStatusTypeError";
+  originalError: Error;
+
+  constructor(message?: string) {
+    this.originalError = new Error(message ?? "Invalid battery status type.");
+  }
+}
+
+export class InvalidBatteryDataError implements SdkError {
+  readonly _tag = "InvalidBatteryDataError";
+  originalError: Error;
+
+  constructor(message?: string) {
+    this.originalError = new Error(message ?? "Invalid battery data.");
+  }
+}
+
+export class InvalidBatteryFlagsError implements SdkError {
+  readonly _tag = "InvalidBatteryFlagsError";
+  originalError: Error;
+
+  constructor(message?: string) {
+    this.originalError = new Error(message ?? "Invalid battery flags.");
+  }
+}
+
+export class InvalidResponseFormatError implements SdkError {
+  readonly _tag = "InvalidResponseFormatError";
+  originalError: Error;
+
+  constructor(message?: string) {
+    this.originalError = new Error(message ?? "Invalid response format.");
+  }
+}

--- a/packages/core/src/api/command/os/GetAppAndVersionCommand.test.ts
+++ b/packages/core/src/api/command/os/GetAppAndVersionCommand.test.ts
@@ -1,4 +1,8 @@
 import { Command } from "@api/command/Command";
+import {
+  InvalidResponseFormatError,
+  InvalidStatusWordError,
+} from "@api/command/Errors";
 import { ApduResponse } from "@internal/device-session/model/ApduResponse";
 
 import {
@@ -71,7 +75,7 @@ describe("GetAppAndVersionCommand", () => {
       });
 
       expect(() => command.parseResponse(FAILED_RESPONSE)).toThrow(
-        "Unexpected status word: 6700",
+        InvalidStatusWordError,
       );
     });
     it("should throw an error if the response returned unsupported format", () => {
@@ -81,7 +85,7 @@ describe("GetAppAndVersionCommand", () => {
       });
 
       expect(() => command.parseResponse(ERROR_RESPONSE)).toThrow(
-        "getAppAndVersion: format not supported",
+        InvalidResponseFormatError,
       );
     });
   });

--- a/packages/core/src/api/command/os/GetAppAndVersionCommand.ts
+++ b/packages/core/src/api/command/os/GetAppAndVersionCommand.ts
@@ -2,6 +2,10 @@ import { Apdu } from "@api/apdu/model/Apdu";
 import { ApduBuilder, ApduBuilderArgs } from "@api/apdu/utils/ApduBuilder";
 import { ApduParser } from "@api/apdu/utils/ApduParser";
 import { Command } from "@api/command/Command";
+import {
+  InvalidResponseFormatError,
+  InvalidStatusWordError,
+} from "@api/command/Errors";
 import { CommandUtils } from "@api/command/utils/CommandUtils";
 import { ApduResponse } from "@internal/device-session/model/ApduResponse";
 
@@ -26,9 +30,8 @@ export class GetAppAndVersionCommand
 
   parseResponse(apduResponse: ApduResponse): GetAppAndVersionResponse {
     const parser = new ApduParser(apduResponse);
-    // [SHOULD] Implement new error treatment logic
     if (!CommandUtils.isSuccessResponse(apduResponse)) {
-      throw new Error(
+      throw new InvalidStatusWordError(
         `Unexpected status word: ${parser.encodeToHexaString(
           apduResponse.statusCode,
         )}`,
@@ -36,8 +39,9 @@ export class GetAppAndVersionCommand
     }
 
     if (parser.extract8BitUint() !== 1) {
-      // TODO: Make dedicated error object
-      throw new Error("getAppAndVersion: format not supported");
+      throw new InvalidResponseFormatError(
+        "getAppAndVersion: format not supported",
+      );
     }
 
     const name = parser.encodeToString(parser.extractFieldLVEncoded());

--- a/packages/core/src/api/command/os/GetBatteryStatusCommand.test.ts
+++ b/packages/core/src/api/command/os/GetBatteryStatusCommand.test.ts
@@ -1,4 +1,8 @@
 import { Command } from "@api/command/Command";
+import {
+  InvalidBatteryStatusTypeError,
+  InvalidStatusWordError,
+} from "@api/command/Errors";
 import { ApduResponse } from "@internal/device-session/model/ApduResponse";
 
 import {
@@ -106,7 +110,7 @@ describe("GetBatteryStatus", () => {
         data: PERCENTAGE_RESPONSE_HEX.slice(0, -2),
       });
       expect(() => command.parseResponse(PERCENTAGE_RESPONSE)).toThrow(
-        "Call getApdu to initialise battery status type.",
+        InvalidBatteryStatusTypeError,
       );
     });
     it("should throw an error if the response returned unsupported format", () => {
@@ -116,7 +120,7 @@ describe("GetBatteryStatus", () => {
       });
       command.getApdu(BatteryStatusType.BATTERY_PERCENTAGE);
       expect(() => command.parseResponse(FAILED_RESPONSE)).toThrow(
-        "Unexpected status word: 6700",
+        InvalidStatusWordError,
       );
     });
   });

--- a/packages/core/src/api/command/os/GetOsVersionCommand.test.ts
+++ b/packages/core/src/api/command/os/GetOsVersionCommand.test.ts
@@ -1,4 +1,5 @@
 import { Command } from "@api/command/Command";
+import { InvalidStatusWordError } from "@api/command/Errors";
 import { DeviceModelId } from "@api/device/DeviceModel";
 import { ApduResponse } from "@internal/device-session/model/ApduResponse";
 
@@ -129,7 +130,7 @@ describe("GetOsVersionCommand", () => {
 
         expect(() =>
           command.parseResponse(response, DeviceModelId.NANO_X),
-        ).toThrow("Unexpected status word: 6e80");
+        ).toThrow(InvalidStatusWordError);
       });
     });
   });

--- a/packages/core/src/api/command/os/GetOsVersionCommand.ts
+++ b/packages/core/src/api/command/os/GetOsVersionCommand.ts
@@ -2,6 +2,7 @@ import { Apdu } from "@api/apdu/model/Apdu";
 import { ApduBuilder } from "@api/apdu/utils/ApduBuilder";
 import { ApduParser } from "@api/apdu/utils/ApduParser";
 import { Command } from "@api/command/Command";
+import { InvalidStatusWordError } from "@api/command/Errors";
 import { CommandUtils } from "@api/command/utils/CommandUtils";
 import { DeviceModelId } from "@api/device/DeviceModel";
 import { ApduResponse } from "@internal/device-session/model/ApduResponse";
@@ -30,7 +31,7 @@ export class GetOsVersionCommand implements Command<GetOsVersionResponse> {
     const parser = new ApduParser(responseApdu);
     if (!CommandUtils.isSuccessResponse(responseApdu)) {
       // [ASK] How de we handle unsuccessful responses?
-      throw new Error(
+      throw new InvalidStatusWordError(
         `Unexpected status word: ${parser.encodeToHexaString(responseApdu.statusCode)}`,
       );
     }


### PR DESCRIPTION
Closes DSDK-292

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- Replace `Error` with `SdkError` in `@api/command`

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [DSDK-292] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[DSDK-292]: https://ledgerhq.atlassian.net/browse/DSDK-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ