### PR TITLE
🐛 (rn-ble) [LIVE-22412]: Map specific error for Android pairing

### DIFF
--- a/.changeset/easy-times-nail.md
+++ b/.changeset/easy-times-nail.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-transport-kit-react-native-ble": minor
+---
+
+Mapping specific error for Android platform

--- a/packages/transport/rn-ble/src/api/transport/RNBleTransport.ts
+++ b/packages/transport/rn-ble/src/api/transport/RNBleTransport.ts
@@ -1,6 +1,7 @@
 import { Platform } from "react-native";
 import {
   BleError,
+  BleErrorCode,
   type BleManager,
   type Device,
   State,
@@ -504,6 +505,13 @@ export class RNBleTransport implements Transport {
              * This happens when the Ledger device reset its pairing, but the
              * iOS system still has that device paired.
              */
+            return throwE(new PeerRemovedPairingError(error));
+          }
+          if (
+            error instanceof BleError &&
+            error.errorCode === BleErrorCode.OperationCancelled &&
+            Platform.OS === "android"
+          ) {
             return throwE(new PeerRemovedPairingError(error));
           }
           return throwE(new OpeningConnectionError(error));


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
On some Android devices(e.g., Google Pixel 8, Android 16), when users removed the pairing on their Ledger devices, they will not be able to connect their Ledger devices and the error `OperationCancelled` will be emitted by `react-native-ble-plx` library. We cannot identify this specific error by given information. So if the error `OperationCancelled` happened during the BLE pairing process on Android platform, it will be always mapped to `PeerRemovedPairingError` that tells the user to forget the device and redo the pairing.


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [LIVE-22412](https://ledgerhq.atlassian.net/browse/LIVE-22412)

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [x] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - `OperationCancelled` error will be mapped to `PeerRemovedPairingError` on Android devices if it happened during BLE pairing.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[LIVE-22412]: https://ledgerhq.atlassian.net/browse/LIVE-22412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ