### PR TITLE
✨ (dmk) [NO-ISSUE]: Add sendApdu in internal API interface

### DIFF
--- a/.changeset/funny-ads-destroy.md
+++ b/.changeset/funny-ads-destroy.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": minor
+---
+
+Add sendApdu in internal API interface

--- a/.changeset/gold-needles-sell.md
+++ b/.changeset/gold-needles-sell.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-bitcoin": minor
+---
+
+Add sendApdu in internal API interface

--- a/.changeset/grumpy-olives-shave.md
+++ b/.changeset/grumpy-olives-shave.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": minor
+---
+
+Add sendApdu in internal API interface

--- a/.changeset/smooth-fireants-sip.md
+++ b/.changeset/smooth-fireants-sip.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": minor
+---
+
+Add sendApdu in internal API interface

--- a/packages/device-management-kit/package.json
+++ b/packages/device-management-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ledgerhq/device-management-kit",
   "version": "0.6.0",
-  "private": true,
+  "private": false,
   "license": "Apache-2.0",
   "exports": {
     ".": {

--- a/packages/device-management-kit/src/api/device-action/DeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/DeviceAction.ts
@@ -1,7 +1,9 @@
+import { type Either } from "purify-ts";
 import { type Observable } from "rxjs";
 
 import { type Command } from "@api/command/Command";
 import { type CommandResult } from "@api/command/model/CommandResult";
+import { type ApduResponse } from "@api/device-session/ApduResponse";
 import { type DeviceSessionState } from "@api/device-session/DeviceSessionState";
 import { type DmkError } from "@api/Error";
 import { type ManagerApiService } from "@internal/manager-api/service/ManagerApiService";
@@ -10,6 +12,9 @@ import { type SecureChannelService } from "@internal/secure-channel/service/Secu
 import { type DeviceActionState } from "./model/DeviceActionState";
 
 export type InternalApi = {
+  readonly sendApdu: (
+    apdu: Uint8Array,
+  ) => Promise<Either<DmkError, ApduResponse>>;
   readonly sendCommand: <Response, Args, ErrorStatusCodes>(
     command: Command<Response, Args, ErrorStatusCodes>,
   ) => Promise<CommandResult<Response, ErrorStatusCodes>>;

--- a/packages/device-management-kit/src/api/device-action/__test-utils__/makeInternalApi.ts
+++ b/packages/device-management-kit/src/api/device-action/__test-utils__/makeInternalApi.ts
@@ -2,6 +2,7 @@ import { type Mocked } from "vitest";
 
 import { type InternalApi } from "@api/device-action/DeviceAction";
 
+const sendApduMock = vi.fn();
 const sendCommandMock = vi.fn();
 const apiGetDeviceSessionStateMock = vi.fn();
 const apiGetDeviceSessionStateObservableMock = vi.fn();
@@ -11,6 +12,7 @@ const getSecureChannelServiceMock = vi.fn();
 
 export function makeDeviceActionInternalApiMock(): Mocked<InternalApi> {
   return {
+    sendApdu: sendApduMock,
     sendCommand: sendCommandMock,
     getDeviceSessionState: apiGetDeviceSessionStateMock,
     getDeviceSessionStateObservable: apiGetDeviceSessionStateObservableMock,

--- a/packages/signer/signer-btc/package.json
+++ b/packages/signer/signer-btc/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "main": "lib/cjs/index.js",
   "types": "lib/cjs/index.d.ts",
-  "private": true,
+  "private": false,
   "exports": {
     ".": {
       "types": "./lib/types/index.d.ts",

--- a/packages/signer/signer-btc/src/internal/app-binder/device-action/__test-utils__/makeInternalApi.ts
+++ b/packages/signer/signer-btc/src/internal/app-binder/device-action/__test-utils__/makeInternalApi.ts
@@ -1,6 +1,7 @@
 import { type InternalApi } from "@ledgerhq/device-management-kit";
 import { type Mocked } from "vitest";
 
+const sendApduMock = vi.fn();
 const sendCommandMock = vi.fn();
 const apiGetDeviceSessionStateMock = vi.fn();
 const apiGetDeviceSessionStateObservableMock = vi.fn();
@@ -10,6 +11,7 @@ const getSecureChannelServiceMock = vi.fn();
 
 export function makeDeviceActionInternalApiMock(): Mocked<InternalApi> {
   return {
+    sendApdu: sendApduMock,
     sendCommand: sendCommandMock,
     getDeviceSessionState: apiGetDeviceSessionStateMock,
     getDeviceSessionStateObservable: apiGetDeviceSessionStateObservableMock,

--- a/packages/signer/signer-eth/package.json
+++ b/packages/signer/signer-eth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ledgerhq/device-signer-kit-ethereum",
   "version": "1.1.0",
-  "private": true,
+  "private": false,
   "license": "Apache-2.0",
   "exports": {
     ".": {

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/__test-utils__/makeInternalApi.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/__test-utils__/makeInternalApi.ts
@@ -1,14 +1,17 @@
 import { type InternalApi } from "@ledgerhq/device-management-kit";
 import { type Mocked } from "vitest";
 
+const sendApduMock = vi.fn();
 const sendCommandMock = vi.fn();
 const apiGetDeviceSessionStateMock = vi.fn();
 const apiGetDeviceSessionStateObservableMock = vi.fn();
 const setDeviceSessionStateMock = vi.fn();
 const getManagerApiServiceMock = vi.fn();
 const getSecureChannelServiceMock = vi.fn();
+
 export function makeDeviceActionInternalApiMock(): Mocked<InternalApi> {
   return {
+    sendApdu: sendApduMock,
     sendCommand: sendCommandMock,
     getDeviceSessionState: apiGetDeviceSessionStateMock,
     getDeviceSessionStateObservable: apiGetDeviceSessionStateObservableMock,

--- a/packages/signer/signer-solana/package.json
+++ b/packages/signer/signer-solana/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ledgerhq/device-signer-kit-solana",
   "version": "1.1.0",
-  "private": true,
+  "private": false,
   "license": "Apache-2.0",
   "exports": {
     ".": {

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/__test-utils__/makeInternalApi.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/__test-utils__/makeInternalApi.ts
@@ -1,6 +1,7 @@
 import { type InternalApi } from "@ledgerhq/device-management-kit";
 import { type Mocked } from "vitest";
 
+const sendApduMock = vi.fn();
 const sendCommandMock = vi.fn();
 const apiGetDeviceSessionStateMock = vi.fn();
 const apiGetDeviceSessionStateObservableMock = vi.fn();
@@ -10,6 +11,7 @@ const getSecureChannelServiceMock = vi.fn();
 
 export function makeDeviceActionInternalApiMock(): Mocked<InternalApi> {
   return {
+    sendApdu: sendApduMock,
     sendCommand: sendCommandMock,
     getDeviceSessionState: apiGetDeviceSessionStateMock,
     getDeviceSessionStateObservable: apiGetDeviceSessionStateObservableMock,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add `sendApdu` method in `InternalApi` interface and adapt unit tests in other packages.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [NO-ISSUE]

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Now `InternalApi` has `sendApdu` method that allows to send a pure APDU of type `Uint8Array`.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
