### PR TITLE
✨ (core) [DSDK-320]: Improve polling behaviour

### DIFF
--- a/packages/core/src/internal/device-session/model/DeviceSession.ts
+++ b/packages/core/src/internal/device-session/model/DeviceSession.ts
@@ -46,7 +46,8 @@ export class DeviceSession {
       {
         refreshInterval: 1000,
         deviceStatus: DeviceStatus.CONNECTED,
-        sendApduFn: (rawApdu: Uint8Array) => this.sendApdu(rawApdu),
+        sendApduFn: (rawApdu: Uint8Array) =>
+          this.sendApdu(rawApdu, { isPolling: true }),
         updateStateFn: (state: DeviceSessionState) =>
           this.setDeviceSessionState(state),
       },
@@ -79,8 +80,11 @@ export class DeviceSession {
     });
   }
 
-  async sendApdu(rawApdu: Uint8Array) {
-    this.updateDeviceStatus(DeviceStatus.BUSY);
+  async sendApdu(
+    rawApdu: Uint8Array,
+    options: { isPolling: boolean } = { isPolling: false },
+  ) {
+    if (!options.isPolling) this.updateDeviceStatus(DeviceStatus.BUSY);
 
     const errorOrResponse = await this._connectedDevice.sendApdu(rawApdu);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
- The refresher observable should not be stopped even though error occurs, it should continue to run until the session closed. So when errors occur, log it out then return `null`, then filter it before subscription;
- The polling will call the `sendApdu` function which will change the state in short time, this will make the state seems like 'unstable' for end users. To avoid this, an option `isPolling` is added, the function call from the refresher will not change the state. Why ?
  - We cannot force the end users to use `rxjs` operator to debounce the state change;
  - The state will not prevent the function calls out of refresher, only the function (`sendApdu`) calls out of refresher will prevent the polling, so this update will not impact the actual behaviour.


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [DSDK-320]

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [x] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[DSDK-320]: https://ledgerhq.atlassian.net/browse/DSDK-320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ