### PR TITLE
✨ (solana-signer) [NO-ISSUE]: Add msg chunking and format to offchain message

### DIFF
--- a/.changeset/thirty-chairs-wait.md
+++ b/.changeset/thirty-chairs-wait.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": minor
+---
+
+Add message chunking and format to offchain message

--- a/packages/signer/signer-solana/src/internal/app-binder/command/SignOffChainMessageCommand.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/SignOffChainMessageCommand.test.ts
@@ -4,46 +4,114 @@ import {
   isSuccessCommandResult,
 } from "@ledgerhq/device-management-kit";
 
-import { DefaultBs58Encoder } from "@internal/app-binder/services/bs58Encoder";
-
-import { SignOffChainMessageCommand } from "./SignOffChainMessageCommand";
+import {
+  CLA,
+  INS,
+  P1,
+  SignOffChainMessageCommand,
+} from "./SignOffChainMessageCommand";
 
 describe("SignOffChainMessageCommand", () => {
-  let command: SignOffChainMessageCommand;
-
   const MESSAGE = new TextEncoder().encode("Solana SignOffChainMessage");
   const SIGNATURE_LENGTH = 64;
 
-  beforeEach(() => {
-    command = new SignOffChainMessageCommand({
-      message: MESSAGE,
-    });
-    vi.clearAllMocks();
-    vi.importActual("@ledgerhq/device-management-kit");
-  });
+  describe("getApdu()", () => {
+    it("builds APDU for a single (final) chunk (p2=INIT)", () => {
+      const cmd = new SignOffChainMessageCommand({
+        chunkedData: MESSAGE,
+        extend: false,
+        more: false,
+      });
 
-  describe("getApdu", () => {
-    it("should return the correct APDU", () => {
-      const apdu = command.getApdu();
+      const apdu = cmd.getApdu();
 
-      const expectedApdu = new ApduBuilder({
-        cla: 0xe0,
-        ins: 0x07,
-        p1: 0x01,
-        p2: 0x00,
+      const expected = new ApduBuilder({
+        cla: CLA,
+        ins: INS,
+        p1: P1,
+        p2: 0x00, // INIT only
       })
         .addBufferToData(MESSAGE)
         .build();
 
-      expect(apdu.getRawApdu()).toEqual(expectedApdu.getRawApdu());
+      expect(apdu.getRawApdu()).toEqual(expected.getRawApdu());
+    });
+
+    it("sets p2 correctly for first of many chunks (INIT|MORE)", () => {
+      const cmd = new SignOffChainMessageCommand({
+        chunkedData: MESSAGE,
+        extend: false,
+        more: true,
+      });
+
+      const apdu = cmd.getApdu();
+
+      const expected = new ApduBuilder({
+        cla: CLA,
+        ins: INS,
+        p1: P1,
+        p2: 0x02, // INIT|MORE
+      })
+        .addBufferToData(MESSAGE)
+        .build();
+
+      expect(apdu.getRawApdu()).toEqual(expected.getRawApdu());
+    });
+
+    it("sets p2 correctly for middle chunks (EXTEND|MORE)", () => {
+      const cmd = new SignOffChainMessageCommand({
+        chunkedData: MESSAGE,
+        extend: true,
+        more: true,
+      });
+
+      const apdu = cmd.getApdu();
+
+      const expected = new ApduBuilder({
+        cla: CLA,
+        ins: INS,
+        p1: P1,
+        p2: 0x03, // EXTEND|MORE
+      })
+        .addBufferToData(MESSAGE)
+        .build();
+
+      expect(apdu.getRawApdu()).toEqual(expected.getRawApdu());
+    });
+
+    it("sets p2 correctly for the final chunk after extends (EXTEND)", () => {
+      const cmd = new SignOffChainMessageCommand({
+        chunkedData: MESSAGE,
+        extend: true,
+        more: false,
+      });
+
+      const apdu = cmd.getApdu();
+
+      const expected = new ApduBuilder({
+        cla: CLA,
+        ins: INS,
+        p1: P1,
+        p2: 0x01, // EXTEND only
+      })
+        .addBufferToData(MESSAGE)
+        .build();
+
+      expect(apdu.getRawApdu()).toEqual(expected.getRawApdu());
     });
   });
 
-  describe("parseResponse", () => {
-    it("should parse the response correctly", () => {
-      const signature = new Uint8Array(SIGNATURE_LENGTH).fill(0x01);
+  describe("parseResponse()", () => {
+    it("returns raw 64-byte signature on the last chunk", () => {
+      const cmd = new SignOffChainMessageCommand({
+        chunkedData: MESSAGE,
+        extend: true,
+        more: false,
+      });
 
-      const parsed = command.parseResponse(
+      const signature = new Uint8Array(SIGNATURE_LENGTH).fill(0x42);
+
+      const parsed = cmd.parseResponse(
         new ApduResponse({
           data: signature,
           statusCode: new Uint8Array([0x90, 0x00]),
@@ -52,68 +120,50 @@ describe("SignOffChainMessageCommand", () => {
 
       expect(isSuccessCommandResult(parsed)).toBe(true);
       if (isSuccessCommandResult(parsed)) {
-        // build expected OCM envelope: [count=1][signature][message]
-        const envelope = new Uint8Array(1 + SIGNATURE_LENGTH + MESSAGE.length);
-        envelope.set(Uint8Array.of(1), 0);
-        envelope.set(signature, 1);
-        envelope.set(MESSAGE, 1 + SIGNATURE_LENGTH);
-
-        const expectedB58 = DefaultBs58Encoder.encode(envelope);
-        expect(parsed.data).toEqual({ signature: expectedB58 });
-      } else {
-        assert.fail("Expected success result");
+        expect(parsed.data).toEqual(signature);
       }
     });
 
-    describe("error handling", () => {
-      it("should return error if response is not success", () => {
-        const result = command.parseResponse(
-          new ApduResponse({
-            statusCode: new Uint8Array([0x6a, 0x82]),
-            data: new Uint8Array(0),
-          }),
-        );
-
-        expect(isSuccessCommandResult(result)).toBe(false);
-        if (!isSuccessCommandResult(result)) {
-          expect(result.error).toEqual(
-            expect.objectContaining({
-              _tag: "SolanaAppCommandError",
-              errorCode: "6a82",
-              message: "Invalid off-chain message format",
-            }),
-          );
-        } else {
-          assert.fail("Expected error");
-        }
+    it("returns empty data for intermediate chunks (no signature yet)", () => {
+      const cmd = new SignOffChainMessageCommand({
+        chunkedData: MESSAGE,
+        extend: true,
+        more: true,
       });
 
-      it("should return error if signature is missing or incomplete", () => {
-        const incompleteSignature = new Uint8Array(SIGNATURE_LENGTH - 1).fill(
-          0x01,
-        );
-        const result = command.parseResponse(
-          new ApduResponse({
-            data: incompleteSignature,
-            statusCode: new Uint8Array([0x90, 0x00]),
-          }),
-        );
+      const parsed = cmd.parseResponse(
+        new ApduResponse({
+          data: new Uint8Array(0), // device returns no data mid-stream
+          statusCode: new Uint8Array([0x90, 0x00]),
+        }),
+      );
 
-        expect(isSuccessCommandResult(result)).toBe(false);
-        if (!isSuccessCommandResult(result)) {
-          if (
-            typeof result.error.originalError === "object" &&
-            result.error.originalError !== null &&
-            "message" in result.error.originalError
-          ) {
-            expect(
-              (result.error.originalError as { message: string }).message,
-            ).toBe("Signature extraction failed");
-          }
-        } else {
-          assert.fail("Expected error");
-        }
+      expect(isSuccessCommandResult(parsed)).toBe(true);
+      if (isSuccessCommandResult(parsed)) {
+        expect(parsed.data).toEqual(new Uint8Array(0));
+      }
+    });
+
+    it("returns empty data if signature is present but not 64 bytes", () => {
+      const cmd = new SignOffChainMessageCommand({
+        chunkedData: MESSAGE,
+        extend: true,
+        more: false,
       });
+
+      const shortSig = new Uint8Array(SIGNATURE_LENGTH - 1).fill(0x99);
+
+      const parsed = cmd.parseResponse(
+        new ApduResponse({
+          data: shortSig,
+          statusCode: new Uint8Array([0x90, 0x00]),
+        }),
+      );
+
+      expect(isSuccessCommandResult(parsed)).toBe(true);
+      if (isSuccessCommandResult(parsed)) {
+        expect(parsed.data).toEqual(new Uint8Array(0));
+      }
     });
   });
 });

--- a/packages/signer/signer-solana/src/internal/app-binder/command/SignOffChainMessageCommand.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/SignOffChainMessageCommand.ts
@@ -6,100 +6,59 @@ import {
   type Command,
   type CommandResult,
   CommandResultFactory,
-  InvalidStatusWordError,
 } from "@ledgerhq/device-management-kit";
-import { CommandErrorHelper } from "@ledgerhq/signer-utils";
-import { Maybe } from "purify-ts";
 
-import {
-  type Bs58Encoder,
-  DefaultBs58Encoder,
-} from "@internal/app-binder/services/bs58Encoder";
+import { type ChunkableCommandArgs } from "@internal/app-binder/task/SendCommandInChunksTask";
 
-import {
-  SOLANA_APP_ERRORS,
-  SolanaAppCommandErrorFactory,
-  type SolanaAppErrorCodes,
-} from "./utils/SolanaApplicationErrors";
+import { type SolanaAppErrorCodes } from "./utils/SolanaApplicationErrors";
+
+export const CLA = 0xe0;
+export const INS = 0x07;
+export const P1 = 0x01;
 
 const SIGNATURE_LENGTH = 64;
 
-export type SignOffChainMessageCommandResponse = {
-  signature: string;
+export const SOL_P2 = {
+  INIT: 0x00,
+  EXTEND: 0x01,
+  MORE: 0x02,
 };
-export type SignOffChainMessageCommandArgs = {
-  readonly message: Uint8Array;
-};
+
+export type SignOffChainRawResponse = Uint8Array;
 
 export class SignOffChainMessageCommand
   implements
-    Command<
-      SignOffChainMessageCommandResponse,
-      SignOffChainMessageCommandArgs,
-      SolanaAppErrorCodes
-    >
+    Command<SignOffChainRawResponse, ChunkableCommandArgs, SolanaAppErrorCodes>
 {
-  private readonly errorHelper = new CommandErrorHelper<
-    SignOffChainMessageCommandResponse,
-    SolanaAppErrorCodes
-  >(SOLANA_APP_ERRORS, SolanaAppCommandErrorFactory);
-
-  args: SignOffChainMessageCommandArgs;
-
-  constructor(
-    args: SignOffChainMessageCommandArgs,
-    private readonly bs58Encoder: Bs58Encoder = DefaultBs58Encoder,
-  ) {
-    this.args = args;
-  }
+  constructor(readonly args: ChunkableCommandArgs) {}
 
   getApdu(): Apdu {
+    const p2 =
+      (this.args.extend ? SOL_P2.EXTEND : SOL_P2.INIT) |
+      (this.args.more ? SOL_P2.MORE : 0);
+
     return new ApduBuilder({
-      cla: 0xe0,
-      ins: 0x07,
-      p1: 0x01,
-      p2: 0x00,
+      cla: CLA,
+      ins: INS,
+      p1: P1,
+      p2,
     })
-      .addBufferToData(this.args.message)
+      .addBufferToData(this.args.chunkedData)
       .build();
   }
 
   parseResponse(
     response: ApduResponse,
-  ): CommandResult<SignOffChainMessageCommandResponse, SolanaAppErrorCodes> {
-    return Maybe.fromNullable(
-      this.errorHelper.getError(response),
-    ).orDefaultLazy(() => {
-      const parser = new ApduParser(response);
+  ): CommandResult<SignOffChainRawResponse, SolanaAppErrorCodes> {
+    const parser = new ApduParser(response);
+    const sig = parser.extractFieldByLength(SIGNATURE_LENGTH);
 
-      // extract raw signature from device response
-      const signature = parser.extractFieldByLength(SIGNATURE_LENGTH);
-      if (!signature || signature.length !== SIGNATURE_LENGTH) {
-        return CommandResultFactory({
-          error: new InvalidStatusWordError("Signature extraction failed"),
-        });
-      }
+    // for intermediate chunks, the device returns 0 bytes of data with 0x9000.
+    // only the last chunk yields the 64-byte signature.
+    if (!sig || sig.length !== SIGNATURE_LENGTH) {
+      return CommandResultFactory({ data: new Uint8Array(0) });
+    }
 
-      // build the OCM envelope: [signatureCount=1][signature][signedMessage]
-      // signatureCount = 1 (single signer)
-      const signatureCount = Uint8Array.of(1);
-
-      // this.args.message is the off-chain message that was signed
-      const msg = this.args.message;
-
-      const envelope = new Uint8Array(
-        signatureCount.length + signature.length + msg.length,
-      );
-      envelope.set(signatureCount, 0);
-      envelope.set(signature, signatureCount.length);
-      envelope.set(msg, signatureCount.length + signature.length);
-
-      // base58-encode the envelope and return { signature: <b58> }
-      const encoded = this.bs58Encoder.encode(envelope);
-
-      return CommandResultFactory({
-        data: { signature: encoded },
-      });
-    });
+    return CommandResultFactory({ data: sig });
   }
 }

--- a/packages/signer/signer-solana/src/internal/app-binder/task/SendSignMessageTask.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/SendSignMessageTask.test.ts
@@ -11,13 +11,21 @@ import { makeDeviceActionInternalApiMock } from "@internal/app-binder/device-act
 import { DefaultBs58Encoder } from "@internal/app-binder/services/bs58Encoder";
 import {
   MAX_MESSAGE_LENGTH,
+  MessageFormat,
   SendSignMessageTask,
 } from "@internal/app-binder/task/SendSignMessageTask";
 
 const DERIVATION_PATH = "44'/501'/0'/0'";
-const PUBKEY = new Uint8Array(32).fill(0x00);
+const PUBKEY = new Uint8Array(32).fill(0x11);
 const PUBKEY_BASE58 = DefaultBs58Encoder.encode(PUBKEY);
-const MESSAGE = new Uint8Array([0xf0, 0xca, 0xcc, 0x1a]);
+
+function solanaHeaderErr() {
+  return {
+    _tag: "SolanaAppCommandError",
+    errorCode: "6a81",
+    message: "Invalid off-chain message header",
+  } as const;
+}
 
 describe("SendSignMessageTask", () => {
   const apiMock = makeDeviceActionInternalApiMock();
@@ -27,155 +35,309 @@ describe("SendSignMessageTask", () => {
   });
 
   describe("run()", () => {
-    it("should error on empty message before any device call", async () => {
-      // given
-      const args = {
+    it("errors on empty message before any device call", async () => {
+      const result = await new SendSignMessageTask(apiMock, {
         derivationPath: DERIVATION_PATH,
         sendingData: new Uint8Array([]),
-      };
+      }).run();
 
-      // when
-      const result = await new SendSignMessageTask(apiMock, args).run();
-
-      // then
       expect(apiMock.sendCommand).toHaveBeenCalledTimes(0);
       expect((result as any).error).toEqual(
         new InvalidStatusWordError("Message cannot be empty"),
       );
     });
 
-    it("should return error if GET_PUBKEY fails", async () => {
-      // given
+    it("errors when GET_PUBKEY fails", async () => {
       apiMock.sendCommand.mockResolvedValueOnce(
         CommandResultFactory({
           error: new InvalidStatusWordError("pubkey error"),
         }),
       );
-      const args = {
+
+      const res = await new SendSignMessageTask(apiMock, {
         derivationPath: DERIVATION_PATH,
-        sendingData: MESSAGE,
-      };
+        sendingData: new Uint8Array([1, 2, 3]),
+      }).run();
 
-      // when
-      const result = await new SendSignMessageTask(apiMock, args).run();
-
-      // then
       expect(apiMock.sendCommand).toHaveBeenCalledTimes(1);
-      expect((result as any).error).toEqual(
+      expect((res as any).error).toEqual(
         new InvalidStatusWordError("Error getting public key from device"),
       );
     });
 
-    it("should return error if SignOffChainMessageCommand fails", async () => {
-      // given
+    it("surfaces command error when signing fails", async () => {
       apiMock.sendCommand
-        .mockResolvedValueOnce(CommandResultFactory({ data: PUBKEY_BASE58 }))
+        .mockResolvedValueOnce(CommandResultFactory({ data: PUBKEY_BASE58 })) // pubkey
         .mockResolvedValueOnce(
           CommandResultFactory({
             error: new InvalidStatusWordError("no signature returned"),
           }),
         );
-      const args = {
+
+      const res = await new SendSignMessageTask(apiMock, {
         derivationPath: DERIVATION_PATH,
-        sendingData: MESSAGE,
-      };
+        sendingData: new Uint8Array([0xaa, 0xbb]),
+      }).run();
 
-      // when
-      const result = await new SendSignMessageTask(apiMock, args).run();
-
-      // then
       expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
-      expect((result as any).error).toEqual(
+      expect((res as any).error).toEqual(
         new InvalidStatusWordError("no signature returned"),
       );
     });
 
-    it("should return success when signing succeeds", async () => {
+    it("returns base58 envelope when signing succeeds", async () => {
       // given
-      const mockSig = new Uint8Array([0xf0, 0xca, 0xcc, 0x1a]);
+      const msg = new Uint8Array([0xf0, 0xca, 0xcc, 0x1a]);
+      const rawSig = new Uint8Array(64).fill(0x33); // mock 64-byte signature
+
       apiMock.sendCommand
-        .mockResolvedValueOnce(CommandResultFactory({ data: PUBKEY_BASE58 }))
-        .mockResolvedValueOnce(CommandResultFactory({ data: mockSig }));
-      const args = {
+        .mockResolvedValueOnce(CommandResultFactory({ data: PUBKEY_BASE58 })) // pubkey
+        .mockResolvedValueOnce(CommandResultFactory({ data: rawSig })); // v0 last chunk
+
+      const task: any = new SendSignMessageTask(apiMock, {
         derivationPath: DERIVATION_PATH,
-        sendingData: MESSAGE,
-      };
+        sendingData: msg,
+      });
+      const v0OCM: Uint8Array = task._buildFullMessage(msg, PUBKEY, false);
 
       // when
-      const result = await new SendSignMessageTask(apiMock, args).run();
+      const res = await task.run();
 
       // then
       expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
-      expect((result as any).data).toEqual(mockSig);
+      expect("data" in res).toBe(true);
+      const b58 = (res as any).data.signature as string;
+
+      // expected envelope = [1][rawSig][v0OCM]
+      const expected = new Uint8Array(1 + rawSig.length + v0OCM.length);
+      expected.set(Uint8Array.of(1), 0);
+      expected.set(rawSig, 1);
+      expected.set(v0OCM, 1 + rawSig.length);
+
+      expect(DefaultBs58Encoder.decode(b58)).toEqual(expected);
     });
 
-    it("should reject invalid derivation path", async () => {
+    it("rejects invalid derivation path", async () => {
       const args = {
         derivationPath: "not/a/path",
-        sendingData: MESSAGE,
+        sendingData: new Uint8Array([1]),
       };
       await expect(
         new SendSignMessageTask(apiMock, args).run(),
       ).rejects.toThrow();
     });
 
-    it("should correctly build APDU command lengths", () => {
-      // given
+    it("builds APDU command with correct structure (prefix + tail)", () => {
+      const msg = new Uint8Array([1, 2, 3]);
       const task: any = new SendSignMessageTask(apiMock, {
         derivationPath: DERIVATION_PATH,
-        sendingData: MESSAGE,
+        sendingData: msg,
       });
 
-      // when
-      const fullMsg = task._buildFullMessage(MESSAGE, PUBKEY);
+      const fullMsg = task._buildFullMessage(msg, PUBKEY, false);
       const paths = [44 | 0x80000000, 501 | 0x80000000, 0 | 0x80000000, 0];
       const apdu = task._buildApduCommand(fullMsg, paths);
-      const expectedLen = 1 + 1 + paths.length * 4 + fullMsg.length;
 
-      // then
-      expect(apdu.length).toBe(expectedLen);
+      // first byte: number of signers
+      expect(apdu[0]).toBe(1);
+      // second byte: number of derivation indices
+      expect(apdu[1]).toBe(paths.length);
+      // tail equals the serialized OCM
+      expect(apdu.slice(apdu.length - fullMsg.length)).toEqual(fullMsg);
     });
 
-    it("should handle maximum allowed message length", async () => {
-      // given
-      const headerAPDU = 1 + 1 + 4 * 4;
-      const fullMsgHeader = 1 + 15 + 1 + 32 + 1 + 1 + 32 + 2;
-      const maxBody = 255 - headerAPDU - fullMsgHeader;
-      const bigMsg = new Uint8Array(maxBody).fill(0x01);
-      const mockSig = new Uint8Array([0xf0, 0xca, 0xcc, 0x1a]);
-      apiMock.sendCommand
-        .mockResolvedValueOnce(CommandResultFactory({ data: PUBKEY_BASE58 }))
-        .mockResolvedValueOnce(CommandResultFactory({ data: mockSig }));
+    it("handles large messages via chunking (no exact call count assertion)", async () => {
+      const bigMsg = new Uint8Array(4000).fill(0x01);
+      const rawSig = new Uint8Array(64).fill(0x44);
 
-      // when
-      const result = await new SendSignMessageTask(apiMock, {
+      apiMock.sendCommand
+        .mockResolvedValueOnce(CommandResultFactory({ data: PUBKEY_BASE58 })) // pubkey
+        .mockResolvedValue(CommandResultFactory({ data: rawSig })); // all subsequent chunks
+
+      const res = await new SendSignMessageTask(apiMock, {
         derivationPath: DERIVATION_PATH,
         sendingData: bigMsg,
       }).run();
 
-      // then
-      expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
-      expect((result as any).data).toEqual(mockSig);
+      expect("data" in res).toBe(true);
     });
 
-    it("should error on message exceeding 16-bit length (65535)", async () => {
-      // given
+    it("errors on message exceeding v0 max (65515)", async () => {
       const tooBig = new Uint8Array(MAX_MESSAGE_LENGTH + 1).fill(0xaa);
-      const args = {
+      const res = await new SendSignMessageTask(apiMock, {
         derivationPath: DERIVATION_PATH,
         sendingData: tooBig,
-      };
+      }).run();
 
-      // when
-      const result = await new SendSignMessageTask(apiMock, args).run();
-
-      // then
       expect(apiMock.sendCommand).toHaveBeenCalledTimes(0);
-      expect((result as any).error).toEqual(
+      expect((res as any).error).toEqual(
         new InvalidStatusWordError(
-          `Message too long: ${tooBig.length} bytes (max is 65535)`,
+          `Message too long: ${tooBig.length} bytes (max is ${MAX_MESSAGE_LENGTH})`,
         ),
       );
     });
+
+    it("falls back to legacy when v0 returns 6a81 (header error)", async () => {
+      // given
+      const msg = new Uint8Array([0x61, 0x62, 0x63]); // "abc"
+      const rawSig = new Uint8Array(64).fill(0x55);
+
+      apiMock.sendCommand
+        .mockResolvedValueOnce(CommandResultFactory({ data: PUBKEY_BASE58 })) // pubkey
+        .mockResolvedValueOnce(
+          CommandResultFactory({ error: solanaHeaderErr() as any }),
+        ) // v0 -> 6a81
+        .mockResolvedValueOnce(CommandResultFactory({ data: rawSig })); // legacy -> OK
+
+      const task: any = new SendSignMessageTask(apiMock, {
+        derivationPath: DERIVATION_PATH,
+        sendingData: msg,
+      });
+
+      // build expected LEGACY OCM to verify envelope
+      const legacyOCM: Uint8Array = task._buildFullMessage(msg, PUBKEY, true);
+
+      // when
+      const res = await task.run();
+
+      // then
+      expect(apiMock.sendCommand).toHaveBeenCalledTimes(3); // pubkey + v0 + legacy
+      const b58 = (res as any).data.signature as string;
+
+      const expected = new Uint8Array(1 + rawSig.length + legacyOCM.length);
+      expected.set(Uint8Array.of(1), 0);
+      expected.set(rawSig, 1);
+      expected.set(legacyOCM, 1 + rawSig.length);
+
+      expect(DefaultBs58Encoder.decode(b58)).toEqual(expected);
+    });
+
+    it("does NOT fallback on non-6a81 errors", async () => {
+      apiMock.sendCommand
+        .mockResolvedValueOnce(CommandResultFactory({ data: PUBKEY_BASE58 }))
+        .mockResolvedValueOnce(
+          CommandResultFactory({ error: new InvalidStatusWordError("oups") }),
+        );
+
+      const res = await new SendSignMessageTask(apiMock, {
+        derivationPath: DERIVATION_PATH,
+        sendingData: new Uint8Array([1, 2]),
+      }).run();
+
+      expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
+      expect((res as any).error).toBeInstanceOf(InvalidStatusWordError);
+    });
+
+    it("propagates 6a81 if body is too large for legacy", async () => {
+      const msg = new Uint8Array(2000).fill(0x31); // > 1232 legacy limit
+
+      apiMock.sendCommand
+        .mockResolvedValueOnce(CommandResultFactory({ data: PUBKEY_BASE58 })) // pubkey
+        .mockResolvedValueOnce(
+          CommandResultFactory({ error: solanaHeaderErr() as any }),
+        ); // v0 -> 6a81
+
+      const res = await new SendSignMessageTask(apiMock, {
+        derivationPath: DERIVATION_PATH,
+        sendingData: msg,
+      }).run();
+
+      // no legacy retry
+      expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
+      expect((res as any).error).toEqual(solanaHeaderErr());
+    });
+  });
+
+  describe("message format detection (indirect via header byte)", () => {
+    it("sets format=0 for ASCII ≤ maxLedgerLen (v0 header)", () => {
+      const ascii = new TextEncoder().encode("hello\nworld"); // newline allowed in non-legacy
+      const task: any = new SendSignMessageTask(apiMock, {
+        derivationPath: DERIVATION_PATH,
+        sendingData: ascii,
+      });
+      const v0 = task._buildFullMessage(ascii, PUBKEY, false);
+      // in v0 format byte is at offset: 16 (domain) + 1 (ver) + 32 (app) = 49
+      expect(v0[49]).toBe(MessageFormat.Ascii);
+    });
+
+    it("sets format=1 for short UTF-8 non-ASCII (v0 header)", () => {
+      const utf8 = new TextEncoder().encode("héllø");
+      const task: any = new SendSignMessageTask(apiMock, {
+        derivationPath: DERIVATION_PATH,
+        sendingData: utf8,
+      });
+      const v0 = task._buildFullMessage(utf8, PUBKEY, false);
+      expect(v0[49]).toBe(MessageFormat.Utf8);
+    });
+
+    it("sets format=2 for long UTF-8 (v0 header)", () => {
+      // must exceed OFFCM_MAX_LEDGER_LEN to get format=2
+      const longUtf8 = new TextEncoder().encode("x".repeat(15313));
+      const task: any = new SendSignMessageTask(apiMock, {
+        derivationPath: DERIVATION_PATH,
+        sendingData: longUtf8,
+      });
+      const v0 = task._buildFullMessage(longUtf8, PUBKEY, false);
+      expect(v0[49]).toBe(MessageFormat.Utf8LongV0);
+    });
+
+    it("legacy header forbids newline in ASCII (so format becomes UTF-8=1)", () => {
+      const asciiWithNl = new TextEncoder().encode("hello\nworld");
+      const task: any = new SendSignMessageTask(apiMock, {
+        derivationPath: DERIVATION_PATH,
+        sendingData: asciiWithNl,
+      });
+      const legacy = task._buildFullMessage(asciiWithNl, PUBKEY, true);
+      // in legacy: format byte is at offset 16 (domain) + 1 (ver) = 17
+      expect(legacy[17]).toBe(MessageFormat.Utf8);
+    });
+
+    it("legacy header sets format=0 for plain ASCII (no newline)", () => {
+      const ascii = new TextEncoder().encode("HELLO_123");
+      const task: any = new SendSignMessageTask(apiMock, {
+        derivationPath: DERIVATION_PATH,
+        sendingData: ascii,
+      });
+      const legacy = task._buildFullMessage(ascii, PUBKEY, true);
+      expect(legacy[17]).toBe(MessageFormat.Ascii);
+    });
+
+    it("message length is little-endian in both headers", () => {
+      const body = new Uint8Array([1, 2, 3]); // length = 3
+      const task: any = new SendSignMessageTask(apiMock, {
+        derivationPath: DERIVATION_PATH,
+        sendingData: body,
+      });
+
+      // v0 offsets:
+      // length starts at: 16(domain) + 1(ver) + 32(app) + 1(format) + 1(count) + 32(pubkey) = 83
+      const v0 = task._buildFullMessage(body, PUBKEY, false);
+      expect(v0[83]).toBe(3); // LSB (0x03)
+      expect(v0[84]).toBe(0); // MSB (0x00)
+
+      // legacy offsets:
+      // length starts at: 16(domain) + 1(ver) + 1(format) = 18
+      const legacy = task._buildFullMessage(body, PUBKEY, true);
+      expect(legacy[18]).toBe(3); // LSB (0x03)
+      expect(legacy[19]).toBe(0); // MSB (0x00)
+    });
+  });
+
+  it("returns error when device returns non-64-byte signature on final chunk", async () => {
+    const msg = new Uint8Array([1, 2, 3]);
+
+    apiMock.sendCommand
+      .mockResolvedValueOnce(CommandResultFactory({ data: PUBKEY_BASE58 }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: new Uint8Array(0) }));
+
+    const res = await new SendSignMessageTask(apiMock, {
+      derivationPath: DERIVATION_PATH,
+      sendingData: msg,
+    }).run();
+
+    expect("error" in res).toBe(true);
+
+    const err = (res as any).error as unknown;
+    expect(err).toBeInstanceOf(InvalidStatusWordError);
   });
 });

--- a/packages/signer/signer-solana/src/internal/app-binder/task/SendSignMessageTask.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/SendSignMessageTask.ts
@@ -1,17 +1,17 @@
 import {
-  APDU_MAX_PAYLOAD,
   ByteArrayBuilder,
   type CommandResult,
   CommandResultFactory,
   type InternalApi,
   InvalidStatusWordError,
+  isSuccessCommandResult,
 } from "@ledgerhq/device-management-kit";
 import { DerivationPathUtils } from "@ledgerhq/signer-utils";
 
 import { GetPubKeyCommand } from "@internal/app-binder/command/GetPubKeyCommand";
 import {
   SignOffChainMessageCommand,
-  type SignOffChainMessageCommandResponse,
+  type SignOffChainRawResponse,
 } from "@internal/app-binder/command/SignOffChainMessageCommand";
 import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
 import {
@@ -19,16 +19,50 @@ import {
   DefaultBs58Encoder,
 } from "@internal/app-binder/services/bs58Encoder";
 
+import {
+  type CommandFactory,
+  SendCommandInChunksTask,
+} from "./SendCommandInChunksTask";
+
+const DEVICE_V0_PAYLOAD_CEILING = 15 * 1024; // 15360
+const DEVICE_LEGACY_PAYLOAD_CEILING = 1280;
+
+// bytes reserved by app/header and transport
+const RESERVED_HEADER_BYTES = 40;
+const RESERVED_TRANSPORT_BYTES = 8;
+
+// derived usable body sizes
+const OFFCHAINMSG_MAX_LEN =
+  DEVICE_V0_PAYLOAD_CEILING - RESERVED_HEADER_BYTES - RESERVED_TRANSPORT_BYTES; // 15312
+
+const LEGACY_OFFCHAINMSG_MAX_LEN =
+  DEVICE_LEGACY_PAYLOAD_CEILING -
+  RESERVED_HEADER_BYTES -
+  RESERVED_TRANSPORT_BYTES; // 1232
+
+// device cap for v0 long UTF-8
+const OFFCHAINMSG_MAX_V0_LEN = 65515;
+
+const MAX_PRINTABLE_ASCII = 0x7e;
+const MIN_PRINTABLE_ASCII = 0x20;
+const LINE_FEED_ASCII = 0x0a;
+
+export enum MessageFormat {
+  Ascii = 0,
+  Utf8 = 1,
+  Utf8LongV0 = 2,
+}
+
+export const MAX_MESSAGE_LENGTH = OFFCHAINMSG_MAX_V0_LEN;
+
 export type SendSignMessageTaskArgs = {
   sendingData: Uint8Array;
   derivationPath: string;
 };
 
 export type SendSignMessageTaskRunFunctionReturn = Promise<
-  CommandResult<SignOffChainMessageCommandResponse, SolanaAppErrorCodes>
+  CommandResult<{ signature: string }, SolanaAppErrorCodes>
 >;
-
-export const MAX_MESSAGE_LENGTH = 0xffff;
 
 export class SendSignMessageTask {
   constructor(
@@ -45,21 +79,19 @@ export class SendSignMessageTask {
         error: new InvalidStatusWordError("Message cannot be empty"),
       });
     }
-
     if (sendingData.length > MAX_MESSAGE_LENGTH) {
       return CommandResultFactory({
         error: new InvalidStatusWordError(
-          `Message too long: ${sendingData.length} bytes (max is 65535)`,
+          `Message too long: ${sendingData.length} bytes (max is ${MAX_MESSAGE_LENGTH})`,
         ),
       });
     }
 
-    const pathIndexes = DerivationPathUtils.splitPath(derivationPath);
+    const paths = DerivationPathUtils.splitPath(derivationPath);
 
     const pubkeyResult = await this.api.sendCommand(
       new GetPubKeyCommand({ derivationPath, checkOnDevice: false }),
     );
-
     if (!("data" in pubkeyResult)) {
       return CommandResultFactory({
         error: new InvalidStatusWordError(
@@ -67,82 +99,214 @@ export class SendSignMessageTask {
         ),
       });
     }
-
     const signerPubkey = this.bs58Encoder.decode(pubkeyResult.data);
-    const fullMessage = this._buildFullMessage(sendingData, signerPubkey);
-    const commandBuffer = this._buildApduCommand(fullMessage, pathIndexes);
 
-    if (commandBuffer.length > APDU_MAX_PAYLOAD) {
-      return CommandResultFactory({
-        error: new InvalidStatusWordError(
-          "The APDU command exceeds the maximum allowable size (255 bytes)",
-        ),
-      });
+    // try v0 first
+    const v0OCM = this._buildFullMessage(sendingData, signerPubkey, false);
+    const v0Payload = this._buildApduCommand(v0OCM, paths);
+    const v0Res = await this._sendInChunks(v0Payload);
+
+    if (isSuccessCommandResult(v0Res)) {
+      try {
+        const sigB58 = this._buildEnvelopeBase58(v0Res.data, v0OCM);
+        return CommandResultFactory({ data: { signature: sigB58 } });
+      } catch (e) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            e instanceof Error ? e.message : String(e),
+          ),
+        });
+      }
     }
 
-    return this.api.sendCommand(
-      new SignOffChainMessageCommand({ message: commandBuffer }),
-    );
+    // if the app says header invalid, try legacy
+    const v0Error: unknown =
+      "error" in v0Res ? (v0Res as { error: unknown }).error : undefined;
+
+    if (this._isInvalidOffchainHeaderError(v0Error)) {
+      if (sendingData.length > LEGACY_OFFCHAINMSG_MAX_LEN) {
+        return v0Res;
+      }
+
+      const legacyOCM = this._buildFullMessage(sendingData, signerPubkey, true);
+      const legacyPayload = this._buildApduCommand(legacyOCM, paths);
+      const legacyRes = await this._sendInChunks(legacyPayload);
+
+      if (isSuccessCommandResult(legacyRes)) {
+        try {
+          const sigB58 = this._buildEnvelopeBase58(legacyRes.data, legacyOCM);
+          return CommandResultFactory({ data: { signature: sigB58 } });
+        } catch (e) {
+          return CommandResultFactory({
+            error: new InvalidStatusWordError(
+              e instanceof Error ? e.message : String(e),
+            ),
+          });
+        }
+      }
+      return legacyRes;
+    }
+
+    return v0Res;
+  }
+
+  private _isUTF8(buf: Uint8Array): boolean {
+    try {
+      new TextDecoder("utf-8", { fatal: true }).decode(buf);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private _findMessageFormat(
+    message: Uint8Array,
+    isLegacy: boolean,
+  ): MessageFormat {
+    const maxLedgerLen = isLegacy
+      ? LEGACY_OFFCHAINMSG_MAX_LEN
+      : OFFCHAINMSG_MAX_LEN;
+
+    if (message.length <= maxLedgerLen) {
+      if (this._isPrintableASCII(message, isLegacy)) return MessageFormat.Ascii;
+      if (this._isUTF8(message)) return MessageFormat.Utf8;
+    } else if (message.length <= OFFCHAINMSG_MAX_V0_LEN) {
+      if (this._isUTF8(message)) return MessageFormat.Utf8LongV0;
+    } else {
+      // unreachable if run() guards length
+      throw new InvalidStatusWordError(
+        `Message too long: ${message.length} bytes (max is ${OFFCHAINMSG_MAX_V0_LEN})`,
+      );
+    }
+    // default to ASCII like legacy
+    return MessageFormat.Ascii;
+  }
+
+  private _isPrintableASCII(buf: Uint8Array, isLegacy: boolean): boolean {
+    for (let i = 0; i < buf.length; i++) {
+      const ch: number = buf[i]!;
+      if (!isLegacy && ch === LINE_FEED_ASCII) continue; // newline allowed only for non-legacy
+      if (ch < MIN_PRINTABLE_ASCII || ch > MAX_PRINTABLE_ASCII) return false;
+    }
+    return true;
   }
 
   /**
-   * builds the serialised off-chain message header and body
+   * build serialised off-chain message header + body
+   * when `isLegacy` is true, build the short legacy header (no app-domain or signers).
    */
   private _buildFullMessage(
-    sendingData: Uint8Array,
+    messageBody: Uint8Array,
     signerPubkey: Uint8Array,
+    isLegacy: boolean,
   ): Uint8Array {
+    const format: MessageFormat = this._findMessageFormat(
+      messageBody,
+      isLegacy,
+    );
+
+    const builder = new ByteArrayBuilder();
+
+    // signing domain: 0xFF + "solana offchain" (16 bytes)
+    builder.add8BitUIntToData(0xff).addAsciiStringToData("solana offchain");
+
+    // header version = 0
+    builder.add8BitUIntToData(0);
+
+    if (!isLegacy) {
+      // application domain = 32 zeros
+      builder.addBufferToData(new Uint8Array(32));
+    }
+
+    // message format
+    builder.add8BitUIntToData(format);
+
+    if (!isLegacy) {
+      // signer count = 1
+      builder.add8BitUIntToData(1);
+      // signer pubkey (32 bytes)
+      builder.addBufferToData(signerPubkey);
+    }
+
+    // message length (LE, 2 bytes)
+    builder.add8BitUIntToData(messageBody.length & 0xff);
+    builder.add8BitUIntToData((messageBody.length >> 8) & 0xff);
+
+    // message body
+    builder.addBufferToData(messageBody);
+
+    return builder.build();
+  }
+
+  // guard for the device’s 0x6A81 “Invalid off-chain message header” error
+  private _isInvalidOffchainHeaderError(
+    e: unknown,
+  ): e is { _tag: string; errorCode: string } {
+    if (!e || typeof e !== "object") return false;
+    const obj = e as Record<string, unknown>;
+    const tag = obj["_tag"];
+    const code = obj["errorCode"];
     return (
-      new ByteArrayBuilder()
-        // 0xFF + prefix
-        .add8BitUIntToData(0xff)
-        .addAsciiStringToData("solana offchain")
-        // version = 0
-        .add8BitUIntToData(0)
-        // domain = 32 zeros
-        .addBufferToData(new Uint8Array(32))
-        // format = 0
-        .add8BitUIntToData(0)
-        // signer count = 1
-        .add8BitUIntToData(1)
-        // signer pubkey (32 bytes)
-        .addBufferToData(signerPubkey)
-        // message length (2 bytes, little endian)
-        .add8BitUIntToData(sendingData.length & 0xff)
-        .add8BitUIntToData((sendingData.length >> 8) & 0xff)
-        // message body
-        .addBufferToData(sendingData)
-        .build()
+      typeof tag === "string" &&
+      typeof code === "string" &&
+      code.toLowerCase() === "6a81"
     );
   }
 
   /**
-   * builds the APDU command to send to the device
+   * build APDU payload:
+   * [signerCount=1][derivationsCount][each 4-byte index][OCM message]
    */
   private _buildApduCommand(
     fullMessage: Uint8Array,
     paths: number[],
   ): Uint8Array {
-    const numberOfSigners = 1;
-    const derivationCount = 1;
-    const pathBytes = paths.length * 4;
     const builder = new ByteArrayBuilder(
-      fullMessage.length + numberOfSigners + derivationCount + pathBytes,
+      1 + 1 + paths.length * 4 + fullMessage.length,
     );
 
-    // number of signers
-    builder.add8BitUIntToData(numberOfSigners);
-    // number of BIP32 derivations
-    builder.add8BitUIntToData(paths.length);
-    // each derivation index
-    paths.forEach((idx) => {
-      const buf = new Uint8Array(4);
-      new DataView(buf.buffer).setUint32(0, idx, false);
-      builder.addBufferToData(buf);
-    });
-    // serialised off-chain message
+    builder.add8BitUIntToData(1); // number of signers
+    builder.add8BitUIntToData(paths.length); // number of derivations
+    paths.forEach((idx) => builder.add32BitUIntToData(idx)); // big-endian
     builder.addBufferToData(fullMessage);
 
-    return builder.build();
+    return builder.build(); // larger than 255 is ok, SendCommandInChunksTask will chunk it
+  }
+
+  // send APDU payload using chunk task, return raw 64-byte signature (last chunk)
+  private async _sendInChunks(
+    apduPayload: Uint8Array,
+  ): Promise<CommandResult<SignOffChainRawResponse, SolanaAppErrorCodes>> {
+    const commandFactory: CommandFactory<SignOffChainRawResponse> = (
+      chunkArgs,
+    ) => new SignOffChainMessageCommand(chunkArgs);
+
+    return await new SendCommandInChunksTask<SignOffChainRawResponse>(
+      this.api,
+      {
+        data: apduPayload,
+        commandFactory,
+      },
+    ).run();
+  }
+
+  // build base58 OCM envelope: [signatureCount=1][signature(64)][serialized OCM]
+  private _buildEnvelopeBase58(
+    rawSignature: Uint8Array,
+    serializedOCM: Uint8Array,
+  ): string {
+    if (rawSignature.length !== 64) {
+      throw new InvalidStatusWordError(
+        `Invalid signature length: ${rawSignature.length} (expected 64)`,
+      );
+    }
+    const sigCount = Uint8Array.of(1);
+    const envelope = new Uint8Array(
+      sigCount.length + rawSignature.length + serializedOCM.length,
+    );
+    envelope.set(sigCount, 0);
+    envelope.set(rawSignature, sigCount.length);
+    envelope.set(serializedOCM, sigCount.length + rawSignature.length);
+    return this.bs58Encoder.encode(envelope);
   }
 }


### PR DESCRIPTION
### 📝 Description

- Added message chunking in signOffchainMsg
- Added message format checks

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [NO-ISSUE]

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
