### PR TITLE
♻️ (core) [DSDK-503]: Improve WebHID reconnection logic & internal logic

### DIFF
--- a/.changeset/twelve-nails-allow.md
+++ b/.changeset/twelve-nails-allow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+WebHid: Rework reconnection logic & fix sendApdu to wait in case of disconnection

--- a/packages/core/src/internal/usb/data/UsbHidConfig.ts
+++ b/packages/core/src/internal/usb/data/UsbHidConfig.ts
@@ -1,4 +1,4 @@
 // [SHOULD] Move it to device-model module
 export const LEDGER_VENDOR_ID = 0x2c97;
 export const FRAME_SIZE = 64;
-export const RECONNECT_DEVICE_TIMEOUT = 2000;
+export const RECONNECT_DEVICE_TIMEOUT = 6000; // in some cases, when opening/closing an app, it takes up to 6s between the HID "disconnect" and "connect" events

--- a/packages/core/src/internal/usb/model/Errors.ts
+++ b/packages/core/src/internal/usb/model/Errors.ts
@@ -73,3 +73,10 @@ export class ReconnectionFailedError extends GeneralSdkError {
     super(err);
   }
 }
+
+export class HidSendReportError extends GeneralSdkError {
+  override readonly _tag = "HidSendReportError";
+  constructor(readonly err?: unknown) {
+    super(err);
+  }
+}

--- a/packages/core/src/internal/usb/model/HidDevice.stub.ts
+++ b/packages/core/src/internal/usb/model/HidDevice.stub.ts
@@ -1,4 +1,5 @@
 const oninputreport = jest.fn().mockResolvedValue(void 0);
+
 export const hidDeviceStubBuilder = (
   props: Partial<HIDDevice> = {},
 ): HIDDevice => ({
@@ -7,9 +8,9 @@ export const hidDeviceStubBuilder = (
   vendorId: 0x2c97,
   productName: "Ledger Nano X",
   collections: [],
-  open: jest.fn(),
+  open: jest.fn().mockResolvedValue(undefined),
   oninputreport,
-  close: jest.fn(),
+  close: jest.fn().mockResolvedValue(undefined),
   sendReport: jest.fn().mockResolvedValue(oninputreport()),
   sendFeatureReport: jest.fn(),
   forget: jest.fn(),

--- a/packages/core/src/internal/usb/service/UsbHidDeviceConnectionFactory.ts
+++ b/packages/core/src/internal/usb/service/UsbHidDeviceConnectionFactory.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from "inversify";
 import { Maybe } from "purify-ts";
 
+import { DeviceId } from "@api/types";
 import { CHANNEL_LENGTH } from "@internal/device-session/data/FramerConst";
 import { deviceSessionTypes } from "@internal/device-session/di/deviceSessionTypes";
 import { ApduReceiverService } from "@internal/device-session/service/ApduReceiverService";
@@ -32,6 +33,7 @@ export class UsbHidDeviceConnectionFactory {
 
   public create(
     device: HIDDevice,
+    params: { onConnectionTerminated: () => void; deviceId: DeviceId },
     channel = Maybe.of(
       FramerUtils.numberToByteArray(this.randomChannel, CHANNEL_LENGTH),
     ),
@@ -39,12 +41,14 @@ export class UsbHidDeviceConnectionFactory {
     return new UsbHidDeviceConnection(
       {
         device,
+        deviceId: params.deviceId,
         apduSender: this.apduSenderFactory({
           frameSize: FRAME_SIZE,
           channel,
           padding: true,
         }),
         apduReceiver: this.apduReceiverFactory({ channel }),
+        onConnectionTerminated: params.onConnectionTerminated,
       },
       this.loggerFactory,
     );

--- a/packages/core/src/internal/usb/transport/UsbHidDeviceConnection.test.ts
+++ b/packages/core/src/internal/usb/transport/UsbHidDeviceConnection.test.ts
@@ -1,12 +1,14 @@
 import { Left, Right } from "purify-ts";
 
+import { DeviceId } from "@api/types";
 import { ApduReceiverService } from "@internal/device-session/service/ApduReceiverService";
 import { ApduSenderService } from "@internal/device-session/service/ApduSenderService";
 import { defaultApduReceiverServiceStubBuilder } from "@internal/device-session/service/DefaultApduReceiverService.stub";
 import { defaultApduSenderServiceStubBuilder } from "@internal/device-session/service/DefaultApduSenderService.stub";
 import { DefaultLoggerPublisherService } from "@internal/logger-publisher/service/DefaultLoggerPublisherService";
+import { RECONNECT_DEVICE_TIMEOUT } from "@internal/usb/data/UsbHidConfig";
 import { ReconnectionFailedError } from "@internal/usb/model/Errors";
-import { hidDeviceStubBuilder } from "@internal/usb/model/HIDDevice.stub";
+import { hidDeviceStubBuilder } from "@internal/usb/model/HidDevice.stub";
 import { UsbHidDeviceConnection } from "@internal/usb/transport/UsbHidDeviceConnection";
 
 jest.useFakeTimers();
@@ -31,16 +33,21 @@ const RESPONSE_SUCCESS = new Uint8Array([
  * Flushes all pending promises
  */
 const flushPromises = () =>
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   new Promise(jest.requireActual("timers").setImmediate);
+
+jest.useFakeTimers();
 
 describe("UsbHidDeviceConnection", () => {
   let device: HIDDevice;
   let apduSender: ApduSenderService;
   let apduReceiver: ApduReceiverService;
+  const onConnectionTerminated = () => {};
+  const deviceId: DeviceId = "test-device-id";
   const logger = (tag: string) => new DefaultLoggerPublisherService([], tag);
 
   beforeEach(() => {
-    device = hidDeviceStubBuilder();
+    device = hidDeviceStubBuilder({ opened: true });
     apduSender = defaultApduSenderServiceStubBuilder(undefined, logger);
     apduReceiver = defaultApduReceiverServiceStubBuilder(undefined, logger);
   });
@@ -48,7 +55,7 @@ describe("UsbHidDeviceConnection", () => {
   it("should get device", () => {
     // given
     const connection = new UsbHidDeviceConnection(
-      { device, apduSender, apduReceiver },
+      { device, apduSender, apduReceiver, onConnectionTerminated, deviceId },
       logger,
     );
     // when
@@ -60,7 +67,7 @@ describe("UsbHidDeviceConnection", () => {
   it("should send APDU through hid report", () => {
     // given
     const connection = new UsbHidDeviceConnection(
-      { device, apduSender, apduReceiver },
+      { device, apduSender, apduReceiver, onConnectionTerminated, deviceId },
       logger,
     );
     // when
@@ -80,7 +87,7 @@ describe("UsbHidDeviceConnection", () => {
       ),
     );
     const connection = new UsbHidDeviceConnection(
-      { device, apduSender, apduReceiver },
+      { device, apduSender, apduReceiver, onConnectionTerminated, deviceId },
       logger,
     );
     // when
@@ -94,98 +101,176 @@ describe("UsbHidDeviceConnection", () => {
     );
   });
 
-  test("sendApdu(whatever, true) should wait for reconnection before resolving if the response is a success", async () => {
-    // given
-    device.sendReport = jest.fn(() =>
-      Promise.resolve(
-        device.oninputreport!({
-          type: "inputreport",
-          data: new DataView(Uint8Array.from(RESPONSE_SUCCESS).buffer),
-        } as HIDInputReportEvent),
-      ),
-    );
-    const connection = new UsbHidDeviceConnection(
-      { device, apduSender, apduReceiver },
-      logger,
-    );
+  describe("anticipating loss of connection after sending an APDU", () => {
+    test("sendApdu(whatever, true) should wait for reconnection before resolving if the response is a success", async () => {
+      // given
+      device.sendReport = jest.fn(() =>
+        Promise.resolve(
+          device.oninputreport!({
+            type: "inputreport",
+            data: new DataView(Uint8Array.from(RESPONSE_SUCCESS).buffer),
+          } as HIDInputReportEvent),
+        ),
+      );
+      const connection = new UsbHidDeviceConnection(
+        { device, apduSender, apduReceiver, onConnectionTerminated, deviceId },
+        logger,
+      );
 
-    let hasResolved = false;
-    const responsePromise = connection
-      .sendApdu(Uint8Array.from([]), true)
-      .then((response) => {
-        hasResolved = true;
-        return response;
-      });
+      let hasResolved = false;
+      const responsePromise = connection
+        .sendApdu(Uint8Array.from([]), true)
+        .then((response) => {
+          hasResolved = true;
+          return response;
+        });
 
-    // before reconnecting
-    await flushPromises();
-    expect(hasResolved).toBe(false);
+      connection.lostConnection();
 
-    // when reconnecting
-    connection.device = device;
-    await flushPromises();
-    expect(hasResolved).toBe(true);
+      // before reconnecting
+      await flushPromises();
+      expect(hasResolved).toBe(false);
 
-    const response = await responsePromise;
+      // when reconnecting
+      connection.reconnectHidDevice(device);
+      await flushPromises();
+      expect(hasResolved).toBe(true);
 
-    expect(response).toEqual(
-      Right({
-        statusCode: new Uint8Array([0x90, 0x00]),
-        data: new Uint8Array([]),
-      }),
-    );
+      const response = await responsePromise;
+
+      expect(response).toEqual(
+        Right({
+          statusCode: new Uint8Array([0x90, 0x00]),
+          data: new Uint8Array([]),
+        }),
+      );
+    });
+
+    test("sendApdu(whatever, true) should not wait for reconnection if the response is not a success", async () => {
+      // given
+      device.sendReport = jest.fn(() =>
+        Promise.resolve(
+          device.oninputreport!({
+            type: "inputreport",
+            data: new DataView(Uint8Array.from(RESPONSE_LOCKED_DEVICE).buffer),
+          } as HIDInputReportEvent),
+        ),
+      );
+      const connection = new UsbHidDeviceConnection(
+        { device, apduSender, apduReceiver, onConnectionTerminated, deviceId },
+        logger,
+      );
+
+      // when
+      const response = await connection.sendApdu(Uint8Array.from([]), true);
+
+      // then
+      expect(response).toEqual(
+        Right({
+          statusCode: new Uint8Array([0x55, 0x15]),
+          data: new Uint8Array([]),
+        }),
+      );
+    });
+
+    test("sendApdu(whatever, true) should return an error if the device gets disconnected while waiting for reconnection", async () => {
+      // given
+      device.sendReport = jest.fn(() =>
+        Promise.resolve(
+          device.oninputreport!({
+            type: "inputreport",
+            data: new DataView(Uint8Array.from(RESPONSE_SUCCESS).buffer),
+          } as HIDInputReportEvent),
+        ),
+      );
+      const connection = new UsbHidDeviceConnection(
+        { device, apduSender, apduReceiver, onConnectionTerminated, deviceId },
+        logger,
+      );
+
+      const responsePromise = connection.sendApdu(Uint8Array.from([]), true);
+
+      // when disconnecting
+      connection.lostConnection();
+      jest.advanceTimersByTime(RECONNECT_DEVICE_TIMEOUT);
+      await flushPromises();
+
+      // then
+      const response = await responsePromise;
+      expect(response).toEqual(Left(new ReconnectionFailedError()));
+    });
   });
 
-  test("sendApdu(whatever, true) should not wait for reconnection if the response is not a success", async () => {
-    // given
-    device.sendReport = jest.fn(() =>
-      Promise.resolve(
-        device.oninputreport!({
-          type: "inputreport",
-          data: new DataView(Uint8Array.from(RESPONSE_LOCKED_DEVICE).buffer),
-        } as HIDInputReportEvent),
-      ),
-    );
-    const connection = new UsbHidDeviceConnection(
-      { device, apduSender, apduReceiver },
-      logger,
-    );
+  describe("connection lost before sending an APDU", () => {
+    test("sendApdu(whatever, false) should return an error if the device connection has been lost and times out", async () => {
+      // given
+      device.sendReport = jest.fn(() =>
+        Promise.resolve(
+          device.oninputreport!({
+            type: "inputreport",
+            data: new DataView(Uint8Array.from(RESPONSE_SUCCESS).buffer),
+          } as HIDInputReportEvent),
+        ),
+      );
+      const connection = new UsbHidDeviceConnection(
+        { device, apduSender, apduReceiver, onConnectionTerminated, deviceId },
+        logger,
+      );
 
-    // when
-    const response = await connection.sendApdu(Uint8Array.from([]), true);
+      // when losing connection
+      connection.lostConnection();
+      jest.advanceTimersByTime(RECONNECT_DEVICE_TIMEOUT);
+      await flushPromises();
 
-    // then
-    expect(response).toEqual(
-      Right({
-        statusCode: new Uint8Array([0x55, 0x15]),
-        data: new Uint8Array([]),
-      }),
-    );
-  });
+      // then
+      const response = await connection.sendApdu(Uint8Array.from([]), false);
+      await flushPromises();
+      expect(response).toEqual(Left(new ReconnectionFailedError()));
+    });
 
-  test("sendApdu(whatever, true) should return an error if the device gets disconnected while waiting for reconnection", async () => {
-    // given
-    device.sendReport = jest.fn(() =>
-      Promise.resolve(
-        device.oninputreport!({
-          type: "inputreport",
-          data: new DataView(Uint8Array.from(RESPONSE_SUCCESS).buffer),
-        } as HIDInputReportEvent),
-      ),
-    );
-    const connection = new UsbHidDeviceConnection(
-      { device, apduSender, apduReceiver },
-      logger,
-    );
+    test("sendApdu(whatever, false) should wait for reconnection to resolve", async () => {
+      // given
+      device.sendReport = jest.fn(() =>
+        Promise.resolve(
+          device.oninputreport!({
+            type: "inputreport",
+            data: new DataView(Uint8Array.from(RESPONSE_SUCCESS).buffer),
+          } as HIDInputReportEvent),
+        ),
+      );
+      const connection = new UsbHidDeviceConnection(
+        { device, apduSender, apduReceiver, onConnectionTerminated, deviceId },
+        logger,
+      );
 
-    const responsePromise = connection.sendApdu(Uint8Array.from([]), true);
+      // when losing connection
+      connection.lostConnection();
 
-    // when disconnecting
-    connection.disconnect();
-    await flushPromises();
+      let hasResolved = false;
+      const responsePromise = connection
+        .sendApdu(Uint8Array.from([]), false)
+        .then((response) => {
+          hasResolved = true;
+          return response;
+        });
 
-    // then
-    const response = await responsePromise;
-    expect(response).toEqual(Left(new ReconnectionFailedError()));
+      // before reconnecting
+      await flushPromises();
+      expect(hasResolved).toBe(false);
+
+      // when reconnecting
+      connection.reconnectHidDevice(device);
+      await flushPromises();
+      expect(hasResolved).toBe(true);
+
+      const response = await responsePromise;
+
+      expect(response).toEqual(
+        Right({
+          statusCode: new Uint8Array([0x90, 0x00]),
+          data: new Uint8Array([]),
+        }),
+      );
+    });
   });
 });

--- a/packages/core/src/internal/usb/transport/UsbHidDeviceConnection.ts
+++ b/packages/core/src/internal/usb/transport/UsbHidDeviceConnection.ts
@@ -1,59 +1,82 @@
 import { inject } from "inversify";
-import { Either, Left, Maybe, Right } from "purify-ts";
+import { Either, Left, Right } from "purify-ts";
 import { Subject } from "rxjs";
 
 import { CommandUtils } from "@api/command/utils/CommandUtils";
 import { ApduResponse } from "@api/device-session/ApduResponse";
 import { SdkError } from "@api/Error";
+import { DeviceId } from "@api/types";
 import { ApduReceiverService } from "@internal/device-session/service/ApduReceiverService";
 import { ApduSenderService } from "@internal/device-session/service/ApduSenderService";
 import { loggerTypes } from "@internal/logger-publisher/di/loggerTypes";
 import type { LoggerPublisherService } from "@internal/logger-publisher/service/LoggerPublisherService";
-import { ReconnectionFailedError } from "@internal/usb/model/Errors";
+import { RECONNECT_DEVICE_TIMEOUT } from "@internal/usb/data/UsbHidConfig";
+import {
+  HidSendReportError,
+  ReconnectionFailedError,
+} from "@internal/usb/model/Errors";
 
 import { DeviceConnection } from "./DeviceConnection";
 
 type UsbHidDeviceConnectionConstructorArgs = {
   device: HIDDevice;
+  deviceId: DeviceId;
   apduSender: ApduSenderService;
   apduReceiver: ApduReceiverService;
+  onConnectionTerminated: () => void;
 };
 
+/**
+ * Class to manage the connection with a USB HID device.
+ * It sends APDU commands to the device and receives the responses.
+ * It handles temporary disconnections and reconnections.
+ */
 export class UsbHidDeviceConnection implements DeviceConnection {
   private _device: HIDDevice;
+  private _deviceId: DeviceId;
   private readonly _apduSender: ApduSenderService;
   private readonly _apduReceiver: ApduReceiverService;
-  private _sendApduSubject: Subject<ApduResponse>;
+  private _sendApduSubject: Subject<ApduResponse> = new Subject();
   private readonly _logger: LoggerPublisherService;
-  private _settleReconnectionPromise: Maybe<{
-    resolve(): void;
-    reject(err: SdkError): void;
-  }> = Maybe.zero();
+
+  /** Callback to notify the connection termination */
+  private _onConnectionTerminated: () => void;
+  /** Subject to notify the reconnection status */
+  private reconnectionSubject: Subject<"success" | SdkError> = new Subject();
+  /** Flag to indicate if the connection is waiting for a reconnection */
+  private waitingForReconnection = false;
+  /** Timeout to wait for the device to reconnect */
+  private lostConnectionTimeout: NodeJS.Timeout | null = null;
+  /** Flag to indicate if the connection is terminated */
+  private terminated = false;
 
   constructor(
-    { device, apduSender, apduReceiver }: UsbHidDeviceConnectionConstructorArgs,
+    {
+      device,
+      deviceId,
+      apduSender,
+      apduReceiver,
+      onConnectionTerminated,
+    }: UsbHidDeviceConnectionConstructorArgs,
     @inject(loggerTypes.LoggerPublisherServiceFactory)
     loggerServiceFactory: (tag: string) => LoggerPublisherService,
   ) {
     this._apduSender = apduSender;
     this._apduReceiver = apduReceiver;
-    this._sendApduSubject = new Subject();
+    this._onConnectionTerminated = onConnectionTerminated;
     this._logger = loggerServiceFactory("UsbHidDeviceConnection");
     this._device = device;
     this._device.oninputreport = (event) => this.receiveHidInputReport(event);
+    this._deviceId = deviceId;
+    this._logger.info("🔌 Connected to device");
   }
 
   public get device() {
     return this._device;
   }
 
-  public set device(device: HIDDevice) {
-    this._device = device;
-    this._device.oninputreport = (event) => this.receiveHidInputReport(event);
-
-    this._settleReconnectionPromise.ifJust(() => {
-      this.reconnected();
-    });
+  public get deviceId() {
+    return this._deviceId;
   }
 
   async sendApdu(
@@ -72,7 +95,8 @@ export class UsbHidDeviceConnection implements DeviceConnection {
         this._sendApduSubject.subscribe({
           next: async (r) => {
             if (triggersDisconnection && CommandUtils.isSuccessResponse(r)) {
-              const reconnectionRes = await this.setupWaitForReconnection();
+              // Anticipate the disconnection and wait for the reconnection before resolving
+              const reconnectionRes = await this.waitForReconnection();
               reconnectionRes.caseOf({
                 Left: (err) => resolve(Left(err)),
                 Right: () => resolve(Right(r)),
@@ -88,6 +112,13 @@ export class UsbHidDeviceConnection implements DeviceConnection {
       },
     );
 
+    if (this.waitingForReconnection || !this.device.opened) {
+      const reconnectionRes = await this.waitForReconnection();
+      if (reconnectionRes.isLeft()) {
+        return reconnectionRes;
+      }
+    }
+
     const frames = this._apduSender.getFrames(apdu);
     for (const frame of frames) {
       this._logger.debug("Sending Frame", {
@@ -97,6 +128,7 @@ export class UsbHidDeviceConnection implements DeviceConnection {
         await this._device.sendReport(0, frame.getRawData());
       } catch (error) {
         this._logger.error("Error sending frame", { data: { error } });
+        return Promise.resolve(Left(new HidSendReportError(error)));
       }
     }
 
@@ -126,26 +158,55 @@ export class UsbHidDeviceConnection implements DeviceConnection {
     });
   }
 
-  private setupWaitForReconnection(): Promise<Either<SdkError, void>> {
+  private waitForReconnection(): Promise<Either<SdkError, void>> {
+    if (this.terminated)
+      return Promise.resolve(Left(new ReconnectionFailedError()));
     return new Promise<Either<SdkError, void>>((resolve) => {
-      this._settleReconnectionPromise = Maybe.of({
-        resolve: () => resolve(Right(undefined)),
-        reject: (error: SdkError) => resolve(Left(error)),
+      const sub = this.reconnectionSubject.subscribe({
+        next: (res) => {
+          if (res === "success") {
+            resolve(Right(undefined));
+          } else {
+            resolve(Left(res));
+          }
+          sub.unsubscribe();
+        },
       });
     });
   }
 
-  private reconnected() {
-    this._settleReconnectionPromise.ifJust((promise) => {
-      promise.resolve();
-      this._settleReconnectionPromise = Maybe.zero();
-    });
+  /**
+   * Method called when the HIDDevice gets disconnected.
+   * It starts a timeout to wait for the device to reconnect.
+   * */
+  public lostConnection() {
+    this._logger.info("⏱️ Lost connection, starting timer");
+    this.waitingForReconnection = true;
+    this.lostConnectionTimeout = setTimeout(() => {
+      this._logger.info("❌ Disconnection timeout, terminating connection");
+      this.disconnect();
+    }, RECONNECT_DEVICE_TIMEOUT);
+  }
+
+  /** Reconnect the device after a disconnection */
+  public async reconnectHidDevice(device: HIDDevice) {
+    this._device = device;
+    this._device.oninputreport = (event) => this.receiveHidInputReport(event);
+
+    if (this.lostConnectionTimeout) {
+      this._logger.info("⏱️🔌 Device reconnected");
+      clearTimeout(this.lostConnectionTimeout);
+    }
+    await device.open();
+    this.waitingForReconnection = false;
+    this.reconnectionSubject.next("success");
   }
 
   public disconnect() {
-    this._settleReconnectionPromise.ifJust((promise) => {
-      promise.reject(new ReconnectionFailedError());
-      this._settleReconnectionPromise = Maybe.zero();
-    });
+    this._logger.info("🔚 Disconnect");
+    if (this.lostConnectionTimeout) clearTimeout(this.lostConnectionTimeout);
+    this.terminated = true;
+    this._onConnectionTerminated();
+    this.reconnectionSubject.next(new ReconnectionFailedError());
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

#### Overall improvements:
- `sendApdu`: it will now wait for a reconnection (or timeout) in case the connection has been lost, before trying to call `sendReport` on the `HIDDevice`.
- Multi device support: the previous implementation was not able to handle multiple devices of the same model as we can't get a unique identifier from a device.
  - Previously, successively connecting 2 devices of the same model would break the 1st of the 2 sessions, it's not the case anymore.
- Reconnection logic: it is now more robust.
- Overall I hope that the code is now easier to read and maintain.

#### Explanation of the changes:
Rework `WebUsbHidTransport` internal logic & reconnection logic:
- Stop relying on our own generated `deviceId` for internal mapping of discovered/connected devices, rely on the identity of `HIDDevice` instead:
   - we only have a `Map<DeviceId,WebHidInternalDevice>` (each `WebHidInternalDevice` contains a `InternalDiscoveredDevice` `HIDDevice`) to handle `DeviceId` (which is needed by `connect` `disconnect`) .
   - A `UsbHidDeviceConnection` can be stored in ONE of two places:
  ```ts
    /** Maps all *connected* HIDDevice to their UsbHidDeviceConnection */
  private _deviceConnectionsByHidDevice: Map<
    HIDDevice,
    UsbHidDeviceConnection
  > = new Map();
  /** Set of all the UsbHidDeviceConnection for which HIDDevice has been disconnected, so they are waiting for a reconnection */
  private _deviceConnectionsPendingReconnection: Set<UsbHidDeviceConnection> =
    new Set();
  ```
-  there are mainly 3 scenarios for connection/disconnection:
   - initiating a connection `connect({deviceId})`:
     - we create the `UsbHidDeviceConnection` and store it in  `_deviceConnectionsByHidDevice`
       - this is possible because `HIDDevice` identity is stable as long as the `HIDDevice` is connected, the navigator.hid API will not return a new `HIDDevice` for the same physical device.
   - disconnecting `disconnect({deviceId})`:
     - we find the internal device, which gives us the `HIDDevice`, and we find the associated `UsbHidDeviceConnection` in `_deviceConnectionsByHidDevice`.
   - detection of a disconnection of an `HIDDevice` (can be due to unplugging the device OR app switching):
     - we remove the `HIDDevice` from `_deviceConnectionsByHidDevice` and push the associated `UsbHidDeviceConnection` to `_deviceConnectionsPendingReconnection`.
     - the `UsbHidDeviceConnection` is notified about the disconnection (`.lostConnection()`) and internally starts a timer.
     - IF the timer runs out, the connection is terminated and the `UsbHidDeviceConnection` is removed from `_deviceConnectionsPendingReconnection` and everything is cleaned up
     - ELSE IF a similar device model gets connected, we kill the timer and move back the `UsbHidDeviceConnection` in `_deviceConnectionsByHidDevice`.
- Disconnection handlers & timers have been moved from `WebHidTransport` to `UsbHidDeviceConnection` because they are connection-specific
  - easier to read & maintain.
- `UsbHidDeviceConnection.sendApdu()` will now wait for a reconnection (or timeout) before calling `HIDDevice.sendReport()` in case the connection has been lost. This fix is needed for the integration of the LDMK into Ledger Live Desktop, to properly handle firmware update flows.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [DSDK-503] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - device reconnection to test in the sample app:
      - connection doesn't get lost when opening/closing apps, for instance test the open app device action from one app to another.
      - actual disconnection of a device is handled properly (disconnection after 2s timeout)
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[DSDK-503]: https://ledgerhq.atlassian.net/browse/DSDK-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ