### PR TITLE
✨ (dmk) [NO-ISSUE]: Get manager API service from internal API

### DIFF
--- a/.changeset/green-jobs-pay.md
+++ b/.changeset/green-jobs-pay.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Get manager API service from internal API

--- a/packages/device-management-kit/src/api/device-action/DeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/DeviceAction.ts
@@ -17,7 +17,7 @@ export type InternalApi = {
   readonly setDeviceSessionState: (
     state: DeviceSessionState,
   ) => DeviceSessionState;
-  getMetadataForAppHashes: ManagerApiService["getAppsByHash"];
+  readonly getManagerApiService: () => ManagerApiService;
 };
 
 export type DeviceActionIntermediateValue = {

--- a/packages/device-management-kit/src/api/device-action/__test-utils__/makeInternalApi.ts
+++ b/packages/device-management-kit/src/api/device-action/__test-utils__/makeInternalApi.ts
@@ -4,7 +4,7 @@ const sendCommandMock = jest.fn();
 const apiGetDeviceSessionStateMock = jest.fn();
 const apiGetDeviceSessionStateObservableMock = jest.fn();
 const setDeviceSessionStateMock = jest.fn();
-const getMetadataForAppHashesMock = jest.fn();
+const getManagerApiServiceMock = jest.fn();
 
 export function makeDeviceActionInternalApiMock(): jest.Mocked<InternalApi> {
   return {
@@ -12,6 +12,6 @@ export function makeDeviceActionInternalApiMock(): jest.Mocked<InternalApi> {
     getDeviceSessionState: apiGetDeviceSessionStateMock,
     getDeviceSessionStateObservable: apiGetDeviceSessionStateObservableMock,
     setDeviceSessionState: setDeviceSessionStateMock,
-    getMetadataForAppHashes: getMetadataForAppHashesMock,
+    getManagerApiService: getManagerApiServiceMock,
   };
 }

--- a/packages/device-management-kit/src/api/device-action/os/ListAppsWithMetadata/ListAppsWithMetadataDeviceAction.test.ts
+++ b/packages/device-management-kit/src/api/device-action/os/ListAppsWithMetadata/ListAppsWithMetadataDeviceAction.test.ts
@@ -17,6 +17,7 @@ import { UserInteractionRequired } from "@api/device-action/model/UserInteractio
 import { UnknownDAError } from "@api/device-action/os/Errors";
 import { DeviceSessionStateType } from "@api/device-session/DeviceSessionState";
 import { HttpFetchApiError } from "@internal/manager-api/model/Errors";
+import { type ManagerApiService } from "@internal/manager-api/service/ManagerApiService";
 
 import { ListAppsWithMetadataDeviceAction } from "./ListAppsWithMetadataDeviceAction";
 import { type ListAppsWithMetadataDAState } from "./types";
@@ -24,11 +25,8 @@ import { type ListAppsWithMetadataDAState } from "./types";
 jest.mock("@api/device-action/os/ListApps/ListAppsDeviceAction");
 
 describe("ListAppsWithMetadataDeviceAction", () => {
-  const {
-    getMetadataForAppHashes: getMetadataForAppHashesMock,
-    // getDeviceSessionState: apiGetDeviceSessionStateMock,
-    // setDeviceSessionState: apiSetDeviceSessionStateMock,
-  } = makeDeviceActionInternalApiMock();
+  const { getManagerApiService: getManagerApiServiceMock } =
+    makeDeviceActionInternalApiMock();
 
   const saveSessionStateMock = jest.fn();
   const getDeviceSessionStateMock = jest.fn();
@@ -54,7 +52,9 @@ describe("ListAppsWithMetadataDeviceAction", () => {
           input: {},
         });
 
-      getMetadataForAppHashesMock.mockResolvedValue(Right([]));
+      getManagerApiServiceMock.mockReturnValue({
+        getAppsByHash: jest.fn().mockResolvedValue(Right([])),
+      } as unknown as ManagerApiService);
 
       const expectedStates: Array<ListAppsWithMetadataDAState> = [
         {
@@ -90,7 +90,9 @@ describe("ListAppsWithMetadataDeviceAction", () => {
           input: {},
         });
 
-      getMetadataForAppHashesMock.mockResolvedValue(Right([BTC_APP_METADATA]));
+      getManagerApiServiceMock.mockReturnValue({
+        getAppsByHash: jest.fn().mockResolvedValue(Right([BTC_APP_METADATA])),
+      } as unknown as ManagerApiService);
 
       const expectedStates: Array<ListAppsWithMetadataDAState> = [
         {
@@ -138,9 +140,11 @@ describe("ListAppsWithMetadataDeviceAction", () => {
           input: {},
         });
 
-      getMetadataForAppHashesMock.mockResolvedValue(
-        Right([BTC_APP_METADATA, ETH_APP_METADATA]),
-      );
+      getManagerApiServiceMock.mockReturnValue({
+        getAppsByHash: jest
+          .fn()
+          .mockResolvedValue(Right([BTC_APP_METADATA, ETH_APP_METADATA])),
+      } as unknown as ManagerApiService);
 
       const expectedStates: Array<ListAppsWithMetadataDAState> = [
         {
@@ -188,9 +192,13 @@ describe("ListAppsWithMetadataDeviceAction", () => {
           input: {},
         });
 
-      getMetadataForAppHashesMock.mockResolvedValue(
-        Right([BTC_APP_METADATA, CUSTOM_LOCK_SCREEN_APP_METADATA]),
-      );
+      getManagerApiServiceMock.mockReturnValue({
+        getAppsByHash: jest
+          .fn()
+          .mockResolvedValue(
+            Right([BTC_APP_METADATA, CUSTOM_LOCK_SCREEN_APP_METADATA]),
+          ),
+      } as unknown as ManagerApiService);
 
       const expectedStates: Array<ListAppsWithMetadataDAState> = [
         {
@@ -274,9 +282,11 @@ describe("ListAppsWithMetadataDeviceAction", () => {
           input: {},
         });
 
-      getMetadataForAppHashesMock.mockRejectedValue(
-        new UnknownDAError("getAppsByHash failed"),
-      );
+      getManagerApiServiceMock.mockReturnValue({
+        getAppsByHash: jest
+          .fn()
+          .mockRejectedValue(new UnknownDAError("getAppsByHash failed")),
+      } as unknown as ManagerApiService);
 
       const expectedStates: Array<ListAppsWithMetadataDAState> = [
         {
@@ -320,7 +330,9 @@ describe("ListAppsWithMetadataDeviceAction", () => {
 
       const error = new HttpFetchApiError(new Error("Failed to fetch data"));
 
-      getMetadataForAppHashesMock.mockResolvedValue(Left(error));
+      getManagerApiServiceMock.mockReturnValue({
+        getAppsByHash: jest.fn().mockResolvedValue(Left(error)),
+      } as unknown as ManagerApiService);
 
       const expectedStates: Array<ListAppsWithMetadataDAState> = [
         {

--- a/packages/device-management-kit/src/api/device-action/os/ListAppsWithMetadata/ListAppsWithMetadataDeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/os/ListAppsWithMetadata/ListAppsWithMetadataDeviceAction.ts
@@ -290,7 +290,8 @@ export class ListAppsWithMetadataDeviceAction extends XStateDeviceAction<
 
   extractDependencies(internalApi: InternalApi): MachineDependencies {
     return {
-      getAppsByHash: ({ input }) => internalApi.getMetadataForAppHashes(input),
+      getAppsByHash: ({ input }) =>
+        internalApi.getManagerApiService().getAppsByHash(input),
       getDeviceSessionState: () => internalApi.getDeviceSessionState(),
       saveSessionState: (state: DeviceSessionState) =>
         internalApi.setDeviceSessionState(state),

--- a/packages/device-management-kit/src/internal/device-session/model/DeviceSession.ts
+++ b/packages/device-management-kit/src/internal/device-session/model/DeviceSession.ts
@@ -4,7 +4,6 @@ import { v4 as uuidv4 } from "uuid";
 
 import { type Command } from "@api/command/Command";
 import { type CommandResult } from "@api/command/model/CommandResult";
-import { type ListAppsResponse } from "@api/command/os/ListAppsCommand";
 import { CommandUtils } from "@api/command/utils/CommandUtils";
 import { DeviceStatus } from "@api/device/DeviceStatus";
 import {
@@ -165,8 +164,7 @@ export class DeviceSession {
         this.setDeviceSessionState(state);
         return this._deviceState.getValue();
       },
-      getMetadataForAppHashes: (apps: ListAppsResponse) =>
-        this._managerApiService.getAppsByHash(apps),
+      getManagerApiService: () => this._managerApiService,
     });
 
     return {

--- a/packages/signer/signer-btc/src/internal/app-binder/device-action/__test-utils__/makeInternalApi.ts
+++ b/packages/signer/signer-btc/src/internal/app-binder/device-action/__test-utils__/makeInternalApi.ts
@@ -4,7 +4,7 @@ const sendCommandMock = jest.fn();
 const apiGetDeviceSessionStateMock = jest.fn();
 const apiGetDeviceSessionStateObservableMock = jest.fn();
 const setDeviceSessionStateMock = jest.fn();
-const getMetadataForAppHashesMock = jest.fn();
+const getManagerApiServiceMock = jest.fn();
 
 export function makeDeviceActionInternalApiMock(): jest.Mocked<InternalApi> {
   return {
@@ -12,6 +12,6 @@ export function makeDeviceActionInternalApiMock(): jest.Mocked<InternalApi> {
     getDeviceSessionState: apiGetDeviceSessionStateMock,
     getDeviceSessionStateObservable: apiGetDeviceSessionStateObservableMock,
     setDeviceSessionState: setDeviceSessionStateMock,
-    getMetadataForAppHashes: getMetadataForAppHashesMock,
+    getManagerApiService: getManagerApiServiceMock,
   };
 }

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/__test-utils__/makeInternalApi.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/__test-utils__/makeInternalApi.ts
@@ -4,7 +4,7 @@ const sendCommandMock = jest.fn();
 const apiGetDeviceSessionStateMock = jest.fn();
 const apiGetDeviceSessionStateObservableMock = jest.fn();
 const setDeviceSessionStateMock = jest.fn();
-const getMetadataForAppHashesMock = jest.fn();
+const getManagerApiServiceMock = jest.fn();
 
 export function makeDeviceActionInternalApiMock(): jest.Mocked<InternalApi> {
   return {
@@ -12,6 +12,6 @@ export function makeDeviceActionInternalApiMock(): jest.Mocked<InternalApi> {
     getDeviceSessionState: apiGetDeviceSessionStateMock,
     getDeviceSessionStateObservable: apiGetDeviceSessionStateObservableMock,
     setDeviceSessionState: setDeviceSessionStateMock,
-    getMetadataForAppHashes: getMetadataForAppHashesMock,
+    getManagerApiService: getManagerApiServiceMock,
   };
 }

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/__test-utils__/makeInternalApi.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/__test-utils__/makeInternalApi.ts
@@ -4,7 +4,7 @@ const sendCommandMock = jest.fn();
 const apiGetDeviceSessionStateMock = jest.fn();
 const apiGetDeviceSessionStateObservableMock = jest.fn();
 const setDeviceSessionStateMock = jest.fn();
-const getMetadataForAppHashesMock = jest.fn();
+const getManagerApiServiceMock = jest.fn();
 
 export function makeDeviceActionInternalApiMock(): jest.Mocked<InternalApi> {
   return {
@@ -12,6 +12,6 @@ export function makeDeviceActionInternalApiMock(): jest.Mocked<InternalApi> {
     getDeviceSessionState: apiGetDeviceSessionStateMock,
     getDeviceSessionStateObservable: apiGetDeviceSessionStateObservableMock,
     setDeviceSessionState: setDeviceSessionStateMock,
-    getMetadataForAppHashes: getMetadataForAppHashesMock,
+    getManagerApiService: getManagerApiServiceMock,
   };
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Get Manager API service from `InternalApi` interface in order to get each necessary service from it.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [NO-ISSUE]

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
