### PR TITLE
:bug: (core) [DSDK-353]: Get battery status command: issue on parsing of response for BATTERY_CURRENT

### DIFF
--- a/packages/core/src/api/command/os/GetBatteryStatusCommand.ts
+++ b/packages/core/src/api/command/os/GetBatteryStatusCommand.ts
@@ -110,14 +110,14 @@ export class GetBatteryStatusCommand
     switch (this.args.statusType) {
       case BatteryStatusType.BATTERY_PERCENTAGE: {
         const percentage = parser.extract8BitUint();
-        if (!percentage) {
+        if (percentage === undefined) {
           throw new InvalidBatteryDataError("Cannot parse APDU response");
         }
         return percentage > 100 ? -1 : percentage;
       }
       case BatteryStatusType.BATTERY_VOLTAGE: {
         const data = parser.extract16BitUInt();
-        if (!data) {
+        if (data === undefined) {
           throw new InvalidBatteryDataError("Cannot parse APDU response");
         }
         return data;
@@ -125,14 +125,14 @@ export class GetBatteryStatusCommand
       case BatteryStatusType.BATTERY_TEMPERATURE:
       case BatteryStatusType.BATTERY_CURRENT: {
         const data = parser.extract8BitUint();
-        if (!data) {
+        if (data === undefined) {
           throw new InvalidBatteryDataError("Cannot parse APDU response");
         }
         return (data << 24) >> 24;
       }
       case BatteryStatusType.BATTERY_FLAGS: {
         const flags = parser.extract32BitUInt();
-        if (!flags) {
+        if (flags === undefined) {
           throw new InvalidBatteryFlagsError("Cannot parse APDU response");
         }
         const chargingUSB = !!(flags & FlagMasks.USB_POWERED);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fix parsing of getBatteryStatus command result, 0 value treated as undefined

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [DSDK-353]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [x] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [x] **Any new dependencies** have been justified and documented.


[DSDK-353]: https://ledgerhq.atlassian.net/browse/DSDK-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ