### PR TITLE
:bug: (keyring-eth) [NO-ISSUE]: Early return when EIP712 Domain fails to be sent

### DIFF
--- a/.changeset/twelve-stingrays-shake.md
+++ b/.changeset/twelve-stingrays-shake.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": patch
+---
+
+Early return when EIP712 Domain fails to be sent

--- a/packages/core/src/internal/config/data/LocalConfigDataSource.test.ts
+++ b/packages/core/src/internal/config/data/LocalConfigDataSource.test.ts
@@ -1,6 +1,7 @@
 import { Either, Left } from "purify-ts";
 
 import { JSONParseError, ReadFileError } from "@internal/config/model/Errors";
+import pkg from "@root/package.json";
 
 import { LocalConfigDataSource } from "./ConfigDataSource";
 import * as LocalConfig from "./LocalConfigDataSource";
@@ -70,7 +71,7 @@ describe("LocalConfigDataSource", () => {
       expect(LocalConfig.stubFsReadFile()).toEqual(
         JSON.stringify({
           name: "@ledgerhq/device-management-kit",
-          version: "0.3.0",
+          version: pkg.version,
         }),
       );
     });

--- a/packages/signer/keyring-eth/src/internal/app-binder/task/ProvideEIP712ContextTask.test.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/task/ProvideEIP712ContextTask.test.ts
@@ -556,4 +556,43 @@ describe("ProvideEIP712ContextTask", () => {
       CommandResultFactory({ error: new UnknownDeviceExchangeError("error") }),
     );
   });
+
+  it("Error when sending struct implementations", async () => {
+    // GIVEN
+    const args: ProvideEIP712ContextTaskArgs = {
+      types: TEST_TYPES,
+      domain: TEST_DOMAIN_VALUES,
+      message: TEST_MESSAGE_VALUES,
+      clearSignContext: Nothing,
+    };
+    // WHEN
+    apiMock.sendCommand
+      // Struct definitions
+      .mockResolvedValueOnce(CommandResultFactory({ data: undefined }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: undefined }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: undefined }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: undefined }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: undefined }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: undefined }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: undefined }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: undefined }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: undefined }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: undefined }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: undefined }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: undefined }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: undefined }))
+      // Struct implementations
+      .mockResolvedValueOnce(
+        CommandResultFactory({
+          error: new UnknownDeviceExchangeError("error"),
+        }),
+      )
+      .mockResolvedValue(CommandResultFactory({ data: undefined }));
+    const promise = new ProvideEIP712ContextTask(apiMock, args).run();
+
+    // THEN
+    await expect(promise).resolves.toStrictEqual(
+      CommandResultFactory({ error: new UnknownDeviceExchangeError("error") }),
+    );
+  });
 });

--- a/packages/signer/keyring-eth/src/internal/app-binder/task/ProvideEIP712ContextTask.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/task/ProvideEIP712ContextTask.ts
@@ -93,7 +93,10 @@ export class ProvideEIP712ContextTask {
 
     // Send domain implementation values.
     for (const value of this.args.domain) {
-      await this.getImplementationTask(value).run();
+      result = await this.getImplementationTask(value).run();
+      if (!isSuccessCommandResult(result)) {
+        return result;
+      }
     }
 
     if (this.args.clearSignContext.isJust()) {


### PR DESCRIPTION
### 📝 Description

When providing EIP712 domain implementations, we should early return whenever an APDU returns an error, because it invalidates the whole flow on device side.

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**:

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
