### PR TITLE
:sparkles: (signer-eth) [NO-ISSUE]: Allow signing a message as a byte array

### DIFF
--- a/.changeset/lemon-impalas-flash.md
+++ b/.changeset/lemon-impalas-flash.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": patch
+---
+
+Allow signing a message as a byte array

--- a/packages/signer/signer-eth/src/api/SignerEth.ts
+++ b/packages/signer/signer-eth/src/api/SignerEth.ts
@@ -16,7 +16,7 @@ export interface SignerEth {
   ) => SignTransactionDAReturnType;
   signMessage: (
     derivationPath: string,
-    message: string,
+    message: string | Uint8Array,
   ) => SignPersonalMessageDAReturnType;
   signTypedData: (
     derivationPath: string,

--- a/packages/signer/signer-eth/src/api/app-binder/SignPersonalMessageDeviceActionTypes.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignPersonalMessageDeviceActionTypes.ts
@@ -13,7 +13,7 @@ export type SignPersonalMessageDAOutput = Signature;
 
 export type SignPersonalMessageDAInput = {
   readonly derivationPath: string;
-  readonly message: string;
+  readonly message: string | Uint8Array;
 };
 
 export type SignPersonalMessageDAError =

--- a/packages/signer/signer-eth/src/internal/DefaultSignerEth.ts
+++ b/packages/signer/signer-eth/src/internal/DefaultSignerEth.ts
@@ -49,7 +49,7 @@ export class DefaultSignerEth implements SignerEth {
 
   signMessage(
     _derivationPath: string,
-    _message: string,
+    _message: string | Uint8Array,
   ): SignPersonalMessageDAReturnType {
     return this._container
       .get<SignMessageUseCase>(messageTypes.SignMessageUseCase)

--- a/packages/signer/signer-eth/src/internal/app-binder/EthAppBinder.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/EthAppBinder.ts
@@ -55,7 +55,7 @@ export class EthAppBinder {
 
   signPersonalMessage(args: {
     derivationPath: string;
-    message: string;
+    message: string | Uint8Array;
   }): SignPersonalMessageDAReturnType {
     return this.dmk.executeDeviceAction({
       sessionId: this.sessionId,

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignPersonalMessage/SignPersonalMessageDeviceAction.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignPersonalMessage/SignPersonalMessageDeviceAction.ts
@@ -26,7 +26,7 @@ export type MachineDependencies = {
   readonly signPersonalMessage: (arg0: {
     input: {
       derivationPath: string;
-      message: string;
+      message: string | Uint8Array;
     };
   }) => Promise<CommandResult<Signature>>;
 };
@@ -215,7 +215,7 @@ export class SignPersonalMessageDeviceAction extends XStateDeviceAction<
     const signPersonalMessage = async (arg0: {
       input: {
         derivationPath: string;
-        message: string;
+        message: string | Uint8Array;
       };
     }) => new SendSignPersonalMessageTask(internalApi, arg0.input).run();
 

--- a/packages/signer/signer-eth/src/internal/app-binder/task/SendSignPersonalMessageTask.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/SendSignPersonalMessageTask.test.ts
@@ -8,6 +8,9 @@ import { makeDeviceActionInternalApiMock } from "@internal/app-binder/device-act
 import { SendSignPersonalMessageTask } from "./SendSignPersonalMessageTask";
 
 const SEND_MESSAGE_HELLO_WORLD = "Hello, World!";
+const SEND_MESSAGE_HELLO_WORLD_BYTES = new Uint8Array([
+  0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21,
+]);
 const SEND_MESSAGE_HELLO_WORLD_DATA = new Uint8Array([
   0x05, 0x80, 0x00, 0x00, 0x2c, 0x80, 0x00, 0x00, 0x3c, 0x80, 0x00, 0x00, 0x00,
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0d, 0x48,
@@ -78,6 +81,30 @@ describe("SendSignPersonalMessageTask", () => {
       const args = {
         derivationPath: "44'/60'/0'/0/0",
         message: SEND_MESSAGE_HELLO_WORLD,
+      };
+      apiMock.sendCommand.mockResolvedValueOnce(resultOk);
+      apiMock.sendCommand.mockResolvedValueOnce(resultNothing);
+
+      // WHEN
+      const result = await new SendSignPersonalMessageTask(apiMock, args).run();
+
+      // THEN
+      expect(apiMock.sendCommand.mock.calls).toHaveLength(1);
+      expect(apiMock.sendCommand.mock.calls[0]![0]).toStrictEqual(
+        new SignPersonalMessageCommand({
+          data: new Uint8Array(SEND_MESSAGE_HELLO_WORLD_DATA),
+          isFirstChunk: true,
+        }),
+      );
+      // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+      expect((result as any).data).toStrictEqual(signature);
+    });
+
+    it("should send the message as byte arrays", async () => {
+      // GIVEN
+      const args = {
+        derivationPath: "44'/60'/0'/0/0",
+        message: SEND_MESSAGE_HELLO_WORLD_BYTES,
       };
       apiMock.sendCommand.mockResolvedValueOnce(resultOk);
       apiMock.sendCommand.mockResolvedValueOnce(resultNothing);

--- a/packages/signer/signer-eth/src/internal/app-binder/task/SendSignPersonalMessageTask.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/SendSignPersonalMessageTask.ts
@@ -20,7 +20,7 @@ const PATH_SIZE = 4;
 
 type SendSignPersonalMessageTaskArgs = {
   derivationPath: string;
-  message: string;
+  message: string | Uint8Array;
 };
 
 export class SendSignPersonalMessageTask {
@@ -45,7 +45,11 @@ export class SendSignPersonalMessageTask {
     // add message length
     builder.add32BitUIntToData(message.length);
     // add the message
-    builder.addAsciiStringToData(message);
+    if (typeof message === "string") {
+      builder.addAsciiStringToData(message);
+    } else {
+      builder.addBufferToData(message);
+    }
 
     const buffer = builder.build();
 

--- a/packages/signer/signer-eth/src/internal/message/use-case/SignMessageUseCase.ts
+++ b/packages/signer/signer-eth/src/internal/message/use-case/SignMessageUseCase.ts
@@ -17,7 +17,7 @@ export class SignMessageUseCase {
 
   execute(
     derivationPath: string,
-    message: string,
+    message: string | Uint8Array,
   ): SignPersonalMessageDAReturnType {
     // 1- Sign the transaction using the app binding
     return this._appBinding.signPersonalMessage({


### PR DESCRIPTION
### 📝 Description

Allow to give a byte array as personal message to be signed.
It can be useful for some usecases such as signing a hash

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**:

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
