### PR TITLE
:adhesive_bandage: (core) [NO-ISSUE]: ListDeviceSessionsUC returns only id

### DIFF
--- a/.changeset/chilly-plums-fly.md
+++ b/.changeset/chilly-plums-fly.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+ListDeviceSessions usecase returns sessions id

--- a/packages/core/src/api/DeviceSdk.ts
+++ b/packages/core/src/api/DeviceSdk.ts
@@ -26,7 +26,6 @@ import {
 import { configTypes } from "@internal/config/di/configTypes";
 import { GetSdkVersionUseCase } from "@internal/config/use-case/GetSdkVersionUseCase";
 import { deviceSessionTypes } from "@internal/device-session/di/deviceSessionTypes";
-import { DeviceSession } from "@internal/device-session/model/DeviceSession";
 import { CloseSessionsUseCase } from "@internal/device-session/use-case/CloseSessionsUseCase";
 import { GetDeviceSessionStateUseCase } from "@internal/device-session/use-case/GetDeviceSessionStateUseCase";
 import { ListDeviceSessionsUseCase } from "@internal/device-session/use-case/ListDeviceSessionsUseCase";
@@ -219,9 +218,9 @@ export class DeviceSdk {
   /**
    * Lists all device sessions.
    *
-   * @returns {DeviceSession[]} The list of device sessions.
+   * @returns {DeviceSessionId[]} The list of device sessions.
    */
-  listDeviceSessions(): DeviceSession[] {
+  listDeviceSessions(): DeviceSessionId[] {
     return this.container
       .get<ListDeviceSessionsUseCase>(
         deviceSessionTypes.ListDeviceSessionsUseCase,

--- a/packages/core/src/internal/device-session/use-case/ListDeviceSessionsUseCase.test.ts
+++ b/packages/core/src/internal/device-session/use-case/ListDeviceSessionsUseCase.test.ts
@@ -49,7 +49,7 @@ describe("ListDeviceSessionsUseCase", () => {
     const response = useCase.execute();
 
     // then
-    expect(response).toStrictEqual([deviceSession1, deviceSession2]);
+    expect(response).toStrictEqual([deviceSession1.id, deviceSession2.id]);
   });
 
   it("should return empty array if no device sessions", () => {

--- a/packages/core/src/internal/device-session/use-case/ListDeviceSessionsUseCase.ts
+++ b/packages/core/src/internal/device-session/use-case/ListDeviceSessionsUseCase.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from "inversify";
 
+import { DeviceSessionId } from "@api/types";
 import { deviceSessionTypes } from "@internal/device-session/di/deviceSessionTypes";
-import { DeviceSession } from "@internal/device-session/model/DeviceSession";
 import type { DeviceSessionService } from "@internal/device-session/service/DeviceSessionService";
 import { loggerTypes } from "@internal/logger-publisher/di/loggerTypes";
 import { LoggerPublisherService } from "@internal/logger-publisher/service/LoggerPublisherService";
@@ -24,8 +24,10 @@ export class ListDeviceSessionsUseCase {
     this._logger = loggerFactory("ListDeviceSessionsUseCase");
   }
 
-  execute(): DeviceSession[] {
+  execute(): DeviceSessionId[] {
     this._logger.info("Listing device sessions");
-    return this._sessionService.getDeviceSessions();
+    return this._sessionService
+      .getDeviceSessions()
+      .map((dSession) => dSession.id);
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Returns session id instead of complete object in ListDeviceSessionsUC

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [NO-ISSUE]

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
