### PR TITLE
👷 (release) [NO-ISSUE]: Only build libs during relese workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: Pull Request
+name: Pull Request Checks
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: publish npm packages
+name: Publish npm packages
 on:
   push:
     branches:

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -1,4 +1,4 @@
-name: publish snapshot version of npm packages
+name: Publish snapshot version of npm packages
 on:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,4 +1,4 @@
-name: create release pull request
+name: Create release pull request
 on:
   push:
     branches:
@@ -19,7 +19,7 @@ jobs:
         run: pnpm install
 
       - name: build libraries
-        run: pnpm build
+        run: pnpm build:libs
 
       - name: create release pull request or publish
         uses: changesets/action@v1

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "turbo run build",
+    "build:libs": "turbo run build --filter=./packages/**",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Just realised that we build everything (including the sample app) when going through the release flow (the version.yaml flow) while we only need the libs
Added a new script to build only the libraries and updated the flow to use it.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - new root package.json command `build:libs`
  - usage of `build:libs` in the version.yaml workflow
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
