### PR TITLE
:bug: (signer-eth) [DSDK-913]: Don't fail clear signing if a sub context cannot be provided

### DIFF
--- a/.changeset/famous-donkeys-add.md
+++ b/.changeset/famous-donkeys-add.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": patch
+---
+
+Don't fail clear signing if a sub context cannot be provided

--- a/packages/signer/signer-eth/src/internal/app-binder/task/ProvideContextsTask.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/ProvideContextsTask.ts
@@ -94,10 +94,8 @@ export class ProvideContextsTask {
           continue;
         }
 
-        const res = await this.provideContext(subcontext);
-        if (!isSuccessCommandResult(res)) {
-          return Left(res);
-        }
+        // Don't fail immediately on subcontext errors because the main context may still be successful
+        await this.provideContext(subcontext);
       }
 
       if (context.type === ClearSignContextType.PROXY_INFO) {


### PR DESCRIPTION
### 📝 Description

We may not be able to provide a subcontext to the device, but still be able to continue with the main flow and so have at least a partial clear signing. In that case we should continue and not fallback on blind signing 

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/DSDK-913

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
