### PR TITLE
:sparkles: (dmk) [DSDK-704]: Implement OpenAppWithDependencies device action

### DIFF
--- a/.changeset/tame-yaks-care.md
+++ b/.changeset/tame-yaks-care.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": minor
+---
+
+Implement OpenAppWithDependencies device action

--- a/apps/sample/src/components/DeviceActionsView/AllDeviceActions.tsx
+++ b/apps/sample/src/components/DeviceActionsView/AllDeviceActions.tsx
@@ -50,6 +50,10 @@ import {
   type OpenAppDAIntermediateValue,
   type OpenAppDAOutput,
   OpenAppDeviceAction,
+  type OpenAppWithDependenciesDAError,
+  type OpenAppWithDependenciesDAIntermediateValue,
+  type OpenAppWithDependenciesDAOutput,
+  OpenAppWithDependenciesDeviceAction,
   type UninstallAppDAError,
   type UninstallAppDAInput,
   type UninstallAppDAIntermediateValue,
@@ -113,6 +117,62 @@ export const AllDeviceActions: React.FC<{ sessionId: string }> = ({
         },
         OpenAppDAError,
         OpenAppDAIntermediateValue
+      >,
+      {
+        title: `Open app with dependencies ${SECURE_CHANNEL_SIGN}`,
+        description:
+          "Perform all the actions necessary to open an app on the device and install its dependencies",
+        executeDeviceAction: (
+          {
+            appName,
+            dependencies,
+            compatibleAppNames,
+            requireLatestFirmware,
+            unlockTimeout,
+          },
+          inspect,
+        ) => {
+          const application = { name: appName };
+          const dependenciesArray = dependencies
+            .split(",")
+            .map((app) => ({ name: app.trim() }));
+          const compatibleAppNamesArray = compatibleAppNames
+            .split(",")
+            .map((app) => app.trim());
+          const deviceAction = new OpenAppWithDependenciesDeviceAction({
+            input: {
+              application,
+              dependencies: dependenciesArray,
+              compatibleAppNames: compatibleAppNamesArray,
+              requireLatestFirmware,
+              unlockTimeout,
+            },
+            inspect,
+          });
+          return dmk.executeDeviceAction({
+            sessionId,
+            deviceAction,
+          });
+        },
+        initialValues: {
+          appName: "Ethereum",
+          dependencies: "Uniswap,1inch",
+          compatibleAppNames: "",
+          requireLatestFirmware: false,
+          unlockTimeout: UNLOCK_TIMEOUT,
+        },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        OpenAppWithDependenciesDAOutput,
+        {
+          appName: string;
+          dependencies: string;
+          compatibleAppNames: string;
+          requireLatestFirmware: boolean;
+          unlockTimeout: number;
+        },
+        OpenAppWithDependenciesDAError,
+        OpenAppWithDependenciesDAIntermediateValue
       >,
       {
         title: "Get device status",

--- a/packages/device-management-kit/src/api/device-action/__test-utils__/setupTestMachine.ts
+++ b/packages/device-management-kit/src/api/device-action/__test-utils__/setupTestMachine.ts
@@ -8,7 +8,13 @@ import { GetDeviceMetadataDeviceAction } from "@api/device-action/os/GetDeviceMe
 import { type GetDeviceMetadataDAOutput } from "@api/device-action/os/GetDeviceMetadata/types";
 import { GetDeviceStatusDeviceAction } from "@api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction";
 import { GoToDashboardDeviceAction } from "@api/device-action/os/GoToDashboard/GoToDashboardDeviceAction";
+import { InstallOrUpdateAppsDeviceAction } from "@api/device-action/os/InstallOrUpdateApps/InstallOrUpdateAppsDeviceAction";
+import {
+  type InstallOrUpdateAppsDAIntermediateValue,
+  type InstallOrUpdateAppsDAOutput,
+} from "@api/device-action/os/InstallOrUpdateApps/types";
 import { ListAppsDeviceAction } from "@api/device-action/os/ListApps/ListAppsDeviceAction";
+import { OpenAppDeviceAction } from "@api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction";
 import { type DmkError } from "@api/Error";
 import { ListInstalledAppsDeviceAction } from "@api/secure-channel/device-action/ListInstalledApps/ListInstalledAppsDeviceAction";
 import { type InstalledApp } from "@api/secure-channel/device-action/ListInstalledApps/types";
@@ -76,6 +82,69 @@ export const setupGetDeviceMetadataMock = (
           return error
             ? Left(new UnknownDAError("GetDeviceMetadata failed"))
             : Right(metadata);
+        },
+      }),
+    ),
+  }));
+};
+
+export const setupInstallOrUpdateAppsMock = (
+  result: InstallOrUpdateAppsDAOutput,
+  intermediateValue: InstallOrUpdateAppsDAIntermediateValue,
+  error = false,
+) => {
+  (InstallOrUpdateAppsDeviceAction as Mock).mockImplementation(() => ({
+    makeStateMachine: vi.fn().mockImplementation(() =>
+      createMachine({
+        id: "MockInstallOrUpdateAppsDeviceAction",
+        initial: "ready",
+        states: {
+          ready: {
+            after: {
+              0: "done",
+            },
+            entry: assign({
+              intermediateValue: () => intermediateValue,
+            }),
+          },
+          done: {
+            type: "final",
+          },
+        },
+        output: () => {
+          return error
+            ? Left(new UnknownDAError("InstallOrUpdateApps failed"))
+            : Right(result);
+        },
+      }),
+    ),
+  }));
+};
+
+export const setupOpenAppMock = (error: boolean = false) => {
+  (OpenAppDeviceAction as Mock).mockImplementation(() => ({
+    makeStateMachine: vi.fn().mockImplementation(() =>
+      createMachine({
+        initial: "ready",
+        states: {
+          ready: {
+            entry: assign({
+              intermediateValue: {
+                requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+              },
+            }),
+            after: {
+              0: "done",
+            },
+          },
+          done: {
+            type: "final",
+          },
+        },
+        output: () => {
+          return error
+            ? Left(new UnknownDAError("OpenApp failed"))
+            : Right(undefined);
         },
       }),
     ),

--- a/packages/device-management-kit/src/api/device-action/os/Errors.ts
+++ b/packages/device-management-kit/src/api/device-action/os/Errors.ts
@@ -18,6 +18,15 @@ export class DeviceLockedError implements DmkError {
   }
 }
 
+export class UnsupportedFirmwareDAError implements DmkError {
+  readonly _tag = "UnsupportedFirmwareDAError";
+  readonly originalError?: Error;
+
+  constructor(message?: string) {
+    this.originalError = new Error(message ?? "Unknown error.");
+  }
+}
+
 export class OutOfMemoryDAError implements DmkError {
   readonly _tag = "OutOfMemoryDAError";
   readonly originalError?: Error;

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceMetadata/types.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceMetadata/types.ts
@@ -1,14 +1,13 @@
 import { type CommandErrorResult } from "@api/command/model/CommandResult";
 import { type DeviceActionState } from "@api/device-action/model/DeviceActionState";
-import { type UserInteractionRequired } from "@api/device-action/model/UserInteractionRequired";
 import {
   type GoToDashboardDAError,
   type GoToDashboardDAInput,
-  type GoToDashboardDAIntermediateValue,
+  type GoToDashboardDARequiredInteraction,
 } from "@api/device-action/os/GoToDashboard/types";
 import {
   type ListAppsDAError,
-  type ListAppsDAIntermediateValue,
+  type ListAppsDARequiredInteraction,
 } from "@api/device-action/os/ListApps/types";
 import {
   type Catalog,
@@ -19,7 +18,7 @@ import {
 } from "@api/device-session/DeviceSessionState";
 import {
   type ListInstalledAppsDAError,
-  type ListInstalledAppsDAIntermediateValue,
+  type ListInstalledAppsDARequiredInteraction,
 } from "@api/secure-channel/device-action/ListInstalledApps/types";
 import { type Application } from "@internal/manager-api/model/Application";
 
@@ -45,15 +44,13 @@ export type GetDeviceMetadataDAError =
   | CommandErrorResult["error"];
 
 export type GetDeviceMetadataDARequiredInteraction =
-  UserInteractionRequired.None;
+  | GoToDashboardDARequiredInteraction
+  | ListAppsDARequiredInteraction
+  | ListInstalledAppsDARequiredInteraction;
 
-export type GetDeviceMetadataDAIntermediateValue =
-  | GoToDashboardDAIntermediateValue
-  | ListAppsDAIntermediateValue
-  | ListInstalledAppsDAIntermediateValue
-  | {
-      requiredUserInteraction: GetDeviceMetadataDARequiredInteraction;
-    };
+export type GetDeviceMetadataDAIntermediateValue = {
+  requiredUserInteraction: GetDeviceMetadataDARequiredInteraction;
+};
 
 export type GetDeviceMetadataDAState = DeviceActionState<
   GetDeviceMetadataDAOutput,

--- a/packages/device-management-kit/src/api/device-action/os/GoToDashboard/types.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GoToDashboard/types.ts
@@ -1,11 +1,10 @@
 import { type CommandErrorResult } from "@api/command/model/CommandResult";
 import { type DeviceActionState } from "@api/device-action/model/DeviceActionState";
-import { type UserInteractionRequired } from "@api/device-action/model/UserInteractionRequired";
 import { type UnknownDAError } from "@api/device-action/os/Errors";
 import {
   type GetDeviceStatusDAError,
   type GetDeviceStatusDAInput,
-  type GetDeviceStatusDAIntermediateValue,
+  type GetDeviceStatusDARequiredInteraction,
 } from "@api/device-action/os/GetDeviceStatus/types";
 
 export type GoToDashboardDAOutput = void;
@@ -16,13 +15,12 @@ export type GoToDashboardDAError =
   | UnknownDAError
   | CommandErrorResult["error"];
 
-export type GoToDashboardDARequiredInteraction = UserInteractionRequired.None;
+export type GoToDashboardDARequiredInteraction =
+  GetDeviceStatusDARequiredInteraction;
 
-export type GoToDashboardDAIntermediateValue =
-  | GetDeviceStatusDAIntermediateValue
-  | {
-      readonly requiredUserInteraction: GoToDashboardDARequiredInteraction;
-    };
+export type GoToDashboardDAIntermediateValue = {
+  readonly requiredUserInteraction: GoToDashboardDARequiredInteraction;
+};
 
 export type GoToDashboardDAState = DeviceActionState<
   GoToDashboardDAOutput,

--- a/packages/device-management-kit/src/api/device-action/os/InstallOrUpdateApps/types.ts
+++ b/packages/device-management-kit/src/api/device-action/os/InstallOrUpdateApps/types.ts
@@ -4,8 +4,9 @@ import type { DeviceActionState } from "@api/device-action/model/DeviceActionSta
 import type { OutOfMemoryDAError } from "@api/device-action/os/Errors";
 import type {
   GetDeviceMetadataDAError,
-  GetDeviceMetadataDAIntermediateValue,
+  GetDeviceMetadataDARequiredInteraction,
 } from "@api/device-action/os/GetDeviceMetadata/types";
+import type { GoToDashboardDARequiredInteraction } from "@api/device-action/os/GoToDashboard/types";
 import type { GoToDashboardDAInput } from "@api/device-action/os/GoToDashboard/types";
 import type { InstallAppDAError } from "@api/secure-channel/device-action/InstallApp/types";
 import type { Application } from "@internal/manager-api/model/Application";
@@ -77,10 +78,14 @@ export type InstallOrUpdateAppsDAError =
   | OutOfMemoryDAError
   | CommandErrorResult["error"];
 
-export type InstallOrUpdateAppsDAIntermediateValue =
-  GetDeviceMetadataDAIntermediateValue & {
-    installPlan: InstallPlan | null;
-  };
+export type InstallOrUpdateAppsDARequiredInteraction =
+  | GoToDashboardDARequiredInteraction
+  | GetDeviceMetadataDARequiredInteraction;
+
+export type InstallOrUpdateAppsDAIntermediateValue = {
+  requiredUserInteraction: InstallOrUpdateAppsDARequiredInteraction;
+  installPlan: InstallPlan | null;
+};
 
 export type InstallOrUpdateAppsDAState = DeviceActionState<
   InstallOrUpdateAppsDAOutput,

--- a/packages/device-management-kit/src/api/device-action/os/OpenAppWithDependencies/OpenAppWithDependenciesDeviceAction.test.ts
+++ b/packages/device-management-kit/src/api/device-action/os/OpenAppWithDependencies/OpenAppWithDependenciesDeviceAction.test.ts
@@ -1,0 +1,352 @@
+import { makeDeviceActionInternalApiMock } from "@api/device-action/__test-utils__/makeInternalApi";
+import {
+  setupGetDeviceMetadataMock,
+  setupInstallOrUpdateAppsMock,
+  setupOpenAppMock,
+} from "@api/device-action/__test-utils__/setupTestMachine";
+import { testDeviceActionStates } from "@api/device-action/__test-utils__/testDeviceActionStates";
+import { DeviceActionStatus } from "@api/device-action/model/DeviceActionState";
+import { UserInteractionRequired } from "@api/device-action/model/UserInteractionRequired";
+import {
+  UnknownDAError,
+  UnsupportedFirmwareDAError,
+} from "@api/device-action/os/Errors";
+import type { GetDeviceMetadataDAOutput } from "@api/device-action/os/GetDeviceMetadata/types";
+import type { InstallOrUpdateAppsDAIntermediateValue } from "@api/device-action/os/InstallOrUpdateApps/types";
+import type { Application } from "@internal/manager-api/model/Application";
+
+import { OpenAppWithDependenciesDeviceAction } from "./OpenAppWithDependenciesDeviceAction";
+import type { OpenAppWithDependenciesDAState } from "./types";
+
+vi.mock("@api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction");
+vi.mock(
+  "@api/device-action/os/InstallOrUpdateApps/InstallOrUpdateAppsDeviceAction",
+);
+vi.mock(
+  "@api/device-action/os/GetDeviceMetadata/GetDeviceMetadataDeviceAction",
+);
+
+describe("OpenAppWithDependenciesDeviceAction", () => {
+  const apiMock = makeDeviceActionInternalApiMock();
+
+  const DEVICE_METADATA = {
+    firmwareUpdateContext: {},
+  } as unknown as GetDeviceMetadataDAOutput;
+
+  const INSTALL_INTERMEDIATE_VALUE: InstallOrUpdateAppsDAIntermediateValue = {
+    requiredUserInteraction: UserInteractionRequired.None,
+    installPlan: {
+      installPlan: [{ versionName: "1inch" }] as unknown as Application[],
+      alreadyInstalled: ["Ethereum", "Uniswap"],
+      missingApplications: [""],
+      currentIndex: 0,
+      currentProgress: 0.5,
+    },
+  };
+
+  const INSTALL_RESULT = {
+    successfullyInstalled: [
+      { versionName: "1inch" },
+    ] as unknown as Application[],
+    alreadyInstalled: ["Ethereum", "Uniswap"],
+    missingApplications: [""],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("success cases", () => {
+    it("Open app with dependencies", () =>
+      new Promise<void>((resolve, reject) => {
+        setupGetDeviceMetadataMock(DEVICE_METADATA);
+        setupInstallOrUpdateAppsMock(
+          INSTALL_RESULT,
+          INSTALL_INTERMEDIATE_VALUE,
+        );
+        setupOpenAppMock();
+        const deviceAction = new OpenAppWithDependenciesDeviceAction({
+          input: {
+            application: { name: "Ethereum" },
+            dependencies: [{ name: "Uniswap" }, { name: "1inch" }],
+            requireLatestFirmware: false,
+          },
+        });
+
+        const expectedStates: Array<OpenAppWithDependenciesDAState> = [
+          // GetDeviceMetadata
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              installPlan: null,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              installPlan: null,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          // InstallOrUpdateApps
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              installPlan: null,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: INSTALL_INTERMEDIATE_VALUE,
+            status: DeviceActionStatus.Pending,
+          },
+          // OpenApp
+          {
+            intermediateValue: INSTALL_INTERMEDIATE_VALUE,
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+              installPlan: null,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          // Success
+          {
+            output: {
+              deviceMetadata: DEVICE_METADATA,
+              installResult: INSTALL_RESULT,
+            },
+            status: DeviceActionStatus.Completed,
+          },
+        ];
+
+        testDeviceActionStates(deviceAction, expectedStates, apiMock, {
+          onDone: resolve,
+          onError: reject,
+        });
+      }));
+  });
+
+  describe("error cases", () => {
+    it("Get device metadata error", () =>
+      new Promise<void>((resolve, reject) => {
+        setupGetDeviceMetadataMock(DEVICE_METADATA, true);
+        const deviceAction = new OpenAppWithDependenciesDeviceAction({
+          input: {
+            application: { name: "Ethereum" },
+            dependencies: [{ name: "Uniswap" }, { name: "1inch" }],
+            requireLatestFirmware: false,
+          },
+        });
+
+        const expectedStates: Array<OpenAppWithDependenciesDAState> = [
+          // GetDeviceMetadata
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              installPlan: null,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              installPlan: null,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          // Error
+          {
+            error: new UnknownDAError("GetDeviceMetadata failed"),
+            status: DeviceActionStatus.Error,
+          },
+        ];
+
+        testDeviceActionStates(deviceAction, expectedStates, apiMock, {
+          onDone: resolve,
+          onError: reject,
+        });
+      }));
+
+    it("Unsupported firmware", () =>
+      new Promise<void>((resolve, reject) => {
+        const metadataWithUpdate = {
+          firmwareUpdateContext: {
+            availableUpdate: "mockUpdate",
+          },
+        } as unknown as GetDeviceMetadataDAOutput;
+        setupGetDeviceMetadataMock(metadataWithUpdate);
+        const deviceAction = new OpenAppWithDependenciesDeviceAction({
+          input: {
+            application: { name: "Ethereum" },
+            dependencies: [{ name: "Uniswap" }, { name: "1inch" }],
+            requireLatestFirmware: true,
+          },
+        });
+
+        const expectedStates: Array<OpenAppWithDependenciesDAState> = [
+          // GetDeviceMetadata
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              installPlan: null,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              installPlan: null,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          // Error
+          {
+            error: new UnsupportedFirmwareDAError(
+              "Firmware is not the latest version",
+            ),
+            status: DeviceActionStatus.Error,
+          },
+        ];
+
+        testDeviceActionStates(deviceAction, expectedStates, apiMock, {
+          onDone: resolve,
+          onError: reject,
+        });
+      }));
+
+    it("Install apps error", () =>
+      new Promise<void>((resolve, reject) => {
+        const metadataWithUpdate = {
+          firmwareUpdateContext: {
+            availableUpdate: "mockUpdate",
+          },
+        } as unknown as GetDeviceMetadataDAOutput;
+        setupGetDeviceMetadataMock(metadataWithUpdate);
+        setupInstallOrUpdateAppsMock(
+          INSTALL_RESULT,
+          INSTALL_INTERMEDIATE_VALUE,
+          true,
+        );
+        const deviceAction = new OpenAppWithDependenciesDeviceAction({
+          input: {
+            application: { name: "Ethereum" },
+            dependencies: [{ name: "Uniswap" }, { name: "1inch" }],
+            requireLatestFirmware: false,
+          },
+        });
+
+        const expectedStates: Array<OpenAppWithDependenciesDAState> = [
+          // GetDeviceMetadata
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              installPlan: null,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              installPlan: null,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          // InstallOrUpdateApps
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              installPlan: null,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: INSTALL_INTERMEDIATE_VALUE,
+            status: DeviceActionStatus.Pending,
+          },
+          // Error
+          {
+            error: new UnknownDAError("InstallOrUpdateApps failed"),
+            status: DeviceActionStatus.Error,
+          },
+        ];
+
+        testDeviceActionStates(deviceAction, expectedStates, apiMock, {
+          onDone: resolve,
+          onError: reject,
+        });
+      }));
+
+    it("Open app error", () =>
+      new Promise<void>((resolve, reject) => {
+        setupGetDeviceMetadataMock(DEVICE_METADATA);
+        setupInstallOrUpdateAppsMock(
+          INSTALL_RESULT,
+          INSTALL_INTERMEDIATE_VALUE,
+        );
+        setupOpenAppMock(true);
+        const deviceAction = new OpenAppWithDependenciesDeviceAction({
+          input: {
+            application: { name: "Ethereum" },
+            dependencies: [{ name: "Uniswap" }, { name: "1inch" }],
+            requireLatestFirmware: false,
+          },
+        });
+
+        const expectedStates: Array<OpenAppWithDependenciesDAState> = [
+          // GetDeviceMetadata
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              installPlan: null,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              installPlan: null,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          // InstallOrUpdateApps
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              installPlan: null,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: INSTALL_INTERMEDIATE_VALUE,
+            status: DeviceActionStatus.Pending,
+          },
+          // OpenApp
+          {
+            intermediateValue: INSTALL_INTERMEDIATE_VALUE,
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+              installPlan: null,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          // Error
+          {
+            error: new UnknownDAError("OpenApp failed"),
+            status: DeviceActionStatus.Error,
+          },
+        ];
+
+        testDeviceActionStates(deviceAction, expectedStates, apiMock, {
+          onDone: resolve,
+          onError: reject,
+        });
+      }));
+  });
+});

--- a/packages/device-management-kit/src/api/device-action/os/OpenAppWithDependencies/OpenAppWithDependenciesDeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/os/OpenAppWithDependencies/OpenAppWithDependenciesDeviceAction.ts
@@ -1,0 +1,353 @@
+import { Left, Right } from "purify-ts";
+import { assign, setup } from "xstate";
+
+import { type InternalApi } from "@api/device-action/DeviceAction";
+import { UserInteractionRequired } from "@api/device-action/model/UserInteractionRequired";
+import { DEFAULT_UNLOCK_TIMEOUT_MS } from "@api/device-action/os/Const";
+import { UnsupportedFirmwareDAError } from "@api/device-action/os/Errors";
+import { GetDeviceMetadataDeviceAction } from "@api/device-action/os/GetDeviceMetadata/GetDeviceMetadataDeviceAction";
+import type { GetDeviceMetadataDAOutput } from "@api/device-action/os/GetDeviceMetadata/types";
+import { InstallOrUpdateAppsDeviceAction } from "@api/device-action/os/InstallOrUpdateApps/InstallOrUpdateAppsDeviceAction";
+import type { InstallOrUpdateAppsDAOutput } from "@api/device-action/os/InstallOrUpdateApps/types";
+import { OpenAppDeviceAction } from "@api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction";
+import { type StateMachineTypes } from "@api/device-action/xstate-utils/StateMachineTypes";
+import {
+  type DeviceActionStateMachine,
+  XStateDeviceAction,
+} from "@api/device-action/xstate-utils/XStateDeviceAction";
+
+import {
+  type OpenAppWithDependenciesDAError,
+  type OpenAppWithDependenciesDAInput,
+  type OpenAppWithDependenciesDAIntermediateValue,
+  type OpenAppWithDependenciesDAOutput,
+} from "./types";
+
+type OpenAppWithDependenciesMachineInternalState = {
+  readonly error: OpenAppWithDependenciesDAError | null;
+  readonly deviceMetadata: GetDeviceMetadataDAOutput | null;
+  readonly installResult: InstallOrUpdateAppsDAOutput | null;
+};
+
+export class OpenAppWithDependenciesDeviceAction extends XStateDeviceAction<
+  OpenAppWithDependenciesDAOutput,
+  OpenAppWithDependenciesDAInput,
+  OpenAppWithDependenciesDAError,
+  OpenAppWithDependenciesDAIntermediateValue,
+  OpenAppWithDependenciesMachineInternalState
+> {
+  makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    OpenAppWithDependenciesDAOutput,
+    OpenAppWithDependenciesDAInput,
+    OpenAppWithDependenciesDAError,
+    OpenAppWithDependenciesDAIntermediateValue,
+    OpenAppWithDependenciesMachineInternalState
+  > {
+    type types = StateMachineTypes<
+      OpenAppWithDependenciesDAOutput,
+      OpenAppWithDependenciesDAInput,
+      OpenAppWithDependenciesDAError,
+      OpenAppWithDependenciesDAIntermediateValue,
+      OpenAppWithDependenciesMachineInternalState
+    >;
+
+    const unlockTimeout = this.input.unlockTimeout ?? DEFAULT_UNLOCK_TIMEOUT_MS;
+
+    const getMetadataMachine = new GetDeviceMetadataDeviceAction({
+      input: {
+        unlockTimeout,
+        useSecureChannel: true,
+        forceUpdate: false,
+      },
+    }).makeStateMachine(internalApi);
+
+    const installAppsMachine = new InstallOrUpdateAppsDeviceAction({
+      input: {
+        unlockTimeout,
+        applications: [...this.input.dependencies, this.input.application],
+        allowMissingApplication: false,
+      },
+    }).makeStateMachine(internalApi);
+
+    const openAppMachine = new OpenAppDeviceAction({
+      input: {
+        unlockTimeout,
+        appName: this.input.application.name,
+        compatibleAppNames: this.input.compatibleAppNames,
+      },
+    }).makeStateMachine(internalApi);
+
+    return setup({
+      types: {
+        input: {
+          unlockTimeout,
+        } as types["input"],
+        context: {} as types["context"],
+        output: {} as types["output"],
+      },
+      actors: {
+        getMetadata: getMetadataMachine,
+        installApps: installAppsMachine,
+        openApp: openAppMachine,
+      },
+      guards: {
+        hasError: ({ context }) => context._internalState.error !== null,
+      },
+      actions: {
+        assignErrorFromEvent: assign({
+          _internalState: (_) => ({
+            ..._.context._internalState,
+            error: _.event["error"], // NOTE: it should never happen, the error is not typed anymore here
+          }),
+        }),
+      },
+    }).createMachine({
+      id: "OpenAppWithDependenciesDeviceAction",
+      initial: "DeviceReady",
+      context: (_) => {
+        return {
+          input: {
+            application: _.input.application,
+            dependencies: _.input.dependencies,
+            compatibleAppNames: _.input.compatibleAppNames,
+            requireLatestFirmware: _.input.requireLatestFirmware,
+            unlockTimeout: _.input.unlockTimeout,
+          },
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            installPlan: null,
+          },
+          _internalState: {
+            error: null,
+            deviceMetadata: null,
+            installResult: null,
+          },
+        };
+      },
+      states: {
+        DeviceReady: {
+          always: [
+            {
+              target: "GetDeviceMetadata",
+            },
+          ],
+        },
+        GetDeviceMetadata: {
+          exit: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              requiredUserInteraction: UserInteractionRequired.None,
+            }),
+          }),
+          invoke: {
+            id: "getMetadata",
+            src: "getMetadata",
+            input: (_) => ({
+              unlockTimeout: _.context.input.unlockTimeout,
+              useSecureChannel: true,
+              forceUpdate: false,
+            }),
+            onSnapshot: {
+              actions: assign({
+                intermediateValue: (_) => ({
+                  ..._.context.intermediateValue,
+                  requiredUserInteraction:
+                    _.event.snapshot.context.intermediateValue
+                      .requiredUserInteraction,
+                }),
+              }),
+            },
+            onDone: {
+              target: "GetDeviceMetadataCheck",
+              actions: assign({
+                _internalState: (_) =>
+                  _.event.output.caseOf<OpenAppWithDependenciesMachineInternalState>(
+                    {
+                      Right: (data) => {
+                        if (
+                          _.context.input.requireLatestFirmware &&
+                          data.firmwareUpdateContext.availableUpdate !==
+                            undefined
+                        ) {
+                          return {
+                            ..._.context._internalState,
+                            error: new UnsupportedFirmwareDAError(
+                              "Firmware is not the latest version",
+                            ),
+                          };
+                        } else {
+                          return {
+                            ..._.context._internalState,
+                            deviceMetadata: data,
+                          };
+                        }
+                      },
+                      Left: (error) => ({
+                        ..._.context._internalState,
+                        error,
+                      }),
+                    },
+                  ),
+              }),
+            },
+            onError: {
+              target: "Error",
+              actions: "assignErrorFromEvent",
+            },
+          },
+        },
+        GetDeviceMetadataCheck: {
+          always: [
+            {
+              target: "Error",
+              guard: "hasError",
+            },
+            {
+              target: "InstallDependencies",
+            },
+          ],
+        },
+        InstallDependencies: {
+          exit: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              requiredUserInteraction: UserInteractionRequired.None,
+            }),
+          }),
+          invoke: {
+            src: "installApps",
+            input: (_) => ({
+              unlockTimeout: _.context.input.unlockTimeout,
+              applications: [
+                ..._.context.input.dependencies,
+                _.context.input.application,
+              ],
+              allowMissingApplication: false,
+            }),
+            onSnapshot: {
+              actions: assign({
+                intermediateValue: (_) => ({
+                  ..._.context.intermediateValue,
+                  requiredUserInteraction:
+                    _.event.snapshot.context.intermediateValue
+                      .requiredUserInteraction,
+                  installPlan:
+                    _.event.snapshot.context.intermediateValue.installPlan,
+                }),
+              }),
+            },
+            onDone: {
+              target: "InstallDependenciesCheck",
+              actions: assign({
+                _internalState: (_) =>
+                  _.event.output.caseOf<OpenAppWithDependenciesMachineInternalState>(
+                    {
+                      Right: (data) => ({
+                        ..._.context._internalState,
+                        installResult: data,
+                      }),
+                      Left: (error) => ({
+                        ..._.context._internalState,
+                        error,
+                      }),
+                    },
+                  ),
+              }),
+            },
+            onError: {
+              target: "Error",
+              actions: "assignErrorFromEvent",
+            },
+          },
+        },
+        InstallDependenciesCheck: {
+          always: [
+            {
+              guard: "hasError",
+              target: "Error",
+            },
+            {
+              target: "OpenApp",
+            },
+          ],
+        },
+        OpenApp: {
+          exit: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              requiredUserInteraction: UserInteractionRequired.None,
+            }),
+          }),
+          invoke: {
+            src: "openApp",
+            input: (_) => ({
+              unlockTimeout: _.context.input.unlockTimeout,
+              appName: _.context.input.application.name,
+              compatibleAppNames: this.input.compatibleAppNames,
+            }),
+            onSnapshot: {
+              actions: assign({
+                intermediateValue: (_) => ({
+                  ..._.context.intermediateValue,
+                  requiredUserInteraction:
+                    _.event.snapshot.context.intermediateValue
+                      .requiredUserInteraction,
+                  installPlan: null,
+                }),
+              }),
+            },
+            onDone: {
+              target: "OpenAppCheck",
+              actions: assign({
+                _internalState: (_) =>
+                  _.event.output.caseOf<OpenAppWithDependenciesMachineInternalState>(
+                    {
+                      Right: () => _.context._internalState,
+                      Left: (error) => ({
+                        ..._.context._internalState,
+                        error,
+                      }),
+                    },
+                  ),
+              }),
+            },
+            onError: {
+              target: "Error",
+              actions: "assignErrorFromEvent",
+            },
+          },
+        },
+        OpenAppCheck: {
+          always: [
+            {
+              guard: "hasError",
+              target: "Error",
+            },
+            {
+              target: "Success",
+            },
+          ],
+        },
+        Success: {
+          type: "final",
+        },
+        Error: {
+          type: "final",
+        },
+      },
+      output: (args) => {
+        const { context } = args;
+        const { error, deviceMetadata, installResult } = context._internalState;
+        if (error) {
+          return Left(error);
+        }
+        return Right({
+          deviceMetadata: deviceMetadata!,
+          installResult: installResult!,
+        });
+      },
+    });
+  }
+}

--- a/packages/device-management-kit/src/api/device-action/os/OpenAppWithDependencies/types.ts
+++ b/packages/device-management-kit/src/api/device-action/os/OpenAppWithDependencies/types.ts
@@ -1,0 +1,57 @@
+import type { CommandErrorResult } from "@api/command/model/CommandResult";
+import type { DeviceActionState } from "@api/device-action/model/DeviceActionState";
+import type {
+  UnknownDAError,
+  UnsupportedFirmwareDAError,
+} from "@api/device-action/os/Errors";
+import type {
+  GetDeviceMetadataDAOutput,
+  GetDeviceMetadataDARequiredInteraction,
+} from "@api/device-action/os/GetDeviceMetadata/types";
+import type { GetDeviceStatusDAInput } from "@api/device-action/os/GetDeviceStatus/types";
+import type {
+  ApplicationDependency,
+  InstallOrUpdateAppsDAError,
+  InstallOrUpdateAppsDAOutput,
+  InstallOrUpdateAppsDARequiredInteraction,
+  InstallPlan,
+} from "@api/device-action/os/InstallOrUpdateApps/types";
+import type {
+  OpenAppDAError,
+  OpenAppDARequiredInteraction,
+} from "@api/device-action/os/OpenAppDeviceAction/types";
+
+export type OpenAppWithDependenciesDAOutput = {
+  deviceMetadata: GetDeviceMetadataDAOutput;
+  installResult: InstallOrUpdateAppsDAOutput;
+};
+
+export type OpenAppWithDependenciesDAInput = GetDeviceStatusDAInput & {
+  readonly application: ApplicationDependency;
+  readonly dependencies: ApplicationDependency[];
+  readonly compatibleAppNames?: string[];
+  readonly requireLatestFirmware?: boolean;
+};
+
+export type OpenAppWithDependenciesDAError =
+  | InstallOrUpdateAppsDAError
+  | OpenAppDAError
+  | UnknownDAError
+  | UnsupportedFirmwareDAError
+  | CommandErrorResult["error"];
+
+export type OpenAppWithDependenciesDARequiredInteraction =
+  | GetDeviceMetadataDARequiredInteraction
+  | InstallOrUpdateAppsDARequiredInteraction
+  | OpenAppDARequiredInteraction;
+
+export type OpenAppWithDependenciesDAIntermediateValue = {
+  requiredUserInteraction: OpenAppWithDependenciesDARequiredInteraction;
+  installPlan: InstallPlan | null;
+};
+
+export type OpenAppWithDependenciesDAState = DeviceActionState<
+  OpenAppWithDependenciesDAOutput,
+  OpenAppWithDependenciesDAError,
+  OpenAppWithDependenciesDAIntermediateValue
+>;

--- a/packages/device-management-kit/src/api/index.ts
+++ b/packages/device-management-kit/src/api/index.ts
@@ -61,7 +61,12 @@ export {
 } from "@api/device-action/model/DeviceActionState";
 export { UserInteractionRequired } from "@api/device-action/model/UserInteractionRequired";
 export { CallTaskInAppDeviceAction } from "@api/device-action/os/CallTaskInAppDeviceAction/CallTaskInAppDeviceAction";
-export { UnknownDAError } from "@api/device-action/os/Errors";
+export {
+  DeviceLockedError,
+  OutOfMemoryDAError,
+  UnknownDAError,
+  UnsupportedFirmwareDAError,
+} from "@api/device-action/os/Errors";
 export { GetDeviceMetadataDeviceAction } from "@api/device-action/os/GetDeviceMetadata/GetDeviceMetadataDeviceAction";
 export { GetDeviceStatusDeviceAction } from "@api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction";
 export { GoToDashboardDeviceAction } from "@api/device-action/os/GoToDashboard/GoToDashboardDeviceAction";
@@ -69,6 +74,7 @@ export { InstallOrUpdateAppsDeviceAction } from "@api/device-action/os/InstallOr
 export { ListAppsDeviceAction } from "@api/device-action/os/ListApps/ListAppsDeviceAction";
 export { ListAppsWithMetadataDeviceAction } from "@api/device-action/os/ListAppsWithMetadata/ListAppsWithMetadataDeviceAction";
 export { OpenAppDeviceAction } from "@api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction";
+export { OpenAppWithDependenciesDeviceAction } from "@api/device-action/os/OpenAppWithDependencies/OpenAppWithDependenciesDeviceAction";
 export { SendCommandInAppDeviceAction } from "@api/device-action/os/SendCommandInAppDeviceAction/SendCommandInAppDeviceAction";
 export {
   type DeviceActionStateMachine,
@@ -87,6 +93,7 @@ export { GenuineCheckDeviceAction } from "@api/secure-channel/device-action/Genu
 export { InstallAppDeviceAction } from "@api/secure-channel/device-action/InstallApp/InstallAppDeviceAction";
 export { ListInstalledAppsDeviceAction } from "@api/secure-channel/device-action/ListInstalledApps/ListInstalledAppsDeviceAction";
 export { UninstallAppDeviceAction } from "@api/secure-channel/device-action/UninstallApp/UninstallAppDeviceAction";
+export { SecureChannelError } from "@internal/secure-channel/model/Errors";
 // TODO: remove from exported
 export { defaultApduReceiverServiceStubBuilder } from "@api/device-session/service/DefaultApduReceiverService.stub";
 export { defaultApduSenderServiceStubBuilder } from "@api/device-session/service/DefaultApduSenderService.stub";

--- a/packages/device-management-kit/src/api/types.ts
+++ b/packages/device-management-kit/src/api/types.ts
@@ -47,11 +47,15 @@ export {
   type GoToDashboardDAState,
 } from "@api/device-action/os/GoToDashboard/types";
 export {
+  type ApplicationConstraint,
+  type ApplicationDependency,
+  type ApplicationVersionConstraint,
   type InstallOrUpdateAppsDAError,
   type InstallOrUpdateAppsDAInput,
   type InstallOrUpdateAppsDAIntermediateValue,
   type InstallOrUpdateAppsDAOutput,
   type InstallOrUpdateAppsDAState,
+  type InstallPlan,
 } from "@api/device-action/os/InstallOrUpdateApps/types";
 export {
   type ListAppsDAError,
@@ -76,6 +80,14 @@ export {
   type OpenAppDAState,
 } from "@api/device-action/os/OpenAppDeviceAction/types";
 export {
+  type OpenAppWithDependenciesDAError,
+  type OpenAppWithDependenciesDAInput,
+  type OpenAppWithDependenciesDAIntermediateValue,
+  type OpenAppWithDependenciesDAOutput,
+  type OpenAppWithDependenciesDARequiredInteraction,
+  type OpenAppWithDependenciesDAState,
+} from "@api/device-action/os/OpenAppWithDependencies/types";
+export {
   type SendCommandInAppDAError,
   type SendCommandInAppDAInput,
   type SendCommandInAppDAIntermediateValue,
@@ -84,7 +96,16 @@ export {
 export type { ExecuteDeviceActionUseCaseArgs } from "@api/device-action/use-case/ExecuteDeviceActionUseCase";
 export { type StateMachineTypes } from "@api/device-action/xstate-utils/StateMachineTypes";
 export { type DeviceModelDataSource } from "@api/device-model/data/DeviceModelDataSource";
-export type { DeviceSessionState } from "@api/device-session/DeviceSessionState";
+export type {
+  Catalog,
+  CustomImage,
+  DeviceSessionState,
+  FirmwareUpdate,
+  FirmwareUpdateContext,
+  FirmwareVersion,
+  InstalledLanguagePackage,
+  RunningApp,
+} from "@api/device-session/DeviceSessionState";
 export { type ApduReceiverService } from "@api/device-session/service/ApduReceiverService";
 export { type ApduReceiverServiceFactory } from "@api/device-session/service/ApduReceiverService";
 export { type ApduSenderServiceFactory } from "@api/device-session/service/ApduSenderService";


### PR DESCRIPTION
### 📝 Description

Part of connectApp state machines for Ledger Live migration

Ticket: https://ledgerhq.atlassian.net/browse/DSDK-704
Documentation: https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/5675549070/OS+Open+application+with+dependencies

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**:

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
