### PR TITLE
🚑️ (hotfix) [NO-ISSUE]: Release device-management-kit 0.6.3

### DIFF
--- a/.changeset/calm-flowers-wait.md
+++ b/.changeset/calm-flowers-wait.md
@@ -1,5 +1,0 @@
----
-"@ledgerhq/device-management-kit": minor
----
-
-Add ListInstalledApps device action

--- a/.changeset/pink-doors-joke.md
+++ b/.changeset/pink-doors-joke.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Fix condition in DeviceSession to handle locked device

--- a/packages/device-management-kit/package.json
+++ b/packages/device-management-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ledgerhq/device-management-kit",
   "version": "0.6.2",
-  "private": true,
+  "private": false,
   "license": "Apache-2.0",
   "exports": {
     ".": {

--- a/packages/device-management-kit/src/internal/device-session/model/DeviceSession.ts
+++ b/packages/device-management-kit/src/internal/device-session/model/DeviceSession.ts
@@ -219,7 +219,11 @@ export class DeviceSession {
 
     await new Promise<void>((resolve) => {
       deviceStateSub = this._deviceState.subscribe((state) => {
-        if (state.deviceStatus === DeviceStatus.CONNECTED) {
+        if (
+          [DeviceStatus.LOCKED, DeviceStatus.CONNECTED].includes(
+            state.deviceStatus,
+          )
+        ) {
           deviceStateSub?.unsubscribe();
           resolve();
         }

--- a/packages/transport/web-ble/package.json
+++ b/packages/transport/web-ble/package.json
@@ -2,7 +2,7 @@
   "name": "@ledgerhq/device-transport-kit-web-ble",
   "version": "1.1.0",
   "license": "Apache-2.0",
-  "private": false,
+  "private": true,
   "exports": {
     ".": {
       "types": "./lib/types/index.d.ts",

--- a/packages/transport/web-hid/package.json
+++ b/packages/transport/web-hid/package.json
@@ -2,7 +2,7 @@
   "name": "@ledgerhq/device-transport-kit-web-hid",
   "version": "1.1.0",
   "license": "Apache-2.0",
-  "private": false,
+  "private": true,
   "exports": {
     ".": {
       "types": "./lib/types/index.d.ts",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Hotfix release

Fixes an issue in the DeviceSession where in case the refresher is disabled, we would be in limbo if we send an apdu to a locked device

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**:

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
