### PR TITLE
✨ (keyring-eth) [DSDK-380]: Implement `SendEIP712StructImplemCommand`

### DIFF
--- a/.changeset/late-flies-smile.md
+++ b/.changeset/late-flies-smile.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/keyring-eth": patch
+---
+
+Implement SendEIP712StructImplemCommand

--- a/packages/signer/keyring-eth/src/internal/app-binder/command/SendEIP712StructImplemCommand.test.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/command/SendEIP712StructImplemCommand.test.ts
@@ -1,0 +1,108 @@
+import {
+  SendEIP712StructImplemCommand,
+  type SendEIP712StructImplemCommandArgs,
+  StructImplemType,
+} from "./SendEIP712StructImplemCommand";
+
+const ROOT_APDU = Uint8Array.from([
+  0xe0, 0x1c, 0x00, 0x00, 0x06, 0x6c, 0x65, 0x64, 0x67, 0x65, 0x72,
+]);
+
+const ARRAY_APDU = Uint8Array.from([0xe0, 0x1c, 0x00, 0x0f, 0x01, 0x13]);
+
+const FIELD_LAST_CHUNK_APDU = Uint8Array.from([
+  0xe0, 0x1c, 0x00, 0xff, 0x06, 0x00, 0x04, 0x01, 0x02, 0x03, 0x04,
+]);
+
+const FIELD_OTHER_CHUNK_APDU = Uint8Array.from([
+  0xe0, 0x1c, 0x01, 0xff, 0x05, 0x05, 0x06, 0x07, 0x08, 0x09,
+]);
+
+describe("SendEIP712StructImplemCommand", () => {
+  describe("getApdu", () => {
+    it("should return the correct APDU for ROOT", () => {
+      // GIVEN
+      const args: SendEIP712StructImplemCommandArgs = {
+        type: StructImplemType.ROOT,
+        value: "ledger",
+      };
+      // WHEN
+      const command = new SendEIP712StructImplemCommand(args);
+      const apdu = command.getApdu();
+      // THEN
+      expect(apdu.getRawApdu()).toStrictEqual(ROOT_APDU);
+    });
+    it("should return the correct APDU for ARRAY", () => {
+      // GIVEN
+      const args: SendEIP712StructImplemCommandArgs = {
+        type: StructImplemType.ARRAY,
+        value: 19,
+      };
+      // WHEN
+      const command = new SendEIP712StructImplemCommand(args);
+      const apdu = command.getApdu();
+      // THEN
+      expect(apdu.getRawApdu()).toStrictEqual(ARRAY_APDU);
+    });
+    it("should return the correct APDU for FIELD when receiving last chunk", () => {
+      // GIVEN
+      const args: SendEIP712StructImplemCommandArgs = {
+        type: StructImplemType.FIELD,
+        value: {
+          data: Uint8Array.from([0x00, 0x04, 0x01, 0x02, 0x03, 0x04]),
+          isLastChunk: true,
+        },
+      };
+      // WHEN
+      const command = new SendEIP712StructImplemCommand(args);
+      const apdu = command.getApdu();
+      // THEN
+      expect(apdu.getRawApdu()).toStrictEqual(FIELD_LAST_CHUNK_APDU);
+    });
+    it("should return the correct APDU for FIELD when receiving other chunk", () => {
+      // GIVEN
+      const args: SendEIP712StructImplemCommandArgs = {
+        type: StructImplemType.FIELD,
+        value: {
+          data: Uint8Array.from([0x05, 0x06, 0x07, 0x08, 0x09]),
+          isLastChunk: false,
+        },
+      };
+      // WHEN
+      const command = new SendEIP712StructImplemCommand(args);
+      const apdu = command.getApdu();
+      // THEN
+      expect(apdu.getRawApdu()).toStrictEqual(FIELD_OTHER_CHUNK_APDU);
+    });
+  });
+  describe("parseResponse", () => {
+    it("should throw an error if the response status code is not success", () => {
+      // GIVEN
+      const response = {
+        data: new Uint8Array(),
+        statusCode: new Uint8Array([0x6a, 0x80]),
+      };
+      // WHEN
+      const command = new SendEIP712StructImplemCommand({
+        type: StructImplemType.ROOT,
+        value: "ledger",
+      });
+      // THEN
+      expect(() => command.parseResponse(response)).toThrow();
+    });
+    it("should not throw an error if the response status code is success", () => {
+      // GIVEN
+      const response = {
+        data: new Uint8Array(),
+        statusCode: new Uint8Array([0x90, 0x00]),
+      };
+      // WHEN
+      const command = new SendEIP712StructImplemCommand({
+        type: StructImplemType.ROOT,
+        value: "ledger",
+      });
+      // THEN
+      expect(() => command.parseResponse(response)).not.toThrow();
+    });
+  });
+});

--- a/packages/signer/keyring-eth/src/internal/app-binder/command/SendEIP712StructImplemCommand.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/command/SendEIP712StructImplemCommand.ts
@@ -1,2 +1,81 @@
 // https://github.com/LedgerHQ/app-ethereum/blob/develop/doc/ethapp.adoc#eip712-send-struct-implementation
-export class SendEIP712StructImplemCommand {}
+import {
+  Apdu,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  ApduParser,
+  ApduResponse,
+  type Command,
+  CommandUtils,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-sdk-core";
+
+export enum StructImplemType {
+  ROOT = 0x00,
+  ARRAY = 0x0f,
+  FIELD = 0xff,
+}
+
+export type SendEIP712StructImplemCommandArgs =
+  | {
+      type: StructImplemType.ROOT;
+      value: string;
+    }
+  | {
+      type: StructImplemType.ARRAY;
+      value: number;
+    }
+  | {
+      type: StructImplemType.FIELD;
+      value: {
+        /**
+         * The chunk of the data that is ready to send, that is to say, prefixed by its length in two bytes.
+         * Eg. 01020304 => [0x00, 0x04, 0x01, 0x02, 0x03, 0x04] where 0x00, 0x04 are the length of the data.
+         */
+        data: Uint8Array;
+        isLastChunk: boolean;
+      };
+    };
+
+export class SendEIP712StructImplemCommand implements Command<void> {
+  constructor(private readonly args: SendEIP712StructImplemCommandArgs) {}
+
+  getApdu(): Apdu {
+    const apduBuilderArgs: ApduBuilderArgs = {
+      cla: 0xe0,
+      ins: 0x1c,
+      p1:
+        this.args.type != StructImplemType.FIELD || this.args.value.isLastChunk
+          ? 0x00
+          : 0x01,
+      p2: this.args.type,
+    };
+    switch (this.args.type) {
+      case StructImplemType.ROOT:
+        return new ApduBuilder(apduBuilderArgs)
+          .addAsciiStringToData(this.args.value)
+          .build();
+      case StructImplemType.ARRAY:
+        return new ApduBuilder(apduBuilderArgs)
+          .add8BitUIntToData(this.args.value)
+          .build();
+      case StructImplemType.FIELD:
+        return new ApduBuilder(apduBuilderArgs)
+          .addBufferToData(this.args.value.data)
+          .build();
+    }
+  }
+
+  parseResponse(response: ApduResponse): void {
+    const parser = new ApduParser(response);
+
+    // TODO: handle the error correctly using a generic error handler
+    if (!CommandUtils.isSuccessResponse(response)) {
+      throw new InvalidStatusWordError(
+        `Unexpected status word: ${parser.encodeToHexaString(
+          response.statusCode,
+        )}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
- Implement `SendEIP712StructImplemCommand`;
- Ref: https://github.com/LedgerHQ/app-ethereum/blob/develop/doc/ethapp.adoc#eip712-send-struct-implementation
- The official reference is not clear enough, [the relative code](https://github.com/LedgerHQ/ledger-live/blob/9badf390838517c751b61159ad2b0c8a0285d0ea/libs/ledgerjs/packages/hw-app-eth/src/modules/EIP712/index.ts#L190C7-L190C23) in LL maybe help. As there is a loop when type is field, we cannot do this in single command, the chunks should be prepared at a higher level (an async function).

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [DSDK-380]

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** 
  - Implement `SendEIP712StructImplemCommand`;

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [x] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[DSDK-380]: https://ledgerhq.atlassian.net/browse/DSDK-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ