### PR TITLE
✨ (keyring) [DSDK-815]: Add signBlock commands

### DIFF
--- a/packages/trusted-apps/ledger-keyring-protocol/src/api/app-binder/SignBlockHeaderCommandTypes.ts
+++ b/packages/trusted-apps/ledger-keyring-protocol/src/api/app-binder/SignBlockHeaderCommandTypes.ts
@@ -1,0 +1,5 @@
+export interface SignBlockHeaderCommandArgs {
+  header: Uint8Array;
+}
+
+export type SignBlockHeaderCommandResponse = Uint8Array;

--- a/packages/trusted-apps/ledger-keyring-protocol/src/api/app-binder/SignBlockSignatureCommandTypes.ts
+++ b/packages/trusted-apps/ledger-keyring-protocol/src/api/app-binder/SignBlockSignatureCommandTypes.ts
@@ -1,0 +1,6 @@
+export type SignBlockSignatureCommandArgs = Record<string, never>;
+
+export interface SignBlockSignatureCommandResponse {
+  signature: Uint8Array;
+  sessionKey: Uint8Array;
+}

--- a/packages/trusted-apps/ledger-keyring-protocol/src/api/app-binder/SignBlockSingleCommandTypes.ts
+++ b/packages/trusted-apps/ledger-keyring-protocol/src/api/app-binder/SignBlockSingleCommandTypes.ts
@@ -1,0 +1,5 @@
+export interface SignBlockSingleCommandArgs {
+  command: Uint8Array;
+}
+
+export type SignBlockSingleCommandResponse = Uint8Array;

--- a/packages/trusted-apps/ledger-keyring-protocol/src/internal/app-binder/command/SignBlockHeader.test.ts
+++ b/packages/trusted-apps/ledger-keyring-protocol/src/internal/app-binder/command/SignBlockHeader.test.ts
@@ -1,0 +1,104 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  ApduResponse,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { describe, expect, it } from "vitest";
+
+import {
+  type SignBlockHeaderCommandArgs,
+  type SignBlockHeaderCommandResponse,
+} from "@api/app-binder/SignBlockHeaderCommandTypes";
+
+import { SignBlockHeaderCommand } from "./SignBlockHeader";
+
+const HEADER_BYTES = Uint8Array.from([0xf0, 0xca, 0xcc, 0x1a]);
+const TLV_VALUE = Uint8Array.from([0xf0, 0xca, 0xcc, 0x1a]);
+const IV_TLV = Uint8Array.from([0x00, TLV_VALUE.length, ...TLV_VALUE]);
+const ISSUER_TLV = Uint8Array.from([0x81, TLV_VALUE.length, ...TLV_VALUE]);
+const FULL_TLV_PAYLOAD = new Uint8Array([...IV_TLV, ...ISSUER_TLV]);
+
+describe("SignBlockHeaderCommand", () => {
+  describe("getApdu()", () => {
+    it("should build the correct APDU for a given header", () => {
+      // given
+      const args: SignBlockHeaderCommandArgs = { header: HEADER_BYTES };
+      const cmd = new SignBlockHeaderCommand(args);
+
+      // when
+      const apdu = cmd.getApdu();
+      const expected = Uint8Array.from([
+        0xe0,
+        0x07,
+        0x00,
+        0x00,
+        HEADER_BYTES.length,
+        ...HEADER_BYTES,
+      ]);
+
+      // then
+      expect(apdu.getRawApdu()).toEqual(expected);
+    });
+  });
+
+  describe("parseResponse()", () => {
+    it("should return raw payload on success", () => {
+      // given
+      const args: SignBlockHeaderCommandArgs = { header: HEADER_BYTES };
+      const cmd = new SignBlockHeaderCommand(args);
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x90, 0x00]),
+        data: FULL_TLV_PAYLOAD,
+      });
+
+      // when
+      const result = cmd.parseResponse(response);
+
+      // then
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        const res: SignBlockHeaderCommandResponse = result.data;
+        expect(res).toEqual(FULL_TLV_PAYLOAD);
+      }
+    });
+
+    it("should map SW errors to CommandResult errors", () => {
+      // given
+      const args: SignBlockHeaderCommandArgs = { header: HEADER_BYTES };
+      const cmd = new SignBlockHeaderCommand(args);
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x6a, 0x86]),
+        data: new Uint8Array(),
+      });
+
+      // when
+      const result = cmd.parseResponse(response);
+
+      // then
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect((result.error as any).errorCode).toBe("6a86");
+      }
+    });
+
+    it("should error if no data is returned", () => {
+      // given
+      const args: SignBlockHeaderCommandArgs = { header: HEADER_BYTES };
+      const cmd = new SignBlockHeaderCommand(args);
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x90, 0x00]),
+        data: new Uint8Array(),
+      });
+
+      // when
+      const result = cmd.parseResponse(response);
+
+      // then
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data).toEqual(new Uint8Array([]));
+      }
+    });
+  });
+});

--- a/packages/trusted-apps/ledger-keyring-protocol/src/internal/app-binder/command/SignBlockSignatureCommand.test.ts
+++ b/packages/trusted-apps/ledger-keyring-protocol/src/internal/app-binder/command/SignBlockSignatureCommand.test.ts
@@ -1,0 +1,115 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import {
+  ApduResponse,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { describe, expect, it } from "vitest";
+
+import { type SignBlockSignatureCommandResponse } from "@api/app-binder/SignBlockSignatureCommandTypes";
+
+import { SignBlockSignatureCommand } from "./SignBlockSignatureCommand";
+
+const SIG_AND_KEY = Uint8Array.from([0xf0, 0xca, 0xcc, 0x1a]);
+
+describe("SignBlockSignatureCommand", () => {
+  describe("getApdu()", () => {
+    it("should build the correct APDU for finalize-signature", () => {
+      const cmd = new SignBlockSignatureCommand();
+      const apdu = cmd.getApdu();
+      expect(apdu.getRawApdu()).toEqual(
+        Uint8Array.from([0xe0, 0x07, 0x02, 0x00, 0x00]),
+      );
+    });
+  });
+
+  describe("parseResponse()", () => {
+    it("should return signature and sessionKey on success", () => {
+      // given
+      const payload = new Uint8Array([
+        SIG_AND_KEY.length,
+        ...SIG_AND_KEY,
+        SIG_AND_KEY.length,
+        ...SIG_AND_KEY,
+      ]);
+      const cmd = new SignBlockSignatureCommand();
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x90, 0x00]),
+        data: payload,
+      });
+
+      // when
+      const result = cmd.parseResponse(response);
+
+      // then
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        const res: SignBlockSignatureCommandResponse = result.data;
+        expect(res.signature).toEqual(SIG_AND_KEY);
+        expect(res.sessionKey).toEqual(SIG_AND_KEY);
+      }
+    });
+
+    it("should map SW errors to CommandResult errors", () => {
+      // given
+      const cmd = new SignBlockSignatureCommand();
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x6a, 0x86]),
+        data: new Uint8Array(),
+      });
+
+      // when
+      const result = cmd.parseResponse(response);
+
+      // then
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect((result.error as any).errorCode).toBe("6a86");
+      }
+    });
+
+    it("should error if missing length or reserved byte", () => {
+      // given
+      const cmd = new SignBlockSignatureCommand();
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x90, 0x00]),
+        data: new Uint8Array(),
+      });
+
+      // when
+      const result = cmd.parseResponse(response);
+
+      // then
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect((result.error as any)._tag).toBe("InvalidStatusWordError");
+        expect((result.error as any).originalError.message).toBe(
+          "Invalid response: missing signature length or reserved byte",
+        );
+      }
+    });
+
+    it("should error if signature length out of bounds", () => {
+      // given
+      const bad = Uint8Array.from([5, 0xaa, 0xbb]);
+      const cmd = new SignBlockSignatureCommand();
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x90, 0x00]),
+        data: bad,
+      });
+
+      // when
+      const result = cmd.parseResponse(response);
+
+      // then
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect((result.error as any)._tag).toBe("InvalidStatusWordError");
+        expect((result.error as any).originalError.message).toBe(
+          "Signature length out of bounds",
+        );
+      }
+    });
+  });
+});

--- a/packages/trusted-apps/ledger-keyring-protocol/src/internal/app-binder/command/SignBlockSignatureCommand.ts
+++ b/packages/trusted-apps/ledger-keyring-protocol/src/internal/app-binder/command/SignBlockSignatureCommand.ts
@@ -1,0 +1,99 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import {
+  type SignBlockSignatureCommandArgs,
+  type SignBlockSignatureCommandResponse,
+} from "@api/app-binder/SignBlockSignatureCommandTypes";
+
+import {
+  LEDGER_SYNC_ERRORS,
+  type LedgerKeyringProtocolErrorCodes,
+  LedgerKeyringProtocolErrorFactory,
+} from "./utils/ledgerKeyringProtocolErrors";
+
+export class SignBlockSignatureCommand
+  implements
+    Command<
+      SignBlockSignatureCommandResponse,
+      SignBlockSignatureCommandArgs,
+      LedgerKeyringProtocolErrorCodes
+    >
+{
+  private readonly errorHelper = new CommandErrorHelper<
+    SignBlockSignatureCommandResponse,
+    LedgerKeyringProtocolErrorCodes
+  >(LEDGER_SYNC_ERRORS, LedgerKeyringProtocolErrorFactory);
+
+  constructor() {}
+
+  getApdu(): Apdu {
+    return new ApduBuilder({
+      cla: 0xe0,
+      ins: 0x07,
+      p1: 0x02,
+      p2: 0x00,
+    }).build();
+  }
+
+  parseResponse(
+    apduResponse: ApduResponse,
+  ): CommandResult<
+    SignBlockSignatureCommandResponse,
+    LedgerKeyringProtocolErrorCodes
+  > {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      const parser = new ApduParser(apduResponse);
+      const rem = parser.getUnparsedRemainingLength();
+      const data = parser.extractFieldByLength(rem);
+      if (!data) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            "No data returned by SignBlockSignatureCommand",
+          ),
+        });
+      }
+
+      if (data.length < 2) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            "Invalid response: missing signature length or reserved byte",
+          ),
+        });
+      }
+
+      const raw = data[0];
+      if (raw === undefined) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            "Invalid response: unable to read signature length",
+          ),
+        });
+      }
+
+      const sigLen = raw;
+      if (data.length < 2 + sigLen) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Signature length out of bounds"),
+        });
+      }
+
+      const signature = data.slice(1, 1 + sigLen);
+      const sessionKey = data.slice(1 + sigLen + 1);
+
+      return CommandResultFactory({ data: { signature, sessionKey } });
+    });
+  }
+}

--- a/packages/trusted-apps/ledger-keyring-protocol/src/internal/app-binder/command/SignBlockSingleCommand.test.ts
+++ b/packages/trusted-apps/ledger-keyring-protocol/src/internal/app-binder/command/SignBlockSingleCommand.test.ts
@@ -1,0 +1,101 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  ApduResponse,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { describe, expect, it } from "vitest";
+
+import {
+  type SignBlockSingleCommandArgs,
+  type SignBlockSingleCommandResponse,
+} from "@api/app-binder/SignBlockSingleCommandTypes";
+
+import { SignBlockSingleCommand } from "./SignBlockSingleCommand";
+
+const COMMAND_BYTES = Uint8Array.from([0xf0, 0xca, 0xcc, 0x1a]);
+const TLV_PAYLOAD = Uint8Array.from([0xf0, 0xca, 0xcc, 0x1a]);
+
+describe("SignBlockSingleCommand", () => {
+  describe("getApdu()", () => {
+    it("should build the correct APDU for a given command", () => {
+      // given
+      const args: SignBlockSingleCommandArgs = { command: COMMAND_BYTES };
+      const cmd = new SignBlockSingleCommand(args);
+
+      // when
+      const apdu = cmd.getApdu();
+      const expected = Uint8Array.from([
+        0xe0,
+        0x07,
+        0x01,
+        0x00,
+        COMMAND_BYTES.length,
+        ...COMMAND_BYTES,
+      ]);
+
+      // then
+      expect(apdu.getRawApdu()).toEqual(expected);
+    });
+  });
+
+  describe("parseResponse()", () => {
+    it("should return the raw TLV blob on success", () => {
+      // given
+      const args: SignBlockSingleCommandArgs = { command: COMMAND_BYTES };
+      const cmd = new SignBlockSingleCommand(args);
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x90, 0x00]),
+        data: TLV_PAYLOAD,
+      });
+
+      // when
+      const result = cmd.parseResponse(response);
+
+      // then
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        const data: SignBlockSingleCommandResponse = result.data;
+        expect(data).toEqual(TLV_PAYLOAD);
+      }
+    });
+
+    it("should map SW errors to CommandResult errors", () => {
+      // given
+      const args: SignBlockSingleCommandArgs = { command: COMMAND_BYTES };
+      const cmd = new SignBlockSingleCommand(args);
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x6a, 0x86]),
+        data: new Uint8Array(),
+      });
+
+      // when
+      const result = cmd.parseResponse(response);
+
+      // then
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect((result.error as any).errorCode).toBe("6a86");
+      }
+    });
+
+    it("should return an empty Uint8Array if no data is returned", () => {
+      // given
+      const args: SignBlockSingleCommandArgs = { command: COMMAND_BYTES };
+      const cmd = new SignBlockSingleCommand(args);
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x90, 0x00]),
+        data: new Uint8Array(),
+      });
+
+      // when
+      const result = cmd.parseResponse(response);
+
+      // then
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data).toEqual(new Uint8Array());
+      }
+    });
+  });
+});

--- a/packages/trusted-apps/ledger-keyring-protocol/src/internal/app-binder/command/SignBlockSingleCommand.ts
+++ b/packages/trusted-apps/ledger-keyring-protocol/src/internal/app-binder/command/SignBlockSingleCommand.ts
@@ -1,0 +1,73 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import {
+  type SignBlockSingleCommandArgs,
+  type SignBlockSingleCommandResponse,
+} from "@api/app-binder/SignBlockSingleCommandTypes";
+
+import {
+  LEDGER_SYNC_ERRORS,
+  type LedgerKeyringProtocolErrorCodes,
+  LedgerKeyringProtocolErrorFactory,
+} from "./utils/ledgerKeyringProtocolErrors";
+
+export class SignBlockSingleCommand
+  implements
+    Command<
+      SignBlockSingleCommandResponse,
+      SignBlockSingleCommandArgs,
+      LedgerKeyringProtocolErrorCodes
+    >
+{
+  private readonly errorHelper = new CommandErrorHelper<
+    SignBlockSingleCommandResponse,
+    LedgerKeyringProtocolErrorCodes
+  >(LEDGER_SYNC_ERRORS, LedgerKeyringProtocolErrorFactory);
+
+  constructor(private readonly args: SignBlockSingleCommandArgs) {}
+
+  getApdu(): Apdu {
+    return new ApduBuilder({
+      cla: 0xe0,
+      ins: 0x07,
+      p1: 0x01,
+      p2: 0x00,
+    })
+      .addBufferToData(this.args.command)
+      .build();
+  }
+
+  parseResponse(
+    apduResponse: ApduResponse,
+  ): CommandResult<
+    SignBlockSingleCommandResponse,
+    LedgerKeyringProtocolErrorCodes
+  > {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      const parser = new ApduParser(apduResponse);
+      const remaining = parser.getUnparsedRemainingLength();
+      const tlvBlob = parser.extractFieldByLength(remaining);
+      if (!tlvBlob) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            "No data returned by SignBlockSingleCommand",
+          ),
+        });
+      }
+      return CommandResultFactory({ data: tlvBlob });
+    });
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

added signBlock commands

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**:[DSDK-815](https://ledgerhq.atlassian.net/browse/DSDK-815)
- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[DSDK-815]: https://ledgerhq.atlassian.net/browse/DSDK-815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ