### PR TITLE
✨ (core) [DSDK-335]: Limit the usage of `as` keyword for type assertion

### DIFF
--- a/apps/sample/src/components/ApduView/index.tsx
+++ b/apps/sample/src/components/ApduView/index.tsx
@@ -78,7 +78,7 @@ export const ApduView: React.FC = () => {
       try {
         rawApduResponse = await sdk.sendApdu({
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-          sessionId: selectedSessionId!,
+          sessionId: selectedSessionId ?? "",
           apdu: getRawApdu(values),
         });
         setApduResponse(rawApduResponse);

--- a/apps/sample/src/components/Sidebar/index.tsx
+++ b/apps/sample/src/components/Sidebar/index.tsx
@@ -53,7 +53,7 @@ export const Sidebar: React.FC = () => {
       .getVersion()
       .then((v) => setVersion(v))
       .catch((error: unknown) => {
-        console.error(error as Error);
+        console.error(new Error(String(error)));
         setVersion("");
       });
   }, [sdk]);

--- a/apps/sample/src/hooks/useApduForm.ts
+++ b/apps/sample/src/hooks/useApduForm.ts
@@ -37,7 +37,7 @@ export function useApduForm() {
               .map((char) => Number(`0x${char}`))
               .filter((nbr) => !Number.isNaN(nbr)),
           ],
-          [] as number[],
+          Array<number>(),
         ),
       ),
     [],

--- a/packages/config/eslint/index.js
+++ b/packages/config/eslint/index.js
@@ -5,7 +5,7 @@ const project = resolve(process.cwd(), "tsconfig.json");
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   extends: ["eslint:recommended", "prettier", "turbo"],
-  plugins: ["simple-import-sort"],
+  plugins: ["no-type-assertion", "simple-import-sort"],
   globals: {
     React: true,
     JSX: true,
@@ -82,6 +82,13 @@ module.exports = {
           "error",
           { argsIgnorePattern: "^_" },
         ],
+        "no-type-assertion/no-type-assertion": "error",
+      },
+    },
+    {
+      files: ["**/*.test.ts", "**/*.stub.ts"],
+      rules: {
+        "no-type-assertion/no-type-assertion": "off",
       },
     },
   ],

--- a/packages/config/eslint/package.json
+++ b/packages/config/eslint/package.json
@@ -12,6 +12,7 @@
     "@vercel/style-guide": "^6.0.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-turbo": "^1.13.2",
+    "eslint-plugin-no-type-assertion": "^1.3.0",
     "eslint-plugin-simple-import-sort": "^12.0.0"
   }
 }

--- a/packages/core/src/api/Error.ts
+++ b/packages/core/src/api/Error.ts
@@ -1,5 +1,5 @@
 export interface SdkError {
   readonly _tag: string;
-  originalError?: Error;
+  originalError?: unknown;
   // [could] message?: string;
 }

--- a/packages/core/src/api/apdu/utils/ApduParser.ts
+++ b/packages/core/src/api/apdu/utils/ApduParser.ts
@@ -111,16 +111,14 @@ export class ApduParser {
   extractFieldTLVEncoded(): TaggedField | undefined {
     if (this._outOfRange(2)) return;
 
-    // extract the tag field
     const tag = this.extract8BitUint();
     const value = this.extractFieldLVEncoded();
 
-    // if the field is inconsistent then roll back to the initial point
-    if (!value) {
+    if (!tag || !value) {
       this._index--;
       return;
     }
-    return { tag, value } as TaggedField;
+    return { tag, value };
   }
 
   /**

--- a/packages/core/src/api/command/os/GetAppAndVersionCommand.ts
+++ b/packages/core/src/api/command/os/GetAppAndVersionCommand.ts
@@ -58,10 +58,10 @@ export class GetAppAndVersionCommand
     const version = parser.encodeToString(parser.extractFieldLVEncoded());
 
     if (parser.getUnparsedRemainingLength() === 0) {
-      return { name, version } as GetAppAndVersionResponse;
+      return { name, version };
     }
 
     const flags = parser.extractFieldLVEncoded();
-    return { name, version, flags } as GetAppAndVersionResponse;
+    return { name, version, flags };
   }
 }

--- a/packages/core/src/internal/config/model/Config.ts
+++ b/packages/core/src/internal/config/model/Config.ts
@@ -4,3 +4,19 @@ export type Config = {
   version: string;
   name: string;
 };
+
+/**
+ * Checks if the provided object is a valid Config object.
+ * @param obj - The object to be checked.
+ * @returns A boolean indicating whether the object is a Config object.
+ */
+export function isConfig(obj: unknown): obj is Config {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "version" in obj &&
+    "name" in obj &&
+    typeof obj.version === "string" &&
+    typeof obj.name === "string"
+  );
+}

--- a/packages/core/src/internal/device-model/data/StaticDeviceModelDataSource.ts
+++ b/packages/core/src/internal/device-model/data/StaticDeviceModelDataSource.ts
@@ -83,6 +83,7 @@ export class StaticDeviceModelDataSource implements DeviceModelDataSource {
   ): InternalDeviceModel[] {
     return this.getAllDeviceModels().filter((deviceModel) => {
       return Object.entries(params).every(([key, value]) => {
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
         return deviceModel[key as keyof InternalDeviceModel] === value;
       });
     });

--- a/packages/core/src/internal/device-session/model/DeviceSessionRefresher.ts
+++ b/packages/core/src/internal/device-session/model/DeviceSessionRefresher.ts
@@ -97,11 +97,15 @@ export class DeviceSessionRefresher {
         filter((parsedResponse) => parsedResponse !== null),
       )
       .subscribe((parsedResponse: GetAppAndVersionResponse | null) => {
-        // batteryStatus and firmwareVersion are not available in the polling response.
+        // This should never happen and it should be abled to handle in next version of TypeScript.
+        if (parsedResponse === null) {
+          return;
+        }
+        // `batteryStatus` and `firmwareVersion` are not available in the polling response.
         updateStateFn({
           sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
           deviceStatus: this._deviceStatus,
-          currentApp: parsedResponse!.name,
+          currentApp: parsedResponse.name,
         });
       });
   }

--- a/packages/core/src/internal/device-session/service/DefaultApduReceiverService.ts
+++ b/packages/core/src/internal/device-session/service/DefaultApduReceiverService.ts
@@ -57,8 +57,10 @@ export class DefaultApduReceiverService implements ApduReceiverService {
         data: { frame: value.getRawData() },
       });
       this._pendingFrames.push(value);
-
-      const dataSize = this._pendingFrames[0]!.getHeader().getDataLength();
+      if (!this._pendingFrames[0]) {
+        return Nothing;
+      }
+      const dataSize = this._pendingFrames[0].getHeader().getDataLength();
       return this.getCompleteFrame(dataSize);
     });
   }

--- a/packages/core/src/internal/usb/model/Errors.ts
+++ b/packages/core/src/internal/usb/model/Errors.ts
@@ -6,59 +6,63 @@ export type PromptDeviceAccessError =
 
 export type ConnectError = UnknownDeviceError | OpeningConnectionError;
 
-export class DeviceNotRecognizedError implements SdkError {
-  readonly _tag = "DeviceNotRecognizedError";
-  originalError?: Error;
-  constructor(readonly err?: Error) {
-    this.originalError = err;
+class GeneralSdkError implements SdkError {
+  _tag = "GeneralSdkError";
+  originalError?: unknown;
+  constructor(err?: unknown) {
+    if (err instanceof Error) {
+      this.originalError = err;
+    } else {
+      this.originalError = new Error(String(err));
+    }
   }
 }
 
-export class NoAccessibleDeviceError implements SdkError {
-  readonly _tag = "NoAccessibleDeviceError";
-  originalError?: Error;
-  constructor(readonly err?: Error) {
-    this.originalError = err;
+export class DeviceNotRecognizedError extends GeneralSdkError {
+  override readonly _tag = "DeviceNotRecognizedError";
+  constructor(readonly err?: unknown) {
+    super(err);
   }
 }
 
-export class OpeningConnectionError implements SdkError {
-  readonly _tag = "ConnectionOpeningError";
-  originalError?: Error;
-  constructor(readonly err?: Error) {
-    this.originalError = err;
+export class NoAccessibleDeviceError extends GeneralSdkError {
+  override readonly _tag = "NoAccessibleDeviceError";
+  constructor(readonly err?: unknown) {
+    super(err);
   }
 }
 
-export class UnknownDeviceError implements SdkError {
-  readonly _tag = "UnknownDeviceError";
-  originalError?: Error;
-  constructor(readonly err?: Error) {
-    this.originalError = err;
+export class OpeningConnectionError extends GeneralSdkError {
+  override readonly _tag = "ConnectionOpeningError";
+  constructor(readonly err?: unknown) {
+    super(err);
   }
 }
 
-export class UsbHidTransportNotSupportedError implements SdkError {
-  readonly _tag = "UsbHidTransportNotSupportedError";
-  originalError?: Error;
-  constructor(readonly err?: Error) {
-    this.originalError = err;
+export class UnknownDeviceError extends GeneralSdkError {
+  override readonly _tag = "UnknownDeviceError";
+  constructor(readonly err?: unknown) {
+    super(err);
   }
 }
 
-export class SendApduConcurrencyError implements SdkError {
-  readonly _tag = "SendApduConcurrencyError";
-  originalError?: Error;
-  constructor(readonly err?: Error) {
-    this.originalError = err;
+export class UsbHidTransportNotSupportedError extends GeneralSdkError {
+  override readonly _tag = "UsbHidTransportNotSupportedError";
+  constructor(readonly err?: unknown) {
+    super(err);
   }
 }
 
-export class DisconnectError implements SdkError {
-  readonly _tag = "DisconnectError";
-  originalError?: Error;
+export class SendApduConcurrencyError extends GeneralSdkError {
+  override readonly _tag = "SendApduConcurrencyError";
+  constructor(readonly err?: unknown) {
+    super(err);
+  }
+}
 
-  constructor(readonly err?: Error) {
-    this.originalError = err;
+export class DisconnectError extends GeneralSdkError {
+  override readonly _tag = "DisconnectError";
+  constructor(readonly err?: unknown) {
+    super(err);
   }
 }

--- a/packages/core/src/internal/usb/model/HIDDevice.stub.ts
+++ b/packages/core/src/internal/usb/model/HIDDevice.stub.ts
@@ -1,4 +1,4 @@
-const oninputreport = jest.fn();
+const oninputreport = jest.fn().mockResolvedValue(void 0);
 export const hidDeviceStubBuilder = (
   props: Partial<HIDDevice> = {},
 ): HIDDevice => ({
@@ -10,7 +10,7 @@ export const hidDeviceStubBuilder = (
   open: jest.fn(),
   oninputreport,
   close: jest.fn(),
-  sendReport: jest.fn(async () => oninputreport()),
+  sendReport: jest.fn().mockImplementation(() => oninputreport()),
   sendFeatureReport: jest.fn(),
   forget: jest.fn(),
   receiveFeatureReport: jest.fn(),

--- a/packages/core/src/internal/usb/transport/UsbHidDeviceConnection.test.ts
+++ b/packages/core/src/internal/usb/transport/UsbHidDeviceConnection.test.ts
@@ -38,7 +38,7 @@ describe("UsbHidDeviceConnection", () => {
     expect(cDevice).toStrictEqual(device);
   });
 
-  it("should send APDU through hid report", async () => {
+  it("should send APDU through hid report", () => {
     // given
     const connection = new UsbHidDeviceConnection(
       { device, apduSender, apduReceiver },
@@ -50,7 +50,7 @@ describe("UsbHidDeviceConnection", () => {
     expect(device.sendReport).toHaveBeenCalled();
   });
 
-  it("should receive APDU through hid report", async () => {
+  it("should receive APDU through hid report", () => {
     // given
     device.sendReport = jest.fn(() =>
       Promise.resolve(

--- a/packages/core/src/internal/usb/transport/WebUsbHidTransport.test.ts
+++ b/packages/core/src/internal/usb/transport/WebUsbHidTransport.test.ts
@@ -244,7 +244,7 @@ describe("WebUsbHidTransport", () => {
         const connect = await transport.connect(connectParams);
 
         expect(connect).toStrictEqual(
-          Left(new UnknownDeviceError(new Error("Unknown device fake"))),
+          Left(new UnknownDeviceError("Unknown device fake")),
         );
       });
 
@@ -254,7 +254,7 @@ describe("WebUsbHidTransport", () => {
         const connect = await transport.connect(device);
 
         expect(connect).toStrictEqual(
-          Left(new UnknownDeviceError(new Error("Unknown device fake"))),
+          Left(new UnknownDeviceError("Unknown device fake")),
         );
       });
 
@@ -376,11 +376,7 @@ describe("WebUsbHidTransport", () => {
         });
 
         expect(disconnect).toStrictEqual(
-          Left(
-            new UnknownDeviceError(
-              new Error(`Unknown device ${connectedDevice.id}`),
-            ),
-          ),
+          Left(new UnknownDeviceError(`Unknown device ${connectedDevice.id}`)),
         );
       });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 6.2.11
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.12.7)
+        version: 29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4))
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
@@ -46,7 +46,7 @@ importers:
         version: 5.0.5
       ts-jest:
         specifier: ^29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4)
+        version: 29.1.2(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(jest@29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4)))(typescript@5.4.4)
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.8
@@ -67,13 +67,13 @@ importers:
         version: link:../../packages/core
       '@ledgerhq/react-ui':
         specifier: ^0.14.16
-        version: 0.14.16(@types/react@18.2.75)(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.11)
+        version: 0.14.16(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@5.3.11(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0))
       '@sentry/nextjs':
         specifier: ^7.109.0
-        version: 7.109.0(next@14.1.4)(react@18.2.0)
+        version: 7.109.0(next@14.1.4(@babel/core@7.24.4)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       next:
         specifier: 14.1.4
-        version: 14.1.4(@babel/core@7.24.4)(react-dom@18.2.0)(react@18.2.0)
+        version: 14.1.4(@babel/core@7.24.4)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: ^18
         version: 18.2.0
@@ -82,7 +82,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       styled-components:
         specifier: ^5.3.11
-        version: 5.3.11(@babel/core@7.24.4)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+        version: 5.3.11(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)
     devDependencies:
       '@ledgerhq/eslint-config-dsdk':
         specifier: workspace:*
@@ -113,19 +113,22 @@ importers:
     devDependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.6.0
-        version: 7.6.0(@typescript-eslint/parser@7.6.0)(eslint@9.0.0)(typescript@5.4.4)
+        version: 7.6.0(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(typescript@5.4.4)
       '@typescript-eslint/parser':
         specifier: ^7.6.0
         version: 7.6.0(eslint@9.0.0)(typescript@5.4.4)
       '@vercel/style-guide':
         specifier: ^6.0.0
-        version: 6.0.0(eslint@9.0.0)(jest@29.7.0)(prettier@3.2.5)(typescript@5.4.4)
+        version: 6.0.0(@next/eslint-plugin-next@14.1.4)(eslint@9.0.0)(jest@29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4)))(prettier@3.2.5)(typescript@5.4.4)
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.0(eslint@9.0.0)
       eslint-config-turbo:
         specifier: ^1.13.2
         version: 1.13.2(eslint@9.0.0)
+      eslint-plugin-no-type-assertion:
+        specifier: ^1.3.0
+        version: 1.3.0(eslint@9.0.0)
       eslint-plugin-simple-import-sort:
         specifier: ^12.0.0
         version: 12.0.0(eslint@9.0.0)
@@ -2374,6 +2377,12 @@ packages:
     engines: {node: '>=4.0'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+
+  eslint-plugin-no-type-assertion@1.3.0:
+    resolution: {integrity: sha512-04wuuIP5ptNzp969tTt0gf/Jsw4G0T5md2/nbgv3dRL/HySSNU7H4vIKNjkuno9T+6h2daj1T9Aki6bDgmXDEw==}
+    engines: {node: '>=12.0.0', yarn: ^1.13.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
 
   eslint-plugin-playwright@1.5.4:
     resolution: {integrity: sha512-J38Wy3Vc2f9y73J+KRmgXgbYI8TZ3zbz6qBbTj3PhpFndUS572jZ7kqQ3rJ9si5BaMHT7lmZzraO+3UjwIDV4Q==}
@@ -5546,9 +5555,10 @@ snapshots:
       '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
       '@emotion/utils': 1.2.1
       '@emotion/weak-memoize': 0.3.1
-      '@types/react': 18.2.75
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.75
 
   '@emotion/serialize@1.1.3':
     dependencies:
@@ -5633,7 +5643,7 @@ snapshots:
       '@floating-ui/core': 1.5.3
       '@floating-ui/utils': 0.2.1
 
-  '@floating-ui/react-dom@0.4.3(@types/react@18.2.75)(react-dom@18.2.0)(react@18.2.0)':
+  '@floating-ui/react-dom@0.4.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@floating-ui/dom': 0.1.10
       react: 18.2.0
@@ -5715,7 +5725,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -5729,7 +5739,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.7)
+      jest-config: 29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -5890,28 +5900,29 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@ledgerhq/crypto-icons-ui@1.1.0(@types/react@18.2.75)(react@18.2.0)(styled-components@5.3.11)(styled-system@5.1.5)':
+  '@ledgerhq/crypto-icons-ui@1.1.0(@types/react@18.2.75)(react@18.2.0)(styled-components@5.3.11(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0))(styled-system@5.1.5)':
     dependencies:
-      '@types/react': 18.2.75
       react: 18.2.0
-      styled-components: 5.3.11(@babel/core@7.24.4)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+      styled-components: 5.3.11(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)
       styled-system: 5.1.5
-
-  '@ledgerhq/icons-ui@0.6.3(@types/react@18.2.75)(react@18.2.0)(styled-components@5.3.11)(styled-system@5.1.5)':
-    dependencies:
+    optionalDependencies:
       '@types/react': 18.2.75
-      react: 18.2.0
-      styled-components: 5.3.11(@babel/core@7.24.4)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-      styled-system: 5.1.5
 
-  '@ledgerhq/react-ui@0.14.16(@types/react@18.2.75)(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.11)':
+  '@ledgerhq/icons-ui@0.6.3(@types/react@18.2.75)(react@18.2.0)(styled-components@5.3.11(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0))(styled-system@5.1.5)':
     dependencies:
-      '@floating-ui/react-dom': 0.4.3(@types/react@18.2.75)(react-dom@18.2.0)(react@18.2.0)
-      '@ledgerhq/crypto-icons-ui': 1.1.0(@types/react@18.2.75)(react@18.2.0)(styled-components@5.3.11)(styled-system@5.1.5)
-      '@ledgerhq/icons-ui': 0.6.3(@types/react@18.2.75)(react@18.2.0)(styled-components@5.3.11)(styled-system@5.1.5)
+      react: 18.2.0
+      styled-components: 5.3.11(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)
+      styled-system: 5.1.5
+    optionalDependencies:
+      '@types/react': 18.2.75
+
+  '@ledgerhq/react-ui@0.14.16(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@5.3.11(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0))':
+    dependencies:
+      '@floating-ui/react-dom': 0.4.3(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@ledgerhq/crypto-icons-ui': 1.1.0(@types/react@18.2.75)(react@18.2.0)(styled-components@5.3.11(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0))(styled-system@5.1.5)
+      '@ledgerhq/icons-ui': 0.6.3(@types/react@18.2.75)(react@18.2.0)(styled-components@5.3.11(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0))(styled-system@5.1.5)
       '@ledgerhq/ui-shared': 0.2.1
-      '@tippyjs/react': 4.2.6(react-dom@18.2.0)(react@18.2.0)
-      '@types/react': 18.2.75
+      '@tippyjs/react': 4.2.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       chart.js: 3.9.1
       chartjs-adapter-moment: 1.0.1(chart.js@3.9.1)(moment@2.30.1)
       color: 4.2.3
@@ -5921,12 +5932,14 @@ snapshots:
       react-chartjs-2: 3.3.0(chart.js@3.9.1)(react@18.2.0)
       react-dom: 18.2.0(react@18.2.0)
       react-is: 17.0.2
-      react-select: 5.8.0(@types/react@18.2.75)(react-dom@18.2.0)(react@18.2.0)
-      react-spring: 8.0.27(react-dom@18.2.0)(react@18.2.0)
-      react-transition-group: 4.4.5(react-dom@18.2.0)(react@18.2.0)
-      react-window: 1.8.10(react-dom@18.2.0)(react@18.2.0)
-      styled-components: 5.3.11(@babel/core@7.24.4)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+      react-select: 5.8.0(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-spring: 8.0.27(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-transition-group: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-window: 1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      styled-components: 5.3.11(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)
       styled-system: 5.1.5
+    optionalDependencies:
+      '@types/react': 18.2.75
 
   '@ledgerhq/ui-shared@0.2.1': {}
 
@@ -6112,6 +6125,7 @@ snapshots:
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.27.0
+    optionalDependencies:
       rollup: 2.78.0
 
   '@rollup/pluginutils@5.1.0(rollup@2.78.0)':
@@ -6119,6 +6133,7 @@ snapshots:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    optionalDependencies:
       rollup: 2.78.0
 
   '@rushstack/eslint-patch@1.10.1': {}
@@ -6188,7 +6203,7 @@ snapshots:
       '@sentry/types': 6.19.7
       tslib: 1.14.1
 
-  '@sentry/nextjs@7.109.0(next@14.1.4)(react@18.2.0)':
+  '@sentry/nextjs@7.109.0(next@14.1.4(@babel/core@7.24.4)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@rollup/plugin-commonjs': 24.0.0(rollup@2.78.0)
       '@sentry/core': 7.109.0
@@ -6200,7 +6215,7 @@ snapshots:
       '@sentry/vercel-edge': 7.109.0
       '@sentry/webpack-plugin': 1.21.0
       chalk: 3.0.0
-      next: 14.1.4(@babel/core@7.24.4)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.1.4(@babel/core@7.24.4)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       resolve: 1.22.8
       rollup: 2.78.0
@@ -6337,7 +6352,7 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tippyjs/react@4.2.6(react-dom@18.2.0)(react@18.2.0)':
+  '@tippyjs/react@4.2.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -6490,7 +6505,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.6.0)(eslint@9.0.0)(typescript@5.4.4)':
+  '@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(typescript@5.4.4)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 7.6.0(eslint@9.0.0)(typescript@5.4.4)
@@ -6505,6 +6520,7 @@ snapshots:
       natural-compare: 1.4.0
       semver: 7.6.0
       ts-api-utils: 1.3.0(typescript@5.4.4)
+    optionalDependencies:
       typescript: 5.4.4
     transitivePeerDependencies:
       - supports-color
@@ -6517,6 +6533,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 9.0.0
+    optionalDependencies:
       typescript: 5.4.4
     transitivePeerDependencies:
       - supports-color
@@ -6529,6 +6546,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 7.6.0
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 9.0.0
+    optionalDependencies:
       typescript: 5.4.4
     transitivePeerDependencies:
       - supports-color
@@ -6560,6 +6578,7 @@ snapshots:
       debug: 4.3.4(supports-color@5.5.0)
       eslint: 9.0.0
       ts-api-utils: 1.3.0(typescript@5.4.4)
+    optionalDependencies:
       typescript: 5.4.4
     transitivePeerDependencies:
       - supports-color
@@ -6581,6 +6600,7 @@ snapshots:
       is-glob: 4.0.3
       semver: 7.6.0
       tsutils: 3.21.0(typescript@5.4.4)
+    optionalDependencies:
       typescript: 5.4.4
     transitivePeerDependencies:
       - supports-color
@@ -6595,6 +6615,7 @@ snapshots:
       minimatch: 9.0.3
       semver: 7.6.0
       ts-api-utils: 1.3.0(typescript@5.4.4)
+    optionalDependencies:
       typescript: 5.4.4
     transitivePeerDependencies:
       - supports-color
@@ -6609,6 +6630,7 @@ snapshots:
       minimatch: 9.0.3
       semver: 7.6.0
       ts-api-utils: 1.3.0(typescript@5.4.4)
+    optionalDependencies:
       typescript: 5.4.4
     transitivePeerDependencies:
       - supports-color
@@ -6623,6 +6645,7 @@ snapshots:
       minimatch: 9.0.4
       semver: 7.6.0
       ts-api-utils: 1.3.0(typescript@5.4.4)
+    optionalDependencies:
       typescript: 5.4.4
     transitivePeerDependencies:
       - supports-color
@@ -6692,30 +6715,32 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vercel/style-guide@6.0.0(eslint@9.0.0)(jest@29.7.0)(prettier@3.2.5)(typescript@5.4.4)':
+  '@vercel/style-guide@6.0.0(@next/eslint-plugin-next@14.1.4)(eslint@9.0.0)(jest@29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4)))(prettier@3.2.5)(typescript@5.4.4)':
     dependencies:
       '@babel/core': 7.24.4
       '@babel/eslint-parser': 7.24.1(@babel/core@7.24.4)(eslint@9.0.0)
       '@rushstack/eslint-patch': 1.10.1
-      '@typescript-eslint/eslint-plugin': 7.6.0(@typescript-eslint/parser@7.6.0)(eslint@9.0.0)(typescript@5.4.4)
+      '@typescript-eslint/eslint-plugin': 7.6.0(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(typescript@5.4.4)
       '@typescript-eslint/parser': 7.6.0(eslint@9.0.0)(typescript@5.4.4)
-      eslint: 9.0.0
       eslint-config-prettier: 9.1.0(eslint@9.0.0)
-      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.29.1)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.6.0)(eslint-plugin-import@2.29.1)(eslint@9.0.0)
+      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint-plugin-import@2.29.1)(eslint@9.0.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@9.0.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.6.0)(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0)
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@7.6.0)(eslint@9.0.0)(jest@29.7.0)(typescript@5.4.4)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(jest@29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4)))(typescript@5.4.4)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@9.0.0)
-      eslint-plugin-playwright: 1.5.4(eslint-plugin-jest@27.9.0)(eslint@9.0.0)
+      eslint-plugin-playwright: 1.5.4(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(jest@29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4)))(typescript@5.4.4))(eslint@9.0.0)
       eslint-plugin-react: 7.34.1(eslint@9.0.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@9.0.0)
       eslint-plugin-testing-library: 6.2.0(eslint@9.0.0)(typescript@5.4.4)
       eslint-plugin-tsdoc: 0.2.17
       eslint-plugin-unicorn: 51.0.1(eslint@9.0.0)
-      eslint-plugin-vitest: 0.3.26(@typescript-eslint/eslint-plugin@7.6.0)(eslint@9.0.0)(typescript@5.4.4)
-      prettier: 3.2.5
+      eslint-plugin-vitest: 0.3.26(@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(typescript@5.4.4)
       prettier-plugin-packagejson: 2.4.14(prettier@3.2.5)
+    optionalDependencies:
+      '@next/eslint-plugin-next': 14.1.4
+      eslint: 9.0.0
+      prettier: 3.2.5
       typescript: 5.4.4
     transitivePeerDependencies:
       - eslint-import-resolver-node
@@ -6751,7 +6776,7 @@ snapshots:
       - supports-color
 
   ajv-formats@2.1.1(ajv@8.12.0):
-    dependencies:
+    optionalDependencies:
       ajv: 8.12.0
 
   ajv@6.12.6:
@@ -6974,14 +6999,14 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.8
 
-  babel-plugin-styled-components@2.1.4(@babel/core@7.24.4)(styled-components@5.3.11):
+  babel-plugin-styled-components@2.1.4(@babel/core@7.24.4)(styled-components@5.3.11(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)):
     dependencies:
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-module-imports': 7.22.15
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.24.4)
       lodash: 4.17.21
       picomatch: 2.3.1
-      styled-components: 5.3.11(@babel/core@7.24.4)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+      styled-components: 5.3.11(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
 
@@ -7354,13 +7379,13 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
-  create-jest@29.7.0(@types/node@20.12.7):
+  create-jest@29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.12.7)
+      jest-config: 29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -7495,6 +7520,7 @@ snapshots:
   debug@4.3.4(supports-color@5.5.0):
     dependencies:
       ms: 2.1.2
+    optionalDependencies:
       supports-color: 5.5.0
 
   decamelize-keys@1.1.1:
@@ -7510,7 +7536,9 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
-  dedent@1.5.1: {}
+  dedent@1.5.1(babel-plugin-macros@3.1.0):
+    optionalDependencies:
+      babel-plugin-macros: 3.1.0
 
   deep-extend@0.6.0: {}
 
@@ -7768,11 +7796,12 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@9.0.0)(typescript@5.4.4)
       eslint: 9.0.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.0.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.0.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@9.0.0)
       eslint-plugin-react: 7.34.1(eslint@9.0.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@9.0.0)
+    optionalDependencies:
       typescript: 5.4.4
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
@@ -7787,9 +7816,9 @@ snapshots:
       eslint: 9.0.0
       eslint-plugin-turbo: 1.13.2(eslint@9.0.0)
 
-  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.29.1):
+  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)):
     dependencies:
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.6.0)(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0)
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
@@ -7799,13 +7828,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.0.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.0.0):
     dependencies:
       debug: 4.3.4(supports-color@5.5.0)
       enhanced-resolve: 5.16.0
       eslint: 9.0.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.0.0))(eslint@9.0.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -7816,13 +7845,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.6.0)(eslint-plugin-import@2.29.1)(eslint@9.0.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint-plugin-import@2.29.1)(eslint@9.0.0):
     dependencies:
       debug: 4.3.4(supports-color@5.5.0)
       enhanced-resolve: 5.16.0
       eslint: 9.0.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.6.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.6.0)(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint-plugin-import@2.29.1)(eslint@9.0.0))(eslint@9.0.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -7833,23 +7862,25 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.0.0))(eslint@9.0.0):
     dependencies:
+      debug: 3.2.7
+    optionalDependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@9.0.0)(typescript@5.4.4)
-      debug: 3.2.7
       eslint: 9.0.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.0.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.0.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.6.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint-plugin-import@2.29.1)(eslint@9.0.0))(eslint@9.0.0):
     dependencies:
-      '@typescript-eslint/parser': 7.6.0(eslint@9.0.0)(typescript@5.4.4)
       debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.6.0(eslint@9.0.0)(typescript@5.4.4)
       eslint: 9.0.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.6.0)(eslint-plugin-import@2.29.1)(eslint@9.0.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint-plugin-import@2.29.1)(eslint@9.0.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7859,9 +7890,35 @@ snapshots:
       eslint: 9.0.0
       ignore: 5.3.0
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0):
     dependencies:
+      array-includes: 3.1.8
+      array.prototype.findlastindex: 1.2.5
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.0.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.0.0))(eslint@9.0.0)
+      hasown: 2.0.2
+      is-core-module: 2.13.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.0
+      semver: 6.3.1
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@9.0.0)(typescript@5.4.4)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0):
+    dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
@@ -7870,7 +7927,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.0.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.6.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint-plugin-import@2.29.1)(eslint@9.0.0))(eslint@9.0.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -7880,43 +7937,20 @@ snapshots:
       object.values: 1.2.0
       semver: 6.3.1
       tsconfig-paths: 3.15.0
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.6.0)(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0):
-    dependencies:
+    optionalDependencies:
       '@typescript-eslint/parser': 7.6.0(eslint@9.0.0)(typescript@5.4.4)
-      array-includes: 3.1.8
-      array.prototype.findlastindex: 1.2.5
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.0.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.6.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.0.0)
-      hasown: 2.0.2
-      is-core-module: 2.13.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.0
-      semver: 6.3.1
-      tsconfig-paths: 3.15.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.6.0)(eslint@9.0.0)(jest@29.7.0)(typescript@5.4.4):
+  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(jest@29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4)))(typescript@5.4.4):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.6.0(@typescript-eslint/parser@7.6.0)(eslint@9.0.0)(typescript@5.4.4)
       '@typescript-eslint/utils': 5.62.0(eslint@9.0.0)(typescript@5.4.4)
       eslint: 9.0.0
-      jest: 29.7.0(@types/node@20.12.7)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 7.6.0(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(typescript@5.4.4)
+      jest: 29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -7941,11 +7975,16 @@ snapshots:
       object.entries: 1.1.8
       object.fromentries: 2.0.8
 
-  eslint-plugin-playwright@1.5.4(eslint-plugin-jest@27.9.0)(eslint@9.0.0):
+  eslint-plugin-no-type-assertion@1.3.0(eslint@9.0.0):
     dependencies:
       eslint: 9.0.0
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@7.6.0)(eslint@9.0.0)(jest@29.7.0)(typescript@5.4.4)
+
+  eslint-plugin-playwright@1.5.4(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(jest@29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4)))(typescript@5.4.4))(eslint@9.0.0):
+    dependencies:
+      eslint: 9.0.0
       globals: 13.24.0
+    optionalDependencies:
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(jest@29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4)))(typescript@5.4.4)
 
   eslint-plugin-react-hooks@4.6.0(eslint@9.0.0):
     dependencies:
@@ -8017,11 +8056,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-vitest@0.3.26(@typescript-eslint/eslint-plugin@7.6.0)(eslint@9.0.0)(typescript@5.4.4):
+  eslint-plugin-vitest@0.3.26(@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(typescript@5.4.4):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.6.0(@typescript-eslint/parser@7.6.0)(eslint@9.0.0)(typescript@5.4.4)
       '@typescript-eslint/utils': 7.5.0(eslint@9.0.0)(typescript@5.4.4)
       eslint: 9.0.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 7.6.0(@typescript-eslint/parser@7.6.0(eslint@9.0.0)(typescript@5.4.4))(eslint@9.0.0)(typescript@5.4.4)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -8980,7 +9020,7 @@ snapshots:
       jest-util: 29.7.0
       p-limit: 3.1.0
 
-  jest-circus@29.7.0:
+  jest-circus@29.7.0(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/environment': 29.7.0
       '@jest/expect': 29.7.0
@@ -8989,7 +9029,7 @@ snapshots:
       '@types/node': 20.12.7
       chalk: 4.1.2
       co: 4.6.0
-      dedent: 1.5.1
+      dedent: 1.5.1(babel-plugin-macros@3.1.0)
       is-generator-fn: 2.1.0
       jest-each: 29.7.0
       jest-matcher-utils: 29.7.0
@@ -9006,16 +9046,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.12.7):
+  jest-cli@29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4)):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.12.7)
+      create-jest: 29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.12.7)
+      jest-config: 29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -9025,19 +9065,18 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.12.7):
+  jest-config@29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4)):
     dependencies:
       '@babel/core': 7.24.4
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.12.7
       babel-jest: 29.7.0(@babel/core@7.24.4)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      jest-circus: 29.7.0
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
       jest-environment-node: 29.7.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
@@ -9050,6 +9089,9 @@ snapshots:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.12.7
+      ts-node: 10.9.2(@types/node@20.12.7)(typescript@5.4.4)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -9131,7 +9173,7 @@ snapshots:
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
-    dependencies:
+    optionalDependencies:
       jest-resolve: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -9269,12 +9311,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.12.7):
+  jest@29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4)):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.12.7)
+      jest-cli: 29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9609,7 +9651,7 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next@14.1.4(@babel/core@7.24.4)(react-dom@18.2.0)(react@18.2.0):
+  next@14.1.4(@babel/core@7.24.4)(babel-plugin-macros@3.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@next/env': 14.1.4
       '@swc/helpers': 0.5.2
@@ -9619,7 +9661,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.24.4)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.24.4)(babel-plugin-macros@3.1.0)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.1.4
       '@next/swc-darwin-x64': 14.1.4
@@ -9939,9 +9981,10 @@ snapshots:
 
   prettier-plugin-packagejson@2.4.14(prettier@3.2.5):
     dependencies:
-      prettier: 3.2.5
       sort-package-json: 2.10.0
       synckit: 0.9.0
+    optionalDependencies:
+      prettier: 3.2.5
 
   prettier@2.8.8: {}
 
@@ -10050,7 +10093,7 @@ snapshots:
 
   react-is@18.2.0: {}
 
-  react-select@5.8.0(@types/react@18.2.75)(react-dom@18.2.0)(react@18.2.0):
+  react-select@5.8.0(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.24.4
       '@emotion/cache': 11.11.0
@@ -10061,19 +10104,19 @@ snapshots:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-transition-group: 4.4.5(react-dom@18.2.0)(react@18.2.0)
+      react-transition-group: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       use-isomorphic-layout-effect: 1.1.2(@types/react@18.2.75)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
 
-  react-spring@8.0.27(react-dom@18.2.0)(react@18.2.0):
+  react-spring@8.0.27(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.24.4
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  react-transition-group@4.4.5(react-dom@18.2.0)(react@18.2.0):
+  react-transition-group@4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.24.4
       dom-helpers: 5.2.1
@@ -10082,7 +10125,7 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  react-window@1.8.10(react-dom@18.2.0)(react@18.2.0):
+  react-window@1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.24.4
       memoize-one: 5.2.1
@@ -10538,14 +10581,14 @@ snapshots:
 
   stubborn-fs@1.2.5: {}
 
-  styled-components@5.3.11(@babel/core@7.24.4)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0):
+  styled-components@5.3.11(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0):
     dependencies:
       '@babel/helper-module-imports': 7.22.15
       '@babel/traverse': 7.24.1(supports-color@5.5.0)
       '@emotion/is-prop-valid': 1.2.1
       '@emotion/stylis': 0.8.5
       '@emotion/unitless': 0.7.5
-      babel-plugin-styled-components: 2.1.4(@babel/core@7.24.4)(styled-components@5.3.11)
+      babel-plugin-styled-components: 2.1.4(@babel/core@7.24.4)(styled-components@5.3.11(@babel/core@7.24.4)(react-dom@18.2.0(react@18.2.0))(react-is@18.2.0)(react@18.2.0))
       css-to-react-native: 3.2.0
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
@@ -10556,11 +10599,13 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
 
-  styled-jsx@5.1.1(@babel/core@7.24.4)(react@18.2.0):
+  styled-jsx@5.1.1(@babel/core@7.24.4)(babel-plugin-macros@3.1.0)(react@18.2.0):
     dependencies:
-      '@babel/core': 7.24.4
       client-only: 0.0.1
       react: 18.2.0
+    optionalDependencies:
+      '@babel/core': 7.24.4
+      babel-plugin-macros: 3.1.0
 
   styled-system@5.1.5:
     dependencies:
@@ -10656,12 +10701,11 @@ snapshots:
     dependencies:
       typescript: 5.4.4
 
-  ts-jest@29.1.2(@babel/core@7.24.4)(jest@29.7.0)(typescript@5.4.4):
+  ts-jest@29.1.2(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(jest@29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4)))(typescript@5.4.4):
     dependencies:
-      '@babel/core': 7.24.4
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.12.7)
+      jest: 29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -10669,6 +10713,10 @@ snapshots:
       semver: 7.6.0
       typescript: 5.4.4
       yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.24.4
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.24.4)
 
   ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.4):
     dependencies:
@@ -10866,8 +10914,9 @@ snapshots:
 
   use-isomorphic-layout-effect@1.1.2(@types/react@18.2.75)(react@18.2.0):
     dependencies:
-      '@types/react': 18.2.75
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.2.75
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- Add ESLint rules to forbid the usage of `as` keyword in type assertion;
- Exclue all test files of format `**.test.ts`;
- Bypass one file at `packages/core/src/internal/device-model/data/StaticDeviceModelDataSource.ts` due to no better solution.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [DSDK-335]

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [x] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [x] **Any new dependencies** have been justified and documented.


[DSDK-335]: https://ledgerhq.atlassian.net/browse/DSDK-335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ