### PR TITLE
:lipstick: (smpl) [NO-ISSUE]: Pretty print buffers in device actions logs

### DIFF
--- a/.changeset/fuzzy-dryers-speak.md
+++ b/.changeset/fuzzy-dryers-speak.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit-sample": patch
+---
+
+Pretty print buffers in device actions logs

--- a/apps/sample/src/components/DeviceActionsView/DeviceActionResponse.tsx
+++ b/apps/sample/src/components/DeviceActionsView/DeviceActionResponse.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  bufferToHexaString,
   type DeviceActionIntermediateValue,
   type DeviceActionState,
   DeviceActionStatus,
@@ -38,6 +39,14 @@ const TooltipTitle = styled(Text).attrs({
   flex-grow: 0;
 `;
 
+function bufferStringifyReplacer(_key: string, value: unknown): unknown {
+  // Pretty-print buffers to make signatures or public keys readable
+  if (value instanceof Uint8Array) {
+    return bufferToHexaString(value);
+  }
+  return value;
+}
+
 /**
  * Component to display an event emitted by a device action.
  */
@@ -69,7 +78,7 @@ export function DeviceActionResponse<
         content={
           <Text color="neutral.c00" whiteSpace="pre-wrap">
             Arguments:{"\n"}
-            {JSON.stringify(args, null, 2)}
+            {JSON.stringify(args, bufferStringifyReplacer, 2)}
           </Text>
         }
       >
@@ -96,7 +105,11 @@ export function DeviceActionResponse<
           ? inspect(props.error, { depth: null })
           : props.deviceActionState.status === DeviceActionStatus.Error
             ? inspect(props.deviceActionState.error, { depth: null })
-            : JSON.stringify(props.deviceActionState, null, 2)}
+            : JSON.stringify(
+                props.deviceActionState,
+                bufferStringifyReplacer,
+                2,
+              )}
       </Text>
       {!isError &&
       props.deviceActionState.status === DeviceActionStatus.Pending ? (


### PR DESCRIPTION
### 📝 Description

In the sample app, device actions results are currently logged through a simple `JSON.stringify`.
That's not readable for `Uint8Array` buffers such as signatures, or public keys.
It's especially visible when signing a bitcoin PSBT.

With that PR, the result is shown as

    {
      "status": "completed",
      "output": [
        {
          "inputIndex": 0,
          "signature": "0x3044022077ad57e037df32da3ef3e95279ae5d2a5f0b2d5cf18e4623e66f0172458546e802207bbe945fd1b0e42279752449295a8a042a8ba8c409ef10ea146fd8112e511b1a01",
          "pubkey": "0x028220639970ba251fdea46ad8ce0017df7e53f2cc065e41d55d5111110685a628"
        },
        {
          "inputIndex": 1,
          "signature": "0x3045022100ef37773e74c769c9246d10e23c991a14d864661e496b1b128a85af285c64d14102201e6b24b6ee89838ebe83ddc52fa5e530f86dacfd8d5ce7a3290212fa10b80ecb01",
          "pubkey": "0x023bc9074a36b88da185f5568fa663fdec1f5fd185fb4922c7eff8537cd4ba598c"
        },
        {
          "inputIndex": 2,
          "signature": "0x30440220302ff057bc5083706780bb63d8576bda0f5f8fa4c40b68835a083b36be408033022027e368b7fe395efe88688365cf038b46b5c009dca4d00676e5365b23daca0fef01",
          "pubkey": "0x029fa8bea08b199e0b3cec251faf31fb63e44b3cc678270685a5c00a87dd75f606"
        }
      ]
    }

instead of

    {
      "status": "completed",
      "output": [
        {
          "inputIndex": 0,
          "signature": {
            "0": 48,
            "1": 68,
            "2": 2,
            "3": 32,
            "4": 119,
            "5": 173,
            "6": 87,
            "7": 224,
            "8": 55,
            "9": 223,
            "10": 50,
            "11": 218,
            "12": 62,
            "13": 243,
            "14": 233,
            "15": 82,
            "16": 121,
            "17": 174,
            "18": 93,
            "19": 42,
            "20": 95,
            "21": 11,
            "22": 45,
            "23": 92,
            "24": 241,
            "25": 142,
            "26": 70,
            "27": 35,
            "28": 230,
            "29": 111,
            "30": 1,
            ...

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**:

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
