### PR TITLE
:sparkles: (sample-app) [DSDK-424]: Add SignTypedData to Ethereum Keyring

### DIFF
--- a/.changeset/chatty-mice-hear.md
+++ b/.changeset/chatty-mice-hear.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-sdk-sample": patch
+---
+
+Add SignTypedData to Ethereum Keyring

--- a/apps/sample/src/components/DeviceActionsView/DeviceAction.tsx
+++ b/apps/sample/src/components/DeviceActionsView/DeviceAction.tsx
@@ -35,6 +35,7 @@ export type DeviceActionProps<
     debug?: boolean,
   ) => ExecuteDeviceActionReturnType<Output, Error, IntermediateValue>;
   initialValues: Input;
+  validateValues?: (args: Input) => boolean;
   valueSelector?: ValueSelector<FieldType>;
 };
 
@@ -44,11 +45,13 @@ export function DeviceActionDrawer<
   Error extends SdkError,
   IntermediateValue extends DeviceActionIntermediateValue,
 >(props: DeviceActionProps<Output, Input, Error, IntermediateValue>) {
-  const { initialValues, executeDeviceAction, valueSelector } = props;
+  const { initialValues, executeDeviceAction, valueSelector, validateValues } =
+    props;
 
   const nonce = useRef(-1);
 
   const [values, setValues] = useState<Input>(initialValues);
+  const [valuesInvalid, setValuesInvalid] = useState<boolean>(false);
   const [inspect, setInspect] = useState(false);
 
   const [responses, setResponses] = useState<
@@ -126,6 +129,12 @@ export function DeviceActionDrawer<
     () => cancelDeviceActionRef.current();
   }, []);
 
+  useEffect(() => {
+    if (validateValues) {
+      setValuesInvalid(!validateValues(values));
+    }
+  }, [validateValues, values]);
+
   return (
     <>
       <Block>
@@ -154,7 +163,7 @@ export function DeviceActionDrawer<
           <Button
             variant="main"
             onClick={handleClickExecute}
-            disabled={loading}
+            disabled={loading || valuesInvalid}
             Icon={() =>
               loading ? <InfiniteLoader size={20} /> : <Icons.ArrowRight />
             }

--- a/apps/sample/src/components/KeyringEthView/index.tsx
+++ b/apps/sample/src/components/KeyringEthView/index.tsx
@@ -6,7 +6,11 @@ import {
   GetAddressDAError,
   GetAddressDAIntermediateValue,
   GetAddressDAOutput,
+  SignTypedDataDAError,
+  SignTypedDataDAIntermediateValue,
+  SignTypedDataDAOutput,
   KeyringEthBuilder,
+  TypedData,
 } from "@ledgerhq/keyring-eth";
 import {
   DeviceAction,
@@ -51,6 +55,48 @@ export const KeyringEthView: React.FC<{ sessionId: string }> = ({
         },
         GetAddressDAError,
         GetAddressDAIntermediateValue
+      >,
+      {
+        title: "Sign typed message",
+        description:
+          "Perform all the actions necessary to sign a typed message on the device",
+        executeDeviceAction: ({ derivationPath, message }) => {
+          const typedData = JSON.parse(message) as TypedData;
+          return keyring.signTypedData(derivationPath, typedData);
+        },
+        initialValues: {
+          derivationPath: "44'/60'/0'/0/0",
+          message: `{"domain":{"name":"USD Coin","verifyingContract":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","chainId":1,"version":"2"},"primaryType":"Permit","message":{"deadline":1718992051,"nonce":0,"spender":"0x111111125421ca6dc452d289314280a0f8842a65","owner":"0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d","value":"115792089237316195423570985008687907853269984665640564039457584007913129639935"},"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Permit":[{"name":"owner","type":"address"},{"name":"spender","type":"address"},{"name":"value","type":"uint256"},{"name":"nonce","type":"uint256"},{"name":"deadline","type":"uint256"}]}}`,
+        },
+        validateValues: ({ message }) => {
+          try {
+            const parsedData = JSON.parse(message);
+            if (
+              typeof parsedData !== "object" ||
+              typeof parsedData.domain !== "object" ||
+              typeof parsedData.types !== "object" ||
+              typeof parsedData.primaryType !== "string" ||
+              typeof parsedData.message !== "object"
+            ) {
+              console.log(
+                `Invalid typed message format: should conform to EIP712 specification`,
+              );
+              return false;
+            }
+          } catch (error) {
+            console.log(`Invalid typed message format (${error})`);
+            return false;
+          }
+          return true;
+        },
+      } satisfies DeviceActionProps<
+        SignTypedDataDAOutput,
+        {
+          derivationPath: string;
+          message: string;
+        },
+        SignTypedDataDAError,
+        SignTypedDataDAIntermediateValue
       >,
     ],
     [],

--- a/packages/signer/keyring-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.test.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.test.ts
@@ -187,7 +187,7 @@ describe("SignTypedDataDeviceAction", () => {
         },
         {
           intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
+            requiredUserInteraction: UserInteractionRequired.SignTypedData,
           },
           status: DeviceActionStatus.Pending,
         },
@@ -376,7 +376,7 @@ describe("SignTypedDataDeviceAction", () => {
         },
         {
           intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
+            requiredUserInteraction: UserInteractionRequired.SignTypedData,
           },
           status: DeviceActionStatus.Pending,
         },
@@ -443,7 +443,7 @@ describe("SignTypedDataDeviceAction", () => {
         },
         {
           intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
+            requiredUserInteraction: UserInteractionRequired.SignTypedData,
           },
           status: DeviceActionStatus.Pending,
         },

--- a/packages/signer/keyring-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.ts
@@ -178,6 +178,16 @@ export class SignTypedDataDeviceAction extends XStateDeviceAction<
           },
         },
         ProvideContext: {
+          entry: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.SignTypedData,
+            },
+          }),
+          exit: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          }),
           invoke: {
             id: "provideContext",
             src: "provideContext",


### PR DESCRIPTION
### 📝 Description

The goal is to add SignTypedData to Ethereum keyring in the sample app.
It can be tested with any EIP712 message,  notably one of those available here:
https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-app-eth/tests/fixtures/messages

Note that I had to add a user interaction in ProvideContext state, in addition to SignTypedData state.
This is because in practice, while we provide context to the device, the device may be waiting for the user to swipe to the next screen. Therefore this is an interaction, even before signing the message.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/DSDK-424

### ✅ Checklist

- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
