### PR TITLE
:sparkles: (keyring-eth) [DSDK-536]: Add support for EIP712 filters with missing token

### DIFF
--- a/.changeset/great-paws-sell.md
+++ b/.changeset/great-paws-sell.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": patch
+---
+
+Add support for EIP712 filters with missing token

--- a/packages/signer/context-module/src/typed-data/domain/DefaultTypedDataContextLoader.test.ts
+++ b/packages/signer/context-module/src/typed-data/domain/DefaultTypedDataContextLoader.test.ts
@@ -305,7 +305,7 @@ describe("TokenContextLoader", () => {
       });
     });
 
-    it("should return an error if tokens are unavailable", async () => {
+    it("success with unavailable tokens", async () => {
       // GIVEN
       const ctx = {
         verifyingContract: "0x000000000022d473030f116ddee9f6b43ac78ba3",
@@ -349,8 +349,24 @@ describe("TokenContextLoader", () => {
 
       // THEN
       expect(result).toEqual({
-        type: "error",
-        error: new Error("token error"),
+        type: "success",
+        messageInfo: {
+          displayName: "Permit2",
+          filtersCount: 2,
+          signature:
+            "3045022100e3c597d13d28a87a88b0239404c668373cf5063362f2a81d09eed4582941dfe802207669aabb504fd5b95b2734057f6b8bbf51f14a69a5f9bdf658a5952cefbf44d3",
+        },
+        tokens: {},
+        filters: {
+          "details.token": {
+            displayName: "Amount allowance",
+            path: "details.token",
+            signature:
+              "3044022075103b38995e031d1ebbfe38ac6603bec32854b5146a664e49b4cc4f460c1da6022029f4b0fd1f3b7995ffff1627d4b57f27888a2dcc9b3a4e85c37c67571092c733",
+            tokenIndex: 0,
+            type: "token",
+          },
+        },
       });
     });
 

--- a/packages/signer/context-module/src/typed-data/domain/DefaultTypedDataContextLoader.test.ts
+++ b/packages/signer/context-module/src/typed-data/domain/DefaultTypedDataContextLoader.test.ts
@@ -34,7 +34,7 @@ describe("TokenContextLoader", () => {
     ],
     PermitDetails: [
       {
-        type: "address",
+        type: "address[]",
         name: "token",
       },
       {
@@ -67,7 +67,7 @@ describe("TokenContextLoader", () => {
   };
   const TEST_VALUES = [
     {
-      path: "details.token",
+      path: "details.token.[]",
       value: Uint8Array.from([
         0x7c, 0xeb, 0x23, 0xfd, 0x6b, 0xc0, 0xad, 0xd5, 0x9e, 0x62, 0xac, 0x25,
         0x57, 0x82, 0x70, 0xcf, 0xf1, 0xb9, 0xf6, 0x19,
@@ -88,7 +88,7 @@ describe("TokenContextLoader", () => {
   ];
 
   beforeEach(() => {
-    jest.restoreAllMocks();
+    jest.clearAllMocks();
     jest
       .spyOn(mockTokenDataSource, "getTokenInfosPayload")
       .mockImplementation(({ address }) =>
@@ -121,7 +121,7 @@ describe("TokenContextLoader", () => {
                 {
                   type: "token",
                   displayName: "Amount allowance",
-                  path: "details.token",
+                  path: "details.token.[]",
                   tokenIndex: 0,
                   signature:
                     "3044022075103b38995e031d1ebbfe38ac6603bec32854b5146a664e49b4cc4f460c1da6022029f4b0fd1f3b7995ffff1627d4b57f27888a2dcc9b3a4e85c37c67571092c733",
@@ -184,9 +184,9 @@ describe("TokenContextLoader", () => {
               "3044022056b3381e4540629ad73bc434ec49d80523234b82f62340fbb77157fb0eb21a680220459fe9cf6ca309f9c7dfc6d4711fea1848dba661563c57f77b3c2dc480b3a63b",
             type: "datetime",
           },
-          "details.token": {
+          "details.token.[]": {
             displayName: "Amount allowance",
-            path: "details.token",
+            path: "details.token.[]",
             signature:
               "3044022075103b38995e031d1ebbfe38ac6603bec32854b5146a664e49b4cc4f460c1da6022029f4b0fd1f3b7995ffff1627d4b57f27888a2dcc9b3a4e85c37c67571092c733",
             tokenIndex: 0,
@@ -227,7 +227,7 @@ describe("TokenContextLoader", () => {
                 {
                   type: "token",
                   displayName: "Amount allowance",
-                  path: "details.token",
+                  path: "details.token.[]",
                   tokenIndex: 0,
                   signature:
                     "3044022075103b38995e031d1ebbfe38ac6603bec32854b5146a664e49b4cc4f460c1da6022029f4b0fd1f3b7995ffff1627d4b57f27888a2dcc9b3a4e85c37c67571092c733",
@@ -270,9 +270,9 @@ describe("TokenContextLoader", () => {
             tokenIndex: 255,
             type: "amount",
           },
-          "details.token": {
+          "details.token.[]": {
             displayName: "Amount allowance",
-            path: "details.token",
+            path: "details.token.[]",
             signature:
               "3044022075103b38995e031d1ebbfe38ac6603bec32854b5146a664e49b4cc4f460c1da6022029f4b0fd1f3b7995ffff1627d4b57f27888a2dcc9b3a4e85c37c67571092c733",
             tokenIndex: 0,
@@ -329,7 +329,7 @@ describe("TokenContextLoader", () => {
                 {
                   type: "token",
                   displayName: "Amount allowance",
-                  path: "details.token",
+                  path: "details.token.[]",
                   tokenIndex: 0,
                   signature:
                     "3044022075103b38995e031d1ebbfe38ac6603bec32854b5146a664e49b4cc4f460c1da6022029f4b0fd1f3b7995ffff1627d4b57f27888a2dcc9b3a4e85c37c67571092c733",
@@ -358,9 +358,9 @@ describe("TokenContextLoader", () => {
         },
         tokens: {},
         filters: {
-          "details.token": {
+          "details.token.[]": {
             displayName: "Amount allowance",
-            path: "details.token",
+            path: "details.token.[]",
             signature:
               "3044022075103b38995e031d1ebbfe38ac6603bec32854b5146a664e49b4cc4f460c1da6022029f4b0fd1f3b7995ffff1627d4b57f27888a2dcc9b3a4e85c37c67571092c733",
             tokenIndex: 0,
@@ -368,6 +368,120 @@ describe("TokenContextLoader", () => {
           },
         },
       });
+    });
+
+    it("success with several identic tokens", async () => {
+      // GIVEN
+      const ctx = {
+        verifyingContract: "0x000000000022d473030f116ddee9f6b43ac78ba3",
+        chainId: 1,
+        version: "v2",
+        schema: TEST_TYPES,
+        fieldsValues: [
+          {
+            path: "details.token.[]",
+            value: Uint8Array.from([
+              0x7c, 0xeb, 0x23, 0xfd, 0x6b, 0xc0, 0xad, 0xd5, 0x9e, 0x62, 0xac,
+              0x25, 0x57, 0x82, 0x70, 0xcf, 0xf1, 0xb9, 0xf6, 0x19,
+            ]),
+          },
+          ...TEST_VALUES,
+        ],
+      } as TypedDataContext;
+      jest
+        .spyOn(mockTypedDataDataSource, "getTypedDataFilters")
+        .mockImplementation(() =>
+          Promise.resolve(
+            Right({
+              messageInfo: {
+                displayName: "Permit2",
+                filtersCount: 2,
+                signature:
+                  "3045022100e3c597d13d28a87a88b0239404c668373cf5063362f2a81d09eed4582941dfe802207669aabb504fd5b95b2734057f6b8bbf51f14a69a5f9bdf658a5952cefbf44d3",
+              },
+              filters: [
+                {
+                  type: "token",
+                  displayName: "Amount allowance",
+                  path: "details.token.[]",
+                  tokenIndex: 0,
+                  signature:
+                    "3044022075103b38995e031d1ebbfe38ac6603bec32854b5146a664e49b4cc4f460c1da6022029f4b0fd1f3b7995ffff1627d4b57f27888a2dcc9b3a4e85c37c67571092c733",
+                },
+              ],
+            }),
+          ),
+        );
+      jest
+        .spyOn(mockTokenDataSource, "getTokenInfosPayload")
+        .mockImplementation(() =>
+          Promise.resolve(Left(new Error("token error"))),
+        );
+
+      // WHEN
+      const result = await loader.load(ctx);
+
+      // THEN
+      expect(mockTokenDataSource.getTokenInfosPayload).toHaveBeenCalledWith({
+        address: "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        chainId: 1,
+      });
+      expect(result.type).toEqual("success");
+    });
+
+    it("success with several different tokens", async () => {
+      // GIVEN
+      const ctx = {
+        verifyingContract: "0x000000000022d473030f116ddee9f6b43ac78ba3",
+        chainId: 1,
+        version: "v2",
+        schema: TEST_TYPES,
+        fieldsValues: [
+          {
+            path: "details.token.[]",
+            value: Uint8Array.from([
+              0x7c, 0xeb, 0x23, 0xfd, 0x6b, 0xc0, 0xad, 0xd5, 0x9e, 0x62, 0xac,
+              0x25, 0x57, 0x82, 0x70, 0xcf, 0xf1, 0xb9, 0xf6, 0xff,
+            ]),
+          },
+          ...TEST_VALUES,
+        ],
+      } as TypedDataContext;
+      jest
+        .spyOn(mockTypedDataDataSource, "getTypedDataFilters")
+        .mockImplementation(() =>
+          Promise.resolve(
+            Right({
+              messageInfo: {
+                displayName: "Permit2",
+                filtersCount: 2,
+                signature:
+                  "3045022100e3c597d13d28a87a88b0239404c668373cf5063362f2a81d09eed4582941dfe802207669aabb504fd5b95b2734057f6b8bbf51f14a69a5f9bdf658a5952cefbf44d3",
+              },
+              filters: [
+                {
+                  type: "token",
+                  displayName: "Amount allowance",
+                  path: "details.token.[]",
+                  tokenIndex: 0,
+                  signature:
+                    "3044022075103b38995e031d1ebbfe38ac6603bec32854b5146a664e49b4cc4f460c1da6022029f4b0fd1f3b7995ffff1627d4b57f27888a2dcc9b3a4e85c37c67571092c733",
+                },
+              ],
+            }),
+          ),
+        );
+      // WHEN
+      const result = await loader.load(ctx);
+
+      // THEN
+      expect(mockTokenDataSource.getTokenInfosPayload).not.toHaveBeenCalledWith(
+        { address: "0x7ceb23fd6bc0add59e62ac25578270cff1b9f6ff", chainId: 1 },
+      );
+      expect(mockTokenDataSource.getTokenInfosPayload).not.toHaveBeenCalledWith(
+        { address: "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619", chainId: 1 },
+      );
+      expect(result.type).toEqual("success");
     });
 
     it("should return an error if value is not found", async () => {

--- a/packages/signer/context-module/src/typed-data/domain/DefaultTypedDataContextLoader.ts
+++ b/packages/signer/context-module/src/typed-data/domain/DefaultTypedDataContextLoader.ts
@@ -81,12 +81,6 @@ export class DefaultTypedDataContextLoader implements TypedDataContextLoader {
           address,
           chainId,
         });
-        if (payload.isLeft()) {
-          return {
-            type: "error",
-            error: payload.extract(),
-          };
-        }
         payload.ifRight((payload) => {
           mappedTokens[tokenIndex] = payload;
         });
@@ -105,12 +99,6 @@ export class DefaultTypedDataContextLoader implements TypedDataContextLoader {
           address,
           chainId,
         });
-        if (payload.isLeft()) {
-          return {
-            type: "error",
-            error: payload.extract(),
-          };
-        }
         payload.ifRight((payload) => {
           mappedTokens[tokenIndex] = payload;
         });

--- a/packages/signer/context-module/src/typed-data/domain/DefaultTypedDataContextLoader.ts
+++ b/packages/signer/context-module/src/typed-data/domain/DefaultTypedDataContextLoader.ts
@@ -63,10 +63,10 @@ export class DefaultTypedDataContextLoader implements TypedDataContextLoader {
 
       // If the filter is a token, get token address from typed message values, and fetch descriptor
       if (filter.type === "token") {
-        const value = typedData.fieldsValues.find(
+        const values = typedData.fieldsValues.filter(
           (entry) => entry.path === filter.path,
         );
-        if (value === undefined) {
+        if (values.length === 0) {
           return {
             type: "error",
             error: new Error(
@@ -74,16 +74,26 @@ export class DefaultTypedDataContextLoader implements TypedDataContextLoader {
             ),
           };
         }
-        // Fetch descriptor
+        const value = values[0]!;
         const address = this.convertAddressToHexaString(value.value);
-        const chainId = typedData.chainId;
-        const payload = await this.tokenDataSource.getTokenInfosPayload({
-          address,
-          chainId,
-        });
-        payload.ifRight((payload) => {
-          mappedTokens[tokenIndex] = payload;
-        });
+
+        // Arrays with different tokens are not supported since there is only 1 tokenIndex per filter.
+        // Only fetch tokens if all values are the same.
+        if (
+          values.every(
+            (entry) => this.convertAddressToHexaString(entry.value) === address,
+          )
+        ) {
+          // Fetch descriptor
+          const chainId = typedData.chainId;
+          const payload = await this.tokenDataSource.getTokenInfosPayload({
+            address,
+            chainId,
+          });
+          payload.ifRight((payload) => {
+            mappedTokens[tokenIndex] = payload;
+          });
+        }
       }
 
       // If the filter is an amount with a reference to the verifyingContract, fetch verifyingContract descriptor.

--- a/packages/signer/keyring-eth/src/internal/app-binder/task/BuildEIP712ContextTask.test.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/task/BuildEIP712ContextTask.test.ts
@@ -172,7 +172,7 @@ describe("BuildEIP712ContextTask", () => {
       sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
       deviceStatus: DeviceStatus.CONNECTED,
       installedApps: [],
-      currentApp: { name: "Ethereum", version: "1.11.0" },
+      currentApp: { name: "Ethereum", version: "1.12.0" },
     });
     contextMouleMock.getTypedDataFilters.mockResolvedValueOnce({
       type: "error",
@@ -208,7 +208,7 @@ describe("BuildEIP712ContextTask", () => {
       sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
       deviceStatus: DeviceStatus.CONNECTED,
       installedApps: [],
-      currentApp: { name: "Ethereum", version: "1.11.0" },
+      currentApp: { name: "Ethereum", version: "1.12.0" },
     });
     contextMouleMock.getTypedDataFilters.mockResolvedValueOnce(
       TEST_CLEAR_SIGN_CONTEXT,
@@ -260,7 +260,7 @@ describe("BuildEIP712ContextTask", () => {
       sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
       deviceStatus: DeviceStatus.CONNECTED,
       installedApps: [],
-      currentApp: { name: "Ethereum", version: "1.10.0" },
+      currentApp: { name: "Ethereum", version: "1.11.0" },
     });
     contextMouleMock.getTypedDataFilters.mockResolvedValueOnce(
       TEST_CLEAR_SIGN_CONTEXT,

--- a/packages/signer/keyring-eth/src/internal/app-binder/task/BuildEIP712ContextTask.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/task/BuildEIP712ContextTask.ts
@@ -77,7 +77,13 @@ export class BuildEIP712ContextTask {
     }
     // EIP712 v2 (amount & datetime filters) supported since 1.11.0:
     // https://github.com/LedgerHQ/app-ethereum/blob/develop/doc/ethapp.adoc#1110-1
-    const shouldUseV2Filters = gte(deviceState.currentApp.version, "1.11.0");
+    // But some issues were still present until 1.12.0 among which:
+    // * V2 descriptor with missing token not supported by the app
+    // * Empty arrays with filters not correctly handled
+    // * Trusted name filters not yet released
+    // Therefore it's safer and easier to use V1 filters before 1.12.0:
+    // https://github.com/LedgerHQ/app-ethereum/blob/develop/doc/ethapp.adoc#1120
+    const shouldUseV2Filters = gte(deviceState.currentApp.version, "1.12.0");
     return shouldUseV2Filters ? Just("v2") : Just("v1");
   }
 }


### PR DESCRIPTION
### 📝 Description

Currently, when we have an EIP712 filter referencing a token, which is missing from the CAL, the whole message signing fails...
This was fixed in 1.12.0 version of ethereum app, which now supports missing tokens and just display a warning to the user (??? placeholder).

This can be tested with supported messages (such as https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledgerjs/packages/hw-app-eth/tests/fixtures/messages/18-1inch-fusion.json) by modifying token address values to an unknown address.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/DSDK-536

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
