### PR TITLE
📝 (signer-eth) [NO-ISSUE]: Fix SignerEthBuilder dmk parameter in docs

### DIFF
--- a/apps/docs/content/docs/references/signers/eth.mdx
+++ b/apps/docs/content/docs/references/signers/eth.mdx
@@ -48,7 +48,7 @@ To initialise an Ethereum signer instance, you need a Ledger Device Management K
 ```typescript
 // Initialise an Ethereum signer instance using default context module
 const signerEth = new SignerEthBuilder({
-  sdk,
+  dmk,
   sessionId,
   originToken: "origin-token", // replace with your origin token
 }).build();
@@ -61,7 +61,7 @@ You can also configure the context module yourself:
 
 ```typescript
 // Initialise an Ethereum signer instance using customized context module
-const signerEth = new SignerEthBuilder({ sdk, sessionId })
+const signerEth = new SignerEthBuilder({ dmk, sessionId })
   .withContextModule(customContextModule)
   .build();
 ```

--- a/packages/signer/signer-eth/README.md
+++ b/packages/signer/signer-eth/README.md
@@ -42,14 +42,14 @@ To initialise an Ethereum signer instance, you need a Ledger Device Management K
 
 ```typescript
 // Initialise an Ethereum signer instance using default context module
-const signerEth = new SignerEthBuilder({ sdk, sessionId }).build();
+const signerEth = new SignerEthBuilder({ dmk, sessionId }).build();
 ```
 
 You can also configure the context module yourself:
 
 ```typescript
 // Initialise an Ethereum signer instance using customized context module
-const signerEth = new SignerEthBuilder({ sdk, sessionId })
+const signerEth = new SignerEthBuilder({ dmk, sessionId })
   .withContextModule(customContextModule)
   .build();
 ```


### PR DESCRIPTION
### 📝 Description

This PR updates the usage example of SignerEthBuilder:

```diff
- const signerEth = new SignerEthBuilder({ sdk, sessionId })
+ const signerEth = new SignerEthBuilder({ dmk, sessionId })
```

The correct parameter name is dmk, not sdk. This change aligns the example with the actual constructor signature.

### Changelog

- Fixed: The correct parameter name is dmk, not sdk, to match the actual SignerEthBuilder constructor.