### PR TITLE
➖ (dmk) [NO-ISSUE]: Remove statelyai/inspect from dependencies

### DIFF
--- a/.changeset/healthy-donuts-divide.md
+++ b/.changeset/healthy-donuts-divide.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Move statelyai/inspect to devDependencies

--- a/packages/device-management-kit/package.json
+++ b/packages/device-management-kit/package.json
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "@sentry/minimal": "^6.19.7",
-    "@statelyai/inspect": "^0.4.0",
     "axios": "^1.7.9",
     "inversify": "^6.2.2",
     "inversify-logger-middleware": "^3.1.0",
@@ -54,6 +53,7 @@
     "@ledgerhq/prettier-config-dsdk": "workspace:*",
     "@ledgerhq/tsconfig-dsdk": "workspace:*",
     "@ledgerhq/vitest-config-dmk": "workspace:*",
+    "@statelyai/inspect": "^0.4.0",
     "@types/semver": "^7.5.8",
     "@types/uuid": "^10.0.0",
     "@types/ws": "^8.5.14",

--- a/packages/device-management-kit/src/api/device-action/xstate-utils/XStateDeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/xstate-utils/XStateDeviceAction.ts
@@ -1,4 +1,4 @@
-import { createBrowserInspector } from "@statelyai/inspect";
+// import { createBrowserInspector } from "@statelyai/inspect";
 import { Observable, ReplaySubject, share } from "rxjs";
 import {
   createActor,
@@ -114,7 +114,7 @@ export abstract class XStateDeviceAction<
     const actor = createActor(stateMachine, {
       input: this.input,
       // optional inspector for debugging
-      inspect: this.inspect ? createBrowserInspector().inspect : undefined,
+      // inspect: this.inspect ? createBrowserInspector().inspect : undefined,
     });
 
     /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,9 +267,6 @@ importers:
       '@sentry/minimal':
         specifier: ^6.19.7
         version: 6.19.7
-      '@statelyai/inspect':
-        specifier: ^0.4.0
-        version: 0.4.0(ws@8.18.0)(xstate@5.19.2)
       axios:
         specifier: ^1.7.9
         version: 1.7.9
@@ -316,6 +313,9 @@ importers:
       '@ledgerhq/vitest-config-dmk':
         specifier: workspace:*
         version: link:../config/vitest
+      '@statelyai/inspect':
+        specifier: ^0.4.0
+        version: 0.4.0(ws@8.18.0)(xstate@5.19.2)
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Move statelyai/inspect to devDependencies

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**:

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
