### PR TITLE
:bug: (signer-eth) [DSDK-871]: Don't try to clearsign exchange flows

### DIFF
--- a/.changeset/stupid-forks-deny.md
+++ b/.changeset/stupid-forks-deny.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": minor
+---
+
+Don't try to clearsign exchange flows

--- a/packages/signer/signer-eth/src/internal/shared/utils/ApplicationChecker.test.ts
+++ b/packages/signer/signer-eth/src/internal/shared/utils/ApplicationChecker.test.ts
@@ -37,6 +37,25 @@ describe("ApplicationChecker", () => {
     expect(result).toStrictEqual(true);
   });
 
+  it("should reject the check for exchange flows", () => {
+    // GIVEN
+    const state = {
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Exchange", version: "1.13.0-rc" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    };
+    const config = createAppConfig("1.13.0");
+    // WHEN
+    const result = new ApplicationChecker(state, config)
+      .withMinVersionExclusive("1.12.0")
+      .check();
+    // THEN
+    expect(result).toStrictEqual(false);
+  });
+
   it("should reject the check for exclusive version", () => {
     // GIVEN
     const state = {

--- a/packages/signer/signer-eth/src/internal/shared/utils/ApplicationChecker.ts
+++ b/packages/signer/signer-eth/src/internal/shared/utils/ApplicationChecker.ts
@@ -23,7 +23,12 @@ export class ApplicationChecker {
       this.isCompatible = false;
       return;
     }
-    if (deviceState.currentApp.name === "Ethereum") {
+    if (deviceState.currentApp.name === "Exchange") {
+      // Advanced clear signing is not supported in exchange flows, only basic loaders
+      // such as token should be provided.
+      this.isCompatible = false;
+      return;
+    } else if (deviceState.currentApp.name === "Ethereum") {
       this.version = deviceState.currentApp.version;
     } else {
       // Fallback on appConfig version if a plugin is running.


### PR DESCRIPTION
### 📝 Description

When swapping USDT to another chain in an exchange flow, the Signer ETH will try to clear sign the USDT using the generic parser. Clear signing is done by the exchange app instead in those flows.

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/DSDK-871

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
