### PR TITLE
⬆️ (repo) [DSDK-453]: Bump xstate from 5.15.0 to 5.18.1 and fix types

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "rxjs": "^7.8.1",
     "semver": "^7.6.3",
     "uuid": "^10.0.0",
-    "xstate": "^5.15.0"
+    "xstate": "^5.18.1"
   },
   "devDependencies": {
     "@ledgerhq/eslint-config-dsdk": "workspace:*",

--- a/packages/core/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.ts
+++ b/packages/core/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.ts
@@ -25,7 +25,10 @@ import {
   UnknownDAError,
 } from "@api/device-action/os/Errors";
 import { StateMachineTypes } from "@api/device-action/xstate-utils/StateMachineTypes";
-import { XStateDeviceAction } from "@api/device-action/xstate-utils/XStateDeviceAction";
+import {
+  DeviceActionStateMachine,
+  XStateDeviceAction,
+} from "@api/device-action/xstate-utils/XStateDeviceAction";
 import {
   DeviceSessionState,
   DeviceSessionStateType,
@@ -67,7 +70,15 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
   GetDeviceStatusDAIntermediateValue,
   GetDeviceStatusMachineInternalState
 > {
-  makeStateMachine(internalApi: InternalApi) {
+  makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    GetDeviceStatusDAOutput,
+    GetDeviceStatusDAInput,
+    GetDeviceStatusDAError,
+    GetDeviceStatusDAIntermediateValue,
+    GetDeviceStatusMachineInternalState
+  > {
     type types = StateMachineTypes<
       GetDeviceStatusDAOutput,
       GetDeviceStatusDAInput,

--- a/packages/core/src/api/device-action/os/GoToDashboard/GoToDashboardDeviceAction.ts
+++ b/packages/core/src/api/device-action/os/GoToDashboard/GoToDashboardDeviceAction.ts
@@ -22,7 +22,10 @@ import { DEFAULT_UNLOCK_TIMEOUT_MS } from "@api/device-action/os/Const";
 import { UnknownDAError } from "@api/device-action/os/Errors";
 import { GetDeviceStatusDeviceAction } from "@api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction";
 import { StateMachineTypes } from "@api/device-action/xstate-utils/StateMachineTypes";
-import { XStateDeviceAction } from "@api/device-action/xstate-utils/XStateDeviceAction";
+import {
+  DeviceActionStateMachine,
+  XStateDeviceAction,
+} from "@api/device-action/xstate-utils/XStateDeviceAction";
 import { DeviceSessionState } from "@api/device-session/DeviceSessionState";
 
 import {
@@ -55,7 +58,15 @@ export class GoToDashboardDeviceAction extends XStateDeviceAction<
   GoToDashboardDAIntermediateValue,
   GoToDashboardMachineInternalState
 > {
-  makeStateMachine(internalApi: InternalApi) {
+  makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    GoToDashboardDAOutput,
+    GoToDashboardDAInput,
+    GoToDashboardDAError,
+    GoToDashboardDAIntermediateValue,
+    GoToDashboardMachineInternalState
+  > {
     type types = StateMachineTypes<
       GoToDashboardDAOutput,
       GoToDashboardDAInput,

--- a/packages/core/src/api/device-action/os/ListApps/ListAppsDeviceAction.ts
+++ b/packages/core/src/api/device-action/os/ListApps/ListAppsDeviceAction.ts
@@ -12,7 +12,10 @@ import { UserInteractionRequired } from "@api/device-action/model/UserInteractio
 import { DEFAULT_UNLOCK_TIMEOUT_MS } from "@api/device-action/os/Const";
 import { GoToDashboardDeviceAction } from "@api/device-action/os/GoToDashboard/GoToDashboardDeviceAction";
 import { StateMachineTypes } from "@api/device-action/xstate-utils/StateMachineTypes";
-import { XStateDeviceAction } from "@api/device-action/xstate-utils/XStateDeviceAction";
+import {
+  DeviceActionStateMachine,
+  XStateDeviceAction,
+} from "@api/device-action/xstate-utils/XStateDeviceAction";
 
 import {
   ListAppsDAError,
@@ -46,7 +49,15 @@ export class ListAppsDeviceAction extends XStateDeviceAction<
   ListAppsDAIntermediateValue,
   ListAppsMachineInternalState
 > {
-  makeStateMachine(internalApi: InternalApi) {
+  makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    ListAppsDAOutput,
+    ListAppsDAInput,
+    ListAppsDAError,
+    ListAppsDAIntermediateValue,
+    ListAppsMachineInternalState
+  > {
     type types = StateMachineTypes<
       ListAppsDAOutput,
       ListAppsDAInput,

--- a/packages/core/src/api/device-action/os/ListAppsWithMetadata/ListAppsWithMetadataDeviceAction.ts
+++ b/packages/core/src/api/device-action/os/ListAppsWithMetadata/ListAppsWithMetadataDeviceAction.ts
@@ -14,7 +14,10 @@ import { DEFAULT_UNLOCK_TIMEOUT_MS } from "@api/device-action/os/Const";
 import { ListAppsDeviceAction } from "@api/device-action/os/ListApps/ListAppsDeviceAction";
 import { ListAppsDAOutput } from "@api/device-action/os/ListApps/types";
 import { StateMachineTypes } from "@api/device-action/xstate-utils/StateMachineTypes";
-import { XStateDeviceAction } from "@api/device-action/xstate-utils/XStateDeviceAction";
+import {
+  DeviceActionStateMachine,
+  XStateDeviceAction,
+} from "@api/device-action/xstate-utils/XStateDeviceAction";
 import { DeviceSessionState } from "@api/device-session/DeviceSessionState";
 import { HttpFetchApiError } from "@internal/manager-api/model/Errors";
 import { Application } from "@internal/manager-api/model/ManagerApiType";
@@ -49,7 +52,15 @@ export class ListAppsWithMetadataDeviceAction extends XStateDeviceAction<
   ListAppsWithMetadataDAIntermediateValue,
   ListAppsWithMetadataMachineInternalState
 > {
-  makeStateMachine(internalAPI: InternalApi) {
+  makeStateMachine(
+    internalAPI: InternalApi,
+  ): DeviceActionStateMachine<
+    ListAppsWithMetadataDAOutput,
+    ListAppsWithMetadataDAInput,
+    ListAppsWithMetadataDAError,
+    ListAppsWithMetadataDAIntermediateValue,
+    ListAppsWithMetadataMachineInternalState
+  > {
     type types = StateMachineTypes<
       ListAppsWithMetadataDAOutput,
       ListAppsWithMetadataDAInput,

--- a/packages/core/src/api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction.ts
+++ b/packages/core/src/api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction.ts
@@ -22,7 +22,10 @@ import {
   DeviceNotOnboardedError,
 } from "@api/device-action/os/Errors";
 import { StateMachineTypes } from "@api/device-action/xstate-utils/StateMachineTypes";
-import { XStateDeviceAction } from "@api/device-action/xstate-utils/XStateDeviceAction";
+import {
+  DeviceActionStateMachine,
+  XStateDeviceAction,
+} from "@api/device-action/xstate-utils/XStateDeviceAction";
 import {
   DeviceSessionState,
   DeviceSessionStateType,
@@ -79,7 +82,15 @@ export class OpenAppDeviceAction extends XStateDeviceAction<
   OpenAppDAIntermediateValue,
   OpenAppStateMachineInternalState
 > {
-  makeStateMachine(internalApi: InternalApi) {
+  makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    OpenAppDAOutput,
+    OpenAppDAInput,
+    OpenAppDAError,
+    OpenAppDAIntermediateValue,
+    OpenAppStateMachineInternalState
+  > {
     type types = StateMachineTypes<
       OpenAppDAOutput,
       OpenAppDAInput,

--- a/packages/core/src/api/device-action/os/SendCommandInAppDeviceAction/SendCommandInAppDeviceAction.ts
+++ b/packages/core/src/api/device-action/os/SendCommandInAppDeviceAction/SendCommandInAppDeviceAction.ts
@@ -10,7 +10,10 @@ import { UserInteractionRequired } from "@api/device-action/model/UserInteractio
 import { UnknownDAError } from "@api/device-action/os/Errors";
 import { OpenAppDeviceAction } from "@api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction";
 import { StateMachineTypes } from "@api/device-action/xstate-utils/StateMachineTypes";
-import { XStateDeviceAction } from "@api/device-action/xstate-utils/XStateDeviceAction";
+import {
+  DeviceActionStateMachine,
+  XStateDeviceAction,
+} from "@api/device-action/xstate-utils/XStateDeviceAction";
 import { Command } from "@api/types";
 
 import {
@@ -64,7 +67,20 @@ export class SendCommandInAppDeviceAction<
   SendCommandInAppDAIntermediateValue<UserInteraction>,
   SendCommandInAppDAInternalState<CommandResponse, CommandErrorCodes>
 > {
-  makeStateMachine(internalAPI: InternalApi) {
+  makeStateMachine(
+    internalAPI: InternalApi,
+  ): DeviceActionStateMachine<
+    SendCommandInAppDAOutput<CommandResponse>,
+    SendCommandInAppDAInput<
+      CommandResponse,
+      CommandArgs,
+      CommandErrorCodes,
+      UserInteraction
+    >,
+    SendCommandInAppDAError<CommandErrorCodes>,
+    SendCommandInAppDAIntermediateValue<UserInteraction>,
+    SendCommandInAppDAInternalState<CommandResponse, CommandErrorCodes>
+  > {
     type types = StateMachineTypes<
       SendCommandInAppDAOutput<CommandResponse>,
       SendCommandInAppDAInput<

--- a/packages/core/src/api/device-action/xstate-utils/XStateDeviceAction.ts
+++ b/packages/core/src/api/device-action/xstate-utils/XStateDeviceAction.ts
@@ -1,6 +1,6 @@
 import { createBrowserInspector } from "@statelyai/inspect";
 import { Observable, ReplaySubject, share } from "rxjs";
-import { createActor, SnapshotFrom, StateMachine } from "xstate";
+import { createActor, SnapshotFrom, StateMachine, StateSchema } from "xstate";
 
 import {
   DeviceAction,
@@ -16,7 +16,7 @@ import { SdkError } from "@api/Error";
 
 import { StateMachineTypes } from "./StateMachineTypes";
 
-type DeviceActionStateMachine<
+export type DeviceActionStateMachine<
   Output,
   Input,
   Error extends SdkError,
@@ -60,8 +60,9 @@ type DeviceActionStateMachine<
   >["output"],
   /* eslint-disable @typescript-eslint/no-explicit-any */
   any,
-  any
+  any,
   /* eslint-enable @typescript-eslint/no-explicit-any */
+  StateSchema
 >;
 
 /**

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -108,7 +108,10 @@ export {
   type SendCommandInAppDAOutput,
 } from "@api/device-action/os/SendCommandInAppDeviceAction/SendCommandInAppDeviceActionTypes";
 export { type StateMachineTypes } from "@api/device-action/xstate-utils/StateMachineTypes";
-export { XStateDeviceAction } from "@api/device-action/xstate-utils/XStateDeviceAction";
+export {
+  type DeviceActionStateMachine,
+  XStateDeviceAction,
+} from "@api/device-action/xstate-utils/XStateDeviceAction";
 export {
   type DeviceSessionState,
   DeviceSessionStateType,

--- a/packages/signer/keyring-eth/package.json
+++ b/packages/signer/keyring-eth/package.json
@@ -48,7 +48,7 @@
     "inversify-logger-middleware": "^3.1.0",
     "purify-ts": "^2.1.0",
     "reflect-metadata": "^0.2.2",
-    "xstate": "^5.15.0"
+    "xstate": "^5.18.1"
   },
   "devDependencies": {
     "@ledgerhq/context-module": "workspace:*",

--- a/packages/signer/keyring-eth/src/internal/app-binder/device-action/SignPersonalMessage/SignPersonalMessageDeviceAction.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/device-action/SignPersonalMessage/SignPersonalMessageDeviceAction.ts
@@ -1,5 +1,6 @@
 import {
   CommandResult,
+  type DeviceActionStateMachine,
   InternalApi,
   isSuccessCommandResult,
   OpenAppDeviceAction,
@@ -41,7 +42,15 @@ export class SignPersonalMessageDeviceAction extends XStateDeviceAction<
   SignPersonalMessageDAIntermediateValue,
   SignPersonalMessageDAInternalState
 > {
-  makeStateMachine(internalApi: InternalApi) {
+  makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    SignPersonalMessageDAOutput,
+    SignPersonalMessageDAInput,
+    SignPersonalMessageDAError,
+    SignPersonalMessageDAIntermediateValue,
+    SignPersonalMessageDAInternalState
+  > {
     type types = StateMachineTypes<
       SignPersonalMessageDAOutput,
       SignPersonalMessageDAInput,

--- a/packages/signer/keyring-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.ts
@@ -5,6 +5,7 @@ import {
 import {
   CommandErrorResult,
   CommandResult,
+  type DeviceActionStateMachine,
   InternalApi,
   isSuccessCommandResult,
   OpenAppDeviceAction,
@@ -75,7 +76,15 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
   SignTransactionDAIntermediateValue,
   SignTransactionDAInternalState
 > {
-  makeStateMachine(internalApi: InternalApi) {
+  makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    SignTransactionDAOutput,
+    SignTransactionDAInput,
+    SignTransactionDAError,
+    SignTransactionDAIntermediateValue,
+    SignTransactionDAInternalState
+  > {
     type types = StateMachineTypes<
       SignTransactionDAOutput,
       SignTransactionDAInput,

--- a/packages/signer/keyring-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.ts
@@ -1,6 +1,7 @@
 import { ContextModule } from "@ledgerhq/context-module";
 import {
   CommandResult,
+  type DeviceActionStateMachine,
   InternalApi,
   isSuccessCommandResult,
   OpenAppDeviceAction,
@@ -56,7 +57,15 @@ export class SignTypedDataDeviceAction extends XStateDeviceAction<
   SignTypedDataDAIntermediateValue,
   SignTypedDataDAInternalState
 > {
-  makeStateMachine(internalApi: InternalApi) {
+  makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    SignTypedDataDAOutput,
+    SignTypedDataDAInput,
+    SignTypedDataDAError,
+    SignTypedDataDAIntermediateValue,
+    SignTypedDataDAInternalState
+  > {
     type types = StateMachineTypes<
       SignTypedDataDAOutput,
       SignTypedDataDAInput,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,8 +190,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0
       xstate:
-        specifier: ^5.15.0
-        version: 5.15.0
+        specifier: ^5.18.1
+        version: 5.18.1
     devDependencies:
       '@ledgerhq/eslint-config-dsdk':
         specifier: workspace:*
@@ -207,7 +207,7 @@ importers:
         version: link:../config/typescript
       '@statelyai/inspect':
         specifier: ^0.4.0
-        version: 0.4.0(ws@8.17.1)(xstate@5.15.0)
+        version: 0.4.0(ws@8.17.1)(xstate@5.18.1)
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
@@ -285,8 +285,8 @@ importers:
         specifier: ^0.2.2
         version: 0.2.2
       xstate:
-        specifier: ^5.15.0
-        version: 5.15.0
+        specifier: ^5.18.1
+        version: 5.18.1
     devDependencies:
       '@ledgerhq/context-module':
         specifier: workspace:*
@@ -6376,8 +6376,8 @@ packages:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
     engines: {node: '>=12'}
 
-  xstate@5.15.0:
-    resolution: {integrity: sha512-0DGArbj+ych7PcCqHzhEvXH1qVG41lhenwdbEPBRJyxQP9TLooUsR7oiR4YWYHblLOVWvz/esiw8HUtHXp/kZA==}
+  xstate@5.18.1:
+    resolution: {integrity: sha512-m02IqcCQbaE/kBQLunwub/5i8epvkD2mFutnL17Oeg1eXTShe1sRF4D5mhv1dlaFO4vbW5gRGRhraeAD5c938g==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -9390,7 +9390,7 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.0
 
-  '@statelyai/inspect@0.4.0(ws@8.17.1)(xstate@5.15.0)':
+  '@statelyai/inspect@0.4.0(ws@8.17.1)(xstate@5.18.1)':
     dependencies:
       fast-safe-stringify: 2.1.1
       isomorphic-ws: 5.0.0(ws@8.17.1)
@@ -9398,7 +9398,7 @@ snapshots:
       safe-stable-stringify: 2.4.3
       superjson: 1.13.3
       uuid: 9.0.1
-      xstate: 5.15.0
+      xstate: 5.18.1
     transitivePeerDependencies:
       - ws
 
@@ -14058,7 +14058,7 @@ snapshots:
 
   xdg-basedir@5.1.0: {}
 
-  xstate@5.15.0: {}
+  xstate@5.18.1: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- Update of XState from 5.15.0 to 5.18.1: https://github.com/statelyai/xstate/compare/xstate@5.15.0...xstate@5.18.1
- [Some type params of XState `StateMachine` type became required in the new versions](https://github.com/statelyai/xstate/commit/51d4c4fc5bd303a00a554534956d8b994ea82e99). 
- The return type of `makeStateMachine` had to be made explicit to avoid this kind of errors:
```
The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.
```

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [DSDK-453] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - all device actions

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[DSDK-453]: https://ledgerhq.atlassian.net/browse/DSDK-453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ