### PR TITLE
:sparkles: (keyring-eth) [DSDK-433]: Add support for V1 clear signing contexts

### DIFF
--- a/.changeset/loud-balloons-poke.md
+++ b/.changeset/loud-balloons-poke.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": patch
+---
+
+Add support for V1 clear signing contexts

--- a/packages/signer/keyring-eth/package.json
+++ b/packages/signer/keyring-eth/package.json
@@ -38,16 +38,18 @@
     "inversify-logger-middleware": "^3.1.0",
     "purify-ts": "^2.1.0",
     "reflect-metadata": "^0.2.2",
+    "semver": "^7.6.3",
     "xstate": "^5.18.2"
   },
   "devDependencies": {
-    "@ledgerhq/esbuild-tools": "workspace:*",
     "@ledgerhq/context-module": "workspace:*",
     "@ledgerhq/device-management-kit": "workspace:*",
+    "@ledgerhq/esbuild-tools": "workspace:*",
     "@ledgerhq/eslint-config-dsdk": "workspace:*",
     "@ledgerhq/jest-config-dsdk": "workspace:*",
     "@ledgerhq/prettier-config-dsdk": "workspace:*",
     "@ledgerhq/tsconfig-dsdk": "workspace:*",
+    "@types/semver": "^7.5.8",
     "rxjs": "^7.8.1",
     "ts-node": "^10.9.2"
   },

--- a/packages/signer/keyring-eth/src/internal/app-binder/task/BuildEIP712ContextTask.test.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/task/BuildEIP712ContextTask.test.ts
@@ -172,7 +172,7 @@ describe("BuildEIP712ContextTask", () => {
       sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
       deviceStatus: DeviceStatus.CONNECTED,
       installedApps: [],
-      currentApp: { name: "Ethereum", version: "1.0" },
+      currentApp: { name: "Ethereum", version: "1.11.0" },
     });
     contextMouleMock.getTypedDataFilters.mockResolvedValueOnce({
       type: "error",
@@ -208,7 +208,7 @@ describe("BuildEIP712ContextTask", () => {
       sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
       deviceStatus: DeviceStatus.CONNECTED,
       installedApps: [],
-      currentApp: { name: "Ethereum", version: "1.0" },
+      currentApp: { name: "Ethereum", version: "1.11.0" },
     });
     contextMouleMock.getTypedDataFilters.mockResolvedValueOnce(
       TEST_CLEAR_SIGN_CONTEXT,
@@ -227,6 +227,51 @@ describe("BuildEIP712ContextTask", () => {
       verifyingContract: "0x000000000022d473030f116ddee9f6b43ac78ba3",
       chainId: 137,
       version: "v2",
+      schema: TEST_DATA["types"],
+      fieldsValues: [
+        {
+          path: "details.amount",
+          value: Uint8Array.from([0x12]),
+        },
+        {
+          path: "details.expiration",
+          value: Uint8Array.from([0x13]),
+        },
+      ],
+    });
+  });
+
+  it("Build context with clear signing context V1", async () => {
+    // GIVEN
+    const task = new BuildEIP712ContextTask(
+      apiMock,
+      contextMouleMock,
+      parserMock,
+      TEST_DATA,
+    );
+    parserMock.parse.mockReturnValueOnce(
+      Right({
+        types: TEST_TYPES,
+        domain: TEST_DOMAIN_VALUES,
+        message: TEST_MESSAGE_VALUES,
+      }),
+    );
+    apiMock.getDeviceSessionState.mockReturnValueOnce({
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Ethereum", version: "1.10.0" },
+    });
+    contextMouleMock.getTypedDataFilters.mockResolvedValueOnce(
+      TEST_CLEAR_SIGN_CONTEXT,
+    );
+    // WHEN
+    await task.run();
+    // THEN
+    expect(contextMouleMock.getTypedDataFilters).toHaveBeenCalledWith({
+      verifyingContract: "0x000000000022d473030f116ddee9f6b43ac78ba3",
+      chainId: 137,
+      version: "v1",
       schema: TEST_DATA["types"],
       fieldsValues: [
         {

--- a/packages/signer/keyring-eth/src/internal/app-binder/task/BuildEIP712ContextTask.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/task/BuildEIP712ContextTask.ts
@@ -7,6 +7,7 @@ import {
   type InternalApi,
 } from "@ledgerhq/device-management-kit";
 import { Just, Maybe, Nothing } from "purify-ts";
+import { gte } from "semver";
 
 import { type TypedData } from "@api/model/TypedData";
 import { type ProvideEIP712ContextTaskArgs } from "@internal/app-binder/task/ProvideEIP712ContextTask";
@@ -74,8 +75,9 @@ export class BuildEIP712ContextTask {
     if (deviceState.currentApp.name !== "Ethereum") {
       return Nothing;
     }
-    // TODO add currentAppVersion to session state
-    // const shouldUseV2Filters = semver.gte(deviceState.currentAppVersion!, "1.11.1-0");
-    return Just("v2");
+    // EIP712 v2 (amount & datetime filters) supported since 1.11.0:
+    // https://github.com/LedgerHQ/app-ethereum/blob/develop/doc/ethapp.adoc#1110-1
+    const shouldUseV2Filters = gte(deviceState.currentApp.version, "1.11.0");
+    return shouldUseV2Filters ? Just("v2") : Just("v1");
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,6 +378,9 @@ importers:
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
+      semver:
+        specifier: ^7.6.3
+        version: 7.6.3
       xstate:
         specifier: ^5.18.2
         version: 5.18.2
@@ -403,6 +406,9 @@ importers:
       '@ledgerhq/tsconfig-dsdk':
         specifier: workspace:*
         version: link:../../config/typescript
+      '@types/semver':
+        specifier: ^7.5.8
+        version: 7.5.8
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1


### PR DESCRIPTION
### 📝 Description

Add support of older ethereum app versions: before 1.11.0, we should use clear signing context V1 for EIP712, instead of V2.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/DSDK-433

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
