### PR TITLE
:sparkles: (keyring-eth) [DSDK-390]: Implement SignTypedData use case

### DIFF
--- a/packages/core/src/api/device-action/model/UserInteractionRequired.ts
+++ b/packages/core/src/api/device-action/model/UserInteractionRequired.ts
@@ -8,6 +8,7 @@ export enum UserInteractionRequired {
   AllowSecureConnection = "allow-secure-connection",
   ConfirmOpenApp = "confirm-open-app",
   SignTransaction = "sign-transaction",
+  SignTypedData = "sign-typed-data",
   AllowListApps = "allow-list-apps",
   VerifyAddress = "verify-address",
 }

--- a/packages/core/src/api/device-action/os/OpenAppDeviceAction/types.ts
+++ b/packages/core/src/api/device-action/os/OpenAppDeviceAction/types.ts
@@ -19,7 +19,7 @@ export type OpenAppDAError =
   | UnknownDAError
   | SdkError; /// TODO: remove, we should have an exhaustive list of errors
 
-type OpenAppDARequiredInteraction =
+export type OpenAppDARequiredInteraction =
   | UserInteractionRequired.None
   | UserInteractionRequired.UnlockDevice
   | UserInteractionRequired.ConfirmOpenApp;

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -84,6 +84,7 @@ export {
   type OpenAppDAInput,
   type OpenAppDAIntermediateValue,
   type OpenAppDAOutput,
+  type OpenAppDARequiredInteraction,
   type OpenAppDAState,
 } from "@api/device-action/os/OpenAppDeviceAction/types";
 export { SendCommandInAppDeviceAction } from "@api/device-action/os/SendCommandInAppDeviceAction/SendCommandInAppDeviceAction";

--- a/packages/signer/keyring-eth/package.json
+++ b/packages/signer/keyring-eth/package.json
@@ -47,7 +47,8 @@
     "inversify": "^6.0.2",
     "inversify-logger-middleware": "^3.1.0",
     "purify-ts": "^2.1.0",
-    "reflect-metadata": "^0.2.2"
+    "reflect-metadata": "^0.2.2",
+    "xstate": "^5.15.0"
   },
   "devDependencies": {
     "@ledgerhq/context-module": "workspace:*",

--- a/packages/signer/keyring-eth/src/api/KeyringEth.ts
+++ b/packages/signer/keyring-eth/src/api/KeyringEth.ts
@@ -1,4 +1,5 @@
 import { GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
+import { SignTypedDataDAReturnType } from "@api/app-binder/SignTypedDataDeviceActionTypes";
 import { AddressOptions } from "@api/model/AddressOptions";
 import { Signature } from "@api/model/Signature";
 import { Transaction } from "@api/model/Transaction";
@@ -15,7 +16,7 @@ export interface KeyringEth {
   signTypedData: (
     derivationPath: string,
     typedData: TypedData,
-  ) => Promise<Signature>;
+  ) => SignTypedDataDAReturnType;
   getAddress: (
     derivationPath: string,
     options?: AddressOptions,

--- a/packages/signer/keyring-eth/src/api/app-binder/SignTypedDataDeviceActionTypes.ts
+++ b/packages/signer/keyring-eth/src/api/app-binder/SignTypedDataDeviceActionTypes.ts
@@ -1,0 +1,60 @@
+import { ContextModule } from "@ledgerhq/context-module";
+import {
+  DeviceActionState,
+  ExecuteDeviceActionReturnType,
+  OpenAppDAError,
+  OpenAppDARequiredInteraction,
+  SdkError,
+  UserInteractionRequired,
+} from "@ledgerhq/device-sdk-core";
+
+import { Signature } from "@api/model/Signature";
+import { TypedData } from "@api/model/TypedData";
+import type { ProvideEIP712ContextTaskArgs } from "@internal/app-binder/task/ProvideEIP712ContextTask";
+import { TypedDataParserService } from "@internal/typed-data/service/TypedDataParserService";
+
+export type SignTypedDataDAOutput = Signature;
+
+export type SignTypedDataDAInput = {
+  readonly derivationPath: string;
+  readonly data: TypedData;
+  readonly parser: TypedDataParserService;
+  readonly contextModule: ContextModule;
+};
+
+export class SignTypedDataError implements SdkError {
+  readonly _tag = "SignTypedDataError";
+  readonly originalError?: Error;
+
+  constructor(message?: string) {
+    this.originalError = new Error(message ?? "Sign typed data error.");
+  }
+}
+
+export type SignTypedDataDAError = OpenAppDAError | SdkError; /// TODO: remove, we should have an exhaustive list of errors
+
+type SignTypedDataDARequiredInteraction =
+  | OpenAppDARequiredInteraction
+  | UserInteractionRequired.SignTypedData;
+
+export type SignTypedDataDAIntermediateValue = {
+  requiredUserInteraction: SignTypedDataDARequiredInteraction;
+};
+
+export type SignTypedDataDAState = DeviceActionState<
+  SignTypedDataDAOutput,
+  SignTypedDataDAError,
+  SignTypedDataDAIntermediateValue
+>;
+
+export type SignTypedDataDAInternalState = {
+  readonly error: OpenAppDAError | null;
+  readonly typedDataContext: ProvideEIP712ContextTaskArgs | null;
+  readonly signature: Signature | null;
+};
+
+export type SignTypedDataDAReturnType = ExecuteDeviceActionReturnType<
+  SignTypedDataDAOutput,
+  SignTypedDataDAError,
+  SignTypedDataDAIntermediateValue
+>;

--- a/packages/signer/keyring-eth/src/api/index.ts
+++ b/packages/signer/keyring-eth/src/api/index.ts
@@ -1,4 +1,11 @@
 export * from "@api/app-binder/GetAddressDeviceActionTypes";
+export {
+  type SignTypedDataDAError,
+  type SignTypedDataDAInput,
+  type SignTypedDataDAIntermediateValue,
+  type SignTypedDataDAOutput,
+  type SignTypedDataDAState,
+} from "@api/app-binder/SignTypedDataDeviceActionTypes";
 export * from "@api/KeyringEth";
 export * from "@api/KeyringEthBuilder";
 export * from "@api/model/Address";

--- a/packages/signer/keyring-eth/src/internal/DefaultKeyringEth.ts
+++ b/packages/signer/keyring-eth/src/internal/DefaultKeyringEth.ts
@@ -3,6 +3,7 @@ import { DeviceSdk, DeviceSessionId } from "@ledgerhq/device-sdk-core";
 import { Container } from "inversify";
 
 import { GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
+import { SignTypedDataDAReturnType } from "@api/app-binder/SignTypedDataDeviceActionTypes";
 import { KeyringEth } from "@api/KeyringEth";
 import { AddressOptions } from "@api/model/AddressOptions";
 import { Signature } from "@api/model/Signature";
@@ -55,10 +56,10 @@ export class DefaultKeyringEth implements KeyringEth {
       .execute(_derivationPath, _message);
   }
 
-  async signTypedData(
+  signTypedData(
     _derivationPath: string,
     _typedData: TypedData,
-  ): Promise<Signature> {
+  ): SignTypedDataDAReturnType {
     return this._container
       .get<SignTypedDataUseCase>(typedDataTypes.SignTypedDataUseCase)
       .execute(_derivationPath, _typedData);

--- a/packages/signer/keyring-eth/src/internal/app-binder/EthAppBinder.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/EthAppBinder.ts
@@ -1,23 +1,31 @@
+import { type ContextModule } from "@ledgerhq/context-module";
 import { DeviceSdk, type DeviceSessionId } from "@ledgerhq/device-sdk-core";
 import { SendCommandInAppDeviceAction } from "@ledgerhq/device-sdk-core";
 import { UserInteractionRequired } from "@ledgerhq/device-sdk-core";
 import { inject, injectable } from "inversify";
 
 import { GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
+import { SignTypedDataDAReturnType } from "@api/app-binder/SignTypedDataDeviceActionTypes";
+import { TypedData } from "@api/model/TypedData";
+import { SignTypedDataDeviceAction } from "@internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction";
 import { externalTypes } from "@internal/externalTypes";
+import { TypedDataParserService } from "@internal/typed-data/service/TypedDataParserService";
 
 import { GetAddressCommand } from "./command/GetAddressCommand";
 
 @injectable()
 export class EthAppBinder {
   private _sdk: DeviceSdk;
+  private _contextModule: ContextModule;
   private _sessionId: DeviceSessionId;
 
   constructor(
     @inject(externalTypes.Sdk) sdk: DeviceSdk,
+    @inject(externalTypes.ContextModule) contextModule: ContextModule,
     @inject(externalTypes.SessionId) sessionId: DeviceSessionId,
   ) {
     this._sdk = sdk;
+    this._contextModule = contextModule;
     this._sessionId = sessionId;
   }
 
@@ -35,6 +43,24 @@ export class EthAppBinder {
           requiredUserInteraction: args.checkOnDevice
             ? UserInteractionRequired.VerifyAddress
             : UserInteractionRequired.None,
+        },
+      }),
+    });
+  }
+
+  signTypedData(args: {
+    derivationPath: string;
+    parser: TypedDataParserService;
+    data: TypedData;
+  }): SignTypedDataDAReturnType {
+    return this._sdk.executeDeviceAction({
+      sessionId: this._sessionId,
+      deviceAction: new SignTypedDataDeviceAction({
+        input: {
+          derivationPath: args.derivationPath,
+          data: args.data,
+          parser: args.parser,
+          contextModule: this._contextModule,
         },
       }),
     });

--- a/packages/signer/keyring-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.test.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.test.ts
@@ -1,0 +1,462 @@
+import { type ContextModule } from "@ledgerhq/context-module";
+import {
+  DeviceActionStatus,
+  OpenAppDeviceAction,
+  UserInteractionRequired,
+} from "@ledgerhq/device-sdk-core";
+import { Just, Left, Nothing, Right } from "purify-ts";
+import { assign, createMachine } from "xstate";
+
+import {
+  SignTypedDataDAState,
+  SignTypedDataError,
+} from "@api/app-binder/SignTypedDataDeviceActionTypes";
+import { makeDeviceActionInternalApiMock } from "@internal/app-binder/device-action/__test-utils__/makeInternalApi";
+import { testDeviceActionStates } from "@internal/app-binder/device-action/__test-utils__/testDeviceActionStates";
+import { type ProvideEIP712ContextTaskArgs } from "@internal/app-binder/task/ProvideEIP712ContextTask";
+import {
+  PrimitiveType,
+  StructType,
+  TypedDataValueField,
+} from "@internal/typed-data/model/Types";
+import { TypedDataParserService } from "@internal/typed-data/service/TypedDataParserService";
+
+import { SignTypedDataDeviceAction } from "./SignTypedDataDeviceAction";
+
+jest.mock(
+  "@ledgerhq/device-sdk-core",
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  () => ({
+    ...jest.requireActual("@ledgerhq/device-sdk-core"),
+    OpenAppDeviceAction: jest.fn(() => ({
+      makeStateMachine: jest.fn(),
+    })),
+  }),
+);
+
+const setupOpenAppDAMock = (error?: unknown) => {
+  (OpenAppDeviceAction as jest.Mock).mockImplementation(() => ({
+    makeStateMachine: jest.fn().mockImplementation(() =>
+      createMachine({
+        initial: "pending",
+        states: {
+          pending: {
+            entry: assign({
+              intermediateValue: {
+                requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+              },
+            }),
+            after: {
+              0: "done",
+            },
+          },
+          done: {
+            type: "final",
+          },
+        },
+        output: () => (error ? Left(error) : Right(undefined)),
+      }),
+    ),
+  }));
+};
+
+describe("SignTypedDataDeviceAction", () => {
+  const TEST_MESSAGE = {
+    domain: {},
+    message: {},
+    primaryType: "TestMessage",
+    types: {},
+  };
+  const TEST_BUILT_CONTEXT: ProvideEIP712ContextTaskArgs = {
+    types: {
+      PermitSingle: {
+        details: new StructType("PermitDetails"),
+        spender: new PrimitiveType("address", "address", Nothing),
+        sigDeadline: new PrimitiveType("uint256", "uint", Just(32)),
+      },
+    },
+    domain: [
+      {
+        path: "chainId",
+        type: "uint256",
+        value: new TypedDataValueField(Uint8Array.from([137])),
+      },
+    ],
+    message: [
+      {
+        path: "details.expiration",
+        type: "uint48",
+        value: new TypedDataValueField(Uint8Array.from([0x13])),
+      },
+    ],
+    clearSignContext: Just({
+      type: "success",
+      messageInfo: {
+        displayName: "Permit2",
+        filtersCount: 1,
+        signature:
+          "3045022100e3c597d13d28a87a88b0239404c668373cf5063362f2a81d09eed4582941dfe802207669aabb504fd5b95b2734057f6b8bbf51f14a69a5f9bdf658a5952cefbf44d3",
+      },
+      tokens: {},
+      filters: {
+        "details.amount": {
+          displayName: "Amount allowance",
+          path: "details.amount",
+          signature:
+            "304402201a46e6b4ef89eaf9fcf4945d053bfc5616a826400fd758312fbbe976bafc07ec022025a9b408722baf983ee053f90179c75b0c55bb0668f437d55493e36069bbd5a3",
+          tokenIndex: 255,
+          type: "amount",
+        },
+      },
+    }),
+  };
+
+  const mockParser: TypedDataParserService = {
+    parse: jest.fn(),
+  };
+  const mockContextModule: ContextModule = {
+    getContexts: jest.fn(),
+    getTypedDataFilters: jest.fn(),
+  };
+  const buildContextMock = jest.fn();
+  const provideContextMock = jest.fn();
+  const signTypedDataMock = jest.fn();
+  function extractDependenciesMock() {
+    return {
+      buildContext: buildContextMock,
+      provideContext: provideContextMock,
+      signTypedData: signTypedDataMock,
+    };
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("Success case", () => {
+    it("should call external dependencies with the correct parameters", (done) => {
+      setupOpenAppDAMock();
+
+      const deviceAction = new SignTypedDataDeviceAction({
+        input: {
+          derivationPath: "44'/60'/0'/0/0",
+          data: TEST_MESSAGE,
+          contextModule: mockContextModule,
+          parser: mockParser,
+        },
+      });
+
+      // Mock the dependencies to return some sample data
+      jest
+        .spyOn(deviceAction, "extractDependencies")
+        .mockReturnValue(extractDependenciesMock());
+      buildContextMock.mockResolvedValueOnce(TEST_BUILT_CONTEXT);
+      signTypedDataMock.mockResolvedValueOnce({
+        v: 0x1c,
+        r: "0x8a540510e13b0f2b11a451275716d29e08caad07e89a1c84964782fb5e1ad788",
+        s: "0x64a0de235b270fbe81e8e40688f4a9f9ad9d283d690552c9331d7773ceafa513",
+      });
+
+      // Expected intermediate values for the following state sequence:
+      //   Initial -> OpenApp -> BuildContext -> ProvideContext -> SignTypedData
+      const expectedStates: Array<SignTypedDataDAState> = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.SignTypedData,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          output: {
+            v: 0x1c,
+            r: "0x8a540510e13b0f2b11a451275716d29e08caad07e89a1c84964782fb5e1ad788",
+            s: "0x64a0de235b270fbe81e8e40688f4a9f9ad9d283d690552c9331d7773ceafa513",
+          },
+          status: DeviceActionStatus.Completed,
+        },
+      ];
+
+      const { observable } = testDeviceActionStates(
+        deviceAction,
+        expectedStates,
+        makeDeviceActionInternalApiMock(),
+        done,
+      );
+
+      // Verify mocks calls parameters
+      observable.subscribe({
+        complete: () => {
+          try {
+            expect(buildContextMock).toHaveBeenCalledWith(
+              expect.objectContaining({
+                input: {
+                  contextModule: mockContextModule,
+                  parser: mockParser,
+                  data: TEST_MESSAGE,
+                },
+              }),
+            );
+            expect(provideContextMock).toHaveBeenCalledWith(
+              expect.objectContaining({
+                input: {
+                  taskArgs: TEST_BUILT_CONTEXT,
+                },
+              }),
+            );
+            expect(signTypedDataMock).toHaveBeenCalledWith(
+              expect.objectContaining({
+                input: {
+                  derivationPath: "44'/60'/0'/0/0",
+                },
+              }),
+            );
+          } catch (e) {
+            done(e);
+          }
+        },
+      });
+    });
+  });
+
+  describe("error cases", () => {
+    it("Error if the open app fails", (done) => {
+      setupOpenAppDAMock(new SignTypedDataError("Mocked error"));
+
+      const expectedStates: Array<SignTypedDataDAState> = [
+        {
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+        },
+        {
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+        },
+        {
+          status: DeviceActionStatus.Error,
+          error: new SignTypedDataError("Mocked error"),
+        },
+      ];
+
+      const deviceAction = new SignTypedDataDeviceAction({
+        input: {
+          derivationPath: "44'/60'/0'/0/0",
+          data: TEST_MESSAGE,
+          contextModule: mockContextModule,
+          parser: mockParser,
+        },
+      });
+
+      testDeviceActionStates(
+        deviceAction,
+        expectedStates,
+        makeDeviceActionInternalApiMock(),
+        done,
+      );
+    });
+
+    it("Error while building context", (done) => {
+      setupOpenAppDAMock();
+
+      const deviceAction = new SignTypedDataDeviceAction({
+        input: {
+          derivationPath: "44'/60'/0'/0/0",
+          data: TEST_MESSAGE,
+          contextModule: mockContextModule,
+          parser: mockParser,
+        },
+      });
+
+      // Mock the parsing error
+      jest
+        .spyOn(deviceAction, "extractDependencies")
+        .mockReturnValue(extractDependenciesMock());
+      buildContextMock.mockRejectedValueOnce(new Error("Error"));
+
+      const expectedStates: Array<SignTypedDataDAState> = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: new SignTypedDataError(
+            "Error while building the clear signing context",
+          ),
+          status: DeviceActionStatus.Error,
+        },
+      ];
+
+      testDeviceActionStates(
+        deviceAction,
+        expectedStates,
+        makeDeviceActionInternalApiMock(),
+        done,
+      );
+    });
+
+    it("Error while providing context", (done) => {
+      setupOpenAppDAMock();
+
+      const deviceAction = new SignTypedDataDeviceAction({
+        input: {
+          derivationPath: "44'/60'/0'/0/0",
+          data: TEST_MESSAGE,
+          contextModule: mockContextModule,
+          parser: mockParser,
+        },
+      });
+
+      // Mock the providing error
+      jest
+        .spyOn(deviceAction, "extractDependencies")
+        .mockReturnValue(extractDependenciesMock());
+      buildContextMock.mockResolvedValueOnce(TEST_BUILT_CONTEXT);
+      provideContextMock.mockRejectedValueOnce(new Error("Error"));
+
+      const expectedStates: Array<SignTypedDataDAState> = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: new SignTypedDataError(
+            "Error while providing the clear signing context",
+          ),
+          status: DeviceActionStatus.Error,
+        },
+      ];
+
+      testDeviceActionStates(
+        deviceAction,
+        expectedStates,
+        makeDeviceActionInternalApiMock(),
+        done,
+      );
+    });
+
+    it("Error while signing", (done) => {
+      setupOpenAppDAMock();
+
+      const deviceAction = new SignTypedDataDeviceAction({
+        input: {
+          derivationPath: "44'/60'/0'/0/0",
+          data: TEST_MESSAGE,
+          contextModule: mockContextModule,
+          parser: mockParser,
+        },
+      });
+
+      // Mock signing error
+      jest
+        .spyOn(deviceAction, "extractDependencies")
+        .mockReturnValue(extractDependenciesMock());
+      buildContextMock.mockResolvedValueOnce(TEST_BUILT_CONTEXT);
+      signTypedDataMock.mockRejectedValueOnce(new Error("Error"));
+
+      const expectedStates: Array<SignTypedDataDAState> = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.SignTypedData,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: new SignTypedDataError("Error while signing the typed data"),
+          status: DeviceActionStatus.Error,
+        },
+      ];
+
+      testDeviceActionStates(
+        deviceAction,
+        expectedStates,
+        makeDeviceActionInternalApiMock(),
+        done,
+      );
+    });
+  });
+});

--- a/packages/signer/keyring-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.ts
@@ -1,0 +1,304 @@
+import { ContextModule } from "@ledgerhq/context-module";
+import {
+  InternalApi,
+  OpenAppDeviceAction,
+  StateMachineTypes,
+  UserInteractionRequired,
+  XStateDeviceAction,
+} from "@ledgerhq/device-sdk-core";
+import { Left, Nothing, Right } from "purify-ts";
+import { assign, fromPromise, setup } from "xstate";
+
+import {
+  SignTypedDataDAError,
+  SignTypedDataDAInput,
+  SignTypedDataDAIntermediateValue,
+  SignTypedDataDAInternalState,
+  SignTypedDataDAOutput,
+  SignTypedDataError,
+} from "@api/app-binder/SignTypedDataDeviceActionTypes";
+import { Signature } from "@api/model/Signature";
+import { TypedData } from "@api/model/TypedData";
+import { SignEIP712Command } from "@internal/app-binder/command/SignEIP712Command";
+import { BuildEIP712ContextTask } from "@internal/app-binder/task/BuildEIP712ContextTask";
+import {
+  ProvideEIP712ContextTask,
+  type ProvideEIP712ContextTaskArgs,
+} from "@internal/app-binder/task/ProvideEIP712ContextTask";
+import { TypedDataParserService } from "@internal/typed-data/service/TypedDataParserService";
+
+export type MachineDependencies = {
+  readonly buildContext: (arg0: {
+    input: {
+      contextModule: ContextModule;
+      parser: TypedDataParserService;
+      data: TypedData;
+    };
+  }) => Promise<ProvideEIP712ContextTaskArgs>;
+  readonly provideContext: (arg0: {
+    input: {
+      taskArgs: ProvideEIP712ContextTaskArgs;
+    };
+  }) => Promise<void>;
+  readonly signTypedData: (arg0: {
+    input: {
+      derivationPath: string;
+    };
+  }) => Promise<Signature>;
+};
+
+export type ExtractMachineDependencies = (
+  internalApi: InternalApi,
+) => MachineDependencies;
+
+export class SignTypedDataDeviceAction extends XStateDeviceAction<
+  SignTypedDataDAOutput,
+  SignTypedDataDAInput,
+  SignTypedDataDAError,
+  SignTypedDataDAIntermediateValue,
+  SignTypedDataDAInternalState
+> {
+  makeStateMachine(internalApi: InternalApi) {
+    type types = StateMachineTypes<
+      SignTypedDataDAOutput,
+      SignTypedDataDAInput,
+      SignTypedDataDAError,
+      SignTypedDataDAIntermediateValue,
+      SignTypedDataDAInternalState
+    >;
+
+    const { buildContext, provideContext, signTypedData } =
+      this.extractDependencies(internalApi);
+
+    return setup({
+      types: {
+        input: {} as types["input"],
+        context: {} as types["context"],
+        output: {} as types["output"],
+      },
+      actors: {
+        openAppStateMachine: new OpenAppDeviceAction({
+          input: { appName: "Ethereum" },
+        }).makeStateMachine(internalApi),
+        buildContext: fromPromise(buildContext),
+        provideContext: fromPromise(provideContext),
+        signTypedData: fromPromise(signTypedData),
+      },
+      guards: {
+        noInternalError: ({ context }) => context._internalState.error === null,
+      },
+    }).createMachine({
+      id: "SignTypedDataDeviceAction",
+      initial: "OpenAppDeviceAction",
+      context: ({ input }) => {
+        return {
+          input,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          _internalState: {
+            error: null,
+            typedDataContext: null,
+            signature: null,
+          },
+        };
+      },
+      states: {
+        OpenAppDeviceAction: {
+          exit: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          }),
+          invoke: {
+            id: "openAppStateMachine",
+            input: { appName: "Ethereum" },
+            src: "openAppStateMachine",
+            onSnapshot: {
+              actions: assign({
+                intermediateValue: (_) =>
+                  _.event.snapshot.context.intermediateValue,
+              }),
+            },
+            onDone: {
+              actions: assign({
+                _internalState: (_) => {
+                  return _.event.output.caseOf<SignTypedDataDAInternalState>({
+                    Right: () => _.context._internalState,
+                    Left: (error) => ({
+                      ..._.context._internalState,
+                      error,
+                    }),
+                  });
+                },
+              }),
+              target: "CheckOpenAppDeviceActionResult",
+            },
+          },
+        },
+        CheckOpenAppDeviceActionResult: {
+          always: [
+            {
+              target: "BuildContext",
+              guard: "noInternalError",
+            },
+            "Error",
+          ],
+        },
+        BuildContext: {
+          invoke: {
+            id: "buildContext",
+            src: "buildContext",
+            input: ({ context }) => ({
+              contextModule: context.input.contextModule,
+              parser: context.input.parser,
+              data: context.input.data,
+            }),
+            onDone: {
+              target: "ProvideContext",
+              actions: [
+                assign({
+                  _internalState: ({ event, context }) => ({
+                    ...context._internalState,
+                    typedDataContext: event.output,
+                  }),
+                }),
+              ],
+            },
+            onError: {
+              target: "Error",
+              actions: assign({
+                _internalState: (_) => ({
+                  ..._.context._internalState,
+                  error: new SignTypedDataError(
+                    "Error while building the clear signing context",
+                  ),
+                }),
+              }),
+            },
+          },
+        },
+        ProvideContext: {
+          invoke: {
+            id: "provideContext",
+            src: "provideContext",
+            input: ({ context }) => ({
+              taskArgs: context._internalState.typedDataContext!,
+            }),
+            onDone: {
+              target: "SignTypedData",
+            },
+            onError: {
+              target: "Error",
+              actions: assign({
+                _internalState: (_) => ({
+                  ..._.context._internalState,
+                  error: new SignTypedDataError(
+                    "Error while providing the clear signing context",
+                  ),
+                }),
+              }),
+            },
+          },
+        },
+        SignTypedData: {
+          entry: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.SignTypedData,
+            },
+          }),
+          exit: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          }),
+          invoke: {
+            id: "signTypedData",
+            src: "signTypedData",
+            input: ({ context }) => ({
+              derivationPath: context.input.derivationPath,
+            }),
+            onDone: {
+              target: "Success",
+              actions: [
+                // TODO: when we have proper error handling, we should handle the error here
+                assign({
+                  _internalState: ({ event, context }) => ({
+                    ...context._internalState,
+                    signature: event.output,
+                  }),
+                }),
+              ],
+            },
+            onError: {
+              target: "Error",
+              actions: [
+                assign({
+                  _internalState: (_) => ({
+                    ..._.context._internalState,
+                    error: new SignTypedDataError(
+                      "Error while signing the typed data",
+                    ),
+                  }),
+                }),
+              ],
+            },
+          },
+        },
+        Success: {
+          type: "final",
+        },
+        Error: {
+          type: "final",
+        },
+      },
+      output: ({ context }) =>
+        context._internalState.signature
+          ? Right(context._internalState.signature)
+          : Left(
+              context._internalState.error ||
+                new SignTypedDataError("No error in final state"),
+            ),
+    });
+  }
+
+  extractDependencies(internalApi: InternalApi): MachineDependencies {
+    const buildContext = async (arg0: {
+      input: {
+        contextModule: ContextModule;
+        parser: TypedDataParserService;
+        data: TypedData;
+      };
+    }) =>
+      new BuildEIP712ContextTask(
+        internalApi,
+        arg0.input.contextModule,
+        arg0.input.parser,
+        arg0.input.data,
+      ).run();
+
+    const provideContext = async (arg0: {
+      input: {
+        taskArgs: ProvideEIP712ContextTaskArgs;
+      };
+    }) => new ProvideEIP712ContextTask(internalApi, arg0.input.taskArgs).run();
+
+    const signTypedData = async (arg0: {
+      input: {
+        derivationPath: string;
+      };
+    }) =>
+      internalApi.sendCommand(
+        new SignEIP712Command({
+          derivationPath: arg0.input.derivationPath,
+          legacyArgs: Nothing,
+        }),
+      );
+
+    return {
+      buildContext,
+      provideContext,
+      signTypedData,
+    };
+  }
+}

--- a/packages/signer/keyring-eth/src/internal/app-binder/device-action/__test-utils__/testDeviceActionStates.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/device-action/__test-utils__/testDeviceActionStates.ts
@@ -1,0 +1,48 @@
+import {
+  DeviceAction,
+  DeviceActionIntermediateValue,
+  DeviceActionState,
+  InternalApi,
+  SdkError,
+} from "@ledgerhq/device-sdk-core";
+
+/**
+ * Test that the states emitted by a device action match the expected states.
+ * @param deviceAction The device action to test.
+ * @param expectedStates The expected states.
+ * @param done The Jest done callback.
+ */
+export function testDeviceActionStates<
+  Output,
+  Input,
+  Error extends SdkError,
+  IntermediateValue extends DeviceActionIntermediateValue,
+>(
+  deviceAction: DeviceAction<Output, Input, Error, IntermediateValue>,
+  expectedStates: Array<DeviceActionState<Output, Error, IntermediateValue>>,
+  internalApi: InternalApi,
+  done: jest.DoneCallback,
+) {
+  const observedStates: Array<
+    DeviceActionState<Output, Error, IntermediateValue>
+  > = [];
+
+  const { observable, cancel } = deviceAction._execute(internalApi);
+  observable.subscribe({
+    next: (state) => {
+      observedStates.push(state);
+    },
+    error: (error) => {
+      done(error);
+    },
+    complete: () => {
+      try {
+        expect(observedStates).toEqual(expectedStates);
+        done();
+      } catch (e) {
+        done(e);
+      }
+    },
+  });
+  return { observable, cancel };
+}

--- a/packages/signer/keyring-eth/src/internal/typed-data/service/TypedDataParser.test.ts
+++ b/packages/signer/keyring-eth/src/internal/typed-data/service/TypedDataParser.test.ts
@@ -218,7 +218,7 @@ describe("TypedDataParser - types parsing", () => {
 describe("TypedDataParser - message parsing", () => {
   const MESSAGE: TypedData = {
     domain: {
-      chainId: 5,
+      chainId: 0,
       name: "Ether Mail",
       verifyingContract: "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
       version: "1",
@@ -370,7 +370,7 @@ describe("TypedDataParser - message parsing", () => {
       {
         path: "chainId",
         type: "uint256",
-        value: new TypedDataValueField(Uint8Array.from([5])),
+        value: new TypedDataValueField(Uint8Array.from([0])),
       },
       {
         path: "verifyingContract",

--- a/packages/signer/keyring-eth/src/internal/typed-data/service/TypedDataParser.ts
+++ b/packages/signer/keyring-eth/src/internal/typed-data/service/TypedDataParser.ts
@@ -252,12 +252,12 @@ export class TypedDataParser {
     callback: (parsedValue: TypedDataValue) => void,
   ): boolean {
     const structType = this.structs[type];
-    if (!structType || !this.isRecord(value)) {
+    if (structType === undefined || !this.isRecord(value)) {
       return false;
     }
     for (const [fieldName, fieldType] of Object.entries(structType)) {
       const fieldValue = value[fieldName];
-      if (!fieldType || !fieldValue) {
+      if (fieldValue === undefined) {
         return false;
       }
       const nextPath = path.length ? `${path}.${fieldName}` : fieldName;

--- a/packages/signer/keyring-eth/src/internal/typed-data/use-case/SignTypedDataUseCase.test.ts
+++ b/packages/signer/keyring-eth/src/internal/typed-data/use-case/SignTypedDataUseCase.test.ts
@@ -1,0 +1,38 @@
+import { type TypedData } from "@api/model/TypedData";
+import { EthAppBinder } from "@internal/app-binder/EthAppBinder";
+import { type TypedDataParserService } from "@internal/typed-data/service/TypedDataParserService";
+
+import { SignTypedDataUseCase } from "./SignTypedDataUseCase";
+
+describe("SignTypedDataUseCase", () => {
+  it("should call signTypedData on appBinder with the correct arguments", () => {
+    // Given
+    const derivationPath = "m/44'/60'/0'/0/0";
+    const typedData: TypedData = {
+      domain: {},
+      types: {},
+      primaryType: "test",
+      message: {},
+    };
+    const parser: TypedDataParserService = {
+      parse: jest.fn(),
+    };
+    const appBinder = {
+      signTypedData: jest.fn(),
+    };
+    const signTypedDataUseCase = new SignTypedDataUseCase(
+      appBinder as unknown as EthAppBinder,
+      parser,
+    );
+
+    // When
+    signTypedDataUseCase.execute(derivationPath, typedData);
+
+    // Then
+    expect(appBinder.signTypedData).toHaveBeenCalledWith({
+      derivationPath,
+      parser,
+      data: typedData,
+    });
+  });
+});

--- a/packages/signer/keyring-eth/src/internal/typed-data/use-case/SignTypedDataUseCase.ts
+++ b/packages/signer/keyring-eth/src/internal/typed-data/use-case/SignTypedDataUseCase.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from "inversify";
 
-import { Signature } from "@api/model/Signature";
-import { TypedData } from "@api/model/TypedData";
+import { SignTypedDataDAReturnType } from "@api/app-binder/SignTypedDataDeviceActionTypes";
+import { type TypedData } from "@api/model/TypedData";
 import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
 import { EthAppBinder } from "@internal/app-binder/EthAppBinder";
 import { typedDataTypes } from "@internal/typed-data/di/typedDataTypes";
@@ -21,17 +21,14 @@ export class SignTypedDataUseCase {
     this._parser = typedDataParserService;
   }
 
-  async execute(
-    _derivationPath: string,
-    _typedData: TypedData,
-  ): Promise<Signature> {
-    // 1- Parse the typed data and map it to a TypedDataContext
-    // 2- Send the TypedDataContext to the app binding for signing
-    // 2- Sign the transaction
-
-    this._parser;
-    this._appBinding;
-
-    return Promise.resolve({} as Signature);
+  execute(
+    derivationPath: string,
+    typedData: TypedData,
+  ): SignTypedDataDAReturnType {
+    return this._appBinding.signTypedData({
+      derivationPath,
+      parser: this._parser,
+      data: typedData,
+    });
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
+      xstate:
+        specifier: ^5.15.0
+        version: 5.15.0
     devDependencies:
       '@ledgerhq/context-module':
         specifier: workspace:*


### PR DESCRIPTION
### 📝 Description

This is the device action for signing EIP712 typed messages.
Documentation is here: https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/4910120969/KEYRING-ETH+Sign+Typed+Data

This PR is based on top of 2 other PRs, therefore please review only the last commit: 
* `(keyring-eth): Implement SignTypedData use case`

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/DSDK-390

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
