### PR TITLE
:sparkles: (keyring-eth) [DSDK-530]: Handle empty arrays with filters

### DIFF
--- a/.changeset/hip-ducks-study.md
+++ b/.changeset/hip-ducks-study.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": patch
+---
+
+Fix clear signing of EIP712 messages with an empty array

--- a/packages/signer/context-module/src/typed-data/domain/DefaultTypedDataContextLoader.test.ts
+++ b/packages/signer/context-module/src/typed-data/domain/DefaultTypedDataContextLoader.test.ts
@@ -484,7 +484,7 @@ describe("TokenContextLoader", () => {
       expect(result.type).toEqual("success");
     });
 
-    it("should return an error if value is not found", async () => {
+    it("should ignore the token if value is not found", async () => {
       // GIVEN
       const ctx = {
         verifyingContract: "0x000000000022d473030f116ddee9f6b43ac78ba3",
@@ -522,12 +522,13 @@ describe("TokenContextLoader", () => {
       const result = await loader.load(ctx);
 
       // THEN
-      expect(result).toEqual({
-        type: "error",
-        error: new Error(
-          "The token filter references the value details.badtoken which is absent from the message",
-        ),
-      });
+      expect(result.type).toEqual("success");
+      if (result.type === "success") {
+        expect(result.filters["details.badtoken"]?.["displayName"]).toEqual(
+          "Amount allowance",
+        );
+        expect(result.tokens).toEqual({});
+      }
     });
   });
 });

--- a/packages/signer/context-module/src/typed-data/domain/DefaultTypedDataContextLoader.ts
+++ b/packages/signer/context-module/src/typed-data/domain/DefaultTypedDataContextLoader.ts
@@ -67,12 +67,8 @@ export class DefaultTypedDataContextLoader implements TypedDataContextLoader {
           (entry) => entry.path === filter.path,
         );
         if (values.length === 0) {
-          return {
-            type: "error",
-            error: new Error(
-              `The token filter references the value ${filter.path} which is absent from the message`,
-            ),
-          };
+          // No value matching the referenced token. It may be located in an empty array.
+          continue;
         }
         const value = values[0]!;
         const address = this.convertAddressToHexaString(value.value);

--- a/packages/signer/signer-eth/src/internal/app-binder/command/SendEIP712FilteringCommand.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/command/SendEIP712FilteringCommand.test.ts
@@ -57,6 +57,10 @@ const DATE_TIME_APDU = Uint8Array.from([
   0xaf, 0x30, 0x3d, 0xc0, 0x16, 0xda, 0x4c, 0x1c, 0x3d, 0x18, 0x46, 0x63, 0xda,
   0x8f, 0x6a,
 ]);
+const DISCARDED_PATH_APDU = Uint8Array.from([
+  0xe0, 0x1e, 0x00, 0x01, 0x11, 0x10, 0x74, 0x6f, 0x2e, 0x5b, 0x5d, 0x2e, 0x77,
+  0x61, 0x6c, 0x6c, 0x65, 0x74, 0x73, 0x2e, 0x5b, 0x5d,
+]);
 
 describe("SendEIP712FilteringCommand", () => {
   describe("getApdu", () => {
@@ -70,6 +74,19 @@ describe("SendEIP712FilteringCommand", () => {
       const apdu = command.getApdu();
       // THEN
       expect(apdu.getRawApdu()).toStrictEqual(ACTIVATE_APDU);
+    });
+
+    it("Discarded path APDU", () => {
+      // GIVEN
+      const args: SendEIP712FilteringCommandArgs = {
+        type: Eip712FilterType.DiscardedPath,
+        path: "to.[].wallets.[]",
+      };
+      // WHEN
+      const command = new SendEIP712FilteringCommand(args);
+      const apdu = command.getApdu();
+      // THEN
+      expect(apdu.getRawApdu()).toStrictEqual(DISCARDED_PATH_APDU);
     });
 
     it("Message info APDU", () => {
@@ -92,6 +109,7 @@ describe("SendEIP712FilteringCommand", () => {
       // GIVEN
       const args: SendEIP712FilteringCommandArgs = {
         type: Eip712FilterType.Raw,
+        discarded: false,
         displayName: "From",
         signature:
           "3045022100b820e4dfb1a0cde6dc97d9a34eebb1a4eef0b226262e6788118ab3c7fb79fe3502202d426a388b4c3a8096b3f84412a702ea537770e61ee0727ec1b710c1da520c44",
@@ -107,6 +125,7 @@ describe("SendEIP712FilteringCommand", () => {
       // GIVEN
       const args: SendEIP712FilteringCommandArgs = {
         type: Eip712FilterType.Token,
+        discarded: false,
         tokenIndex: 1,
         signature:
           "3045022100ff727847445431e571cd2a0d9db42a7eb62e37877b9bf20e6a96584255347e1902200a6e95b7f8e63b2fab0bef88c747de6a387d06351be5bdc34b2c1f9aea6fdd28",
@@ -122,6 +141,7 @@ describe("SendEIP712FilteringCommand", () => {
       // GIVEN
       const args: SendEIP712FilteringCommandArgs = {
         type: Eip712FilterType.Amount,
+        discarded: false,
         displayName: "Receive minimum",
         tokenIndex: 1,
         signature:
@@ -138,6 +158,7 @@ describe("SendEIP712FilteringCommand", () => {
       // GIVEN
       const args: SendEIP712FilteringCommandArgs = {
         type: Eip712FilterType.Datetime,
+        discarded: false,
         displayName: "Approval expire",
         signature:
           "3045022100e847166e60f851e3c8d1f44139811898ccd0d3a03aed6c77f8c3993813f479d2022031fe6b6a574b56c5104003cf07900d11ffaf303dc016da4c1c3d184663da8f6a",
@@ -147,6 +168,24 @@ describe("SendEIP712FilteringCommand", () => {
       const apdu = command.getApdu();
       // THEN
       expect(apdu.getRawApdu()).toStrictEqual(DATE_TIME_APDU);
+    });
+
+    it("Discarded filter", () => {
+      // GIVEN
+      const args: SendEIP712FilteringCommandArgs = {
+        type: Eip712FilterType.Raw,
+        discarded: true,
+        displayName: "From",
+        signature:
+          "3045022100b820e4dfb1a0cde6dc97d9a34eebb1a4eef0b226262e6788118ab3c7fb79fe3502202d426a388b4c3a8096b3f84412a702ea537770e61ee0727ec1b710c1da520c44",
+      };
+      // WHEN
+      const command = new SendEIP712FilteringCommand(args);
+      const apdu = command.getApdu();
+      // THEN
+      expect(apdu.getRawApdu()).toStrictEqual(
+        Uint8Array.from([...RAW_APDU.slice(0, 2), 0x01, ...RAW_APDU.slice(3)]),
+      );
     });
   });
 

--- a/packages/signer/signer-eth/src/internal/app-binder/task/ProvideEIP712ContextTask.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/ProvideEIP712ContextTask.test.ts
@@ -24,6 +24,7 @@ import {
   type FieldType,
   PrimitiveType,
   StructType,
+  TypedDataValueArray,
   TypedDataValueField,
   TypedDataValueRoot,
 } from "@internal/typed-data/model/Types";
@@ -188,10 +189,11 @@ describe("ProvideEIP712ContextTask", () => {
       type: StructImplemType.ROOT,
       value,
     });
-  /*const sendStructImplArray = (value: number) => new SendEIP712StructImplemCommand({
-    type: StructImplemType.ARRAY,
-    value,
-  });*/
+  const sendStructImplArray = (value: number) =>
+    new SendEIP712StructImplemCommand({
+      type: StructImplemType.ARRAY,
+      value,
+    });
   const sendStructImplField = (data: Uint8Array) =>
     new SendEIP712StructImplemCommand({
       type: StructImplemType.FIELD,
@@ -442,6 +444,7 @@ describe("ProvideEIP712ContextTask", () => {
     expect(apiMock.sendCommand.mock.calls[21]![0]).toStrictEqual(
       new SendEIP712FilteringCommand({
         type: Eip712FilterType.Token,
+        discarded: false,
         tokenIndex: 4,
         signature:
           "3044022075103b38995e031d1ebbfe38ac6603bec32854b5146a664e49b4cc4f460c1da6022029f4b0fd1f3b7995ffff1627d4b57f27888a2dcc9b3a4e85c37c67571092c733",
@@ -463,6 +466,7 @@ describe("ProvideEIP712ContextTask", () => {
     expect(apiMock.sendCommand.mock.calls[24]![0]).toStrictEqual(
       new SendEIP712FilteringCommand({
         type: Eip712FilterType.Amount,
+        discarded: false,
         displayName: "Amount allowance",
         tokenIndex: 255,
         signature:
@@ -475,6 +479,7 @@ describe("ProvideEIP712ContextTask", () => {
     expect(apiMock.sendCommand.mock.calls[26]![0]).toStrictEqual(
       new SendEIP712FilteringCommand({
         type: Eip712FilterType.Datetime,
+        discarded: false,
         displayName: "Approval expire",
         signature:
           "3044022056b3381e4540629ad73bc434ec49d80523234b82f62340fbb77157fb0eb21a680220459fe9cf6ca309f9c7dfc6d4711fea1848dba661563c57f77b3c2dc480b3a63b",
@@ -489,6 +494,7 @@ describe("ProvideEIP712ContextTask", () => {
     expect(apiMock.sendCommand.mock.calls[29]![0]).toStrictEqual(
       new SendEIP712FilteringCommand({
         type: Eip712FilterType.Raw,
+        discarded: false,
         displayName: "Approve to spender",
         signature:
           "3044022033e5713d9cb9bc375b56a9fb53b736c81ea3c4ac5cfb2d3ca7f8b8f0558fe2430220543ca4fef6d6f725f29e343f167fe9dd582aa856ecb5797259050eb990a1befb",
@@ -541,6 +547,7 @@ describe("ProvideEIP712ContextTask", () => {
     expect(apiMock.sendCommand).toHaveBeenCalledWith(
       new SendEIP712FilteringCommand({
         type: Eip712FilterType.Token,
+        discarded: false,
         tokenIndex: 0,
         signature:
           "3044022075103b38995e031d1ebbfe38ac6603bec32854b5146a664e49b4cc4f460c1da6022029f4b0fd1f3b7995ffff1627d4b57f27888a2dcc9b3a4e85c37c67571092c733",
@@ -549,6 +556,7 @@ describe("ProvideEIP712ContextTask", () => {
     expect(apiMock.sendCommand).toHaveBeenCalledWith(
       new SendEIP712FilteringCommand({
         type: Eip712FilterType.Amount,
+        discarded: false,
         displayName: "Amount allowance",
         tokenIndex: 1,
         signature:
@@ -581,6 +589,7 @@ describe("ProvideEIP712ContextTask", () => {
     expect(apiMock.sendCommand).toHaveBeenCalledWith(
       new SendEIP712FilteringCommand({
         type: Eip712FilterType.Token,
+        discarded: false,
         tokenIndex: 0,
         signature:
           "3044022075103b38995e031d1ebbfe38ac6603bec32854b5146a664e49b4cc4f460c1da6022029f4b0fd1f3b7995ffff1627d4b57f27888a2dcc9b3a4e85c37c67571092c733",
@@ -589,6 +598,7 @@ describe("ProvideEIP712ContextTask", () => {
     expect(apiMock.sendCommand).toHaveBeenCalledWith(
       new SendEIP712FilteringCommand({
         type: Eip712FilterType.Amount,
+        discarded: false,
         displayName: "Amount allowance",
         tokenIndex: 255,
         signature:
@@ -621,6 +631,7 @@ describe("ProvideEIP712ContextTask", () => {
     expect(apiMock.sendCommand).toHaveBeenCalledWith(
       new SendEIP712FilteringCommand({
         type: Eip712FilterType.Token,
+        discarded: false,
         tokenIndex: 4,
         signature:
           "3044022075103b38995e031d1ebbfe38ac6603bec32854b5146a664e49b4cc4f460c1da6022029f4b0fd1f3b7995ffff1627d4b57f27888a2dcc9b3a4e85c37c67571092c733",
@@ -629,6 +640,7 @@ describe("ProvideEIP712ContextTask", () => {
     expect(apiMock.sendCommand).toHaveBeenCalledWith(
       new SendEIP712FilteringCommand({
         type: Eip712FilterType.Amount,
+        discarded: false,
         displayName: "Amount allowance",
         tokenIndex: 0,
         signature:
@@ -723,6 +735,116 @@ describe("ProvideEIP712ContextTask", () => {
     // THEN
     await expect(promise).resolves.toStrictEqual(
       CommandResultFactory({ error: new UnknownDeviceExchangeError("error") }),
+    );
+  });
+
+  it("Send struct array", async () => {
+    // GIVEN
+    const args: ProvideEIP712ContextTaskArgs = {
+      types: {},
+      domain: [],
+      message: [
+        // Array containing an element
+        {
+          path: "spenders",
+          type: "address[]",
+          value: new TypedDataValueArray(1),
+        },
+        {
+          path: "spenders.[]",
+          type: "address",
+          value: new TypedDataValueField(
+            hexaStringToBuffer("0x7ceb23fd6bc0add59e62ac25578270cff1b9f619")!,
+          ),
+        },
+        // Empty array
+        {
+          path: "beneficiaries",
+          type: "address[]",
+          value: new TypedDataValueArray(0),
+        },
+      ],
+      clearSignContext: Just({
+        type: "success",
+        messageInfo: {
+          displayName: "Permit2",
+          filtersCount: 2,
+          signature: "sig",
+        },
+        tokens: {},
+        filters: {
+          "spenders.[]": {
+            displayName: "Spender",
+            path: "spenders.[]",
+            signature: "sig",
+            type: "raw",
+          },
+          "beneficiaries.[]": {
+            displayName: "Beneficiary",
+            path: "beneficiaries.[]",
+            signature: "sig",
+            type: "raw",
+          },
+        },
+      }),
+    };
+    // WHEN
+    apiMock.sendCommand.mockResolvedValue(
+      CommandResultFactory({ data: undefined }),
+    );
+    await new ProvideEIP712ContextTask(apiMock, args).run();
+
+    // THEN
+    // Activate the filtering
+    expect(apiMock.sendCommand.mock.calls[0]![0]).toStrictEqual(
+      new SendEIP712FilteringCommand({ type: Eip712FilterType.Activation }),
+    );
+    // Send the message information filter
+    expect(apiMock.sendCommand.mock.calls[1]![0]).toStrictEqual(
+      new SendEIP712FilteringCommand({
+        type: Eip712FilterType.MessageInfo,
+        displayName: "Permit2",
+        filtersCount: 2,
+        signature: "sig",
+      }),
+    );
+    // Send first array containing 1 element
+    expect(apiMock.sendCommand.mock.calls[2]![0]).toStrictEqual(
+      sendStructImplArray(1),
+    );
+    expect(apiMock.sendCommand.mock.calls[3]![0]).toStrictEqual(
+      new SendEIP712FilteringCommand({
+        type: Eip712FilterType.Raw,
+        discarded: false,
+        displayName: "Spender",
+        signature: "sig",
+      }),
+    );
+    expect(apiMock.sendCommand.mock.calls[4]![0]).toStrictEqual(
+      sendStructImplField(
+        Uint8Array.from([
+          0x00, 0x14, 0x7c, 0xeb, 0x23, 0xfd, 0x6b, 0xc0, 0xad, 0xd5, 0x9e,
+          0x62, 0xac, 0x25, 0x57, 0x82, 0x70, 0xcf, 0xf1, 0xb9, 0xf6, 0x19,
+        ]),
+      ),
+    );
+    // Send second empty array, with discarded filter
+    expect(apiMock.sendCommand.mock.calls[5]![0]).toStrictEqual(
+      sendStructImplArray(0),
+    );
+    expect(apiMock.sendCommand.mock.calls[6]![0]).toStrictEqual(
+      new SendEIP712FilteringCommand({
+        type: Eip712FilterType.DiscardedPath,
+        path: "beneficiaries.[]",
+      }),
+    );
+    expect(apiMock.sendCommand.mock.calls[7]![0]).toStrictEqual(
+      new SendEIP712FilteringCommand({
+        type: Eip712FilterType.Raw,
+        discarded: true,
+        displayName: "Beneficiary",
+        signature: "sig",
+      }),
     );
   });
 });


### PR DESCRIPTION
### 📝 Description

Full description available in the Jira ticket.
The goal is to correctly handle clear signing of EIP712 messages when an array is empty.
To do that, we should discard filters of all the fields contained in such arrays.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/DSDK-530

- **Feature**: Fix clear signing of EIP712 messages with an empty array

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
