### PR TITLE
:bug: (dmk) [NO-ISSUE]: Handle transport disconnection during successful OpenApp

### DIFF
--- a/.changeset/weak-walls-joke.md
+++ b/.changeset/weak-walls-joke.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Handle transport disconnection during successful OpenApp

--- a/packages/device-management-kit/src/api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction.test.ts
+++ b/packages/device-management-kit/src/api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction.test.ts
@@ -15,9 +15,10 @@ import {
   UnknownDAError,
 } from "@api/device-action/os/Errors";
 import { DeviceSessionStateType } from "@api/device-session/DeviceSessionState";
+import { DeviceDisconnectedWhileSendingError } from "@api/transport/model/Errors";
 
 import { OpenAppDeviceAction } from "./OpenAppDeviceAction";
-import type { OpenAppDAState } from "./types";
+import type { OpenAppDAError, OpenAppDAState } from "./types";
 
 vi.mock("@api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction");
 
@@ -273,6 +274,95 @@ describe("OpenAppDeviceAction", () => {
             currentApp: { name: "Bitcoin", version: "1.0.0" },
           });
         });
+      }));
+
+    it("should end in a success if disconnection occurs while open app succeeds", () =>
+      new Promise<void>((resolve, reject) => {
+        getDeviceSessionStateMock.mockReturnValue(
+          CommandResultFactory({
+            data: {
+              sessionStateType:
+                DeviceSessionStateType.ReadyWithoutSecureChannel,
+              deviceStatus: DeviceStatus.CONNECTED,
+              currentApp: { name: "BOLOS", version: "0.0.0" },
+            },
+          }),
+        );
+        getAppAndVersionMock.mockResolvedValue(
+          CommandResultFactory({
+            data: {
+              name: "BOLOS",
+              version: "0.0.0",
+            },
+          }),
+        );
+        setupGetDeviceStatusMock([
+          {
+            currentApp: "BOLOS",
+            currentAppVersion: "0.0.0",
+          },
+          {
+            currentApp: "Bitcoin",
+            currentAppVersion: "0.0.0",
+          },
+        ]);
+        openAppMock.mockRejectedValue(
+          new DeviceDisconnectedWhileSendingError(),
+        );
+
+        const openAppDeviceAction = new OpenAppDeviceAction({
+          input: { appName: "Bitcoin" },
+        });
+        vi.spyOn(openAppDeviceAction, "extractDependencies").mockReturnValue(
+          extractDependenciesMock(),
+        );
+
+        const expectedStates: Array<OpenAppDAState> = [
+          {
+            status: DeviceActionStatus.Pending, // get onboarded status
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          },
+          {
+            status: DeviceActionStatus.Pending, // get device status
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          },
+          {
+            status: DeviceActionStatus.Pending, // open app
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+            },
+          },
+          {
+            status: DeviceActionStatus.Pending, // get device status
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          },
+          {
+            status: DeviceActionStatus.Pending,
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          },
+          {
+            status: DeviceActionStatus.Completed,
+            output: undefined,
+          },
+        ];
+
+        testDeviceActionStates(
+          openAppDeviceAction,
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          {
+            onDone: resolve,
+            onError: reject,
+          },
+        );
       }));
 
     it("should end in a success if another app is open, close app succeeds and open app succeeds", () =>
@@ -559,6 +649,95 @@ describe("OpenAppDeviceAction", () => {
           {
             status: DeviceActionStatus.Error,
             error: new InvalidStatusWordError("mocked error"),
+          },
+        ];
+
+        testDeviceActionStates(
+          openAppDeviceAction,
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          {
+            onDone: resolve,
+            onError: reject,
+          },
+        );
+      }));
+
+    it("should end in a success if disconnection occurs while open app failed", () =>
+      new Promise<void>((resolve, reject) => {
+        getDeviceSessionStateMock.mockReturnValue(
+          CommandResultFactory({
+            data: {
+              sessionStateType:
+                DeviceSessionStateType.ReadyWithoutSecureChannel,
+              deviceStatus: DeviceStatus.CONNECTED,
+              currentApp: { name: "BOLOS", version: "0.0.0" },
+            },
+          }),
+        );
+        getAppAndVersionMock.mockResolvedValue(
+          CommandResultFactory({
+            data: {
+              name: "BOLOS",
+              version: "0.0.0",
+            },
+          }),
+        );
+        setupGetDeviceStatusMock([
+          {
+            currentApp: "BOLOS",
+            currentAppVersion: "0.0.0",
+          },
+          {
+            currentApp: "BOLOS",
+            currentAppVersion: "0.0.0",
+          },
+        ]);
+        openAppMock.mockRejectedValue(
+          new DeviceDisconnectedWhileSendingError(),
+        );
+
+        const openAppDeviceAction = new OpenAppDeviceAction({
+          input: { appName: "Bitcoin" },
+        });
+        vi.spyOn(openAppDeviceAction, "extractDependencies").mockReturnValue(
+          extractDependenciesMock(),
+        );
+
+        const expectedStates: Array<OpenAppDAState> = [
+          {
+            status: DeviceActionStatus.Pending, // get onboarded status
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          },
+          {
+            status: DeviceActionStatus.Pending, // get device status
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          },
+          {
+            status: DeviceActionStatus.Pending, // open app
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+            },
+          },
+          {
+            status: DeviceActionStatus.Pending, // get device status
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          },
+          {
+            status: DeviceActionStatus.Pending,
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          },
+          {
+            status: DeviceActionStatus.Error,
+            error: new DeviceDisconnectedWhileSendingError() as OpenAppDAError,
           },
         ];
 


### PR DESCRIPTION
### 📝 Description

With BLE transport, we don't always receive the response from OpenApp APDU even if successfully executed.
This is a side effect of known firmware bug, because the device don't properly close BLE transport when an app is opened.
Therefore we should get the device status when that happens, to verify if the app was successfully opened.
This is a fix for https://ledgerhq.atlassian.net/browse/LIVE-19429

Note that this error was handled in legacy connectApp in Ledger Live.

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**:

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
