### PR TITLE
:sparkles: (signer-eth) [NO-ISSUE]: Add a user interaction for web3checks opt-in in device actions

### DIFF
--- a/.changeset/little-icons-complain.md
+++ b/.changeset/little-icons-complain.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": patch
+---
+
+Add a user interaction for web3checks opt-in in device actions

--- a/packages/device-management-kit/src/api/device-action/model/UserInteractionRequired.ts
+++ b/packages/device-management-kit/src/api/device-action/model/UserInteractionRequired.ts
@@ -12,4 +12,5 @@ export enum UserInteractionRequired {
   AllowListApps = "allow-list-apps",
   VerifyAddress = "verify-address",
   SignPersonalMessage = "sign-personal-message",
+  Web3ChecksOptIn = "web3-checks-opt-in",
 }

--- a/packages/signer/signer-eth/src/api/app-binder/SignTransactionDeviceActionTypes.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignTransactionDeviceActionTypes.ts
@@ -51,7 +51,6 @@ export type SignTransactionDAState = DeviceActionState<
 
 export type SignTransactionDAInternalState = {
   readonly error: SignTransactionDAError | null;
-  readonly challenge: string | null;
   readonly clearSignContexts: ClearSignContextSuccess[] | GenericContext | null;
   readonly web3Check: ClearSignContextSuccess<ClearSignContextType.WEB3_CHECK> | null;
   readonly serializedTransaction: Uint8Array | null;

--- a/packages/signer/signer-eth/src/api/app-binder/SignTransactionDeviceActionTypes.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignTransactionDeviceActionTypes.ts
@@ -37,6 +37,7 @@ export type SignTransactionDAError =
 
 type SignTransactionDARequiredInteraction =
   | OpenAppDARequiredInteraction
+  | UserInteractionRequired.Web3ChecksOptIn
   | UserInteractionRequired.SignTransaction;
 
 export type SignTransactionDAIntermediateValue = {
@@ -52,6 +53,8 @@ export type SignTransactionDAState = DeviceActionState<
 export type SignTransactionDAInternalState = {
   readonly error: SignTransactionDAError | null;
   readonly clearSignContexts: ClearSignContextSuccess[] | GenericContext | null;
+  readonly web3ChecksOptIn: boolean;
+  readonly web3ChecksEnabled: boolean;
   readonly web3Check: ClearSignContextSuccess<ClearSignContextType.WEB3_CHECK> | null;
   readonly serializedTransaction: Uint8Array | null;
   readonly chainId: number | null;

--- a/packages/signer/signer-eth/src/api/app-binder/SignTypedDataDeviceActionTypes.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignTypedDataDeviceActionTypes.ts
@@ -29,6 +29,7 @@ export type SignTypedDataDAError =
 
 type SignTypedDataDARequiredInteraction =
   | OpenAppDARequiredInteraction
+  | UserInteractionRequired.Web3ChecksOptIn
   | UserInteractionRequired.SignTypedData;
 
 export type SignTypedDataDAIntermediateValue = {
@@ -43,6 +44,8 @@ export type SignTypedDataDAState = DeviceActionState<
 
 export type SignTypedDataDAInternalState = {
   readonly error: SignTypedDataDAError | null;
+  web3ChecksOptIn: boolean;
+  web3ChecksEnabled: boolean;
   readonly typedDataContext: ProvideEIP712ContextTaskArgs | null;
   readonly signature: Signature | null;
 };

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.test.ts
@@ -8,7 +8,6 @@ import {
   DeviceActionStatus,
   hexaStringToBuffer,
   UnknownDAError,
-  UnknownDeviceExchangeError,
   UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
 import { InvalidStatusWordError } from "@ledgerhq/device-management-kit";
@@ -49,20 +48,16 @@ describe("SignTransactionDeviceAction", () => {
   const parserMock: TransactionParserService = {
     extractValue: vi.fn(),
   } as unknown as TransactionParserService;
-  const getChallengeMock = vi.fn();
   const buildContextMock = vi.fn();
   const provideContextMock = vi.fn();
   const provideGenericContextMock = vi.fn();
   const signTransactionMock = vi.fn();
-  const getWeb3CheckMock = vi.fn();
   function extractDependenciesMock() {
     return {
-      getChallenge: getChallengeMock,
       buildContext: buildContextMock,
       provideContext: provideContextMock,
       provideGenericContext: provideGenericContextMock,
       signTransaction: signTransactionMock,
-      getWeb3Check: getWeb3CheckMock,
     };
   }
   const defaultOptions = {
@@ -97,14 +92,6 @@ describe("SignTransactionDeviceAction", () => {
         });
 
         // Mock the dependencies to return some sample data
-        getChallengeMock.mockResolvedValueOnce(
-          CommandResultFactory({
-            data: { challenge: "challenge" },
-          }),
-        );
-        getWeb3CheckMock.mockResolvedValueOnce({
-          web3Check: null,
-        });
         buildContextMock.mockResolvedValueOnce({
           clearSignContexts: [
             {
@@ -115,6 +102,7 @@ describe("SignTransactionDeviceAction", () => {
           serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
           chainId: 1,
           transactionType: TransactionType.LEGACY,
+          web3Check: null,
         });
         provideContextMock.mockResolvedValueOnce(Nothing);
         signTransactionMock.mockResolvedValueOnce(
@@ -131,7 +119,7 @@ describe("SignTransactionDeviceAction", () => {
         );
 
         // Expected intermediate values for the following state sequence:
-        //   Initial -> OpenApp -> GetChallenge -> BuildContext -> ProvideContext -> SignTransaction
+        //   Initial -> OpenApp -> BuildContext -> ProvideContext -> SignTransaction
         const expectedStates: Array<SignTransactionDAState> = [
           // Initial state
           {
@@ -144,20 +132,6 @@ describe("SignTransactionDeviceAction", () => {
           {
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetChallenge state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetWeb3Check state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
             },
             status: DeviceActionStatus.Pending,
           },
@@ -200,15 +174,14 @@ describe("SignTransactionDeviceAction", () => {
           {
             onDone: () => {
               // Verify mocks calls parameters
-              expect(getChallengeMock).toHaveBeenCalled();
               expect(buildContextMock).toHaveBeenCalledWith(
                 expect.objectContaining({
                   input: {
-                    challenge: "challenge",
                     contextModule: contextModuleMock,
                     mapper: mapperMock,
                     options: defaultOptions,
                     transaction: defaultTransaction,
+                    derivationPath: "44'/60'/0'/0/0",
                   },
                 }),
               );
@@ -261,14 +234,6 @@ describe("SignTransactionDeviceAction", () => {
         });
 
         // Mock the dependencies to return some sample data
-        getChallengeMock.mockResolvedValueOnce(
-          CommandResultFactory({
-            data: { challenge: "challenge" },
-          }),
-        );
-        getWeb3CheckMock.mockResolvedValueOnce({
-          web3Check: null,
-        });
         buildContextMock.mockResolvedValueOnce({
           clearSignContexts: {
             transactionInfo: "payload-1",
@@ -282,6 +247,7 @@ describe("SignTransactionDeviceAction", () => {
           serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
           chainId: 7,
           transactionType: TransactionType.EIP1559,
+          web3Check: null,
         });
         provideGenericContextMock.mockResolvedValueOnce(Nothing);
         signTransactionMock.mockResolvedValueOnce(
@@ -298,7 +264,7 @@ describe("SignTransactionDeviceAction", () => {
         );
 
         // Expected intermediate values for the following state sequence:
-        //   Initial -> OpenApp -> GetChallenge -> BuildContext -> ProvideGenericContext -> SignTransaction
+        //   Initial -> OpenApp -> BuildContext -> ProvideGenericContext -> SignTransaction
         const expectedStates: Array<SignTransactionDAState> = [
           // Initial state
           {
@@ -311,20 +277,6 @@ describe("SignTransactionDeviceAction", () => {
           {
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetChallenge state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetWeb3Checks state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
             },
             status: DeviceActionStatus.Pending,
           },
@@ -368,15 +320,14 @@ describe("SignTransactionDeviceAction", () => {
             onError: reject,
             onDone: () => {
               // Verify mocks calls parameters
-              expect(getChallengeMock).toHaveBeenCalled();
               expect(buildContextMock).toHaveBeenCalledWith(
                 expect.objectContaining({
                   input: {
-                    challenge: "challenge",
                     contextModule: contextModuleMock,
                     mapper: mapperMock,
                     options: defaultOptions,
                     transaction: defaultTransaction,
+                    derivationPath: "44'/60'/0'/0/0",
                   },
                 }),
               );
@@ -435,14 +386,6 @@ describe("SignTransactionDeviceAction", () => {
         });
 
         // Mock the dependencies to return some sample data
-        getChallengeMock.mockResolvedValueOnce(
-          CommandResultFactory({
-            data: { challenge: "challenge" },
-          }),
-        );
-        getWeb3CheckMock.mockResolvedValueOnce({
-          web3Check: null,
-        });
         buildContextMock.mockResolvedValueOnce({
           clearSignContexts: [
             {
@@ -453,6 +396,7 @@ describe("SignTransactionDeviceAction", () => {
           serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
           chainId: 1,
           transactionType: TransactionType.LEGACY,
+          web3Check: null,
         });
         provideContextMock.mockResolvedValueOnce(
           Just(
@@ -475,7 +419,7 @@ describe("SignTransactionDeviceAction", () => {
         );
 
         // Expected intermediate values for the following state sequence:
-        //   Initial -> OpenApp -> GetChallenge -> BuildContext -> ProvideContext -> SignTransaction
+        //   Initial -> OpenApp -> BuildContext -> ProvideContext -> SignTransaction
         const expectedStates: Array<SignTransactionDAState> = [
           // Initial state
           {
@@ -488,20 +432,6 @@ describe("SignTransactionDeviceAction", () => {
           {
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetChallenge state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetWeb3Checks state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
             },
             status: DeviceActionStatus.Pending,
           },
@@ -545,15 +475,14 @@ describe("SignTransactionDeviceAction", () => {
             onError: reject,
             onDone: () => {
               // Verify mocks calls parameters
-              expect(getChallengeMock).toHaveBeenCalled();
               expect(buildContextMock).toHaveBeenCalledWith(
                 expect.objectContaining({
                   input: {
-                    challenge: "challenge",
                     contextModule: contextModuleMock,
                     mapper: mapperMock,
                     options: defaultOptions,
                     transaction: defaultTransaction,
+                    derivationPath: "44'/60'/0'/0/0",
                   },
                 }),
               );
@@ -603,14 +532,6 @@ describe("SignTransactionDeviceAction", () => {
         });
 
         // Mock the dependencies to return some sample data
-        getChallengeMock.mockResolvedValueOnce(
-          CommandResultFactory({
-            data: { challenge: "challenge" },
-          }),
-        );
-        getWeb3CheckMock.mockResolvedValueOnce({
-          web3Check: null,
-        });
         buildContextMock.mockResolvedValueOnce({
           clearSignContexts: {
             transactionInfo: "payload-1",
@@ -624,6 +545,7 @@ describe("SignTransactionDeviceAction", () => {
           serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
           chainId: 7,
           transactionType: TransactionType.EIP1559,
+          web3Check: null,
         });
 
         provideGenericContextMock.mockResolvedValueOnce(
@@ -649,7 +571,7 @@ describe("SignTransactionDeviceAction", () => {
         );
 
         // Expected intermediate values for the following state sequence:
-        //   Initial -> OpenApp -> GetChallenge -> BuildContext -> ProvideGenericContext -> SignTransaction
+        //   Initial -> OpenApp -> BuildContext -> ProvideGenericContext -> SignTransaction
         const expectedStates: Array<SignTransactionDAState> = [
           // Initial state
           {
@@ -662,20 +584,6 @@ describe("SignTransactionDeviceAction", () => {
           {
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetChallenge state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetWeb3Checks state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
             },
             status: DeviceActionStatus.Pending,
           },
@@ -719,15 +627,14 @@ describe("SignTransactionDeviceAction", () => {
             onError: reject,
             onDone: () => {
               // Verify mocks calls parameters
-              expect(getChallengeMock).toHaveBeenCalled();
               expect(buildContextMock).toHaveBeenCalledWith(
                 expect.objectContaining({
                   input: {
-                    challenge: "challenge",
                     contextModule: contextModuleMock,
                     mapper: mapperMock,
                     options: defaultOptions,
                     transaction: defaultTransaction,
+                    derivationPath: "44'/60'/0'/0/0",
                   },
                 }),
               );
@@ -770,156 +677,6 @@ describe("SignTransactionDeviceAction", () => {
         );
       }));
 
-    it("should continue if getChallenge return an error 6d00 not supported", () =>
-      new Promise<void>((resolve, reject) => {
-        setupOpenAppDAMock();
-
-        const deviceAction = new SignTransactionDeviceAction({
-          input: {
-            derivationPath: "44'/60'/0'/0/0",
-            transaction: defaultTransaction,
-            options: defaultOptions,
-            contextModule: contextModuleMock,
-            mapper: mapperMock,
-            parser: parserMock,
-          },
-        });
-
-        // Mock the dependencies to return some sample data
-        getChallengeMock.mockResolvedValueOnce(
-          CommandResultFactory({
-            error: new UnknownDeviceExchangeError({
-              message: "UnknownError",
-              errorCode: "6d00",
-            }),
-          }),
-        );
-        getWeb3CheckMock.mockResolvedValueOnce({
-          web3Check: null,
-        });
-        buildContextMock.mockResolvedValueOnce({
-          clearSignContexts: [],
-          serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
-          chainId: 7,
-          transactionType: TransactionType.EIP1559,
-        });
-
-        provideGenericContextMock.mockResolvedValueOnce(Nothing);
-
-        signTransactionMock.mockResolvedValueOnce(
-          CommandResultFactory({
-            data: {
-              v: 0x1c,
-              r: "0x8a540510e13b0f2b11a451275716d29e08caad07e89a1c84964782fb5e1ad788",
-              s: "0x64a0de235b270fbe81e8e40688f4a9f9ad9d283d690552c9331d7773ceafa513",
-            },
-          }),
-        );
-
-        vi.spyOn(deviceAction, "extractDependencies").mockReturnValue(
-          extractDependenciesMock(),
-        );
-
-        // Expected intermediate values for the following state sequence:
-        //   Initial -> OpenApp -> GetChallenge -> BuildContext -> ProvideGenericContext -> SignTransaction
-        const expectedStates: Array<SignTransactionDAState> = [
-          // Initial state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // OpenApp interaction
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetChallenge state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetWeb3Checks state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // BuildContext state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // ProvideContext state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // SignTransaction state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // Final state
-          {
-            output: {
-              v: 0x1c,
-              r: "0x8a540510e13b0f2b11a451275716d29e08caad07e89a1c84964782fb5e1ad788",
-              s: "0x64a0de235b270fbe81e8e40688f4a9f9ad9d283d690552c9331d7773ceafa513",
-            },
-            status: DeviceActionStatus.Completed,
-          },
-        ];
-
-        testDeviceActionStates(
-          deviceAction,
-          expectedStates,
-          makeDeviceActionInternalApiMock(),
-          {
-            onError: reject,
-            onDone: () => {
-              // Verify mocks calls parameters
-              expect(getChallengeMock).toHaveBeenCalled();
-              expect(buildContextMock).toHaveBeenCalledWith(
-                expect.objectContaining({
-                  input: {
-                    challenge: null,
-                    contextModule: contextModuleMock,
-                    mapper: mapperMock,
-                    options: defaultOptions,
-                    transaction: defaultTransaction,
-                  },
-                }),
-              );
-              expect(signTransactionMock).toHaveBeenCalledWith(
-                expect.objectContaining({
-                  input: {
-                    derivationPath: "44'/60'/0'/0/0",
-                    serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
-                    isLegacy: true,
-                    chainId: 7,
-                    transactionType: TransactionType.EIP1559,
-                  },
-                }),
-              );
-              resolve();
-            },
-          },
-        );
-      }));
-
     it("should provide web3checks context if getWeb3Check return a value", () =>
       new Promise<void>((resolve, reject) => {
         setupOpenAppDAMock();
@@ -936,20 +693,6 @@ describe("SignTransactionDeviceAction", () => {
         });
 
         // Mock the dependencies to return some sample data
-        getChallengeMock.mockResolvedValueOnce(
-          CommandResultFactory({
-            data: { challenge: "challenge" },
-          }),
-        );
-        getWeb3CheckMock.mockResolvedValueOnce({
-          web3Check: {
-            type: ClearSignContextType.ENUM,
-            id: 1,
-            payload: "0x01020304",
-            value: 1,
-            certificate: undefined,
-          },
-        });
         buildContextMock.mockResolvedValueOnce({
           clearSignContexts: [
             {
@@ -960,6 +703,13 @@ describe("SignTransactionDeviceAction", () => {
           serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
           chainId: 1,
           transactionType: TransactionType.LEGACY,
+          web3Check: {
+            type: ClearSignContextType.ENUM,
+            id: 1,
+            payload: "0x01020304",
+            value: 1,
+            certificate: undefined,
+          },
         });
         provideContextMock.mockResolvedValueOnce(Nothing);
         signTransactionMock.mockResolvedValueOnce(
@@ -976,7 +726,7 @@ describe("SignTransactionDeviceAction", () => {
         );
 
         // Expected intermediate values for the following state sequence:
-        //   Initial -> OpenApp -> GetChallenge -> BuildContext -> ProvideContext -> SignTransaction
+        //   Initial -> OpenApp -> BuildContext -> ProvideContext -> SignTransaction
         const expectedStates: Array<SignTransactionDAState> = [
           // Initial state
           {
@@ -989,20 +739,6 @@ describe("SignTransactionDeviceAction", () => {
           {
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetChallenge state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetWeb3Checks state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
             },
             status: DeviceActionStatus.Pending,
           },
@@ -1046,15 +782,14 @@ describe("SignTransactionDeviceAction", () => {
             onError: reject,
             onDone: () => {
               // Verify mocks calls parameters
-              expect(getChallengeMock).toHaveBeenCalled();
               expect(buildContextMock).toHaveBeenCalledWith(
                 expect.objectContaining({
                   input: {
-                    challenge: "challenge",
                     contextModule: contextModuleMock,
                     mapper: mapperMock,
                     options: defaultOptions,
                     transaction: defaultTransaction,
+                    derivationPath: "44'/60'/0'/0/0",
                   },
                 }),
               );
@@ -1074,169 +809,6 @@ describe("SignTransactionDeviceAction", () => {
                       value: 1,
                       certificate: undefined,
                     },
-                  },
-                }),
-              );
-              expect(signTransactionMock).toHaveBeenCalledWith(
-                expect.objectContaining({
-                  input: {
-                    derivationPath: "44'/60'/0'/0/0",
-                    serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
-                    isLegacy: true,
-                    chainId: 1,
-                    transactionType: TransactionType.LEGACY,
-                  },
-                }),
-              );
-              resolve();
-            },
-          },
-        );
-      }));
-
-    it("should ignore web3checks errors", () =>
-      new Promise<void>((resolve, reject) => {
-        setupOpenAppDAMock();
-
-        const deviceAction = new SignTransactionDeviceAction({
-          input: {
-            derivationPath: "44'/60'/0'/0/0",
-            transaction: defaultTransaction,
-            options: defaultOptions,
-            contextModule: contextModuleMock,
-            mapper: mapperMock,
-            parser: parserMock,
-          },
-        });
-
-        // Mock the dependencies to return some sample data
-        getChallengeMock.mockResolvedValueOnce(
-          CommandResultFactory({
-            data: { challenge: "challenge" },
-          }),
-        );
-        getWeb3CheckMock.mockResolvedValueOnce({
-          web3Check: null,
-          error: new InvalidStatusWordError("getWeb3Check error"),
-        });
-        buildContextMock.mockResolvedValueOnce({
-          clearSignContexts: [
-            {
-              type: "token",
-              payload: "payload-1",
-            },
-          ],
-          serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
-          chainId: 1,
-          transactionType: TransactionType.LEGACY,
-        });
-        provideContextMock.mockResolvedValueOnce(Nothing);
-        signTransactionMock.mockResolvedValueOnce(
-          CommandResultFactory({
-            data: {
-              v: 0x1c,
-              r: "0x8a540510e13b0f2b11a451275716d29e08caad07e89a1c84964782fb5e1ad788",
-              s: "0x64a0de235b270fbe81e8e40688f4a9f9ad9d283d690552c9331d7773ceafa513",
-            },
-          }),
-        );
-        vi.spyOn(deviceAction, "extractDependencies").mockReturnValue(
-          extractDependenciesMock(),
-        );
-
-        // Expected intermediate values for the following state sequence:
-        //   Initial -> OpenApp -> GetChallenge -> BuildContext -> ProvideContext -> SignTransaction
-        const expectedStates: Array<SignTransactionDAState> = [
-          // Initial state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // OpenApp interaction
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetChallenge state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetWeb3Checks state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // BuildContext state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // ProvideContext state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // SignTransaction state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // Final state
-          {
-            output: {
-              v: 0x1c,
-              r: "0x8a540510e13b0f2b11a451275716d29e08caad07e89a1c84964782fb5e1ad788",
-              s: "0x64a0de235b270fbe81e8e40688f4a9f9ad9d283d690552c9331d7773ceafa513",
-            },
-            status: DeviceActionStatus.Completed,
-          },
-        ];
-
-        testDeviceActionStates(
-          deviceAction,
-          expectedStates,
-          makeDeviceActionInternalApiMock(),
-          {
-            onError: reject,
-            onDone: () => {
-              // Verify mocks calls parameters
-              expect(getChallengeMock).toHaveBeenCalled();
-              expect(buildContextMock).toHaveBeenCalledWith(
-                expect.objectContaining({
-                  input: {
-                    challenge: "challenge",
-                    contextModule: contextModuleMock,
-                    mapper: mapperMock,
-                    options: defaultOptions,
-                    transaction: defaultTransaction,
-                  },
-                }),
-              );
-              expect(provideContextMock).toHaveBeenCalledWith(
-                expect.objectContaining({
-                  input: {
-                    clearSignContexts: [
-                      {
-                        type: "token",
-                        payload: "payload-1",
-                      },
-                    ],
-                    web3Check: null,
                   },
                 }),
               );
@@ -1314,212 +886,6 @@ describe("SignTransactionDeviceAction", () => {
       }));
   });
 
-  describe("GetChallenge errors", () => {
-    it("should fail if getChallenge throws an error", () =>
-      new Promise<void>((resolve, reject) => {
-        setupOpenAppDAMock();
-
-        const deviceAction = new SignTransactionDeviceAction({
-          input: {
-            derivationPath: "44'/60'/0'/0/0",
-            transaction: defaultTransaction,
-            options: defaultOptions,
-            contextModule: contextModuleMock,
-            mapper: mapperMock,
-            parser: parserMock,
-          },
-        });
-
-        getChallengeMock.mockRejectedValueOnce(
-          new InvalidStatusWordError("getChallenge error"),
-        );
-        vi.spyOn(deviceAction, "extractDependencies").mockReturnValue(
-          extractDependenciesMock(),
-        );
-
-        const expectedStates: Array<SignTransactionDAState> = [
-          // Initial state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // OpenApp interaction
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetChallenge state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetChallenge error
-          {
-            error: new InvalidStatusWordError("getChallenge error"),
-            status: DeviceActionStatus.Error,
-          },
-        ];
-
-        testDeviceActionStates(
-          deviceAction,
-          expectedStates,
-          makeDeviceActionInternalApiMock(),
-          {
-            onError: reject,
-            onDone: resolve,
-          },
-        );
-      }));
-
-    it("should fail if getChallenge return an error", () =>
-      new Promise<void>((resolve, reject) => {
-        setupOpenAppDAMock();
-
-        const deviceAction = new SignTransactionDeviceAction({
-          input: {
-            derivationPath: "44'/60'/0'/0/0",
-            transaction: defaultTransaction,
-            options: defaultOptions,
-            contextModule: contextModuleMock,
-            mapper: mapperMock,
-            parser: parserMock,
-          },
-        });
-
-        getChallengeMock.mockResolvedValueOnce(
-          CommandResultFactory({
-            error: new InvalidStatusWordError("getChallenge error"),
-          }),
-        );
-        vi.spyOn(deviceAction, "extractDependencies").mockReturnValue(
-          extractDependenciesMock(),
-        );
-
-        const expectedStates: Array<SignTransactionDAState> = [
-          // Initial state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // OpenApp interaction
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetChallenge state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetChallenge error
-          {
-            error: new InvalidStatusWordError("getChallenge error"),
-            status: DeviceActionStatus.Error,
-          },
-        ];
-
-        testDeviceActionStates(
-          deviceAction,
-          expectedStates,
-          makeDeviceActionInternalApiMock(),
-          {
-            onError: reject,
-            onDone: resolve,
-          },
-        );
-      }));
-  });
-
-  describe("GetWeb3Checks errors", () => {
-    it("should fail if GetWeb3Checks throws an error", () =>
-      new Promise<void>((resolve, reject) => {
-        setupOpenAppDAMock();
-
-        const deviceAction = new SignTransactionDeviceAction({
-          input: {
-            derivationPath: "44'/60'/0'/0/0",
-            transaction: defaultTransaction,
-            options: defaultOptions,
-            contextModule: contextModuleMock,
-            mapper: mapperMock,
-            parser: parserMock,
-          },
-        });
-
-        getChallengeMock.mockResolvedValueOnce(
-          CommandResultFactory({
-            data: { challenge: "challenge" },
-          }),
-        );
-        getWeb3CheckMock.mockRejectedValueOnce(
-          new InvalidStatusWordError("getWeb3Checks error"),
-        );
-        vi.spyOn(deviceAction, "extractDependencies").mockReturnValue(
-          extractDependenciesMock(),
-        );
-
-        const expectedStates: Array<SignTransactionDAState> = [
-          // Initial state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // OpenApp interaction
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetChallenge state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetWeb3Checks state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetWeb3Checks error
-          {
-            error: new InvalidStatusWordError("getWeb3Checks error"),
-            status: DeviceActionStatus.Error,
-          },
-        ];
-
-        testDeviceActionStates(
-          deviceAction,
-          expectedStates,
-          makeDeviceActionInternalApiMock(),
-          {
-            onError: reject,
-            onDone: () => {
-              resolve();
-            },
-          },
-        );
-      }));
-  });
-
   describe("BuildContext errors", () => {
     it("should fail if buildContext throws an error", () =>
       new Promise<void>((resolve, reject) => {
@@ -1536,14 +902,6 @@ describe("SignTransactionDeviceAction", () => {
           },
         });
 
-        getChallengeMock.mockResolvedValueOnce(
-          CommandResultFactory({
-            data: { challenge: "challenge" },
-          }),
-        );
-        getWeb3CheckMock.mockResolvedValueOnce({
-          web3Check: null,
-        });
         buildContextMock.mockRejectedValueOnce(
           new InvalidStatusWordError("buildContext error"),
         );
@@ -1563,20 +921,6 @@ describe("SignTransactionDeviceAction", () => {
           {
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetChallenge state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetWeb3Check state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
             },
             status: DeviceActionStatus.Pending,
           },
@@ -1622,14 +966,6 @@ describe("SignTransactionDeviceAction", () => {
           },
         });
 
-        getChallengeMock.mockResolvedValueOnce(
-          CommandResultFactory({
-            data: { challenge: "challenge" },
-          }),
-        );
-        getWeb3CheckMock.mockResolvedValueOnce({
-          web3Check: null,
-        });
         buildContextMock.mockResolvedValueOnce({
           clearSignContexts: [
             {
@@ -1638,6 +974,7 @@ describe("SignTransactionDeviceAction", () => {
             },
           ],
           serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
+          web3Check: null,
         });
         provideContextMock.mockRejectedValueOnce(
           new InvalidStatusWordError("provideContext error"),
@@ -1658,20 +995,6 @@ describe("SignTransactionDeviceAction", () => {
           {
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetChallenge state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetWeb3Check state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
             },
             status: DeviceActionStatus.Pending,
           },
@@ -1724,14 +1047,6 @@ describe("SignTransactionDeviceAction", () => {
           },
         });
 
-        getChallengeMock.mockResolvedValueOnce(
-          CommandResultFactory({
-            data: { challenge: "challenge" },
-          }),
-        );
-        getWeb3CheckMock.mockResolvedValueOnce({
-          web3Check: null,
-        });
         buildContextMock.mockResolvedValueOnce({
           clearSignContexts: [
             {
@@ -1740,6 +1055,7 @@ describe("SignTransactionDeviceAction", () => {
             },
           ],
           serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
+          web3Check: null,
         });
         provideContextMock.mockResolvedValueOnce(Nothing);
         signTransactionMock.mockResolvedValueOnce(
@@ -1763,20 +1079,6 @@ describe("SignTransactionDeviceAction", () => {
           {
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetChallenge state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          // GetWeb3Check state
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
             },
             status: DeviceActionStatus.Pending,
           },

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BuildEIP712ContextTask.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BuildEIP712ContextTask.test.ts
@@ -152,6 +152,7 @@ describe("BuildEIP712ContextTask", () => {
       parserMock,
       TEST_DATA,
       "44'/60'/0'/0/0",
+      false,
       getWeb3ChecksFactoryMock,
     );
     parserMock.parse.mockReturnValueOnce(
@@ -165,8 +166,8 @@ describe("BuildEIP712ContextTask", () => {
       sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
       deviceStatus: DeviceStatus.CONNECTED,
       installedApps: [],
-      currentApp: { name: "Bitcoin", version: "1.0" },
-      deviceModelId: DeviceModelId.FLEX,
+      currentApp: { name: "Ethereum", version: "1.11.0" },
+      deviceModelId: DeviceModelId.NANO_S,
       isSecureConnectionAllowed: false,
     });
     // WHEN
@@ -193,6 +194,7 @@ describe("BuildEIP712ContextTask", () => {
       parserMock,
       TEST_DATA,
       "44'/60'/0'/0/0",
+      false,
       getWeb3ChecksFactoryMock,
     );
     parserMock.parse.mockReturnValueOnce(
@@ -232,14 +234,20 @@ describe("BuildEIP712ContextTask", () => {
 
   it("Build context with clear signing context", async () => {
     // GIVEN
+    const expectedWeb3Check =
+      "web3Check" as unknown as ClearSignContextSuccess<ClearSignContextType.WEB3_CHECK>;
     const task = new BuildEIP712ContextTask(
       apiMock,
       contextMouleMock,
       parserMock,
       TEST_DATA,
       "44'/60'/0'/0/0",
+      false,
       getWeb3ChecksFactoryMock,
     );
+    getWeb3ChecksFactoryMock.mockReturnValueOnce({
+      run: async () => ({ web3Check: expectedWeb3Check }),
+    });
     parserMock.parse.mockReturnValueOnce(
       Right({
         types: TEST_TYPES,
@@ -301,6 +309,7 @@ describe("BuildEIP712ContextTask", () => {
       parserMock,
       TEST_DATA,
       "44'/60'/0'/0/0",
+      true,
       getWeb3ChecksFactoryMock,
     );
     getWeb3ChecksFactoryMock.mockReturnValueOnce({
@@ -353,6 +362,7 @@ describe("BuildEIP712ContextTask", () => {
       parserMock,
       TEST_DATA,
       "44'/60'/0'/0/0",
+      false,
       getWeb3ChecksFactoryMock,
     );
     parserMock.parse.mockReturnValueOnce(
@@ -405,6 +415,7 @@ describe("BuildEIP712ContextTask", () => {
         primaryType: "",
       },
       "44'/60'/0'/0/0",
+      false,
       getWeb3ChecksFactoryMock,
     );
     parserMock.parse.mockReturnValueOnce(
@@ -433,6 +444,7 @@ describe("BuildEIP712ContextTask", () => {
       parserMock,
       TEST_DATA,
       "44'/60'/0'/0/0",
+      false,
       getWeb3ChecksFactoryMock,
     );
     parserMock.parse.mockReturnValueOnce(Left(new Error("Parsing error")));

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BuildTransactionContextTask.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BuildTransactionContextTask.test.ts
@@ -1,13 +1,16 @@
 import {
   type ClearSignContext,
+  type ClearSignContextSuccess,
   ClearSignContextType,
   type PkiCertificate,
 } from "@ledgerhq/context-module";
 import {
+  CommandResultFactory,
   DeviceModelId,
   DeviceSessionStateType,
   DeviceStatus,
   hexaStringToBuffer,
+  UnknownDeviceExchangeError,
 } from "@ledgerhq/device-management-kit";
 import { Transaction } from "ethers";
 import { Left, Right } from "purify-ts";
@@ -49,16 +52,23 @@ describe("BuildTransactionContextTask", () => {
 
   let defaultArgs: BuildTransactionContextTaskArgs;
   const apiMock = makeDeviceActionInternalApiMock();
+  const getWeb3ChecksFactoryMock = vi.fn();
 
   beforeEach(() => {
     vi.resetAllMocks();
+    apiMock.sendCommand.mockResolvedValue(
+      CommandResultFactory({ data: { challenge: "challenge" } }),
+    );
+    getWeb3ChecksFactoryMock.mockReturnValue({
+      run: async () => ({ web3Check: null }),
+    });
 
     defaultArgs = {
       contextModule: contextModuleMock,
       mapper: mapperMock as unknown as TransactionMapperService,
       transaction: defaultTransaction,
       options: defaultOptions,
-      challenge: "challenge",
+      derivationPath: "44'/60'/0'/0/0",
     };
   });
 
@@ -86,6 +96,7 @@ describe("BuildTransactionContextTask", () => {
     const result = await new BuildTransactionContextTask(
       apiMock,
       defaultArgs,
+      getWeb3ChecksFactoryMock,
     ).run();
 
     // THEN
@@ -94,6 +105,49 @@ describe("BuildTransactionContextTask", () => {
       serializedTransaction,
       chainId: 1,
       transactionType: 0,
+      web3Check: null,
+    });
+  });
+
+  it("should build the transaction context with web3checks", async () => {
+    // GIVEN
+    const serializedTransaction = new Uint8Array([0x01, 0x02, 0x03]);
+    const clearSignContexts: ClearSignContext[] = [];
+    const mapperResult: TransactionMapperResult = {
+      subset: { chainId: 1, to: undefined, data: "0x" },
+      serializedTransaction,
+      type: 0,
+    };
+    const expectedWeb3Check =
+      "web3Check" as unknown as ClearSignContextSuccess<ClearSignContextType.WEB3_CHECK>;
+    getWeb3ChecksFactoryMock.mockReturnValueOnce({
+      run: async () => ({ web3Check: expectedWeb3Check }),
+    });
+    mapperMock.mapTransactionToSubset.mockReturnValueOnce(Right(mapperResult));
+    contextModuleMock.getContexts.mockResolvedValueOnce(clearSignContexts);
+    apiMock.getDeviceSessionState.mockReturnValueOnce({
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Ethereum", version: "1.12.0" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    });
+
+    // WHEN
+    const result = await new BuildTransactionContextTask(
+      apiMock,
+      defaultArgs,
+      getWeb3ChecksFactoryMock,
+    ).run();
+
+    // THEN
+    expect(result).toEqual({
+      clearSignContexts,
+      serializedTransaction,
+      chainId: 1,
+      transactionType: 0,
+      web3Check: expectedWeb3Check,
     });
   });
 
@@ -130,6 +184,7 @@ describe("BuildTransactionContextTask", () => {
     const result = await new BuildTransactionContextTask(
       apiMock,
       defaultArgs,
+      getWeb3ChecksFactoryMock,
     ).run();
 
     // THEN
@@ -138,6 +193,7 @@ describe("BuildTransactionContextTask", () => {
       serializedTransaction,
       chainId: 1,
       transactionType: 2,
+      web3Check: null,
     });
   });
 
@@ -186,6 +242,7 @@ describe("BuildTransactionContextTask", () => {
     const result = await new BuildTransactionContextTask(
       apiMock,
       defaultArgs,
+      getWeb3ChecksFactoryMock,
     ).run();
 
     // THEN
@@ -199,6 +256,7 @@ describe("BuildTransactionContextTask", () => {
       serializedTransaction,
       chainId: 1,
       transactionType: 2,
+      web3Check: null,
     });
   });
 
@@ -247,6 +305,7 @@ describe("BuildTransactionContextTask", () => {
     const result = await new BuildTransactionContextTask(
       apiMock,
       defaultArgs,
+      getWeb3ChecksFactoryMock,
     ).run();
 
     // THEN
@@ -260,6 +319,7 @@ describe("BuildTransactionContextTask", () => {
       serializedTransaction,
       chainId: 1,
       transactionType: 2,
+      web3Check: null,
     });
   });
 
@@ -284,12 +344,52 @@ describe("BuildTransactionContextTask", () => {
     });
 
     // WHEN
-    await new BuildTransactionContextTask(apiMock, defaultArgs).run();
+    await new BuildTransactionContextTask(
+      apiMock,
+      defaultArgs,
+      getWeb3ChecksFactoryMock,
+    ).run();
 
     // THEN
     expect(mapperMock.mapTransactionToSubset).toHaveBeenCalledWith(
       defaultTransaction,
     );
+  });
+
+  it("should call the web3checks factory with correct parameters", async () => {
+    // GIVEN
+    const serializedTransaction = new Uint8Array([0x01, 0x02, 0x03]);
+    const clearSignContexts: ClearSignContext[] = [];
+    const mapperResult: TransactionMapperResult = {
+      subset: { chainId: 1, to: undefined, data: "0x" },
+      serializedTransaction,
+      type: 0,
+    };
+    mapperMock.mapTransactionToSubset.mockReturnValueOnce(Right(mapperResult));
+    contextModuleMock.getContexts.mockResolvedValueOnce(clearSignContexts);
+    apiMock.getDeviceSessionState.mockReturnValueOnce({
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Ethereum", version: "1.12.0" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    });
+
+    // WHEN
+    await new BuildTransactionContextTask(
+      apiMock,
+      defaultArgs,
+      getWeb3ChecksFactoryMock,
+    ).run();
+
+    // THEN
+    expect(getWeb3ChecksFactoryMock).toHaveBeenCalledWith(apiMock, {
+      contextModule: contextModuleMock,
+      derivationPath: "44'/60'/0'/0/0",
+      mapper: mapperMock,
+      transaction: defaultTransaction,
+    });
   });
 
   it("should call the context module with the correct parameters", async () => {
@@ -313,12 +413,55 @@ describe("BuildTransactionContextTask", () => {
     });
 
     // WHEN
-    await new BuildTransactionContextTask(apiMock, defaultArgs).run();
+    await new BuildTransactionContextTask(
+      apiMock,
+      defaultArgs,
+      getWeb3ChecksFactoryMock,
+    ).run();
 
     // THEN
     expect(contextModuleMock.getContexts).toHaveBeenCalledWith({
       deviceModelId: DeviceModelId.FLEX,
       challenge: "challenge",
+      domain: "domain-name.eth",
+      ...mapperResult.subset,
+    });
+  });
+
+  it("should call the context module without context on error", async () => {
+    // GIVEN
+    const serializedTransaction = new Uint8Array([0x01, 0x02, 0x03]);
+    const clearSignContexts: ClearSignContext[] = [];
+    const mapperResult: TransactionMapperResult = {
+      subset: { chainId: 1, to: undefined, data: "0x" },
+      serializedTransaction,
+      type: 0,
+    };
+    mapperMock.mapTransactionToSubset.mockReturnValueOnce(Right(mapperResult));
+    contextModuleMock.getContexts.mockResolvedValueOnce(clearSignContexts);
+    apiMock.getDeviceSessionState.mockReturnValueOnce({
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Ethereum", version: "1.12.0" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    });
+    apiMock.sendCommand.mockResolvedValueOnce(
+      CommandResultFactory({ error: new UnknownDeviceExchangeError() }),
+    );
+
+    // WHEN
+    await new BuildTransactionContextTask(
+      apiMock,
+      defaultArgs,
+      getWeb3ChecksFactoryMock,
+    ).run();
+
+    // THEN
+    expect(contextModuleMock.getContexts).toHaveBeenCalledWith({
+      deviceModelId: DeviceModelId.FLEX,
+      challenge: undefined,
       domain: "domain-name.eth",
       ...mapperResult.subset,
     });
@@ -338,7 +481,11 @@ describe("BuildTransactionContextTask", () => {
     });
 
     // WHEN
-    const task = new BuildTransactionContextTask(apiMock, defaultArgs);
+    const task = new BuildTransactionContextTask(
+      apiMock,
+      defaultArgs,
+      getWeb3ChecksFactoryMock,
+    );
 
     // THEN
     await expect(task.run()).rejects.toThrow(error);
@@ -385,6 +532,7 @@ describe("BuildTransactionContextTask", () => {
     const result = await new BuildTransactionContextTask(
       apiMock,
       defaultArgs,
+      getWeb3ChecksFactoryMock,
     ).run();
 
     // THEN
@@ -393,6 +541,7 @@ describe("BuildTransactionContextTask", () => {
       serializedTransaction,
       chainId: 1,
       transactionType: 0,
+      web3Check: null,
     });
   });
 
@@ -445,6 +594,7 @@ describe("BuildTransactionContextTask", () => {
     const result = await new BuildTransactionContextTask(
       apiMock,
       defaultArgs,
+      getWeb3ChecksFactoryMock,
     ).run();
 
     // THEN
@@ -453,6 +603,7 @@ describe("BuildTransactionContextTask", () => {
       serializedTransaction,
       chainId: 1,
       transactionType: 0,
+      web3Check: null,
     });
   });
 
@@ -499,6 +650,7 @@ describe("BuildTransactionContextTask", () => {
     const result = await new BuildTransactionContextTask(
       apiMock,
       defaultArgs,
+      getWeb3ChecksFactoryMock,
     ).run();
 
     // THEN
@@ -507,6 +659,7 @@ describe("BuildTransactionContextTask", () => {
       serializedTransaction,
       chainId: 1,
       transactionType: 0,
+      web3Check: null,
     });
   });
 
@@ -559,6 +712,7 @@ describe("BuildTransactionContextTask", () => {
     const result = await new BuildTransactionContextTask(
       apiMock,
       defaultArgs,
+      getWeb3ChecksFactoryMock,
     ).run();
 
     // THEN
@@ -572,6 +726,7 @@ describe("BuildTransactionContextTask", () => {
       serializedTransaction,
       chainId: 1,
       transactionType: 2,
+      web3Check: null,
     });
   });
 
@@ -617,10 +772,11 @@ describe("BuildTransactionContextTask", () => {
     });
 
     // WHEN
-    const result = await new BuildTransactionContextTask(apiMock, {
-      ...defaultArgs,
-      challenge: null,
-    }).run();
+    const result = await new BuildTransactionContextTask(
+      apiMock,
+      defaultArgs,
+      getWeb3ChecksFactoryMock,
+    ).run();
 
     // THEN
     expect(result).toEqual({
@@ -628,6 +784,7 @@ describe("BuildTransactionContextTask", () => {
       serializedTransaction,
       chainId: 1,
       transactionType: 2,
+      web3Check: null,
     });
   });
 
@@ -673,10 +830,11 @@ describe("BuildTransactionContextTask", () => {
     });
 
     // WHEN
-    const result = await new BuildTransactionContextTask(apiMock, {
-      ...defaultArgs,
-      challenge: null,
-    }).run();
+    const result = await new BuildTransactionContextTask(
+      apiMock,
+      defaultArgs,
+      getWeb3ChecksFactoryMock,
+    ).run();
 
     // THEN
     expect(result).toEqual({
@@ -684,6 +842,7 @@ describe("BuildTransactionContextTask", () => {
       serializedTransaction,
       chainId: 1,
       transactionType: 2,
+      web3Check: null,
     });
   });
 
@@ -726,10 +885,11 @@ describe("BuildTransactionContextTask", () => {
     });
 
     // WHEN
-    const result = await new BuildTransactionContextTask(apiMock, {
-      ...defaultArgs,
-      challenge: null,
-    }).run();
+    const result = await new BuildTransactionContextTask(
+      apiMock,
+      defaultArgs,
+      getWeb3ChecksFactoryMock,
+    ).run();
 
     // THEN
     expect(result).toEqual({
@@ -737,6 +897,7 @@ describe("BuildTransactionContextTask", () => {
       serializedTransaction,
       chainId: 1,
       transactionType: 2,
+      web3Check: null,
     });
   });
 
@@ -778,7 +939,11 @@ describe("BuildTransactionContextTask", () => {
     });
 
     // WHEN
-    const task = new BuildTransactionContextTask(apiMock, defaultArgs);
+    const task = new BuildTransactionContextTask(
+      apiMock,
+      defaultArgs,
+      getWeb3ChecksFactoryMock,
+    );
 
     // THEN
     await expect(task.run()).rejects.toThrow("Unsupported app");
@@ -820,7 +985,11 @@ describe("BuildTransactionContextTask", () => {
     });
 
     // WHEN
-    const task = new BuildTransactionContextTask(apiMock, defaultArgs);
+    const task = new BuildTransactionContextTask(
+      apiMock,
+      defaultArgs,
+      getWeb3ChecksFactoryMock,
+    );
 
     // THEN
     await expect(task.run()).rejects.toThrow(

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BuildTransactionContextTask.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BuildTransactionContextTask.ts
@@ -9,12 +9,18 @@ import {
   type DeviceSessionState,
   DeviceSessionStateType,
   type InternalApi,
+  isSuccessCommandResult,
 } from "@ledgerhq/device-management-kit";
 import { gte } from "semver";
 
 import { type TransactionOptions } from "@api/model/TransactionOptions";
 import { type TransactionType } from "@api/model/TransactionType";
+import { GetChallengeCommand } from "@internal/app-binder/command/GetChallengeCommand";
 import { ETHEREUM_PLUGINS } from "@internal/app-binder/constant/plugins";
+import {
+  GetWeb3CheckTask,
+  type GetWeb3CheckTaskArgs,
+} from "@internal/app-binder/task/GetWeb3CheckTask";
 import { type TransactionMapperService } from "@internal/transaction/service/mapper/TransactionMapperService";
 
 import { type GenericContext } from "./ProvideTransactionGenericContextTask";
@@ -24,6 +30,7 @@ export type BuildTransactionTaskResult = {
   readonly serializedTransaction: Uint8Array;
   readonly chainId: number;
   readonly transactionType: TransactionType;
+  readonly web3Check: ClearSignContextSuccess<ClearSignContextType.WEB3_CHECK> | null;
 };
 
 export type BuildTransactionContextTaskArgs = {
@@ -31,28 +38,52 @@ export type BuildTransactionContextTaskArgs = {
   readonly mapper: TransactionMapperService;
   readonly transaction: Uint8Array;
   readonly options: TransactionOptions;
-  readonly challenge: string | null;
+  readonly derivationPath: string;
 };
 
 export class BuildTransactionContextTask {
   constructor(
     private readonly api: InternalApi,
     private readonly args: BuildTransactionContextTaskArgs,
+    private getWeb3ChecksFactory = (
+      api: InternalApi,
+      args: GetWeb3CheckTaskArgs,
+    ) => new GetWeb3CheckTask(api, args),
   ) {}
 
   async run(): Promise<BuildTransactionTaskResult> {
-    const { contextModule, mapper, transaction, options, challenge } =
+    const { contextModule, mapper, transaction, options, derivationPath } =
       this.args;
     const deviceState = this.api.getDeviceSessionState();
 
+    // Parse transaction
     const parsed = mapper.mapTransactionToSubset(transaction);
     parsed.ifLeft((err) => {
       throw err;
     });
     const { subset, serializedTransaction, type } = parsed.unsafeCoerce();
 
+    // Run the web3checks if needed
+    const web3Check: ClearSignContextSuccess<ClearSignContextType.WEB3_CHECK> | null =
+      (
+        await this.getWeb3ChecksFactory(this.api, {
+          contextModule,
+          derivationPath,
+          mapper,
+          transaction,
+        }).run()
+      ).web3Check;
+
+    // Get challenge
+    let challenge: string | undefined = undefined;
+    const challengeRes = await this.api.sendCommand(new GetChallengeCommand());
+    if (isSuccessCommandResult(challengeRes)) {
+      challenge = challengeRes.data.challenge;
+    }
+
+    // Get the clear sign contexts
     const clearSignContexts = await contextModule.getContexts({
-      challenge: challenge ?? undefined,
+      challenge: challenge,
       domain: options.domain,
       deviceModelId: deviceState.deviceModelId,
       ...subset,
@@ -114,6 +145,7 @@ export class BuildTransactionContextTask {
       serializedTransaction,
       chainId: subset.chainId,
       transactionType: type,
+      web3Check,
     };
   }
 

--- a/packages/signer/signer-eth/src/internal/shared/utils/ApplicationChecker.test.ts
+++ b/packages/signer/signer-eth/src/internal/shared/utils/ApplicationChecker.test.ts
@@ -1,0 +1,209 @@
+import {
+  DeviceModelId,
+  DeviceSessionStateType,
+  DeviceStatus,
+} from "@ledgerhq/device-management-kit";
+
+import { ApplicationChecker } from "./ApplicationChecker";
+
+describe("ApplicationChecker", () => {
+  it("should pass the check for exclusive version", () => {
+    // GIVEN
+    const state = {
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Ethereum", version: "1.13.0-rc" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    };
+    // WHEN
+    const result = new ApplicationChecker(state)
+      .withMinVersionExclusive("1.12.0")
+      .check();
+    // THEN
+    expect(result).toStrictEqual(true);
+  });
+
+  it("should reject the check for exclusive version", () => {
+    // GIVEN
+    const state = {
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Ethereum", version: "1.12.0" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    };
+    // WHEN
+    const result = new ApplicationChecker(state)
+      .withMinVersionExclusive("1.12.0")
+      .check();
+    // THEN
+    expect(result).toStrictEqual(false);
+  });
+
+  it("should pass the check for inclusive version", () => {
+    // GIVEN
+    const state = {
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Ethereum", version: "1.12.0" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    };
+    // WHEN
+    const result = new ApplicationChecker(state)
+      .withMinVersionInclusive("1.12.0")
+      .check();
+    // THEN
+    expect(result).toStrictEqual(true);
+  });
+
+  it("should reject the check for inclusive version", () => {
+    // GIVEN
+    const state = {
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Ethereum", version: "1.11.0" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    };
+    // WHEN
+    const result = new ApplicationChecker(state)
+      .withMinVersionInclusive("1.12.0")
+      .check();
+    // THEN
+    expect(result).toStrictEqual(false);
+  });
+
+  it("should pass the check for excluded device", () => {
+    // GIVEN
+    const state = {
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Ethereum", version: "1.11.0" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    };
+    // WHEN
+    const result = new ApplicationChecker(state)
+      .excludeDeviceModel(DeviceModelId.NANO_S)
+      .check();
+    // THEN
+    expect(result).toStrictEqual(true);
+  });
+
+  it("should reject the check for excluded device", () => {
+    // GIVEN
+    const state = {
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Ethereum", version: "1.11.0" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    };
+    // WHEN
+    const result = new ApplicationChecker(state)
+      .excludeDeviceModel(DeviceModelId.FLEX)
+      .check();
+    // THEN
+    expect(result).toStrictEqual(false);
+  });
+
+  it("should pass the check for chained condition", () => {
+    // GIVEN
+    const state = {
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Ethereum", version: "1.11.0" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    };
+    // WHEN
+    const result = new ApplicationChecker(state)
+      .withMinVersionInclusive("1.11.0")
+      .excludeDeviceModel(DeviceModelId.NANO_S)
+      .check();
+    // THEN
+    expect(result).toStrictEqual(true);
+  });
+
+  it("should reject the check for chained condition", () => {
+    // GIVEN
+    const state = {
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Ethereum", version: "1.10.0" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    };
+    // WHEN
+    const result = new ApplicationChecker(state)
+      .withMinVersionInclusive("1.11.0")
+      .excludeDeviceModel(DeviceModelId.NANO_S)
+      .check();
+    // THEN
+    expect(result).toStrictEqual(false);
+  });
+
+  it("should pass the check in plugins", () => {
+    // GIVEN
+    const state = {
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "1inch", version: "1.13.0-rc" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    };
+    // WHEN
+    const result = new ApplicationChecker(state)
+      .withMinVersionExclusive("1.12.0")
+      .check();
+    // THEN
+    expect(result).toStrictEqual(true);
+  });
+
+  it("should reject the check in unknexpected app", () => {
+    // GIVEN
+    const state = {
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Bitcoin", version: "1.13.0-rc" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    };
+    // WHEN
+    const result = new ApplicationChecker(state)
+      .withMinVersionExclusive("1.12.0")
+      .check();
+    // THEN
+    expect(result).toStrictEqual(false);
+  });
+
+  it("should reject the check in unknexpected state", () => {
+    // GIVEN
+    const state = {
+      sessionStateType: DeviceSessionStateType.Connected,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Bitcoin", version: "1.13.0-rc" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    };
+    // WHEN
+    const result = new ApplicationChecker(state)
+      .withMinVersionExclusive("1.12.0")
+      .check();
+    // THEN
+    expect(result).toStrictEqual(false);
+  });
+});

--- a/packages/signer/signer-eth/src/internal/shared/utils/ApplicationChecker.ts
+++ b/packages/signer/signer-eth/src/internal/shared/utils/ApplicationChecker.ts
@@ -1,0 +1,57 @@
+import {
+  type DeviceModelId,
+  type DeviceSessionState,
+  DeviceSessionStateType,
+} from "@ledgerhq/device-management-kit";
+import { gt, gte } from "semver";
+
+import { ETHEREUM_PLUGINS } from "@internal/app-binder/constant/plugins";
+
+export class ApplicationChecker {
+  private isCompatible: boolean = true;
+  private version: string = "0.0.1";
+  private modelId: DeviceModelId;
+
+  constructor(deviceState: DeviceSessionState) {
+    this.modelId = deviceState.deviceModelId;
+
+    // If device is not ready or app is unexpected, checker cannot be successful
+    if (deviceState.sessionStateType === DeviceSessionStateType.Connected) {
+      this.isCompatible = false;
+      return;
+    }
+    if (
+      deviceState.currentApp.name !== "Ethereum" &&
+      !ETHEREUM_PLUGINS.includes(deviceState.currentApp.name)
+    ) {
+      this.isCompatible = false;
+      return;
+    }
+    this.version = deviceState.currentApp.version;
+  }
+
+  withMinVersionInclusive(version: string): ApplicationChecker {
+    if (!gte(this.version, version)) {
+      this.isCompatible = false;
+    }
+    return this;
+  }
+
+  withMinVersionExclusive(version: string): ApplicationChecker {
+    if (!gt(this.version, version)) {
+      this.isCompatible = false;
+    }
+    return this;
+  }
+
+  excludeDeviceModel(modelId: DeviceModelId): ApplicationChecker {
+    if (this.modelId === modelId) {
+      this.isCompatible = false;
+    }
+    return this;
+  }
+
+  check(): boolean {
+    return this.isCompatible;
+  }
+}


### PR DESCRIPTION
### 📝 Description

When web3check opt-in is triggered, the is a need for user interaction on device.
Therefore we need a specific state in device actions to make that user interaction visible on the UI.
Impacted device actions:
* SignTransaction
* SignTypedData

Since SignTransaction was needlessly complex, I took the chance to simplify it before adding the new state.
The review can be done separately on the too commits

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**:

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
