### PR TITLE
🐛 (keyring-eth) [NO-ISSUE]: Fix getApdu error in `ProvideDomainNameCommand`

### DIFF
--- a/packages/signer/keyring-eth/src/internal/app-binder/command/ProvideDomainNameCommand.test.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/command/ProvideDomainNameCommand.test.ts
@@ -9,40 +9,55 @@ import {
 } from "./ProvideDomainNameCommand";
 
 const FIRST_CHUNK_APDU = Uint8Array.from([
-  0xe0, 0x22, 0x01, 0x00, 0x06, 0x4c, 0x65, 0x64, 0x67, 0x65, 0x72,
+  0xe0, 0x22, 0x01, 0x00, 0x08, 0x00, 0x06, 0x4c, 0x65, 0x64, 0x67, 0x65, 0x72,
 ]);
 
 describe("ProvideDomainNameCommand", () => {
   describe("getApdu", () => {
     it("should return the raw APDU", () => {
+      // GIVEN
       const args: ProvideDomainNameCommandArgs = {
-        data: "4C6564676572",
+        data: "00064C6564676572",
         index: 0,
       };
+      // WHEN
       const command = new ProvideDomainNameCommand(args);
       const apdu = command.getApdu();
+      // THEN
       expect(apdu.getRawApdu()).toStrictEqual(FIRST_CHUNK_APDU);
     });
   });
 
   describe("parseResponse", () => {
     it("should throw an error if the response status code is invalid", () => {
+      // GIVEN
       const response: ApduResponse = {
         data: Buffer.from([]),
         statusCode: Buffer.from([0x6a, 0x80]), // Invalid status code
       };
-      const command = new ProvideDomainNameCommand({ data: "", index: 0 });
+      // WHEN
+      const command = new ProvideDomainNameCommand({
+        data: "",
+        index: 0,
+      });
+      // THEN
       expect(() => command.parseResponse(response)).toThrow(
         InvalidStatusWordError,
       );
     });
 
     it("should not throw if the response status code is correct", () => {
+      // GIVEN
       const response: ApduResponse = {
         data: Buffer.from([]),
         statusCode: Buffer.from([0x90, 0x00]), // Success status code
       };
-      const command = new ProvideDomainNameCommand({ data: "", index: 0 });
+      // WHEN
+      const command = new ProvideDomainNameCommand({
+        data: "",
+        index: 0,
+      });
+      // THEN
       expect(() => command.parseResponse(response)).not.toThrow();
     });
   });

--- a/packages/signer/keyring-eth/src/internal/app-binder/command/ProvideDomainNameCommand.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/command/ProvideDomainNameCommand.ts
@@ -2,6 +2,7 @@
 import {
   Apdu,
   ApduBuilder,
+  type ApduBuilderArgs,
   ApduParser,
   ApduResponse,
   type Command,
@@ -11,8 +12,9 @@ import {
 
 export type ProvideDomainNameCommandArgs = {
   /**
-   * The stringified hexa representation of the domain name.
-   * @example "4C6564676572" (hexa for "Ledger")
+   * The chunk of the stringified hexa representation of the domain name prefixed by its length in two bytes.
+   * If the index equals 0, the first two bytes are the length of the domain name, else all the bytes are the chunk data.
+   * @example "00064C6564676572" (hexa for "Ledger", first chunk and only chunk)
    */
   data: string;
   /**
@@ -24,14 +26,17 @@ export type ProvideDomainNameCommandArgs = {
 /**
  * The command that provides a chunk of the domain name to the device.
  */
-export class ProvideDomainNameCommand implements Command<void, void> {
+export class ProvideDomainNameCommand
+  implements Command<void, ProvideDomainNameCommandArgs>
+{
   constructor(private args: ProvideDomainNameCommandArgs) {}
 
   getApdu(): Apdu {
-    const apduBuilderArgs = {
+    const isFirstChunk = this.args.index === 0;
+    const apduBuilderArgs: ApduBuilderArgs = {
       cla: 0xe0,
       ins: 0x22,
-      p1: this.args.index === 0 ? 0x01 : 0x00,
+      p1: isFirstChunk ? 0x01 : 0x00,
       p2: 0x00,
     };
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
- Fix an error in `getApdu` of `ProvideDomainNameCommand`;
- Ref: https://github.com/LedgerHQ/app-ethereum/blob/develop/doc/ethapp.adoc#provide-domain-name


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Fix an error in `getApdu` of `ProvideDomainNameCommand`.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [x] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
