### PR TITLE
🔥 (keyring-eth) [NO-ISSUE]: Remove legacy parameter for sign transaction

### DIFF
--- a/.changeset/ten-carrots-wait.md
+++ b/.changeset/ten-carrots-wait.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": patch
+---
+
+Remove legacy parameter for internal sign transacion command

--- a/packages/signer/keyring-eth/src/internal/app-binder/command/SignTransactionCommand.test.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/command/SignTransactionCommand.test.ts
@@ -35,7 +35,6 @@ describe("SignTransactionCommand", () => {
   const defaultArgs: SignTransactionCommandArgs = {
     serializedTransaction: new Uint8Array(),
     isFirstChunk: true,
-    isLegacy: true,
   };
 
   describe("getApdu", () => {

--- a/packages/signer/keyring-eth/src/internal/app-binder/command/SignTransactionCommand.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/command/SignTransactionCommand.ts
@@ -33,10 +33,6 @@ export type SignTransactionCommandArgs = {
    * If this is the first chunk of the message
    */
   readonly isFirstChunk: boolean;
-  /**
-   * If we are using the legacy flow
-   */
-  readonly isLegacy: boolean;
 };
 
 export class SignTransactionCommand
@@ -49,34 +45,14 @@ export class SignTransactionCommand
     this.args = args;
   }
 
-  private getP1(): number {
-    const { isLegacy, isFirstChunk } = this.args;
-    if (isLegacy) {
-      return isFirstChunk ? 0x00 : 0x80;
-    }
-
-    return isFirstChunk ? 0x01 : 0x00;
-  }
-
-  private getP2(): number {
-    const { isLegacy } = this.args;
-    if (isLegacy) {
-      return 0x00;
-    }
-
-    return 0x01;
-  }
-
   getApdu(): Apdu {
-    const { serializedTransaction } = this.args;
-
-    const p2 = this.getP2();
+    const { serializedTransaction, isFirstChunk } = this.args;
 
     const signEthTransactionArgs: ApduBuilderArgs = {
       cla: 0xe0,
       ins: 0x04,
-      p1: this.getP1(),
-      p2,
+      p1: isFirstChunk ? 0x00 : 0x80,
+      p2: 0x00,
     };
 
     const builder = new ApduBuilder(signEthTransactionArgs);

--- a/packages/signer/keyring-eth/src/internal/app-binder/command/StartTransactionCommand.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/command/StartTransactionCommand.ts
@@ -32,8 +32,8 @@ export class StartTransactionCommand
     const signEthTransactionArgs: ApduBuilderArgs = {
       cla: 0xe0,
       ins: 0x04,
-      p1: 0x01,
-      p2: 0x03,
+      p1: 0x00,
+      p2: 0x02,
     };
     const builder = new ApduBuilder(signEthTransactionArgs);
     return builder.build();

--- a/packages/signer/keyring-eth/src/internal/app-binder/task/SendSignTransactionTask.test.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/task/SendSignTransactionTask.test.ts
@@ -78,149 +78,140 @@ describe("SendSignTransactionTask", () => {
     jest.resetAllMocks();
   });
 
-  describe("Legacy", () => {
-    describe("run", () => {
-      it("should send the transaction in one command", async () => {
-        // GIVEN
-        const args = {
-          derivationPath: "44'/60'/0'/0/0",
-          serializedTransaction: SIMPLE_TRANSACTION,
-          isLegacy: true,
-        };
-        apiMock.sendCommand.mockResolvedValueOnce(resultOk);
+  describe("run", () => {
+    it("should send the transaction in one command", async () => {
+      // GIVEN
+      const args = {
+        derivationPath: "44'/60'/0'/0/0",
+        serializedTransaction: SIMPLE_TRANSACTION,
+      };
+      apiMock.sendCommand.mockResolvedValueOnce(resultOk);
 
-        // WHEN
-        const result = await new SendSignTransactionTask(apiMock, args).run();
+      // WHEN
+      const result = await new SendSignTransactionTask(apiMock, args).run();
 
-        // THEN
-        expect(apiMock.sendCommand.mock.calls).toHaveLength(1);
-        expect(apiMock.sendCommand.mock.calls[0]![0]).toStrictEqual(
-          new SignTransactionCommand({
-            serializedTransaction: new Uint8Array([
-              ...PATH,
-              ...SIMPLE_TRANSACTION,
-            ]),
-            isFirstChunk: true,
-            isLegacy: true,
-          }),
-        );
-        // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-        expect((result as any).data).toStrictEqual(signature);
-      });
+      // THEN
+      expect(apiMock.sendCommand.mock.calls).toHaveLength(1);
+      expect(apiMock.sendCommand.mock.calls[0]![0]).toStrictEqual(
+        new SignTransactionCommand({
+          serializedTransaction: new Uint8Array([
+            ...PATH,
+            ...SIMPLE_TRANSACTION,
+          ]),
+          isFirstChunk: true,
+        }),
+      );
+      // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+      expect((result as any).data).toStrictEqual(signature);
+    });
 
-      it("should send the transaction in chunks", async () => {
-        // GIVEN
-        const args = {
-          derivationPath: "44'/60'/0'/0/0",
-          serializedTransaction: BIG_TRANSACTION,
-          isLegacy: true,
-        };
-        apiMock.sendCommand.mockResolvedValueOnce(resultNothing);
-        apiMock.sendCommand.mockResolvedValueOnce(resultOk);
+    it("should send the transaction in chunks", async () => {
+      // GIVEN
+      const args = {
+        derivationPath: "44'/60'/0'/0/0",
+        serializedTransaction: BIG_TRANSACTION,
+        isLegacy: true,
+      };
+      apiMock.sendCommand.mockResolvedValueOnce(resultNothing);
+      apiMock.sendCommand.mockResolvedValueOnce(resultOk);
 
-        // WHEN
-        const result = await new SendSignTransactionTask(apiMock, args).run();
+      // WHEN
+      const result = await new SendSignTransactionTask(apiMock, args).run();
 
-        // THEN
-        expect(apiMock.sendCommand.mock.calls).toHaveLength(2);
-        expect(apiMock.sendCommand.mock.calls[0]![0]).toStrictEqual(
-          new SignTransactionCommand({
-            serializedTransaction: new Uint8Array([
-              ...PATH,
-              ...BIG_TRANSACTION,
-            ]).slice(0, APDU_MAX_PAYLOAD),
-            isFirstChunk: true,
-            isLegacy: true,
-          }),
-        );
-        expect(apiMock.sendCommand.mock.calls[1]![0]).toStrictEqual(
-          new SignTransactionCommand({
-            serializedTransaction: new Uint8Array([
-              ...PATH,
-              ...BIG_TRANSACTION,
-            ]).slice(APDU_MAX_PAYLOAD, APDU_MAX_PAYLOAD * 2),
-            isFirstChunk: false,
-            isLegacy: true,
-          }),
-        );
-        // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-        expect((result as any).data).toStrictEqual(signature);
-      });
+      // THEN
+      expect(apiMock.sendCommand.mock.calls).toHaveLength(2);
+      expect(apiMock.sendCommand.mock.calls[0]![0]).toStrictEqual(
+        new SignTransactionCommand({
+          serializedTransaction: new Uint8Array([
+            ...PATH,
+            ...BIG_TRANSACTION,
+          ]).slice(0, APDU_MAX_PAYLOAD),
+          isFirstChunk: true,
+        }),
+      );
+      expect(apiMock.sendCommand.mock.calls[1]![0]).toStrictEqual(
+        new SignTransactionCommand({
+          serializedTransaction: new Uint8Array([
+            ...PATH,
+            ...BIG_TRANSACTION,
+          ]).slice(APDU_MAX_PAYLOAD, APDU_MAX_PAYLOAD * 2),
+          isFirstChunk: false,
+        }),
+      );
+      // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+      expect((result as any).data).toStrictEqual(signature);
+    });
 
-      it("should return an error if the command fails", async () => {
-        // GIVEN
-        const args = {
-          derivationPath: "44'/60'/0'/0/0",
-          serializedTransaction: SIMPLE_TRANSACTION,
-          isLegacy: true,
-        };
-        apiMock.sendCommand.mockResolvedValueOnce(resultNothing);
+    it("should return an error if the command fails", async () => {
+      // GIVEN
+      const args = {
+        derivationPath: "44'/60'/0'/0/0",
+        serializedTransaction: SIMPLE_TRANSACTION,
+        isLegacy: true,
+      };
+      apiMock.sendCommand.mockResolvedValueOnce(resultNothing);
 
-        // WHEN
-        const result = await new SendSignTransactionTask(apiMock, args).run();
+      // WHEN
+      const result = await new SendSignTransactionTask(apiMock, args).run();
 
-        // THEN
-        expect(apiMock.sendCommand.mock.calls).toHaveLength(1);
-        expect(apiMock.sendCommand.mock.calls[0]![0]).toStrictEqual(
-          new SignTransactionCommand({
-            serializedTransaction: new Uint8Array([
-              ...PATH,
-              ...SIMPLE_TRANSACTION,
-            ]),
-            isFirstChunk: true,
-            isLegacy: true,
-          }),
-        );
-        // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-        expect((result as any).error).toStrictEqual(
-          new InvalidStatusWordError("no signature returned"),
-        );
-      });
+      // THEN
+      expect(apiMock.sendCommand.mock.calls).toHaveLength(1);
+      expect(apiMock.sendCommand.mock.calls[0]![0]).toStrictEqual(
+        new SignTransactionCommand({
+          serializedTransaction: new Uint8Array([
+            ...PATH,
+            ...SIMPLE_TRANSACTION,
+          ]),
+          isFirstChunk: true,
+        }),
+      );
+      // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+      expect((result as any).error).toStrictEqual(
+        new InvalidStatusWordError("no signature returned"),
+      );
+    });
 
-      it("should return an error if the command fails in the middle of the transaction", async () => {
-        // GIVEN
-        const args = {
-          derivationPath: "44'/60'/0'/0/0",
-          serializedTransaction: BIG_TRANSACTION,
-          isLegacy: true,
-        };
-        apiMock.sendCommand.mockResolvedValueOnce(resultNothing);
-        apiMock.sendCommand.mockResolvedValueOnce(
-          CommandResultFactory({
-            error: new InvalidStatusWordError("An error"),
-          }),
-        );
+    it("should return an error if the command fails in the middle of the transaction", async () => {
+      // GIVEN
+      const args = {
+        derivationPath: "44'/60'/0'/0/0",
+        serializedTransaction: BIG_TRANSACTION,
+        isLegacy: true,
+      };
+      apiMock.sendCommand.mockResolvedValueOnce(resultNothing);
+      apiMock.sendCommand.mockResolvedValueOnce(
+        CommandResultFactory({
+          error: new InvalidStatusWordError("An error"),
+        }),
+      );
 
-        // WHEN
-        const result = await new SendSignTransactionTask(apiMock, args).run();
+      // WHEN
+      const result = await new SendSignTransactionTask(apiMock, args).run();
 
-        // THEN
-        expect(apiMock.sendCommand.mock.calls).toHaveLength(2);
-        expect(apiMock.sendCommand.mock.calls[0]![0]).toStrictEqual(
-          new SignTransactionCommand({
-            serializedTransaction: new Uint8Array([
-              ...PATH,
-              ...BIG_TRANSACTION,
-            ]).slice(0, APDU_MAX_PAYLOAD),
-            isFirstChunk: true,
-            isLegacy: true,
-          }),
-        );
-        expect(apiMock.sendCommand.mock.calls[1]![0]).toStrictEqual(
-          new SignTransactionCommand({
-            serializedTransaction: new Uint8Array([
-              ...PATH,
-              ...BIG_TRANSACTION,
-            ]).slice(APDU_MAX_PAYLOAD, APDU_MAX_PAYLOAD * 2),
-            isFirstChunk: false,
-            isLegacy: true,
-          }),
-        );
-        // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-        expect((result as any).error).toStrictEqual(
-          new InvalidStatusWordError("An error"),
-        );
-      });
+      // THEN
+      expect(apiMock.sendCommand.mock.calls).toHaveLength(2);
+      expect(apiMock.sendCommand.mock.calls[0]![0]).toStrictEqual(
+        new SignTransactionCommand({
+          serializedTransaction: new Uint8Array([
+            ...PATH,
+            ...BIG_TRANSACTION,
+          ]).slice(0, APDU_MAX_PAYLOAD),
+          isFirstChunk: true,
+        }),
+      );
+      expect(apiMock.sendCommand.mock.calls[1]![0]).toStrictEqual(
+        new SignTransactionCommand({
+          serializedTransaction: new Uint8Array([
+            ...PATH,
+            ...BIG_TRANSACTION,
+          ]).slice(APDU_MAX_PAYLOAD, APDU_MAX_PAYLOAD * 2),
+          isFirstChunk: false,
+        }),
+      );
+      // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+      expect((result as any).error).toStrictEqual(
+        new InvalidStatusWordError("An error"),
+      );
     });
   });
 });

--- a/packages/signer/keyring-eth/src/internal/app-binder/task/SendSignTransactionTask.ts
+++ b/packages/signer/keyring-eth/src/internal/app-binder/task/SendSignTransactionTask.ts
@@ -21,7 +21,6 @@ const PATH_SIZE = 4;
 type SendSignTransactionTaskArgs = {
   derivationPath: string;
   serializedTransaction: Uint8Array;
-  isLegacy: boolean;
 };
 
 export class SendSignTransactionTask {
@@ -57,7 +56,6 @@ export class SendSignTransactionTask {
             new SignTransactionCommand({
               serializedTransaction: args.chunkedData,
               isFirstChunk: args.isFirstChunk,
-              isLegacy: this.args.isLegacy,
             }),
         },
       ).run();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The spec has been updated and there is no need to handle a legacy sign transaction command.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [NO-ISSUE]

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
