### PR TITLE
🩹 (signer-eth) [NO-ISSUE]: Add review user interraction for sign typed obj

### DIFF
--- a/.changeset/funny-rockets-glow.md
+++ b/.changeset/funny-rockets-glow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": patch
+---
+
+Add user interaction for sign typed object device action that was removed before

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.test.ts
@@ -167,7 +167,7 @@ describe("SignTypedDataDeviceAction", () => {
         },
         {
           intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
+            requiredUserInteraction: UserInteractionRequired.SignTypedData,
           },
           status: DeviceActionStatus.Pending,
         },
@@ -277,7 +277,7 @@ describe("SignTypedDataDeviceAction", () => {
         },
         {
           intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
+            requiredUserInteraction: UserInteractionRequired.SignTypedData,
           },
           status: DeviceActionStatus.Pending,
         },
@@ -437,7 +437,7 @@ describe("SignTypedDataDeviceAction", () => {
         },
         {
           intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
+            requiredUserInteraction: UserInteractionRequired.SignTypedData,
           },
           status: DeviceActionStatus.Pending,
         },
@@ -504,7 +504,7 @@ describe("SignTypedDataDeviceAction", () => {
         },
         {
           intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
+            requiredUserInteraction: UserInteractionRequired.SignTypedData,
           },
           status: DeviceActionStatus.Pending,
         },

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.ts
@@ -195,6 +195,16 @@ export class SignTypedDataDeviceAction extends XStateDeviceAction<
           },
         },
         ProvideContext: {
+          entry: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.SignTypedData,
+            },
+          }),
+          exit: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          }),
           invoke: {
             id: "provideContext",
             src: "provideContext",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Restore the user interaction during the provide `SignTypedObjectDA` that was removed. 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [NO-ISSUE]

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
