### PR TITLE
:bug: (signer-eth) [NO-ISSUE]: Don't verify certificate if generic parser is not supported

### DIFF
--- a/.changeset/warm-radios-tie.md
+++ b/.changeset/warm-radios-tie.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": patch
+---
+
+Don't verify certificate if generic parser is not supported

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BuildTransactionContextTask.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BuildTransactionContextTask.test.ts
@@ -855,7 +855,7 @@ describe("BuildTransactionContextTask", () => {
     });
   });
 
-  it("should return an error if the transaction info certificate is missing", async () => {
+  it("should return no clear sign context if the transaction info certificate is missing", async () => {
     // GIVEN
     const serializedTransaction = new Uint8Array([0x01, 0x02, 0x03]);
     const clearSignContexts: ClearSignContext[] = [
@@ -885,21 +885,25 @@ describe("BuildTransactionContextTask", () => {
       sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
       deviceStatus: DeviceStatus.CONNECTED,
       installedApps: [],
-      currentApp: { name: "Ethereum", version: "1.14.0" },
+      currentApp: { name: "Ethereum", version: "1.17.0" },
       deviceModelId: DeviceModelId.FLEX,
       isSecureConnectionAllowed: false,
     });
 
     // WHEN
-    const task = new BuildTransactionContextTask(
+    const result = await new BuildTransactionContextTask(
       apiMock,
       defaultArgs,
       getWeb3ChecksFactoryMock,
-    );
+    ).run();
 
     // THEN
-    await expect(task.run()).rejects.toThrow(
-      "Transaction info certificate is missing",
-    );
+    expect(result).toEqual({
+      clearSignContexts: [],
+      serializedTransaction,
+      chainId: 1,
+      transactionType: 2,
+      web3Check: null,
+    });
   });
 });

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BuildTransactionContextTask.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BuildTransactionContextTask.ts
@@ -120,10 +120,6 @@ export class BuildTransactionContextTask {
       (ctx) => ctx.type === ClearSignContextType.TRANSACTION_INFO,
     );
 
-    if (transactionInfo && !transactionInfo.certificate) {
-      throw new Error("Transaction info certificate is missing");
-    }
-
     // If the device does not support the generic parser,
     // we need to filter out the transaction info and transaction field description
     // as they are not supported by the device
@@ -136,7 +132,7 @@ export class BuildTransactionContextTask {
           ctx.type !== ClearSignContextType.TRANSACTION_INFO &&
           ctx.type !== ClearSignContextType.TRANSACTION_FIELD_DESCRIPTION,
       );
-    } else {
+    } else if (transactionInfo.certificate) {
       const transactionFields = clearSignContextsSuccess.filter(
         (ctx) =>
           ctx.type === ClearSignContextType.TRANSACTION_FIELD_DESCRIPTION,


### PR DESCRIPTION
### 📝 Description

Send USDT fails on LNS, because USDT has an ERC7730 descriptor, but nano S has no certificate (no PKI support).
If device don't support the generic parser, don't verify the certificate

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-18782

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
