### PR TITLE
🐛 (web-ble) [NO-ISSUE]: Fix ble connection on windows

### DIFF
--- a/packages/tools/esbuild-tools/build.mjs
+++ b/packages/tools/esbuild-tools/build.mjs
@@ -1,9 +1,12 @@
 #!/usr/bin/env zx
 
 import "zx/globals";
+import {usePowerShell} from 'zx'
 import esbuild from "esbuild";
 import { nodeExternalsPlugin } from "esbuild-node-externals";
 import { replaceTscAliasPaths } from "tsc-alias";
+
+if ( process.platform === 'win32' ) usePowerShell()
 
 const config = {
   minify: true,

--- a/packages/transport/web-ble/src/api/transport/WebBleTransport.ts
+++ b/packages/transport/web-ble/src/api/transport/WebBleTransport.ts
@@ -255,7 +255,12 @@ export class WebBleTransport implements Transport {
             );
             return discoveredDevice;
           } catch (error) {
-            await bleDevice.forget();
+            this._logger.error("Error while discovering device", {
+              data: { error, bleDevice },
+            });
+            if (bleDevice.forget) {
+              await bleDevice.forget();
+            }
             throw error;
           }
         }).caseOf({
@@ -350,8 +355,9 @@ export class WebBleTransport implements Transport {
 
       return Right(connectedDevice);
     } catch (error) {
-      await internalDevice.bleDevice.forget();
-
+      if (internalDevice.bleDevice.forget) {
+        await internalDevice.bleDevice.forget();
+      }
       this._internalDevicesById.delete(deviceId);
 
       this._logger.error("Error while getting characteristics", {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

BLE connection threw error on connect with windows
Conditioning ble device forget calls fix it

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [NO-ISSUE]

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
