### PR TITLE
:bug: (dmk) [DSDK-749]: Don't rely on refresher in GetDeviceStatus device action

### DIFF
--- a/.changeset/fast-bags-roll.md
+++ b/.changeset/fast-bags-roll.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Don't rely on refresher in GetDeviceStatus device action

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.test.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.test.ts
@@ -154,16 +154,31 @@ describe("GetDeviceStatusDeviceAction", () => {
             }),
         );
 
-        sendCommandMock.mockResolvedValue(
-          CommandResultFactory({
-            data: {
-              name: "BOLOS",
-              version: "1.0.0",
-            },
-          }),
-        );
+        sendCommandMock
+          .mockResolvedValueOnce(
+            CommandResultFactory({
+              error: new GlobalCommandError({
+                ...GLOBAL_ERRORS["5515"],
+                errorCode: "5515",
+              }),
+            }),
+          )
+          .mockResolvedValueOnce(
+            CommandResultFactory({
+              data: {
+                name: "BOLOS",
+                version: "1.0.0",
+              },
+            }),
+          );
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+            status: DeviceActionStatus.Pending,
+          },
           {
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.UnlockDevice,
@@ -259,14 +274,23 @@ describe("GetDeviceStatusDeviceAction", () => {
           currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
         });
 
-        getAppAndVersionMock.mockResolvedValue(
-          CommandResultFactory({
-            data: {
-              name: "BOLOS",
-              version: "1.0.0",
-            },
-          }),
-        );
+        getAppAndVersionMock
+          .mockResolvedValueOnce(
+            CommandResultFactory({
+              error: new GlobalCommandError({
+                ...GLOBAL_ERRORS["5515"],
+                errorCode: "5515",
+              }),
+            }),
+          )
+          .mockResolvedValueOnce(
+            CommandResultFactory({
+              data: {
+                name: "BOLOS",
+                version: "1.0.0",
+              },
+            }),
+          );
 
         waitForDeviceUnlockMock.mockImplementation(
           () =>
@@ -314,6 +338,12 @@ describe("GetDeviceStatusDeviceAction", () => {
         ).mockReturnValue(extractDependenciesMock());
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+            status: DeviceActionStatus.Pending,
+          },
           {
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.UnlockDevice,
@@ -392,6 +422,15 @@ describe("GetDeviceStatusDeviceAction", () => {
           currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
         });
 
+        getAppAndVersionMock.mockResolvedValue(
+          CommandResultFactory({
+            error: new GlobalCommandError({
+              ...GLOBAL_ERRORS["5515"],
+              errorCode: "5515",
+            }),
+          }),
+        );
+
         apiGetDeviceSessionStateObservableMock.mockImplementation(
           () =>
             new Observable((o) => {
@@ -425,6 +464,12 @@ describe("GetDeviceStatusDeviceAction", () => {
         ).mockReturnValue(extractDependenciesMock());
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+            status: DeviceActionStatus.Pending,
+          },
           {
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.UnlockDevice,
@@ -511,12 +556,6 @@ describe("GetDeviceStatusDeviceAction", () => {
         const expectedStates: Array<GetDeviceStatusDAState> = [
           {
             intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.UnlockDevice,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          {
-            intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.None,
             },
             status: DeviceActionStatus.Pending,
@@ -567,12 +606,6 @@ describe("GetDeviceStatusDeviceAction", () => {
         ).mockReturnValue(extractDependenciesMock());
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.UnlockDevice,
-            },
-            status: DeviceActionStatus.Pending,
-          },
           {
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.None,


### PR DESCRIPTION
### 📝 Description

The GetDeviceStatus device action currently rely on the device session to know if a device is locked or not.
It means that when the refresher is disabled, a locked device will stay locked forever in the DMK session, even if the user unlocked it.
The solution is to synchronously get the lock status in GetDeviceStatus instead of reading the session state

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**:

https://ledgerhq.atlassian.net/browse/DSDK-749

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
