### PR TITLE
👔 (webhid) [NO-ISSUE]: Update reconnection error sending

### DIFF
--- a/.changeset/fuzzy-spies-divide.md
+++ b/.changeset/fuzzy-spies-divide.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-transport-kit-web-hid": patch
+---
+
+Update reconnection event to trigger error only after a specific time

--- a/packages/transport/web-hid/src/api/transport/WebHidDeviceConnection.test.ts
+++ b/packages/transport/web-hid/src/api/transport/WebHidDeviceConnection.test.ts
@@ -120,7 +120,7 @@ describe("WebHidDeviceConnection", () => {
   });
 
   describe("anticipating loss of connection after sending an APDU", () => {
-    test("sendApdu(whatever, true) should wait for reconnection before resolving if the response is a success", async () => {
+    it("sendApdu(whatever, true) should wait for reconnection before resolving if the response is a success", async () => {
       // given
       device.sendReport = jest.fn(() =>
         Promise.resolve(
@@ -130,12 +130,14 @@ describe("WebHidDeviceConnection", () => {
           } as HIDInputReportEvent),
         ),
       );
+
       const connection = new WebHidDeviceConnection(
         { device, apduSender, apduReceiver, onConnectionTerminated, deviceId },
         logger,
       );
 
       let hasResolved = false;
+
       const responsePromise = connection
         .sendApdu(Uint8Array.from([]), true)
         .then((response) => {
@@ -164,7 +166,7 @@ describe("WebHidDeviceConnection", () => {
       );
     });
 
-    test("sendApdu(whatever, true) should not wait for reconnection if the response is not a success", async () => {
+    it("sendApdu(whatever, true) should not wait for reconnection if the response is not a success", async () => {
       // given
       device.sendReport = jest.fn(() =>
         Promise.resolve(
@@ -191,7 +193,7 @@ describe("WebHidDeviceConnection", () => {
       );
     });
 
-    test("sendApdu(whatever, true) should return an error if the device gets disconnected while waiting for reconnection", async () => {
+    it("sendApdu(whatever, true) should return an error if the device gets disconnected while waiting for reconnection", async () => {
       // given
       device.sendReport = jest.fn(() =>
         Promise.resolve(
@@ -220,7 +222,7 @@ describe("WebHidDeviceConnection", () => {
   });
 
   describe("connection lost before sending an APDU", () => {
-    test("sendApdu(whatever, false) should return an error if the device connection has been lost and times out", async () => {
+    it("sendApdu(whatever, false) should return an error if the device connection has been lost and times out", async () => {
       // given
       device.sendReport = jest.fn(() =>
         Promise.resolve(
@@ -246,7 +248,7 @@ describe("WebHidDeviceConnection", () => {
       expect(response).toEqual(Left(new ReconnectionFailedError()));
     });
 
-    test("sendApdu(whatever, false) should wait for reconnection to resolve", async () => {
+    it("sendApdu(whatever, false) should wait for reconnection to resolve", async () => {
       // given
       device.sendReport = jest.fn(() =>
         Promise.resolve(
@@ -283,7 +285,13 @@ describe("WebHidDeviceConnection", () => {
 
       const response = await responsePromise;
 
-      expect(response).toEqual(Left(new WebHidSendReportError()));
+      expect(response).toEqual(
+        Left(
+          new WebHidSendReportError(
+            new Error("Device disconnected while waiting for device response"),
+          ),
+        ),
+      );
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Check for the timing between reconnection before sending an error everytime.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [NO-ISSUE]

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
