### PR TITLE
✨ (keyring-eth) [DSDK-382]: Implement `SetPluginCommand`

### DIFF
--- a/.changeset/blue-pandas-wash.md
+++ b/.changeset/blue-pandas-wash.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/keyring-eth": patch
+---
+
+Implement SetPluginCommand

--- a/packages/signer/keyring-eth/src/internal/app-binder/command/SetPluginCommand.test.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/command/SetPluginCommand.test.ts
@@ -1,0 +1,72 @@
+import {
+  ApduResponse,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-sdk-core";
+
+import { SetPluginCommand, SetPluginCommandArgs } from "./SetPluginCommand";
+
+const SET_PLUGIN_COMMAND_PAYLOAD =
+  "010106455243373231c5b07a55501014f36ec5d39d950a321439f6dd7642842e0e0000000000000001020147304502206d9f515916283e08fa6cdab205668c0739c558dcd6691a69ce74cd89fbc2cc6e022100c28c17b058e6d453570a58d69ff62042037dc61149af2f5161d5c36fdc5dc301";
+
+const SET_PLUGIN_COMMAND_APDU = Uint8Array.from([
+  0xe0, 0x16, 0x00, 0x00, 0x73, 0x01, 0x01, 0x06, 0x45, 0x52, 0x43, 0x37, 0x32,
+  0x31, 0xc5, 0xb0, 0x7a, 0x55, 0x50, 0x10, 0x14, 0xf3, 0x6e, 0xc5, 0xd3, 0x9d,
+  0x95, 0x0a, 0x32, 0x14, 0x39, 0xf6, 0xdd, 0x76, 0x42, 0x84, 0x2e, 0x0e, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x01, 0x47, 0x30, 0x45, 0x02,
+  0x20, 0x6d, 0x9f, 0x51, 0x59, 0x16, 0x28, 0x3e, 0x08, 0xfa, 0x6c, 0xda, 0xb2,
+  0x05, 0x66, 0x8c, 0x07, 0x39, 0xc5, 0x58, 0xdc, 0xd6, 0x69, 0x1a, 0x69, 0xce,
+  0x74, 0xcd, 0x89, 0xfb, 0xc2, 0xcc, 0x6e, 0x02, 0x21, 0x00, 0xc2, 0x8c, 0x17,
+  0xb0, 0x58, 0xe6, 0xd4, 0x53, 0x57, 0x0a, 0x58, 0xd6, 0x9f, 0xf6, 0x20, 0x42,
+  0x03, 0x7d, 0xc6, 0x11, 0x49, 0xaf, 0x2f, 0x51, 0x61, 0xd5, 0xc3, 0x6f, 0xdc,
+  0x5d, 0xc3, 0x01,
+]);
+
+describe("SetPluginCommand", () => {
+  describe("getApdu", () => {
+    it("returns the correct APDU", () => {
+      // GIVEN
+      const args: SetPluginCommandArgs = {
+        data: SET_PLUGIN_COMMAND_PAYLOAD,
+      };
+      // WHEN
+      const command = new SetPluginCommand(args);
+      const apdu = command.getApdu();
+      // THEN
+      expect(apdu.getRawApdu()).toStrictEqual(SET_PLUGIN_COMMAND_APDU);
+    });
+  });
+  describe("parseResponse", () => {
+    it("should throw an error if the response status code is invalid", () => {
+      // GIVEN
+      const invalidStatusCodes = [
+        [0x6a, 0x80],
+        [0x69, 0x84],
+        [0x6d, 0x00],
+      ];
+      for (const statusCode of invalidStatusCodes) {
+        const response: ApduResponse = {
+          data: Buffer.from([]),
+          statusCode: Buffer.from(statusCode), // Invalid status code
+        };
+        // WHEN
+        const command = new SetPluginCommand({ data: "" });
+        // THEN
+        expect(() => command.parseResponse(response)).toThrow(
+          InvalidStatusWordError,
+        );
+      }
+    });
+
+    it("should not throw if the response status code is correct", () => {
+      // GIVEN
+      const response: ApduResponse = {
+        data: Buffer.from([]),
+        statusCode: Buffer.from([0x90, 0x00]), // Success status code
+      };
+      // WHEN
+      const command = new SetPluginCommand({ data: "" });
+      // THEN
+      expect(() => command.parseResponse(response)).not.toThrow();
+    });
+  });
+});

--- a/packages/signer/keyring-eth/src/internal/app-binder/command/SetPluginCommand.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/command/SetPluginCommand.ts
@@ -1,2 +1,66 @@
 // https://github.com/LedgerHQ/app-ethereum/blob/develop/doc/ethapp.adoc#set-plugin
-export class SetPluginCommand {}
+import {
+  Apdu,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  ApduParser,
+  ApduResponse,
+  type Command,
+  CommandUtils,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-sdk-core";
+
+export type SetPluginCommandArgs = {
+  /**
+   * The stringified hexa representation of the plugin signature.
+   */
+  data: string;
+};
+
+export class SetPluginCommand implements Command<void, SetPluginCommandArgs> {
+  constructor(private args: SetPluginCommandArgs) {}
+
+  getApdu(): Apdu {
+    const apduBuilderArgs: ApduBuilderArgs = {
+      cla: 0xe0,
+      ins: 0x16,
+      p1: 0x00,
+      p2: 0x00,
+    };
+
+    return new ApduBuilder(apduBuilderArgs)
+      .addHexaStringToData(this.args.data)
+      .build();
+  }
+
+  parseResponse(response: ApduResponse): void {
+    const parser = new ApduParser(response);
+
+    // TODO: handle the error correctly using a generic error handler. These error status codes come from the LL implementation, just for backup for now.
+    if (!CommandUtils.isSuccessResponse(response)) {
+      if (response.statusCode[0] === 0x6a && response.statusCode[1] === 0x80) {
+        throw new InvalidStatusWordError(
+          "The plugin name is too short or too long",
+        );
+      } else if (
+        response.statusCode[0] === 0x69 &&
+        response.statusCode[1] === 0x84
+      ) {
+        throw new InvalidStatusWordError(
+          "the requested plugin is not installed on the device",
+        );
+      } else if (
+        response.statusCode[0] === 0x6d &&
+        response.statusCode[1] === 0x00
+      ) {
+        throw new InvalidStatusWordError("ETH app is not up to date");
+      } else {
+        throw new InvalidStatusWordError(
+          `Unexpected status word: ${parser.encodeToHexaString(
+            response.statusCode,
+          )}`,
+        );
+      }
+    }
+  }
+}


### PR DESCRIPTION
### 📝 Description
- Implement `SetPluginCommand`;
- Ref: https://github.com/LedgerHQ/app-ethereum/blob/develop/doc/ethapp.adoc#set-plugin

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [DSDK-382]

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Implement `SetPluginCommand`.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [x] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[DSDK-382]: https://ledgerhq.atlassian.net/browse/DSDK-382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ