### PR TITLE
:sparkles: (signer-eth) [NO-ISSUE]: Allow to slice static leafs

### DIFF
--- a/.changeset/popular-waves-exist.md
+++ b/.changeset/popular-waves-exist.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": minor
+---
+
+Allow to slice static leafs

--- a/packages/signer/signer-eth/src/internal/transaction/service/parser/TransactionParserService.test.ts
+++ b/packages/signer/signer-eth/src/internal/transaction/service/parser/TransactionParserService.test.ts
@@ -161,6 +161,33 @@ describe("TransactionParserService", () => {
       ]);
     });
 
+    it("Slice the static leaf", () => {
+      // GIVEN
+      const path: DataPathElement[] = [
+        {
+          type: "TUPLE",
+          offset: 0,
+        },
+        {
+          type: "LEAF",
+          leafType: "STATIC_LEAF",
+        },
+        {
+          type: "SLICE",
+          start: -4,
+        },
+      ];
+
+      // WHEN
+      const value = parser.extractValue(TX, path);
+
+      // THEN
+      expect(value.isRight()).toStrictEqual(true);
+      expect(value.unsafeCoerce()).toStrictEqual([
+        hexaStringToBuffer("0x00000045")!,
+      ]);
+    });
+
     it("Out of bounds", () => {
       // GIVEN
       const path: DataPathElement[] = [

--- a/packages/signer/signer-eth/src/internal/transaction/service/parser/TransactionParserService.ts
+++ b/packages/signer/signer-eth/src/internal/transaction/service/parser/TransactionParserService.ts
@@ -230,9 +230,13 @@ export class TransactionParserService {
               );
             case DataPathLeafType.STATIC_LEAF:
               // A static leaf is the chunk of current offset (data of static size)
-              return this.getSlice(data, offset, CHUNK_SIZE).map((leaf) => [
-                leaf,
-              ]);
+              return this.getSlice(data, offset, CHUNK_SIZE).chain((leaf) => {
+                if (leafSlice === null) {
+                  return Right([leaf]);
+                } else {
+                  return this.sliceLeaf(leaf, leafSlice);
+                }
+              });
             case DataPathLeafType.DYNAMIC_LEAF:
               // A dynamic leaf is composed of a length followed by the actual value
               // (data of variable size such as a string).


### PR DESCRIPTION
### 📝 Description

Generic parser allow a slice of static leafs on device side, and the CAL descriptors will also soon allow it:
https://github.com/LedgerHQ/clear-signing-erc7730-registry/pull/102

Therefore the SignerEth transaction parser should also be able to slice static leafs and read data such as addresses in bigger chunks

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**:

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
