### PR TITLE
:bug: (signer-eth) [DSDK-723]: SignerEth should be compatible with Exchange app flows

### DIFF
--- a/.changeset/strange-rules-hang.md
+++ b/.changeset/strange-rules-hang.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": patch
+---
+
+SignerEth should be compatible with Exchange app flows

--- a/packages/signer/signer-eth/src/internal/app-binder/constant/plugins.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/constant/plugins.ts
@@ -46,4 +46,5 @@ export const ETHEREUM_PLUGINS: string[] = [
   "Thales",
   "Yearn",
   "Uniswap",
+  "Exchange", // Not a plugin, but a compatible app during exchange flows
 ];

--- a/packages/signer/signer-eth/src/internal/shared/utils/ApplicationChecker.test.ts
+++ b/packages/signer/signer-eth/src/internal/shared/utils/ApplicationChecker.test.ts
@@ -172,6 +172,23 @@ describe("ApplicationChecker", () => {
     expect(result).toStrictEqual(false);
   });
 
+  it("exchange app should not be compatible with eth features", () => {
+    // GIVEN
+    const state = {
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Exchange", version: "1.11.0-rc" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    };
+    const config = createAppConfig("1.13.0");
+    // WHEN
+    const result = new ApplicationChecker(state, config).check();
+    // THEN
+    expect(result).toStrictEqual(false);
+  });
+
   it("should pass the check in plugins", () => {
     // GIVEN
     const state = {

--- a/packages/signer/signer-eth/src/internal/shared/utils/ApplicationChecker.ts
+++ b/packages/signer/signer-eth/src/internal/shared/utils/ApplicationChecker.ts
@@ -33,6 +33,9 @@ export class ApplicationChecker {
     }
     if (deviceState.currentApp.name === "Ethereum") {
       this.version = deviceState.currentApp.version;
+    } else if (deviceState.currentApp.name === "Exchange") {
+      // Exchanges flows are not compatibles with ethereum features appart from SignTx
+      this.isCompatible = false;
     } else {
       // Fallback on appConfig version if a plugin is running.
       // It won't contain release candidate suffix but it should be enough for that edge case.


### PR DESCRIPTION
### 📝 Description

Bug reproduced when doing swaps with a centralized exchange in Ledger Live, from Eth to another chain.
The flow should be done in Exchange App, but the SignerEth tries to open Ethereum app at the end of the flow to sign the TX, which break the flow.

https://ledgerhq.atlassian.net/browse/DSDK-723

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**:

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
