### PR TITLE
👔 (dmk) [NO-ISSUE]: Update listenToAvailableDevices

### DIFF
--- a/.changeset/real-sheep-join.md
+++ b/.changeset/real-sheep-join.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Update listenToAvailableDevices to accept a transport identifier to scope its discovering process

--- a/apps/sample/src/hooks/useAvailableDevices.tsx
+++ b/apps/sample/src/hooks/useAvailableDevices.tsx
@@ -18,7 +18,7 @@ export function useAvailableDevices(): AvailableDevice[] {
   useEffect(() => {
     if (!subscription.current) {
       subscription.current = dmk
-        .listenToAvailableDevices()
+        .listenToAvailableDevices({})
         .subscribe((devices) => {
           setDiscoveredDevices(devices);
         });

--- a/packages/device-management-kit/src/api/DeviceManagementKit.ts
+++ b/packages/device-management-kit/src/api/DeviceManagementKit.ts
@@ -33,7 +33,10 @@ import { type ConnectUseCase } from "@internal/discovery/use-case/ConnectUseCase
 import { type DisconnectUseCase } from "@internal/discovery/use-case/DisconnectUseCase";
 import { type GetConnectedDeviceUseCase } from "@internal/discovery/use-case/GetConnectedDeviceUseCase";
 import { type ListConnectedDevicesUseCase } from "@internal/discovery/use-case/ListConnectedDevicesUseCase";
-import { type ListenToAvailableDevicesUseCase } from "@internal/discovery/use-case/ListenToAvailableDevicesUseCase";
+import {
+  type ListenToAvailableDevicesUseCase,
+  type ListenToAvailableDevicesUseCaseArgs,
+} from "@internal/discovery/use-case/ListenToAvailableDevicesUseCase";
 import { type ListenToConnectedDeviceUseCase } from "@internal/discovery/use-case/ListenToConnectedDeviceUseCase";
 import type { StartDiscoveringUseCase } from "@internal/discovery/use-case/StartDiscoveringUseCase";
 import type { StopDiscoveringUseCase } from "@internal/discovery/use-case/StopDiscoveringUseCase";
@@ -111,15 +114,17 @@ export class DeviceManagementKit {
 
   /**
    * Listen to list of known discovered devices (and later BLE).
-   *
+   * @param {ListenToAvailableDevicesUseCaseArgs} args - The transport to use for discover, or undefined to discover from all transports.
    * @returns {Observable<DiscoveredDevice[]>} An observable of known discovered devices.
    */
-  listenToAvailableDevices(): Observable<DiscoveredDevice[]> {
+  listenToAvailableDevices(
+    args: ListenToAvailableDevicesUseCaseArgs,
+  ): Observable<DiscoveredDevice[]> {
     return this.container
       .get<ListenToAvailableDevicesUseCase>(
         discoveryTypes.ListenToAvailableDevicesUseCase,
       )
-      .execute();
+      .execute(args);
   }
 
   /**

--- a/packages/device-management-kit/src/api/transport/model/Errors.ts
+++ b/packages/device-management-kit/src/api/transport/model/Errors.ts
@@ -58,7 +58,6 @@ export class TransportNotSupportedError extends GeneralDmkError {
     super(err);
   }
 }
-
 export class SendApduConcurrencyError extends GeneralDmkError {
   override readonly _tag = "SendApduConcurrencyError";
   constructor(readonly err?: unknown) {

--- a/packages/device-management-kit/src/internal/discovery/use-case/ListenToAvailableDevicesUseCase.ts
+++ b/packages/device-management-kit/src/internal/discovery/use-case/ListenToAvailableDevicesUseCase.ts
@@ -1,12 +1,23 @@
 import { inject, injectable } from "inversify";
-import { from, map, merge, Observable, scan } from "rxjs";
+import { from, map, merge, Observable, of, scan } from "rxjs";
 
 import { DeviceModel } from "@api/device/DeviceModel";
-import type { Transport } from "@api/transport/model/Transport";
-import { TransportDiscoveredDevice } from "@api/transport/model/TransportDiscoveredDevice";
-import { DiscoveredDevice } from "@api/types";
+import { LoggerPublisherService } from "@api/logger-publisher/service/LoggerPublisherService";
+import { DiscoveredDevice } from "@api/transport/model/DiscoveredDevice";
+import { type Transport } from "@api/transport/model/Transport";
+import { type TransportDiscoveredDevice } from "@api/transport/model/TransportDiscoveredDevice";
+import { type TransportIdentifier } from "@api/transport/model/TransportIdentifier";
+import { loggerTypes } from "@internal/logger-publisher/di/loggerTypes";
 import { transportDiTypes } from "@internal/transport/di/transportDiTypes";
 import { type TransportService } from "@internal/transport/service/TransportService";
+
+export type ListenToAvailableDevicesUseCaseArgs = {
+  /**
+   * Identifier of the transport to start discovering devices.
+   * Can be undefined to discover all available transports in parallel.
+   */
+  transport?: TransportIdentifier;
+};
 
 /**
  * Listen to list of known discovered devices (and later BLE).
@@ -14,11 +25,17 @@ import { type TransportService } from "@internal/transport/service/TransportServ
 @injectable()
 export class ListenToAvailableDevicesUseCase {
   private readonly _transports: Transport[];
+  private readonly _transportService: TransportService;
+  private readonly _logger: LoggerPublisherService;
   constructor(
     @inject(transportDiTypes.TransportService)
     transportService: TransportService,
+    @inject(loggerTypes.LoggerPublisherServiceFactory)
+    loggerFactory: (tag: string) => LoggerPublisherService,
   ) {
     this._transports = transportService.getAllTransports();
+    this._transportService = transportService;
+    this._logger = loggerFactory("ListenToAvailableDevicesUseCase");
   }
 
   private mapTransportDiscoveredDeviceToDiscoveredDevice(
@@ -38,41 +55,69 @@ export class ListenToAvailableDevicesUseCase {
     };
   }
 
-  execute(): Observable<DiscoveredDevice[]> {
+  execute({
+    transport,
+  }: ListenToAvailableDevicesUseCaseArgs): Observable<DiscoveredDevice[]> {
+    this._logger.info("Listening to available devices");
+
     if (this._transports.length === 0) {
+      this._logger.warn("No transports available");
       return from([[]]);
     }
 
-    /**
-     * Note: we're not using combineLatest because combineLatest will
-     * - wait for all observables to emit at least once before emitting.
-     * - complete as soon as one of the observables completes.
-     * Some transports will just return an empty array and complete.
-     * We want to keep listening to all transports until all have completed.
-     */
+    if (!transport) {
+      this._logger.info("Discovering all available transports");
+      /**
+       * Note: we're not using combineLatest because combineLatest will
+       * - wait for all observables to emit at least once before emitting.
+       * - complete as soon as one of the observables completes.
+       * Some transports will just return an empty array and complete.
+       * We want to keep listening to all transports until all have completed.
+       */
 
-    const observablesWithIndex = this._transports.map((transport, index) =>
-      transport.listenToAvailableDevices().pipe(
-        map((arr) => ({
-          index,
-          arr,
-        })),
-      ),
-    );
+      const observablesWithIndex = this._transports.map((t, index) =>
+        t.listenToAvailableDevices().pipe(
+          map((arr) => ({
+            index,
+            arr,
+          })),
+        ),
+      );
 
-    return merge(...observablesWithIndex).pipe(
-      scan<
-        { index: number; arr: TransportDiscoveredDevice[] },
-        { [key: number]: TransportDiscoveredDevice[] }
-      >((acc, { index, arr }) => {
-        acc[index] = arr;
-        return acc;
-      }, {}),
-      map((acc) =>
-        Object.values(acc)
-          .flat()
-          .map(this.mapTransportDiscoveredDeviceToDiscoveredDevice),
-      ),
-    );
+      return merge(...observablesWithIndex).pipe(
+        scan<
+          { index: number; arr: TransportDiscoveredDevice[] },
+          { [key: number]: TransportDiscoveredDevice[] }
+        >((acc, { index, arr }) => {
+          acc[index] = arr;
+          return acc;
+        }, {}),
+        map((acc) =>
+          Object.values(acc)
+            .flat()
+            .map(this.mapTransportDiscoveredDeviceToDiscoveredDevice),
+        ),
+      );
+    }
+
+    this._logger.info(`Discovering devices on transport ${transport}`);
+
+    const instance = this._transportService.getTransport(transport);
+
+    return instance.caseOf({
+      Nothing: () => {
+        this._logger.error(`Transport ${transport} not found`);
+        return of([]);
+      },
+      Just: (t) => {
+        return t
+          .listenToAvailableDevices()
+          .pipe(
+            map((devices) =>
+              devices.map(this.mapTransportDiscoveredDeviceToDiscoveredDevice),
+            ),
+          );
+      },
+    });
   }
 }


### PR DESCRIPTION
Allow to filter by specific transports

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Allows listenToAvailableDevices to check only for a given transport

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [NO-ISSUE]

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
