### PR TITLE
:sparkles: (dmk) [NO-ISSUE]: Allow to send an apdu with expected disconnection

### DIFF
--- a/.changeset/soft-humans-hang.md
+++ b/.changeset/soft-humans-hang.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Allow to send an apdu with expected disconnection

--- a/packages/device-management-kit/src/internal/send/use-case/SendApduUseCase.ts
+++ b/packages/device-management-kit/src/internal/send/use-case/SendApduUseCase.ts
@@ -23,6 +23,10 @@ export type SendApduUseCaseArgs = {
    * The time, in milliseconds, to wait before aborting an operation.
    */
   abortTimeout?: number;
+  /**
+   * Indicates if a device disconnection should be expected after sending the APDU.
+   */
+  triggersDisconnection?: boolean;
 };
 
 /**
@@ -47,6 +51,7 @@ export class SendApduUseCase {
     sessionId,
     apdu,
     abortTimeout,
+    triggersDisconnection,
   }: SendApduUseCaseArgs): Promise<ApduResponse> {
     const deviceSessionOrError =
       this._sessionService.getDeviceSessionById(sessionId);
@@ -54,7 +59,10 @@ export class SendApduUseCase {
     return deviceSessionOrError.caseOf({
       // Case device session found
       Right: async (deviceSession) => {
-        const response = await deviceSession.sendApdu(apdu, { abortTimeout });
+        const response = await deviceSession.sendApdu(apdu, {
+          abortTimeout,
+          triggersDisconnection,
+        });
         return response.caseOf({
           // Case APDU sent and response received successfully
           Right: (data) => data,


### PR DESCRIPTION
### 📝 Description

In the context of ConnectApp migration, we need to send APDUs that triggers a device disconnection.
That's the case of exchange flow, where the exchange app switch internally to another coin app during the flow, internally in the device. Therefore it behaves as an OpenApp even if it's only applications APDUs.

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**:

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
