### PR TITLE
✨ (core) [DSDK-487]: Update session state after opening app successfully

### DIFF
--- a/.changeset/itchy-eagles-bow.md
+++ b/.changeset/itchy-eagles-bow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Update session state after opening app successfully

--- a/packages/core/src/api/command/os/GetAppAndVersionCommand.ts
+++ b/packages/core/src/api/command/os/GetAppAndVersionCommand.ts
@@ -20,6 +20,9 @@ export type GetAppAndVersionResponse = {
    * The version of the application currently running on the device.
    */
   readonly version: string;
+  /**
+   * Flags that are used to provide additional information about the application.
+   */
   readonly flags?: number | Uint8Array;
 };
 

--- a/packages/core/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.test.ts
+++ b/packages/core/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.test.ts
@@ -24,7 +24,7 @@ describe("GetDeviceStatusDeviceAction", () => {
   const getAppAndVersionMock = jest.fn();
   const getDeviceSessionStateMock = jest.fn();
   const waitForDeviceUnlockMock = jest.fn();
-  const saveSessionStateMock = jest.fn();
+  const setDeviceSessionState = jest.fn();
   const isDeviceOnboardedMock = jest.fn();
 
   function extractDependenciesMock() {
@@ -32,7 +32,7 @@ describe("GetDeviceStatusDeviceAction", () => {
       getAppAndVersion: getAppAndVersionMock,
       getDeviceSessionState: getDeviceSessionStateMock,
       waitForDeviceUnlock: waitForDeviceUnlockMock,
-      saveSessionState: saveSessionStateMock,
+      setDeviceSessionState: setDeviceSessionState,
       isDeviceOnboarded: isDeviceOnboardedMock,
     };
   }
@@ -75,12 +75,6 @@ describe("GetDeviceStatusDeviceAction", () => {
           status: DeviceActionStatus.Pending,
         },
         {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
           output: {
             currentApp: "BOLOS",
             currentAppVersion: "1.0.0",
@@ -105,7 +99,7 @@ describe("GetDeviceStatusDeviceAction", () => {
       apiGetDeviceSessionStateMock.mockReturnValue({
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.LOCKED,
-        currentApp: "mockedCurrentApp",
+        currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
         installedApps: [],
       });
 
@@ -119,7 +113,7 @@ describe("GetDeviceStatusDeviceAction", () => {
                     sessionStateType:
                       DeviceSessionStateType.ReadyWithoutSecureChannel,
                     deviceStatus: DeviceStatus.CONNECTED,
-                    currentApp: "mockedCurrentApp",
+                    currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
                     installedApps: [],
                   });
                   o.complete();
@@ -128,7 +122,7 @@ describe("GetDeviceStatusDeviceAction", () => {
                     sessionStateType:
                       DeviceSessionStateType.ReadyWithoutSecureChannel,
                     deviceStatus: DeviceStatus.LOCKED,
-                    currentApp: "mockedCurrentApp",
+                    currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
                     installedApps: [],
                   });
                 }
@@ -164,12 +158,6 @@ describe("GetDeviceStatusDeviceAction", () => {
           status: DeviceActionStatus.Pending,
         },
         {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
           output: {
             currentApp: "BOLOS",
             currentAppVersion: "1.0.0",
@@ -192,7 +180,7 @@ describe("GetDeviceStatusDeviceAction", () => {
       getDeviceSessionStateMock.mockReturnValue({
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.CONNECTED,
-        currentApp: "mockedCurrentApp",
+        currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
       });
 
       getAppAndVersionMock.mockResolvedValue(
@@ -220,12 +208,6 @@ describe("GetDeviceStatusDeviceAction", () => {
           status: DeviceActionStatus.Pending,
         },
         {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
           status: DeviceActionStatus.Completed,
           output: {
             currentApp: "BOLOS",
@@ -246,7 +228,7 @@ describe("GetDeviceStatusDeviceAction", () => {
       getDeviceSessionStateMock.mockReturnValue({
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.LOCKED,
-        currentApp: "mockedCurrentApp",
+        currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
       });
 
       getAppAndVersionMock.mockResolvedValue(
@@ -268,7 +250,7 @@ describe("GetDeviceStatusDeviceAction", () => {
                     sessionStateType:
                       DeviceSessionStateType.ReadyWithoutSecureChannel,
                     deviceStatus: DeviceStatus.CONNECTED,
-                    currentApp: "mockedCurrentApp",
+                    currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
                   });
                   o.complete();
                 } else {
@@ -276,7 +258,7 @@ describe("GetDeviceStatusDeviceAction", () => {
                     sessionStateType:
                       DeviceSessionStateType.ReadyWithoutSecureChannel,
                     deviceStatus: DeviceStatus.LOCKED,
-                    currentApp: "mockedCurrentApp",
+                    currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
                   });
                 }
               },
@@ -310,12 +292,6 @@ describe("GetDeviceStatusDeviceAction", () => {
           status: DeviceActionStatus.Pending,
         },
         {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
           status: DeviceActionStatus.Completed,
           output: {
             currentApp: "BOLOS",
@@ -338,7 +314,7 @@ describe("GetDeviceStatusDeviceAction", () => {
       getDeviceSessionStateMock.mockReturnValue({
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.LOCKED,
-        currentApp: "mockedCurrentApp",
+        currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
       });
       isDeviceOnboardedMock.mockReturnValue(false);
 
@@ -369,7 +345,7 @@ describe("GetDeviceStatusDeviceAction", () => {
       getDeviceSessionStateMock.mockReturnValue({
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.LOCKED,
-        currentApp: "mockedCurrentApp",
+        currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
       });
 
       apiGetDeviceSessionStateObservableMock.mockImplementation(
@@ -381,7 +357,7 @@ describe("GetDeviceStatusDeviceAction", () => {
                   sessionStateType:
                     DeviceSessionStateType.ReadyWithoutSecureChannel,
                   deviceStatus: DeviceStatus.LOCKED,
-                  currentApp: "mockedCurrentApp",
+                  currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
                   installedApps: [],
                 });
               },
@@ -426,7 +402,7 @@ describe("GetDeviceStatusDeviceAction", () => {
       getDeviceSessionStateMock.mockReturnValue({
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.LOCKED,
-        currentApp: "mockedCurrentApp",
+        currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
       });
 
       const error = new GlobalCommandError({
@@ -446,7 +422,7 @@ describe("GetDeviceStatusDeviceAction", () => {
                     sessionStateType:
                       DeviceSessionStateType.ReadyWithoutSecureChannel,
                     deviceStatus: DeviceStatus.CONNECTED,
-                    currentApp: "mockedCurrentApp",
+                    currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
                   });
                   o.complete();
                 } else {
@@ -454,7 +430,7 @@ describe("GetDeviceStatusDeviceAction", () => {
                     sessionStateType:
                       DeviceSessionStateType.ReadyWithoutSecureChannel,
                     deviceStatus: DeviceStatus.LOCKED,
-                    currentApp: "mockedCurrentApp",
+                    currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
                   });
                 }
               },
@@ -505,7 +481,7 @@ describe("GetDeviceStatusDeviceAction", () => {
       getDeviceSessionStateMock.mockReturnValue({
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.LOCKED,
-        currentApp: "mockedCurrentApp",
+        currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
       });
 
       getAppAndVersionMock.mockImplementation(() => {
@@ -553,100 +529,13 @@ describe("GetDeviceStatusDeviceAction", () => {
         done,
       );
     });
-
-    it("should end in an error if saveSessionState fails", (done) => {
-      getDeviceSessionStateMock.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.LOCKED,
-        currentApp: "mockedCurrentApp",
-      });
-
-      getAppAndVersionMock.mockResolvedValue(
-        CommandResultFactory({
-          data: {
-            app: null,
-            version: null,
-          },
-        }),
-      );
-
-      waitForDeviceUnlockMock.mockImplementation(
-        () =>
-          new Observable((o) => {
-            const inner = interval(50).subscribe({
-              next: (i) => {
-                if (i > 2) {
-                  o.next({
-                    sessionStateType:
-                      DeviceSessionStateType.ReadyWithoutSecureChannel,
-                    deviceStatus: DeviceStatus.CONNECTED,
-                    currentApp: "mockedCurrentApp",
-                  });
-                  o.complete();
-                } else {
-                  o.next({
-                    sessionStateType:
-                      DeviceSessionStateType.ReadyWithoutSecureChannel,
-                    deviceStatus: DeviceStatus.LOCKED,
-                    currentApp: "mockedCurrentApp",
-                  });
-                }
-              },
-            });
-
-            return () => {
-              inner.unsubscribe();
-            };
-          }),
-      );
-
-      const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
-        input: { unlockTimeout: 500 },
-      });
-
-      jest
-        .spyOn(getDeviceStateDeviceAction, "extractDependencies")
-        .mockReturnValue(extractDependenciesMock());
-
-      const expectedStates: Array<GetDeviceStatusDAState> = [
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.UnlockDevice,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          error: new UnknownDAError("SaveAppStateError"),
-          status: DeviceActionStatus.Error,
-        },
-      ];
-
-      testDeviceActionStates(
-        getDeviceStateDeviceAction,
-        expectedStates,
-        makeDeviceActionInternalApiMock(),
-        done,
-      );
-    });
   });
 
   it("should emit a stopped state if the action is cancelled", (done) => {
     apiGetDeviceSessionStateMock.mockReturnValue({
       sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
       deviceStatus: DeviceStatus.CONNECTED,
-      currentApp: "mockedCurrentApp",
+      currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
       installedApps: [],
     });
 

--- a/packages/core/src/api/device-action/os/GoToDashboard/GoToDashboardDeviceAction.test.ts
+++ b/packages/core/src/api/device-action/os/GoToDashboard/GoToDashboardDeviceAction.test.ts
@@ -22,14 +22,14 @@ describe("GoToDashboardDeviceAction", () => {
   const closeAppMock = jest.fn();
   const getAppAndVersionMock = jest.fn();
   const getDeviceSessionStateMock = jest.fn();
-  const saveSessionStateMock = jest.fn();
+  const setDeviceSessionStateMock = jest.fn();
 
   function extractDependenciesMock() {
     return {
       closeApp: closeAppMock,
       getAppAndVersion: getAppAndVersionMock,
       getDeviceSessionState: getDeviceSessionStateMock,
-      saveSessionState: saveSessionStateMock,
+      setDeviceSessionState: setDeviceSessionStateMock,
     };
   }
 
@@ -53,7 +53,7 @@ describe("GoToDashboardDeviceAction", () => {
       apiGetDeviceSessionStateMock.mockReturnValue({
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.CONNECTED,
-        currentApp: "BOLOS",
+        currentApp: { name: "BOLOS", version: "1.5.0" },
         installedApps: [],
       });
 
@@ -63,12 +63,6 @@ describe("GoToDashboardDeviceAction", () => {
             requiredUserInteraction: UserInteractionRequired.None,
           },
           status: DeviceActionStatus.Pending, // GetDeviceStatus events (mocked for tests)
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-          },
-          status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
@@ -103,7 +97,7 @@ describe("GoToDashboardDeviceAction", () => {
       apiGetDeviceSessionStateMock.mockReturnValue({
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.CONNECTED,
-        currentApp: "Bitcoin",
+        currentApp: { name: "Bitcoin", version: "1.0.0" },
         installedApps: [],
       });
 
@@ -113,18 +107,12 @@ describe("GoToDashboardDeviceAction", () => {
           CommandResultFactory({
             data: {
               name: "BOLOS",
-              version: "1.0.0",
+              version: "1.5.0",
             },
           }),
         );
 
       const expectedStates: Array<GoToDashboardDAState> = [
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-          },
-          status: DeviceActionStatus.Pending,
-        },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
@@ -175,12 +163,12 @@ describe("GoToDashboardDeviceAction", () => {
       getDeviceSessionStateMock.mockReturnValue({
         sessionStateType: DeviceSessionStateType.Connected,
         deviceStatus: DeviceStatus.CONNECTED,
-        currentApp: "BOLOS",
+        currentApp: { name: "BOLOS", version: "1.5.0" },
       });
 
       getAppAndVersionMock.mockReturnValue({
         app: "BOLOS",
-        version: "1.0.0",
+        version: "1.5.0",
       });
 
       jest
@@ -188,12 +176,6 @@ describe("GoToDashboardDeviceAction", () => {
         .mockReturnValue(extractDependenciesMock());
 
       const expectedStates: Array<GoToDashboardDAState> = [
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-          },
-          status: DeviceActionStatus.Pending,
-        },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
@@ -241,18 +223,12 @@ describe("GoToDashboardDeviceAction", () => {
         CommandResultFactory({
           data: {
             name: "BOLOS",
-            version: "1.0.0",
+            version: "1.5.0",
           },
         }),
       );
 
       const expectedStates: Array<GoToDashboardDAState> = [
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-          },
-          status: DeviceActionStatus.Pending,
-        },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
@@ -291,7 +267,7 @@ describe("GoToDashboardDeviceAction", () => {
       apiGetDeviceSessionStateMock.mockReturnValue({
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.CONNECTED,
-        currentApp: "BOLOS",
+        currentApp: { name: "BOLOS", version: "1.5.0" },
         installedApps: [],
       });
 
@@ -514,87 +490,6 @@ describe("GoToDashboardDeviceAction", () => {
           {
             status: DeviceActionStatus.Error,
             error: new UnknownDAError("currentApp === null"),
-          },
-        ];
-
-        testDeviceActionStates(
-          goToDashboardDeviceAction,
-          expectedStates,
-          makeDeviceActionInternalApiMock(),
-          done,
-        );
-      });
-
-      it("should return an error if SaveSessionState fails", (done) => {
-        setupGetDeviceStatusMock({
-          currentApp: "Bitcoin",
-          currentAppVersion: "1.0.0",
-        });
-
-        const goToDashboardDeviceAction = new GoToDashboardDeviceAction({
-          input: { unlockTimeout: 500 },
-        });
-
-        jest
-          .spyOn(goToDashboardDeviceAction, "extractDependencies")
-          .mockReturnValue(extractDependenciesMock());
-
-        getDeviceSessionStateMock.mockReturnValue({
-          sessionStateType: DeviceSessionStateType.Connected,
-          deviceStatus: DeviceStatus.CONNECTED,
-          currentApp: "Bitcoin",
-        });
-
-        closeAppMock.mockResolvedValue(
-          CommandResultFactory({ data: undefined }),
-        );
-        getAppAndVersionMock.mockResolvedValue(
-          CommandResultFactory({
-            data: {
-              name: "BOLOS",
-              version: "1.0.0",
-            },
-          }),
-        );
-
-        saveSessionStateMock.mockImplementation(() => {
-          throw new Error("Save session state failed");
-        });
-
-        const expectedStates: Array<GoToDashboardDAState> = [
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          {
-            status: DeviceActionStatus.Error,
-            error: new UnknownDAError("SaveAppStateError"),
           },
         ];
 

--- a/packages/core/src/api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction.ts
+++ b/packages/core/src/api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction.ts
@@ -50,6 +50,7 @@ export type MachineDependencies = {
     input: { appName: string };
   }) => Promise<OpenAppCommandResult>;
   readonly getDeviceSessionState: () => DeviceSessionState;
+  readonly setDeviceSessionState: (state: DeviceSessionState) => void;
   readonly isDeviceOnboarded: () => boolean;
 };
 
@@ -104,6 +105,7 @@ export class OpenAppDeviceAction extends XStateDeviceAction<
       closeApp,
       openApp,
       getDeviceSessionState,
+      setDeviceSessionState,
       isDeviceOnboarded,
     } = this.extractDependencies(internalApi);
 
@@ -180,7 +182,7 @@ export class OpenAppDeviceAction extends XStateDeviceAction<
         }),
       },
     }).createMachine({
-      /** @xstate-layout N4IgpgJg5mDOIC5QHkAOYB2BBVqAiYAbgJYDGYWpALsQPYYB0BJ5ASmAIYQCeAxANoAGALqJQqWrGI16YkAA9EARgCcghgA4ArCoDMGgCwaNAdg27dWgDQhuywSoZGDBwRoBsKleYBMGpQC+ATZomDj4RGQU1HSMyBgARrQcAE4QxBhQAMIAFmCkANYCInISUjIYcooIBiZKToLuum6Clj4m3gY2dgg+WvV9goJaJlrNLn7uQSHo2LjMUZQVDPFJqemZuflF-EqiSCBl0rFViLX1rk0tbR2G3Yj+DA66Jj6DgnWtBtMgoXMRLGiywAMrRChlsnlCsV9uJJMdZAdqhovAwlGYfEoPv5Rn57gh9BoGC8NI0XLoVD53FSfn9wgtyEtYgxQeDNlCdntSvCKqcECjHOiNJjseitHjbIg3j40c8Oq0VEp3J4fLTZvTIoyYvQGOEADZkDgVLCEDjEPUcBJ6sC8CD0MAMDKEWgFB10+aaoHM-WG42m82W60IJ1go2xITCCPc8onJHKF4y9qk7wUryjaySgnuAwMNTNNSmFTuEwmNVhD2Apk6n2kMP0E1mi1WsDsWAAVz1VC20KjByOvLjCCUKPUSl0Bl0Si0rhcSo0+P09SLfQnKh0E4MKjL-wZXuruANtb9jcDLbgHa7HIEXL7PNjoGqw7UaPHk+ngln7nnma0WnUJlcOpzB0N8t2CX51QrRZtUYGs6wwbsdhKW8Y0RB8pR8SwGH6FEJ2aLExh8fEsRMdRTDGJR2lGVQ3m3DVKxg3UD19WJEOvWFDjvNCFAwrCcJUPDBAI3QiJ-FxiR8IwS2GFQzAcOioK1ZY8A4WAcjWNI2N7OFUMqQcqQMLQ0U8JVJw-DpanxNR3GM2TqWzWofDXBSAWg5TVPU5JNKvXYOP7e8eN6bMjKVRUmixWoBJMfExhMXMHD6FMlEM5KXN3KtGCyPVJAoZij1iW17UdDBnVdFZINcpTmSynK4IqYMStDCoI20zjdL5cZ6ixXRi1UV4AKUfFqRzNc1yUMcsW8FE0s9DKGBq2BctQQ94N4MAUhSWgUgYZajQAMy2gBbcry0qvdMuyxa6tiBrnXy+gWuQnSET09CCQ-LrWl62T2gMQafyGBg+jfWpJ0M8wZoY5YFqWlaKlbC8tKetqXo6nCnD+9E-vaIZzCGgwZSE0wSUaEDVXA90zrmmHrvoBHOy0m9noHN7LGHDHxoGnG3F0fEzDiwtxz8LRi3cdFIbc5lKbhgq7QwB0QzKyn0sY6WWPoW6mvDERWv87jqlcHx1HcP9Iq0ZNSPcfFjEcASKQsZLF2GCWqp1NX7owNaNq2naLSoA6UmO5XZtViqZY1kMPcevyuNewLDeN02OnNhxLb5k2gZedweYEtcRhd86Tv+cOMHpy9thhaNUcHFw1wYT4qRF-whSsj4nlaVRktIhwPgLub3fgsvGZj9qa83IyG5Nr9Oe-Ho1xlc2DGzk3xuSwIKYqlXllp0vOB4SuUOrt6jB0eL9BFzxswpKzT556dSXaZUnKCcCMFoCA4DkYOoYCvW4+qAAtFbTMQC+6MV3OwLgPRmYBQNqJHoWIiRJmSuDQYD8wHLFWF5DYkJthVxZoFYW2Epwm1GMqJuGYEFuCBmYFB5s0GCHJjMU6W9mSsgKBCRC+DYGIAGthRok4UQdGLK0fEklHBOQpGOHqOhbgYO9HleCDYAzNm4frZQlEbJCT6GMD8ioRK80zD1XQaI0EWEwk0AC8j9zLXVtgf0TZrRDw5Go-+ygdBaL0KSTwedpzAJ6PoGyBMaKMIAh0ASWhrGwUURULhh8CHVCNuKYhF8hKOUYTFIw9dDCTCXm8NcugolMA8hpCAcSYHqN6EvIyv4iweFeG8TcXQxIyh6sTPwBT0Slg3iwkO0NLqwzsa4vkwtWk4iaE5DcU4YqUQYFPJMdR6FNCKTTGJsRnF4PiTwgkkkiRNCMF4ksZD8ZBNoekxUHwpg9J3H0qWYchlbMqW0sijST4fEktFTMJhs7EgcC4QidRhzfGufRSWbt7kew2YUYZNc3hEmHCKSwIxp5WXGk4eywULBrm6cwm5P8bEl0gTwGFx9ixEgcFOVwjQ17+MQNizQJZ9Ck2MMC3FoLXaMAAMptlIOQWA8BHluJqGuHMIshIAWzsKa+mY1w2SuH0LEZIm5FIAKLexSCS+OZKniKnfNSv6tKEDinUOKU2vVHJ1BfgEIAA */
+      /** @xstate-layout N4IgpgJg5mDOIC5QHkAOYB2BBVqAiYAbgJYDGYWpALsQPYYB0BJ5ASmAIYQCeAxANoAGALqJQqWrGI16YkAA9EARhWCGADgAsAZm1b1SwUoDspgDQhuiAEzX1DbQE5tJlQDYlm414CsAXz8LNEwcfCIyCmo6RmQMACNaDgAnCGIMKABhAAswUgBrARE5CSkZDDlFBCUPbQYfZx91H0FtTRNjCysEbWM1bTdHAzcfH2q9awCg9GxcZgjKMoZYhOTU9Ozcgv4lUSQQEuloiuUauoamlrbzSxtBNTu7pW1BEe1rJUmQYJmwlkjFgAytHyaUyOXyhV24kkh1ke0q7w8DDcxmqjkM1l6Kh8nUQzR8DEEjjcz3UxKUjiMbk+31Cc3IC2iDCBIPW4K2O2KMLKxwQiKUyNRAwxWKUOJu3TaDFsw28bkExmsgnU-Rp0zp4QZUXoDFCABsyBwylhCBxiHqOHE9WBeBB6GAGGlCLQ8g7abNNf8mfrDcbTebLdaEE7gUbokJhBGuaUjvCbCSCdZNI5UQqhg1cQhNOprAxND4XP0xZTHI01SEPX9GTqfaQw-QTWaLVabWAkklaEkGKgLVQAGadgC2S3Vlfm2sYtfr2H9zaDIbrZQjUb2Bx5cb5CelydTxnT2nFXTcmjUBYTzlazkcE0CX1Hv3HiynfqbgbA7FgAFc9VQNhCV9CMZwqAlQuAWZwHiqbStI0mY+PmdRKNYxLZmKgjvDeUwVg+WpPrgBqLtEjYBi2H7fr+7ICJyq7crGIGIK0LwME8dzJuizzNNYmZeLmAysZ4Ph2KYmiaOWPz0l6Nb4b60R-lsRQ0UB5Qbq0pgMM4FJ8dYx4KpomaOJo6k9G4yHvEhBmYmJGpVhOurSYR9ByVRUL7LRwEKAxYq1PUkGtE8+ZaJmBh1A8hieMh17vFZY64UyeAcLAWQrCkTkAa5Sm8tY-TIkmlJvFojjXuocHysiegvB4JJ6P4t7ujhkmMPFiXJRAqXUYBsLKfRfLZSZyYtHYbF2JmQoaMeIweEmJjHtF9XVowGR6pIFD2dOtr2o6GDOq6I7YRJ80MIty3PtEwZbaGS4iGla50R5CBVYSJkFncbzGC4mYoo4zHlfUCo+KieizfttlHbAK09jJ9C8G2HZdj2RoDkkw51cDiyg+DBHTmdzoORgy4KR167dQ9ghPc8A1vUomZIQqeZksmTw9JoJlA56B3oyd9BkT+qUE+lnW8iohgaDoeioUYpgdBKQu5sz8rEgYxjwaJtX3qjTIc6tZTcxRmzOdGAsbqoagmM8Yr-aTTyOCNpXWAW-TGIMfmO6zNmLHVmNlOtGAOiGO0o2ztke5DGDYxd4ZXXzN3uZU1RPBBjTNM7UtdAWxjqQZ6gqv0LyO9oruPkywe49D7adt2vaI8jauB+796e6dC7TvjLnR11d1x955xJ1cKeIAZ6dGEJqJKk4qqq3ttdF-XIc67zrdue3CLVG4gqZyMpbGG4bhBeoq9b-mB7jaTZYT+JU86sX05z5R2wLxlG78oKYpNKW16mx9x6EkhWdGKTSvXgLrFKSENcbsC4Hwa6i9eQHgQgmCkIlBjKmcEFUY24ejaSTMeCkHxPgYFoBAOAcgA5u1um3XkABaHeEoKEEkKvQwQJ4XjKl6ErIBDUmCenATwA2RM7rknUm4FUhV-oiTJFTCUth05j0xJVFUTxt7sIOssRIKRQRyV4bdWOTNkTqDekqAwbxNDIUzFIhwzhZHVHkf0akZ9rKFx1CyPI6j2SaJjsoUsBIBimB8MMeUZJqFdH6PYDwKYBjwQaEYpRtlOYzlfC2NxS8bB6HsM4RUIwiSH0VNxAy6lkL1EEjTYUtisLn1ISAhuDZZxvhvpsRJmVX51FJFlZ4-Qk5wUYcxR2BTTIGUKtEvCoDpwaMUobbqugUzIg8PmEwIiTJ9yqAMaUW90IngCaIgZcUEpJVUa1Vxoy+GVGMbvZiuVf5IM8CoTZOpNZDL4eQjcIlDLIRRH5FhoxDyIGFMiASe8IoFlGNchaS0waxNqfkepG4tACiMGeQw6IiQeBGncMaMycxEl8eoIFu0fiVPbg87qSE3q6MVBpehPQ4K6G+uoZUJIVB7laNiq+2s4DkRGYTLRygs6GSQtmO4iIaWljgvUBgip-K5RErofOdiYocLBZwHhBzOWSkKqKz6Lw3i6U+QgPchlTB7xTPBeCWVHDYoAMqflIOQWA8AlXuO6KMQylImipgMi4BZzhDIKkpM0FEypRimplXNWyABRMuSRIXjNaKvHQ3h0Q0reCYT+3khGNEKgqIRxgAgBCAA */
       id: "OpenAppDeviceAction",
       initial: "DeviceReady",
       context: ({ input }) => {
@@ -196,7 +198,7 @@ export class OpenAppDeviceAction extends XStateDeviceAction<
             currentlyRunningApp:
               sessionStateType ===
               DeviceSessionStateType.ReadyWithoutSecureChannel
-                ? sessionState.currentApp
+                ? sessionState.currentApp.name
                 : null,
           },
         };
@@ -248,6 +250,17 @@ export class OpenAppDeviceAction extends XStateDeviceAction<
               actions: assign({
                 _internalState: (_) => {
                   if (isSuccessCommandResult(_.event.output)) {
+                    const state: DeviceSessionState = getDeviceSessionState();
+                    // Narrow the type to ReadyWithoutSecureChannelState or ReadyWithSecureChannelState
+                    if (
+                      state.sessionStateType !==
+                      DeviceSessionStateType.Connected
+                    ) {
+                      setDeviceSessionState({
+                        ...state,
+                        currentApp: _.event.output.data,
+                      });
+                    }
                     return {
                       ..._.context._internalState,
                       currentlyRunningApp: _.event.output.data.name,
@@ -335,7 +348,7 @@ export class OpenAppDeviceAction extends XStateDeviceAction<
               target: "Error",
               guard: "hasError",
             },
-            "OpenApplication",
+            { target: "OpenApplication" },
           ],
         },
 
@@ -370,13 +383,14 @@ export class OpenAppDeviceAction extends XStateDeviceAction<
             },
           },
         },
+
         OpenApplicationResultCheck: {
           always: [
             {
               target: "Error",
               guard: "hasError",
             },
-            "ApplicationReady",
+            { target: "ApplicationAvailable" },
           ],
         },
 
@@ -417,6 +431,8 @@ export class OpenAppDeviceAction extends XStateDeviceAction<
       closeApp,
       openApp,
       getDeviceSessionState: () => internalApi.getDeviceSessionState(),
+      setDeviceSessionState: (state: DeviceSessionState) =>
+        internalApi.setDeviceSessionState(state),
       isDeviceOnboarded: () => true, // TODO: we don't have this info for now, this can be derived from the "flags" obtained in the getVersion command
     };
   }

--- a/packages/core/src/api/device-session/DeviceSessionState.ts
+++ b/packages/core/src/api/device-session/DeviceSessionState.ts
@@ -1,3 +1,4 @@
+import { GetAppAndVersionResponse } from "@api/command/os/GetAppAndVersionCommand";
 import { BatteryStatusFlags } from "@api/command/os/GetBatteryStatusCommand";
 import { DeviceStatus } from "@api/device/DeviceStatus";
 import { Application } from "@internal/manager-api/model/ManagerApiType";
@@ -32,6 +33,11 @@ export type FirmwareVersion = {
    */
   readonly os: string;
 };
+
+/**
+ * The current application running on a device. Alias of GetAppAndVersionResponse.
+ */
+export type RunningApp = GetAppAndVersionResponse;
 
 /**
  * The state types of a device session.
@@ -72,7 +78,7 @@ type DeviceSessionReadyState = {
   /**
    * The current application running on the device.
    */
-  readonly currentApp: string;
+  readonly currentApp: RunningApp;
 
   /**
    * The current applications installed on the device.

--- a/packages/core/src/internal/device-session/model/DeviceSessionRefresher.ts
+++ b/packages/core/src/internal/device-session/model/DeviceSessionRefresher.ts
@@ -107,7 +107,7 @@ export class DeviceSessionRefresher {
           ...state,
           sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
           deviceStatus: this._deviceStatus,
-          currentApp: parsedResponse.data.name,
+          currentApp: parsedResponse.data,
           installedApps: "installedApps" in state ? state.installedApps : [],
         }));
       });

--- a/packages/signer/keyring-eth/src/internal/app-binder/task/BuildEIP712ContextTask.test.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/task/BuildEIP712ContextTask.test.ts
@@ -140,7 +140,7 @@ describe("BuildEIP712ContextTask", () => {
       sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
       deviceStatus: DeviceStatus.CONNECTED,
       installedApps: [],
-      currentApp: "Bitcoin",
+      currentApp: { name: "Bitcoin", version: "1.0" },
     });
     // WHEN
     const builtContext = await task.run();
@@ -172,7 +172,7 @@ describe("BuildEIP712ContextTask", () => {
       sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
       deviceStatus: DeviceStatus.CONNECTED,
       installedApps: [],
-      currentApp: "Ethereum",
+      currentApp: { name: "Ethereum", version: "1.0" },
     });
     contextMouleMock.getTypedDataFilters.mockResolvedValueOnce({
       type: "error",
@@ -208,7 +208,7 @@ describe("BuildEIP712ContextTask", () => {
       sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
       deviceStatus: DeviceStatus.CONNECTED,
       installedApps: [],
-      currentApp: "Ethereum",
+      currentApp: { name: "Ethereum", version: "1.0" },
     });
     contextMouleMock.getTypedDataFilters.mockResolvedValueOnce(
       TEST_CLEAR_SIGN_CONTEXT,

--- a/packages/signer/keyring-eth/src/internal/app-binder/task/BuildEIP712ContextTask.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/task/BuildEIP712ContextTask.ts
@@ -71,7 +71,7 @@ export class BuildEIP712ContextTask {
     if (deviceState.sessionStateType === DeviceSessionStateType.Connected) {
       return Nothing;
     }
-    if (deviceState.currentApp !== "Ethereum") {
+    if (deviceState.currentApp.name !== "Ethereum") {
       return Nothing;
     }
     // TODO add currentAppVersion to session state


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- Update `currentApp` in session state after opening application successfully.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [DSDK-487](https://ledgerhq.atlassian.net/browse/DSDK-487)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Session state will be updated voluntarily when `OpenAppDeviceAction` succeeds. 
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [x] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[DSDK-487]: https://ledgerhq.atlassian.net/browse/DSDK-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ