### PR TITLE
:bug: (dmk) [DSDK-753]: Update the device session state when refresher is disabled

### DIFF
--- a/.changeset/unlucky-fans-tell.md
+++ b/.changeset/unlucky-fans-tell.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Update the device session state when refresher is disabled

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.ts
@@ -234,14 +234,25 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
                 _internalState: (_) => {
                   if (isSuccessCommandResult(_.event.output)) {
                     const state: DeviceSessionState = getDeviceSessionState();
-                    // Narrow the type to ReadyWithoutSecureChannelState or ReadyWithSecureChannelState
                     if (
                       state.sessionStateType !==
                       DeviceSessionStateType.Connected
                     ) {
+                      // Update the current app
                       setDeviceSessionState({
                         ...state,
                         currentApp: _.event.output.data,
+                      });
+                    } else {
+                      // The device can be set to Ready if GetAppAndVersionCommand was successful
+                      setDeviceSessionState({
+                        deviceModelId: state.deviceModelId,
+                        sessionStateType:
+                          DeviceSessionStateType.ReadyWithoutSecureChannel,
+                        deviceStatus: DeviceStatus.CONNECTED,
+                        currentApp: _.event.output.data,
+                        installedApps: [],
+                        isSecureConnectionAllowed: false,
                       });
                     }
                     return {


### PR DESCRIPTION
### 📝 Description

Bug noticed during Ledger Live integration because of the disabled refresher.
Described here: https://ledgerhq.atlassian.net/browse/DSDK-753

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**:

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
