### PR TITLE
✨ (keyring-eth) [DSDK-381]: Implement SetExternalPluginCommand

### DIFF
--- a/.changeset/old-cups-cheat.md
+++ b/.changeset/old-cups-cheat.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/keyring-eth": patch
+---
+
+Add Set External Plugin command

--- a/packages/signer/keyring-eth/src/internal/app-binder/command/SetExternalPluginCommand.test.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/command/SetExternalPluginCommand.test.ts
@@ -1,0 +1,85 @@
+import {
+  ApduResponse,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-sdk-core";
+
+import { SetExternalPluginCommand } from "@internal/app-binder/command/SetExternalPluginCommand";
+
+/** Test payload contains:
+ * Length of plugin name : 08
+ * Plugin Name : Paraswap
+ * contract address: 0xdef171fe48cf0115b1d80b88dc8eab59176fee57
+ * method selector: 0xa9059cbb
+ * **/
+const SET_EXTERNAL_PLUGIN_PAYLOAD = [
+  0x08, 0x50, 0x61, 0x72, 0x61, 0x73, 0x77, 0x61, 0x70, 0xde, 0xf1, 0x71, 0xfe,
+  0x48, 0xcf, 0x01, 0x15, 0xb1, 0xd8, 0x0b, 0x88, 0xdc, 0x8e, 0xab, 0x59, 0x17,
+  0x6f, 0xee, 0x57, 0xa9, 0x05, 0x9c, 0xbb,
+];
+// Public signature key: https://github.com/LedgerHQ/app-ethereum/blob/develop/doc/ethapp.adoc#set-external-plugin
+const SET_EXTERNAL_PLUGIN_SIGNATURE = [
+  0x04, 0x82, 0xbb, 0xf2, 0xf3, 0x4f, 0x36, 0x7b, 0x2e, 0x5b, 0xc2, 0x18, 0x47,
+  0xb6, 0x56, 0x6f, 0x21, 0xf0, 0x97, 0x6b, 0x22, 0xd3, 0x38, 0x8a, 0x9a, 0x5e,
+  0x44, 0x6a, 0xc6, 0x2d, 0x25, 0xcf, 0x72, 0x5b, 0x62, 0xa2, 0x55, 0x5b, 0x2d,
+  0xd4, 0x64, 0xa4, 0xda, 0x0a, 0xb2, 0xf4, 0xd5, 0x06, 0x82, 0x05, 0x43, 0xaf,
+  0x1d, 0x24, 0x24, 0x70, 0xb1, 0xb1, 0xa9, 0x69, 0xa2, 0x75, 0x78, 0xf3, 0x53,
+];
+const SET_EXTERNAL_PLUGIN_APDU = [
+  0xe0,
+  0x12,
+  0x00,
+  0x00,
+  SET_EXTERNAL_PLUGIN_PAYLOAD.length + SET_EXTERNAL_PLUGIN_SIGNATURE.length,
+  ...SET_EXTERNAL_PLUGIN_PAYLOAD,
+  ...SET_EXTERNAL_PLUGIN_SIGNATURE,
+];
+
+describe("Set External plugin", () => {
+  describe("getApdu", () => {
+    it("should retrieve correct apdu", () => {
+      // given
+      const command = new SetExternalPluginCommand({
+        payload: Uint8Array.from(SET_EXTERNAL_PLUGIN_PAYLOAD),
+        signature: Uint8Array.from(SET_EXTERNAL_PLUGIN_SIGNATURE),
+      });
+      // when
+      const apdu = command.getApdu();
+      // then
+      expect(apdu.getRawApdu()).toStrictEqual(
+        Uint8Array.from(SET_EXTERNAL_PLUGIN_APDU),
+      );
+    });
+  });
+  describe("parseResponse", () => {
+    it("should throw an error if status is invalid", () => {
+      // given
+      const command = new SetExternalPluginCommand({
+        payload: Uint8Array.from([]),
+        signature: Uint8Array.from([]),
+      });
+      // when
+      const apduResponse = new ApduResponse({
+        statusCode: Uint8Array.from([0x6a, 0x80]),
+        data: Uint8Array.from([]),
+      });
+      // then
+      expect(() => command.parseResponse(apduResponse)).toThrowError(
+        InvalidStatusWordError,
+      );
+    });
+    it("should return void if status is success", () => {
+      // given
+      const command = new SetExternalPluginCommand({
+        payload: Uint8Array.from([]),
+        signature: Uint8Array.from([]),
+      });
+      // when
+      const apduResponse = new ApduResponse({
+        statusCode: Uint8Array.from([0x90, 0x00]),
+        data: Uint8Array.from([]),
+      });
+      // then
+      expect(command.parseResponse(apduResponse)).toBe(void 0);
+    });
+  });
+});

--- a/packages/signer/keyring-eth/src/internal/app-binder/command/SetExternalPluginCommand.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/command/SetExternalPluginCommand.ts
@@ -1,2 +1,62 @@
 // https://github.com/LedgerHQ/app-ethereum/blob/develop/doc/ethapp.adoc#set-external-plugin
-export class SetExternalPluginCommand {}
+
+import {
+  Apdu,
+  ApduBuilder,
+  ApduBuilderArgs,
+  ApduParser,
+  ApduResponse,
+  Command,
+  CommandUtils,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-sdk-core";
+
+type SetExternalPluginCommandArgs = {
+  payload: Uint8Array;
+  signature: Uint8Array;
+};
+
+export class SetExternalPluginCommand
+  implements Command<void, SetExternalPluginCommandArgs>
+{
+  constructor(private readonly args: SetExternalPluginCommandArgs) {}
+
+  getApdu(): Apdu {
+    const { payload, signature } = this.args;
+    const setExternalPluginBuilderArgs: ApduBuilderArgs = {
+      cla: 0xe0,
+      ins: 0x12,
+      p1: 0x00,
+      p2: 0x00,
+    };
+    const builder = new ApduBuilder(setExternalPluginBuilderArgs);
+    builder.addBufferToData(payload);
+    builder.addBufferToData(signature);
+
+    return builder.build();
+  }
+
+  parseResponse(apduResponse: ApduResponse): void {
+    if (CommandUtils.isSuccessResponse(apduResponse)) {
+      return;
+    }
+
+    const parser = new ApduParser(apduResponse);
+    const statusCodeHex = parser.encodeToHexaString(apduResponse.statusCode);
+
+    switch (statusCodeHex) {
+      case "6a80":
+        throw new InvalidStatusWordError("Invalid plugin name size");
+      case "6984":
+        throw new InvalidStatusWordError("Plugin not installed on device");
+      case "6d00":
+        throw new InvalidStatusWordError("Version of Eth app not supported");
+      default:
+        throw new InvalidStatusWordError(
+          `Unexpected status word: ${parser.encodeToHexaString(
+            apduResponse.statusCode,
+          )}`,
+        );
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Implement SetExternalPluginCommand

https://github.com/LedgerHQ/app-ethereum/blob/develop/doc/ethapp.adoc#set-external-plugin

⚠️ The command is not full tested yet, as it's require the complete eth app binder device action


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [DSDK-381] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[DSDK-381]: https://ledgerhq.atlassian.net/browse/DSDK-381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ