### PR TITLE
✨ (core) [DSDK-504]: Listen to known devices (WebHID for now) & display them in sample app

### DIFF
--- a/.changeset/twelve-snakes-agree.md
+++ b/.changeset/twelve-snakes-agree.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/device-management-kit": patch
+"@ledgerhq/device-sdk-sample": patch
+---
+
+New use case listenToKnownDevices

--- a/apps/sample/package.json
+++ b/apps/sample/package.json
@@ -28,6 +28,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-lottie": "^1.2.4",
+    "rxjs": "^7.8.1",
     "styled-components": "^5.3.11"
   },
   "devDependencies": {

--- a/apps/sample/src/components/AvailableDevices/index.tsx
+++ b/apps/sample/src/components/AvailableDevices/index.tsx
@@ -1,0 +1,94 @@
+import React, { useCallback, useState } from "react";
+import { DiscoveredDevice } from "@ledgerhq/device-management-kit";
+import { Flex, Icons, Text } from "@ledgerhq/react-ui";
+import styled from "styled-components";
+
+import { AvailableDevice } from "@/components/Device";
+import { useAvailableDevices } from "@/hooks/useAvailableDevices";
+import { useSdk } from "@/providers/DeviceSdkProvider";
+import { useDeviceSessionsContext } from "@/providers/DeviceSessionsProvider";
+
+const Title = styled(Text)<{ disabled: boolean }>`
+  :hover {
+    user-select: none;
+    text-decoration: ${(p) => (p.disabled ? "none" : "underline")};
+    cursor: ${(p) => (p.disabled ? "default" : "pointer")};
+  }
+`;
+
+export const AvailableDevices: React.FC<Record<never, unknown>> = () => {
+  const discoveredDevices = useAvailableDevices();
+  const noDevice = discoveredDevices.length === 0;
+
+  const [unfolded, setUnfolded] = useState(false);
+
+  const toggleUnfolded = useCallback(() => {
+    setUnfolded((prev) => !prev);
+  }, []);
+
+  return (
+    <>
+      <Flex
+        flexDirection="row"
+        onClick={noDevice ? undefined : toggleUnfolded}
+        alignItems="center"
+        mt={1}
+      >
+        <Title variant="tiny" disabled={noDevice}>
+          Available devices ({discoveredDevices.length})
+        </Title>
+        <Flex style={{ visibility: noDevice ? "hidden" : "visible" }}>
+          {unfolded ? (
+            <Icons.ChevronUp size={"XS"} />
+          ) : (
+            <Icons.ChevronDown size={"XS"} />
+          )}
+        </Flex>
+      </Flex>
+      <Flex
+        flexDirection="column"
+        rowGap={4}
+        alignSelf="stretch"
+        mt={unfolded ? 5 : 0}
+        mb={4}
+      >
+        {unfolded
+          ? discoveredDevices.map((device) => (
+              <KnownDevice key={device.id} {...device} />
+            ))
+          : null}
+      </Flex>
+    </>
+  );
+};
+
+const KnownDevice: React.FC<DiscoveredDevice & { connected: boolean }> = (
+  device,
+) => {
+  const { deviceModel, connected } = device;
+  const sdk = useSdk();
+  const { dispatch } = useDeviceSessionsContext();
+  const connectToDevice = useCallback(() => {
+    sdk.connect({ device }).then((sessionId) => {
+      dispatch({
+        type: "add_session",
+        payload: {
+          sessionId,
+          connectedDevice: sdk.getConnectedDevice({ sessionId }),
+        },
+      });
+    });
+  }, [sdk, device, dispatch]);
+
+  return (
+    <Flex flexDirection="row" alignItems="center">
+      <AvailableDevice
+        name={deviceModel.name}
+        model={deviceModel.model}
+        type={"USB"}
+        connected={connected}
+        onConnect={connectToDevice}
+      />
+    </Flex>
+  );
+};

--- a/apps/sample/src/components/Device/index.tsx
+++ b/apps/sample/src/components/Device/index.tsx
@@ -4,7 +4,14 @@ import {
   DeviceModelId,
   DeviceSessionId,
 } from "@ledgerhq/device-management-kit";
-import { Box, DropdownGeneric, Flex, Icons, Text } from "@ledgerhq/react-ui";
+import {
+  Box,
+  Button,
+  DropdownGeneric,
+  Flex,
+  Icons,
+  Text,
+} from "@ledgerhq/react-ui";
 import styled, { DefaultTheme } from "styled-components";
 
 import { useDeviceSessionState } from "@/hooks/useDeviceSessionState";
@@ -112,6 +119,47 @@ export const Device: React.FC<DeviceProps> = ({
           </ActionRow>
         </DropdownGeneric>
       </div>
+    </Root>
+  );
+};
+
+type AvailableDeviceProps = {
+  model: DeviceModelId;
+  name: string;
+  type: ConnectionType;
+  connected: boolean;
+  onConnect: () => void;
+};
+
+export const AvailableDevice: React.FC<AvailableDeviceProps> = ({
+  model,
+  name,
+  type,
+  onConnect,
+  connected,
+}) => {
+  const IconComponent = getIconComponent(model);
+  return (
+    <Root flex={1} mb={0} m={0}>
+      <IconContainer>
+        <IconComponent size="S" />
+      </IconContainer>
+      <Flex flexDirection="column" flex={1} rowGap={2}>
+        <Text variant="body">{name}</Text>
+        <Flex>
+          <Text variant="paragraph" color="neutral.c80">
+            {type}
+          </Text>
+        </Flex>
+      </Flex>
+      <Button
+        size="small"
+        variant="shade"
+        disabled={connected}
+        onClick={onConnect}
+      >
+        Connect
+      </Button>
     </Root>
   );
 };

--- a/apps/sample/src/components/MainView/ConnectDeviceActions.tsx
+++ b/apps/sample/src/components/MainView/ConnectDeviceActions.tsx
@@ -17,7 +17,6 @@ export const ConnectDeviceActions = ({
   onError,
 }: ConnectDeviceActionsProps) => {
   const {
-    dispatch: dispatchSdkConfig,
     state: { transport },
   } = useSdkConfigContext();
   const { dispatch: dispatchDeviceSession } = useDeviceSessionsContext();
@@ -26,10 +25,6 @@ export const ConnectDeviceActions = ({
   const onSelectDeviceClicked = useCallback(
     (selectedTransport: BuiltinTransports) => {
       onError(null);
-      dispatchSdkConfig({
-        type: "set_transport",
-        payload: { transport: selectedTransport },
-      });
       sdk.startDiscovering({ transport: selectedTransport }).subscribe({
         next: (device) => {
           sdk
@@ -56,8 +51,16 @@ export const ConnectDeviceActions = ({
         },
       });
     },
-    [sdk, transport],
+    [dispatchDeviceSession, onError, sdk],
   );
+
+  // This implementation gives the impression that working with the mock server
+  // is a special case, when in fact it's just a transport like the others
+  // TODO: instead of toggling between mock & regular config, we should
+  // just have a menu to select the active transports (where the active menu)
+  // and this here should be a list of one buttons for each active transport
+  // also we should not have a different appearance when the mock server is enabled
+  // we should just display the list of active transports somewhere in the sidebar, discreetly
 
   return transport === BuiltinTransports.MOCK_SERVER ? (
     <ConnectButton

--- a/apps/sample/src/components/MainView/index.tsx
+++ b/apps/sample/src/components/MainView/index.tsx
@@ -42,7 +42,6 @@ export const MainView: React.FC = () => {
       }
     };
   }, [connectionError]);
-
   return (
     <Root>
       <NanoLogo

--- a/apps/sample/src/components/Sidebar/index.tsx
+++ b/apps/sample/src/components/Sidebar/index.tsx
@@ -5,6 +5,7 @@ import { Box, Flex, IconsLegacy, Link, Text } from "@ledgerhq/react-ui";
 import { useRouter } from "next/navigation";
 import styled, { DefaultTheme } from "styled-components";
 
+import { AvailableDevices } from "@/components/AvailableDevices";
 import { Device } from "@/components/Device";
 import { Menu } from "@/components/Menu";
 import { useExportLogsCallback, useSdk } from "@/providers/DeviceSdkProvider";
@@ -90,11 +91,10 @@ export const Sidebar: React.FC = () => {
         Ledger Device Management Kit
         {transport === BuiltinTransports.MOCK_SERVER && <span> (MOCKED)</span>}
       </Link>
-      <Subtitle variant={"small"}>
-        SDK Version: {version ? version : "Loading..."}
-      </Subtitle>
 
-      <Subtitle variant={"tiny"}>Device</Subtitle>
+      <Subtitle variant={"tiny"}>
+        Device sessions ({Object.values(deviceById).length})
+      </Subtitle>
       <div data-testid="container_devices">
         {Object.entries(deviceById).map(([sessionId, device]) => (
           <Device
@@ -110,6 +110,7 @@ export const Sidebar: React.FC = () => {
           />
         ))}
       </div>
+      <AvailableDevices />
       <MenuContainer active={!!selectedId}>
         <Subtitle variant={"tiny"}>Menu</Subtitle>
         <Menu />
@@ -124,10 +125,9 @@ export const Sidebar: React.FC = () => {
         >
           Share logs
         </Link>
-        <VersionText variant={"body"}>
-          Ledger Device Management Kit version {version}
+        <VersionText variant={"body"} whiteSpace="pre" textAlign="center">
+          Ledger Device Management Kit{"\n"}version {version}
         </VersionText>
-        <VersionText variant={"body"}>App version 0.1</VersionText>
       </BottomContainer>
     </Root>
   );

--- a/apps/sample/src/hooks/useAvailableDevices.tsx
+++ b/apps/sample/src/hooks/useAvailableDevices.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { DiscoveredDevice } from "@ledgerhq/device-management-kit";
+import { Subscription } from "rxjs";
+
+import { useSdk } from "@/providers/DeviceSdkProvider";
+import { useDeviceSessionsContext } from "@/providers/DeviceSessionsProvider";
+
+type AvailableDevice = DiscoveredDevice & { connected: boolean };
+
+export function useAvailableDevices(): AvailableDevice[] {
+  const sdk = useSdk();
+  const [discoveredDevices, setDiscoveredDevices] = useState<
+    DiscoveredDevice[]
+  >([]);
+  const { state: deviceSessionsState } = useDeviceSessionsContext();
+
+  const subscription = useRef<Subscription | null>(null);
+  useEffect(() => {
+    if (!subscription.current) {
+      subscription.current = sdk.listenToKnownDevices().subscribe((devices) => {
+        setDiscoveredDevices(devices);
+      });
+    }
+    return () => {
+      if (subscription.current) {
+        setDiscoveredDevices([]);
+        subscription.current.unsubscribe();
+        subscription.current = null;
+      }
+    };
+  }, [sdk]);
+
+  const result = useMemo(
+    () =>
+      discoveredDevices.map((device) => ({
+        ...device,
+        connected: Object.values(deviceSessionsState.deviceById).some(
+          (connectedDevice) => connectedDevice.id === device.id,
+        ),
+      })),
+    [discoveredDevices, deviceSessionsState],
+  );
+
+  return result;
+}

--- a/apps/sample/src/hooks/useHasChanged.tsx
+++ b/apps/sample/src/hooks/useHasChanged.tsx
@@ -1,0 +1,13 @@
+import { useRef } from "react";
+
+/**
+ * A custom hook that returns whether the value has changed since the last render.
+ * @param value The value to compare against the previous render.
+ * @returns A boolean indicating whether the value has changed since the last render.
+ */
+export function useHasChanged<T>(value: T): boolean {
+  const ref = useRef<T>(value);
+  const hasChanged = ref.current !== value;
+  ref.current = value;
+  return hasChanged;
+}

--- a/apps/sample/src/hooks/usePrevious.ts
+++ b/apps/sample/src/hooks/usePrevious.ts
@@ -1,9 +1,13 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
+/**
+ * A custom hook that returns the previous value of the provided value.
+ * @param value The value to compare against the previous render.
+ * @returns The previous value of the provided value.
+ */
 export function usePrevious<T>(value: T) {
   const ref = useRef<T>();
-  useEffect(() => {
-    ref.current = value; //assign the value of ref to the argument
-  }, [value]); //this code will run when the value of 'value' changes
-  return ref.current; //in the end, return the current ref value.
+  const previousValue = ref.current;
+  ref.current = value;
+  return previousValue;
 }

--- a/apps/sample/src/providers/DeviceSdkProvider/index.tsx
+++ b/apps/sample/src/providers/DeviceSdkProvider/index.tsx
@@ -9,62 +9,90 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { FlipperSdkLogger } from "@ledgerhq/device-management-kit-flipper-plugin-client";
 
-import { usePrevious } from "@/hooks/usePrevious";
+import { useHasChanged } from "@/hooks/useHasChanged";
 import { useSdkConfigContext } from "@/providers/SdkConfig";
 
-const webLogsExporterLogger = new WebLogsExporterLogger();
+const SdkContext = createContext<DeviceSdk | null>(null);
+const LogsExporterContext = createContext<WebLogsExporterLogger | null>(null);
 
-const defaultSdk = new DeviceSdkBuilder()
-  .addLogger(new ConsoleLogger())
-  .addTransport(BuiltinTransports.BLE)
-  .addTransport(BuiltinTransports.USB)
-  .addLogger(webLogsExporterLogger)
-  .addLogger(new FlipperSdkLogger())
-  .build();
+function buildDefaultSdk(logsExporter: WebLogsExporterLogger) {
+  return new DeviceSdkBuilder()
+    .addTransport(BuiltinTransports.USB)
+    .addTransport(BuiltinTransports.BLE)
+    .addLogger(new ConsoleLogger())
+    .addLogger(logsExporter)
+    .addLogger(new FlipperSdkLogger())
+    .build();
+}
 
-const SdkContext = createContext<DeviceSdk>(defaultSdk);
+function buildMockSdk(url: string, logsExporter: WebLogsExporterLogger) {
+  return new DeviceSdkBuilder()
+    .addTransport(BuiltinTransports.MOCK_SERVER)
+    .addLogger(new ConsoleLogger())
+    .addLogger(logsExporter)
+    .addLogger(new FlipperSdkLogger())
+    .addConfig({ mockUrl: url })
+    .build();
+}
 
 export const SdkProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const {
     state: { transport, mockServerUrl },
   } = useSdkConfigContext();
-  const previousTransport = usePrevious(transport);
-  const [sdk, setSdk] = useState<DeviceSdk>(defaultSdk);
-  useEffect(() => {
-    if (transport === BuiltinTransports.MOCK_SERVER) {
-      sdk.close();
-      setSdk(
-        new DeviceSdkBuilder()
-          .addLogger(new ConsoleLogger())
-          .addTransport(BuiltinTransports.MOCK_SERVER)
-          .addConfig({ mockUrl: mockServerUrl })
-          .addLogger(webLogsExporterLogger)
-          .addLogger(new FlipperSdkLogger())
-          .build(),
-      );
-    } else if (previousTransport === BuiltinTransports.MOCK_SERVER) {
-      sdk.close();
-      setSdk(
-        new DeviceSdkBuilder()
-          .addLogger(new ConsoleLogger())
-          .addTransport(BuiltinTransports.BLE)
-          .addTransport(BuiltinTransports.USB)
-          .addLogger(webLogsExporterLogger)
-          .addLogger(new FlipperSdkLogger())
-          .build(),
-      );
-    }
-  }, [transport, mockServerUrl, previousTransport]);
 
-  return <SdkContext.Provider value={sdk}>{children}</SdkContext.Provider>;
+  const mockServerEnabled = transport === BuiltinTransports.MOCK_SERVER;
+  const [state, setState] = useState(() => {
+    const logsExporter = new WebLogsExporterLogger();
+    const sdk = mockServerEnabled
+      ? buildMockSdk(mockServerUrl, logsExporter)
+      : buildDefaultSdk(logsExporter);
+    return { sdk, logsExporter };
+  });
+
+  const mockServerEnabledChanged = useHasChanged(mockServerEnabled);
+  const mockServerUrlChanged = useHasChanged(mockServerUrl);
+
+  if (mockServerEnabledChanged || mockServerUrlChanged) {
+    setState(({ logsExporter }) => {
+      return {
+        sdk: mockServerEnabled
+          ? buildMockSdk(mockServerUrl, logsExporter)
+          : buildDefaultSdk(logsExporter),
+        logsExporter,
+      };
+    });
+  }
+
+  useEffect(() => {
+    return () => {
+      state.sdk.close();
+    };
+  }, [state.sdk]);
+
+  return (
+    <SdkContext.Provider value={state.sdk}>
+      <LogsExporterContext.Provider value={state.logsExporter}>
+        {children}
+      </LogsExporterContext.Provider>
+    </SdkContext.Provider>
+  );
 };
 
 export const useSdk = (): DeviceSdk => {
-  return useContext(SdkContext);
+  const sdk = useContext(SdkContext);
+  if (sdk === null)
+    throw new Error("useSdk must be used within a SdkContext.Provider");
+  return sdk;
 };
 
 export function useExportLogsCallback() {
+  const logsExporter = useContext(LogsExporterContext);
+  if (logsExporter === null) {
+    throw new Error(
+      "useExportLogsCallback must be used within LogsExporterContext.Provider",
+    );
+  }
   return useCallback(() => {
-    webLogsExporterLogger.exportLogsToJSON();
-  }, []);
+    logsExporter.exportLogsToJSON();
+  }, [logsExporter]);
 }

--- a/apps/sample/src/providers/DeviceSessionsProvider/index.tsx
+++ b/apps/sample/src/providers/DeviceSessionsProvider/index.tsx
@@ -1,15 +1,23 @@
-import React, { Context, createContext, useContext, useReducer } from "react";
+import React, {
+  Context,
+  createContext,
+  useContext,
+  useEffect,
+  useReducer,
+} from "react";
 
+import { useHasChanged } from "@/hooks/useHasChanged";
+import { useSdk } from "@/providers/DeviceSdkProvider";
 import {
+  DeviceSessionsAction,
   DeviceSessionsInitialState,
   deviceSessionsReducer,
   DeviceSessionsState,
-  DeviseSessionsAction,
 } from "@/reducers/deviceSessions";
 
 type DeviceSessionsContextType = {
   state: DeviceSessionsState;
-  dispatch: (value: DeviseSessionsAction) => void;
+  dispatch: (value: DeviceSessionsAction) => void;
 };
 
 const DeviceSessionsContext: Context<DeviceSessionsContextType> =
@@ -21,10 +29,28 @@ const DeviceSessionsContext: Context<DeviceSessionsContextType> =
 export const DeviceSessionsProvider: React.FC<React.PropsWithChildren> = ({
   children,
 }) => {
+  const sdk = useSdk();
   const [state, dispatch] = useReducer(
     deviceSessionsReducer,
     DeviceSessionsInitialState,
   );
+
+  const sdkHasChanged = useHasChanged(sdk);
+  if (sdkHasChanged) {
+    dispatch({ type: "remove_all_sessions" });
+  }
+
+  useEffect(() => {
+    sdk.listDeviceSessions().map((session) => {
+      dispatch({
+        type: "add_session",
+        payload: {
+          sessionId: session.id,
+          connectedDevice: sdk.getConnectedDevice({ sessionId: session.id }),
+        },
+      });
+    });
+  }, [sdk]);
 
   return (
     <DeviceSessionsContext.Provider value={{ state, dispatch }}>

--- a/apps/sample/src/reducers/deviceSessions.ts
+++ b/apps/sample/src/reducers/deviceSessions.ts
@@ -19,10 +19,15 @@ type RemoveSessionAction = {
   payload: { sessionId: DeviceSessionId };
 };
 
-export type DeviseSessionsAction =
+type RemoveAllSessionsAction = {
+  type: "remove_all_sessions";
+};
+
+export type DeviceSessionsAction =
   | AddSessionAction
   | RemoveSessionAction
-  | SelectSessionAction;
+  | SelectSessionAction
+  | RemoveAllSessionsAction;
 
 export type SelectSessionAction = {
   type: "select_session";
@@ -36,7 +41,7 @@ export const DeviceSessionsInitialState: DeviceSessionsState = {
 
 export const deviceSessionsReducer: Reducer<
   DeviceSessionsState,
-  DeviseSessionsAction
+  DeviceSessionsAction
 > = (state, action) => {
   const sessionsCount = Object.keys(state.deviceById).length;
 
@@ -60,6 +65,9 @@ export const deviceSessionsReducer: Reducer<
             ? Object.keys(state.deviceById)[sessionsCount - 1]
             : undefined,
       };
+    case "remove_all_sessions":
+      return DeviceSessionsInitialState;
+
     case "select_session":
       return {
         ...state,

--- a/apps/sample/src/styles/globalstyles.tsx
+++ b/apps/sample/src/styles/globalstyles.tsx
@@ -11,4 +11,7 @@ export const GlobalStyle = createGlobalStyle`
     margin: 0;
     background-color: #000000;
   }
+  body {
+    user-select: none;
+  }
 `;

--- a/packages/core/src/api/DeviceSdk.ts
+++ b/packages/core/src/api/DeviceSdk.ts
@@ -34,6 +34,7 @@ import { discoveryTypes } from "@internal/discovery/di/discoveryTypes";
 import { ConnectUseCase } from "@internal/discovery/use-case/ConnectUseCase";
 import { DisconnectUseCase } from "@internal/discovery/use-case/DisconnectUseCase";
 import { GetConnectedDeviceUseCase } from "@internal/discovery/use-case/GetConnectedDeviceUseCase";
+import { ListenToKnownDevicesUseCase } from "@internal/discovery/use-case/ListenToKnownDevicesUseCase";
 import type { StartDiscoveringUseCase } from "@internal/discovery/use-case/StartDiscoveringUseCase";
 import type { StopDiscoveringUseCase } from "@internal/discovery/use-case/StopDiscoveringUseCase";
 import { sendTypes } from "@internal/send/di/sendTypes";
@@ -106,6 +107,19 @@ export class DeviceSdk {
   stopDiscovering() {
     return this.container
       .get<StopDiscoveringUseCase>(discoveryTypes.StopDiscoveringUseCase)
+      .execute();
+  }
+
+  /**
+   * Listen to list of known discovered devices (and later BLE).
+   *
+   * @returns {Observable<DiscoveredDevice[]>} An observable of known discovered devices.
+   */
+  listenToKnownDevices(): Observable<DiscoveredDevice[]> {
+    return this.container
+      .get<ListenToKnownDevicesUseCase>(
+        discoveryTypes.ListenToKnownDevicesUseCase,
+      )
       .execute();
   }
 

--- a/packages/core/src/api/transport/model/Transport.ts
+++ b/packages/core/src/api/transport/model/Transport.ts
@@ -25,6 +25,8 @@ export interface Transport {
 
   stopDiscovering(): void;
 
+  listenToKnownDevices(): Observable<InternalDiscoveredDevice[]>;
+
   /**
    * Enables communication with the device by connecting to it.
    *

--- a/packages/core/src/internal/discovery/di/discoveryModule.test.ts
+++ b/packages/core/src/internal/discovery/di/discoveryModule.test.ts
@@ -4,6 +4,7 @@ import { deviceModelModuleFactory } from "@internal/device-model/di/deviceModelM
 import { deviceSessionModuleFactory } from "@internal/device-session/di/deviceSessionModule";
 import { ConnectUseCase } from "@internal/discovery/use-case/ConnectUseCase";
 import { DisconnectUseCase } from "@internal/discovery/use-case/DisconnectUseCase";
+import { ListenToKnownDevicesUseCase } from "@internal/discovery/use-case/ListenToKnownDevicesUseCase";
 import { StartDiscoveringUseCase } from "@internal/discovery/use-case/StartDiscoveringUseCase";
 import { StopDiscoveringUseCase } from "@internal/discovery/use-case/StopDiscoveringUseCase";
 import { loggerModuleFactory } from "@internal/logger-publisher/di/loggerModule";
@@ -58,5 +59,12 @@ describe("discoveryModuleFactory", () => {
 
     const connectUseCase = container.get(discoveryTypes.ConnectUseCase);
     expect(connectUseCase).toBeInstanceOf(ConnectUseCase);
+
+    const listenToKnownDevicesUseCase = container.get(
+      discoveryTypes.ListenToKnownDevicesUseCase,
+    );
+    expect(listenToKnownDevicesUseCase).toBeInstanceOf(
+      ListenToKnownDevicesUseCase,
+    );
   });
 });

--- a/packages/core/src/internal/discovery/di/discoveryModule.ts
+++ b/packages/core/src/internal/discovery/di/discoveryModule.ts
@@ -3,6 +3,7 @@ import { ContainerModule } from "inversify";
 import { ConnectUseCase } from "@internal/discovery/use-case/ConnectUseCase";
 import { DisconnectUseCase } from "@internal/discovery/use-case/DisconnectUseCase";
 import { GetConnectedDeviceUseCase } from "@internal/discovery/use-case/GetConnectedDeviceUseCase";
+import { ListenToKnownDevicesUseCase } from "@internal/discovery/use-case/ListenToKnownDevicesUseCase";
 import { StartDiscoveringUseCase } from "@internal/discovery/use-case/StartDiscoveringUseCase";
 import { StopDiscoveringUseCase } from "@internal/discovery/use-case/StopDiscoveringUseCase";
 import { StubUseCase } from "@root/src/di.stub";
@@ -22,6 +23,9 @@ export const discoveryModuleFactory = ({ stub = false }: FactoryProps) =>
     bind(discoveryTypes.GetConnectedDeviceUseCase).to(
       GetConnectedDeviceUseCase,
     );
+    bind(discoveryTypes.ListenToKnownDevicesUseCase).to(
+      ListenToKnownDevicesUseCase,
+    );
 
     if (stub) {
       rebind(discoveryTypes.StartDiscoveringUseCase).to(StubUseCase);
@@ -29,5 +33,6 @@ export const discoveryModuleFactory = ({ stub = false }: FactoryProps) =>
       rebind(discoveryTypes.ConnectUseCase).to(StubUseCase);
       rebind(discoveryTypes.DisconnectUseCase).to(StubUseCase);
       rebind(discoveryTypes.GetConnectedDeviceUseCase).to(StubUseCase);
+      rebind(discoveryTypes.ListenToKnownDevicesUseCase).to(StubUseCase);
     }
   });

--- a/packages/core/src/internal/discovery/di/discoveryTypes.ts
+++ b/packages/core/src/internal/discovery/di/discoveryTypes.ts
@@ -4,4 +4,5 @@ export const discoveryTypes = {
   ConnectUseCase: Symbol.for("ConnectUseCase"),
   DisconnectUseCase: Symbol.for("DisconnectUseCase"),
   GetConnectedDeviceUseCase: Symbol.for("GetConnectedDeviceUseCase"),
+  ListenToKnownDevicesUseCase: Symbol.for("ListenToKnownDevicesUseCase"),
 };

--- a/packages/core/src/internal/discovery/use-case/ListenToKnownDevicesUseCase.test.ts
+++ b/packages/core/src/internal/discovery/use-case/ListenToKnownDevicesUseCase.test.ts
@@ -1,0 +1,303 @@
+import { Subject } from "rxjs";
+
+import { DeviceId, DeviceModel } from "@api/device/DeviceModel";
+import { DiscoveredDevice, Transport } from "@api/types";
+import { deviceModelStubBuilder } from "@internal/device-model/model/DeviceModel.stub";
+import { InternalDiscoveredDevice } from "@internal/transport/model/InternalDiscoveredDevice";
+
+import { ListenToKnownDevicesUseCase } from "./ListenToKnownDevicesUseCase";
+
+function makeMockTransport(props: Partial<Transport>): Transport {
+  return {
+    listenToKnownDevices: jest.fn(),
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    startDiscovering: jest.fn(),
+    stopDiscovering: jest.fn(),
+    getIdentifier: jest.fn(),
+    isSupported: jest.fn(),
+    ...props,
+  };
+}
+
+const mockInternalDeviceModel = deviceModelStubBuilder();
+function makeMockDeviceModel(id: DeviceId): DeviceModel {
+  return {
+    id,
+    model: mockInternalDeviceModel.id,
+    name: mockInternalDeviceModel.productName,
+  };
+}
+
+function setup2MockTransports() {
+  const transportAKnownDevicesSubject = new Subject<
+    InternalDiscoveredDevice[]
+  >();
+  const transportBKnownDevicesSubject = new Subject<
+    InternalDiscoveredDevice[]
+  >();
+  const transportA = makeMockTransport({
+    listenToKnownDevices: () => transportAKnownDevicesSubject.asObservable(),
+  });
+  const transportB = makeMockTransport({
+    listenToKnownDevices: () => transportBKnownDevicesSubject.asObservable(),
+  });
+  return {
+    transportAKnownDevicesSubject,
+    transportBKnownDevicesSubject,
+    transportA,
+    transportB,
+  };
+}
+
+function makeMockInternalDiscoveredDevice(
+  id: string,
+): InternalDiscoveredDevice {
+  return {
+    id,
+    deviceModel: mockInternalDeviceModel,
+    transport: "mock",
+  };
+}
+
+describe("ListenToKnownDevicesUseCase", () => {
+  describe("when no transports are available", () => {
+    it("should return no discovered devices", (done) => {
+      const useCase = new ListenToKnownDevicesUseCase([]);
+
+      const observedDiscoveredDevices: DiscoveredDevice[][] = [];
+      useCase.execute().subscribe({
+        next: (devices) => {
+          observedDiscoveredDevices.push(devices);
+        },
+        complete: () => {
+          try {
+            expect(observedDiscoveredDevices).toEqual([[]]);
+            done();
+          } catch (error) {
+            done(error);
+          }
+        },
+        error: (error) => {
+          done(error);
+        },
+      });
+    });
+  });
+
+  describe("when one transport is available", () => {
+    it("should return discovered devices from one transport", () => {
+      const { transportA, transportAKnownDevicesSubject } =
+        setup2MockTransports();
+
+      const observedDiscoveredDevices: DiscoveredDevice[][] = [];
+      new ListenToKnownDevicesUseCase([transportA])
+        .execute()
+        .subscribe((devices) => {
+          observedDiscoveredDevices.push(devices);
+        });
+
+      // When transportA emits 1 known device
+      transportAKnownDevicesSubject.next([
+        makeMockInternalDiscoveredDevice("transportA-device1"),
+      ]);
+
+      expect(observedDiscoveredDevices[0]).toEqual([
+        {
+          id: "transportA-device1",
+          deviceModel: makeMockDeviceModel("transportA-device1"),
+          transport: "mock",
+        },
+      ]);
+
+      // When transportA emits 2 known devices
+      transportAKnownDevicesSubject.next([
+        makeMockInternalDiscoveredDevice("transportA-device1"),
+        makeMockInternalDiscoveredDevice("transportA-device2"),
+      ]);
+
+      expect(observedDiscoveredDevices[1]).toEqual([
+        {
+          id: "transportA-device1",
+          deviceModel: makeMockDeviceModel("transportA-device1"),
+          transport: "mock",
+        },
+        {
+          id: "transportA-device2",
+          deviceModel: makeMockDeviceModel("transportA-device2"),
+          transport: "mock",
+        },
+      ]);
+
+      // When transportA emits 1 known device (device1 disconnects)
+      transportAKnownDevicesSubject.next([
+        makeMockInternalDiscoveredDevice("transportA-device2"),
+      ]);
+
+      expect(observedDiscoveredDevices[2]).toEqual([
+        {
+          id: "transportA-device2",
+          deviceModel: makeMockDeviceModel("transportA-device2"),
+          transport: "mock",
+        },
+      ]);
+
+      // When transportA emits 0 known devices (device2 disconnects)
+      transportAKnownDevicesSubject.next([]);
+
+      expect(observedDiscoveredDevices[3]).toEqual([]);
+    });
+  });
+
+  describe("when multiple transports are available", () => {
+    it("should return discovered devices from one of the transports as soon as it emits", () => {
+      const { transportAKnownDevicesSubject, transportA, transportB } =
+        setup2MockTransports();
+
+      const observedDiscoveredDevices: DiscoveredDevice[][] = [];
+
+      const onError = jest.fn();
+      const onComplete = jest.fn();
+
+      new ListenToKnownDevicesUseCase([transportA, transportB])
+        .execute()
+        .subscribe({
+          next: (devices) => {
+            observedDiscoveredDevices.push(devices);
+          },
+          error: onError,
+          complete: onComplete,
+        });
+
+      // When transportA emits 1 known device
+      transportAKnownDevicesSubject.next([
+        makeMockInternalDiscoveredDevice("transportA-device1"),
+      ]);
+
+      expect(observedDiscoveredDevices[0]).toEqual([
+        {
+          id: "transportA-device1",
+          deviceModel: makeMockDeviceModel("transportA-device1"),
+          transport: "mock",
+        },
+      ]);
+
+      // When transport A listen observable completes
+      transportAKnownDevicesSubject.complete();
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(onComplete).not.toHaveBeenCalled(); // Should not complete yet because transportB has not completed
+    });
+
+    it("should combine discovered devices from multiple transports", () => {
+      const {
+        transportAKnownDevicesSubject,
+        transportBKnownDevicesSubject,
+        transportA,
+        transportB,
+      } = setup2MockTransports();
+
+      const observedDiscoveredDevices: DiscoveredDevice[][] = [];
+
+      const onError = jest.fn();
+      const onComplete = jest.fn();
+      new ListenToKnownDevicesUseCase([transportA, transportB])
+        .execute()
+        .subscribe({
+          next: (devices) => {
+            observedDiscoveredDevices.push(devices);
+          },
+          error: onError,
+          complete: onComplete,
+        });
+
+      // When transportA emits 1 known device
+      transportAKnownDevicesSubject.next([
+        makeMockInternalDiscoveredDevice("transportA-device1"),
+      ]);
+
+      expect(observedDiscoveredDevices[0]).toEqual([
+        {
+          id: "transportA-device1",
+          deviceModel: makeMockDeviceModel("transportA-device1"),
+          transport: "mock",
+        },
+      ]);
+
+      // When transportB emits 1 known device
+      transportBKnownDevicesSubject.next([
+        makeMockInternalDiscoveredDevice("transportB-device1"),
+      ]);
+
+      expect(observedDiscoveredDevices[1]).toEqual([
+        {
+          id: "transportA-device1",
+          deviceModel: makeMockDeviceModel("transportA-device1"),
+          transport: "mock",
+        },
+        {
+          id: "transportB-device1",
+          deviceModel: makeMockDeviceModel("transportB-device1"),
+          transport: "mock",
+        },
+      ]);
+
+      // When transportB emits 2 known devices
+      transportBKnownDevicesSubject.next([
+        makeMockInternalDiscoveredDevice("transportB-device1"),
+        makeMockInternalDiscoveredDevice("transportB-device2"),
+      ]);
+
+      expect(observedDiscoveredDevices[2]).toEqual([
+        {
+          id: "transportA-device1",
+          deviceModel: makeMockDeviceModel("transportA-device1"),
+          transport: "mock",
+        },
+        {
+          id: "transportB-device1",
+          deviceModel: makeMockDeviceModel("transportB-device1"),
+          transport: "mock",
+        },
+        {
+          id: "transportB-device2",
+          deviceModel: makeMockDeviceModel("transportB-device2"),
+          transport: "mock",
+        },
+      ]);
+
+      // When transportA emits 0 known devices
+      transportAKnownDevicesSubject.next([]);
+
+      expect(observedDiscoveredDevices[3]).toEqual([
+        {
+          id: "transportB-device1",
+          deviceModel: makeMockDeviceModel("transportB-device1"),
+          transport: "mock",
+        },
+        {
+          id: "transportB-device2",
+          deviceModel: makeMockDeviceModel("transportB-device2"),
+          transport: "mock",
+        },
+      ]);
+
+      // When transport A listen observable completes
+      transportAKnownDevicesSubject.complete();
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(onComplete).not.toHaveBeenCalled(); // Should not complete yet because transportB has not completed
+
+      // When transport B emits 0 known devices
+      transportBKnownDevicesSubject.next([]);
+
+      expect(observedDiscoveredDevices[4]).toEqual([]);
+
+      // When transport B listen observable completes
+      transportBKnownDevicesSubject.complete();
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(onComplete).toHaveBeenCalled(); // Should complete now because all transports have completed
+    });
+  });
+});

--- a/packages/core/src/internal/discovery/use-case/ListenToKnownDevicesUseCase.ts
+++ b/packages/core/src/internal/discovery/use-case/ListenToKnownDevicesUseCase.ts
@@ -1,0 +1,74 @@
+import { injectable, multiInject } from "inversify";
+import { from, map, merge, Observable, scan } from "rxjs";
+
+import { DeviceModel } from "@api/device/DeviceModel";
+import type { Transport } from "@api/transport/model/Transport";
+import { DiscoveredDevice } from "@api/types";
+import { transportDiTypes } from "@internal/transport/di/transportDiTypes";
+import { InternalDiscoveredDevice } from "@internal/transport/model/InternalDiscoveredDevice";
+
+/**
+ * Listen to list of known discovered devices (and later BLE).
+ */
+@injectable()
+export class ListenToKnownDevicesUseCase {
+  private readonly _transports: Transport[];
+  constructor(
+    @multiInject(transportDiTypes.Transport)
+    transports: Transport[],
+  ) {
+    this._transports = transports;
+  }
+
+  private mapInternalDiscoveredDeviceToDiscoveredDevice(
+    discoveredDevice: InternalDiscoveredDevice,
+  ): DiscoveredDevice {
+    return {
+      id: discoveredDevice.id,
+      deviceModel: new DeviceModel({
+        id: discoveredDevice.id,
+        model: discoveredDevice.deviceModel.id,
+        name: discoveredDevice.deviceModel.productName,
+      }),
+      transport: discoveredDevice.transport,
+    };
+  }
+
+  execute(): Observable<DiscoveredDevice[]> {
+    if (this._transports.length === 0) {
+      return from([[]]);
+    }
+
+    /**
+     * Note: we're not using combineLatest because combineLatest will
+     * - wait for all observables to emit at least once before emitting.
+     * - complete as soon as one of the observables completes.
+     * Some transports will just return an empty array and complete.
+     * We want to keep listening to all transports until all have completed.
+     */
+
+    const observablesWithIndex = this._transports.map((transport, index) =>
+      transport.listenToKnownDevices().pipe(
+        map((arr) => ({
+          index,
+          arr,
+        })),
+      ),
+    );
+
+    return merge(...observablesWithIndex).pipe(
+      scan(
+        (acc, { index, arr }) => {
+          acc[index] = arr;
+          return acc;
+        },
+        {} as { [key: number]: Array<InternalDiscoveredDevice> },
+      ),
+      map((acc) =>
+        Object.values(acc)
+          .flat()
+          .map(this.mapInternalDiscoveredDeviceToDiscoveredDevice),
+      ),
+    );
+  }
+}

--- a/packages/core/src/internal/transport/ble/transport/WebBleTransport.ts
+++ b/packages/core/src/internal/transport/ble/transport/WebBleTransport.ts
@@ -94,6 +94,10 @@ export class WebBleTransport implements Transport {
     return this.identifier;
   }
 
+  listenToKnownDevices(): Observable<InternalDiscoveredDevice[]> {
+    return from([]);
+  }
+
   /**
    * Get Bluetooth GATT Primary service that is used to get writeCharacteristic and notifyCharacteristic
    * @param bleDevice

--- a/packages/core/src/internal/transport/ble/transport/__mocks__/WebBleTransport.ts
+++ b/packages/core/src/internal/transport/ble/transport/__mocks__/WebBleTransport.ts
@@ -1,6 +1,12 @@
+import { Observable } from "rxjs";
+
 import { Transport } from "@api/transport/model/Transport";
+import { InternalDiscoveredDevice } from "@internal/transport/model/InternalDiscoveredDevice";
 
 export class WebBleTransport implements Transport {
+  listenToKnownDevices(): Observable<InternalDiscoveredDevice[]> {
+    throw new Error("Method not implemented.");
+  }
   isSupported = jest.fn();
   getIdentifier = jest.fn();
   connect = jest.fn();
@@ -20,6 +26,7 @@ export function usbHidTransportMockBuilder(
     stopDiscovering: jest.fn(),
     connect: jest.fn(),
     disconnect: jest.fn(),
+    listenToKnownDevices: jest.fn(),
     ...props,
   };
 }

--- a/packages/core/src/internal/transport/mockserver/MockserverTransport.ts
+++ b/packages/core/src/internal/transport/mockserver/MockserverTransport.ts
@@ -56,6 +56,10 @@ export class MockTransport implements Transport {
     return this.identifier;
   }
 
+  listenToKnownDevices(): Observable<InternalDiscoveredDevice[]> {
+    return from([]);
+  }
+
   startDiscovering(): Observable<InternalDiscoveredDevice> {
     this.logger.debug("startDiscovering");
     return from(

--- a/packages/core/src/internal/transport/usb/transport/__mocks__/WebUsbHidTransport.ts
+++ b/packages/core/src/internal/transport/usb/transport/__mocks__/WebUsbHidTransport.ts
@@ -8,6 +8,7 @@ export class WebUsbHidTransport implements Transport {
   stopDiscovering = jest.fn();
 
   disconnect = jest.fn();
+  listenToKnownDevices = jest.fn();
 }
 
 export function usbHidTransportMockBuilder(
@@ -20,6 +21,7 @@ export function usbHidTransportMockBuilder(
     stopDiscovering: jest.fn(),
     connect: jest.fn(),
     disconnect: jest.fn(),
+    listenToKnownDevices: jest.fn(),
     ...props,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       react-lottie:
         specifier: ^1.2.4
         version: 1.2.4(react@18.3.1)
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.1
       styled-components:
         specifier: ^5.3.11
         version: 5.3.11(@babel/core@7.24.7)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This new feature allows to observe an array of available devices, as `DiscoveredDevice`.

For WebHID, it means that for devices for which the user has already granted an authorization to the app (via `navigator.hid.requestDevice()`), plugging in a device will make it appear in that array, and unplugging it will make it disappear.

In case of reconnection (in an open/close app for instance), internally, the `HIDDevice` will be a different instance, but we keep the same `DeviceId` so that from the app's point of view, we can identify which of the `DiscoveredDevice` already has an ongoing session.


https://github.com/user-attachments/assets/ce5c5598-f2ff-4183-9177-466644ab7cee



### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [[DSDK-504]](https://ledgerhq.atlassian.net/jira/software/c/projects/DSDK/boards/817?assignee=6144f82ee7c3280070b2507c&selectedIssue=DSDK-504)

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - (core) new use case listen to known devices
  - (sample) display of the known devices in a new section of the side bar, with a connect button (which is grayed out when the device is already connected).
  - (core) small refacto of the internal logic of `WebUsbHidTransport` for discovered devices

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
