### PR TITLE
🎨 (dmk) [LIVE-22278]: Add InvalidGetFirmwareMetadataResponseError

### DIFF
--- a/.changeset/happy-bottles-fetch.md
+++ b/.changeset/happy-bottles-fetch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": minor
+---
+
+Add InvalidGetFirmwareMetadataResponseError

--- a/packages/device-management-kit/src/api/command/Errors.ts
+++ b/packages/device-management-kit/src/api/command/Errors.ts
@@ -44,3 +44,14 @@ export class InvalidResponseFormatError implements DmkError {
     this.originalError = new Error(message ?? "Invalid response format.");
   }
 }
+
+export class InvalidGetFirmwareMetadataResponseError implements DmkError {
+  readonly _tag = "InvalidGetFirmwareMetadataResponseError";
+  readonly originalError: Error;
+
+  constructor(message?: string) {
+    this.originalError = new Error(
+      message ?? "Invalid Firmware Metadata response error.",
+    );
+  }
+}

--- a/packages/device-management-kit/src/api/command/model/CommandResult.ts
+++ b/packages/device-management-kit/src/api/command/model/CommandResult.ts
@@ -1,6 +1,7 @@
 import {
   type InvalidBatteryDataError,
   type InvalidBatteryStatusTypeError,
+  type InvalidGetFirmwareMetadataResponseError,
   type InvalidResponseFormatError,
   type InvalidStatusWordError,
 } from "@api/command/Errors";
@@ -25,6 +26,7 @@ export type CommandErrorResult<SpecificErrorCodes = void> = {
     | InvalidBatteryStatusTypeError
     | InvalidResponseFormatError
     | InvalidStatusWordError
+    | InvalidGetFirmwareMetadataResponseError
     | UnknownDeviceExchangeError;
   status: CommandResultStatus.Error;
 };
@@ -45,6 +47,7 @@ export function CommandResultFactory<Data, SpecificErrorCodes = void>({
         | InvalidBatteryStatusTypeError
         | InvalidResponseFormatError
         | InvalidStatusWordError
+        | InvalidGetFirmwareMetadataResponseError
         | UnknownDeviceExchangeError;
     }): CommandResult<Data, SpecificErrorCodes> {
   if (error) {

--- a/packages/device-management-kit/src/api/device-action/task/GetFirmwareMetadataTask.test.ts
+++ b/packages/device-management-kit/src/api/device-action/task/GetFirmwareMetadataTask.test.ts
@@ -1,6 +1,9 @@
 import { EitherAsync } from "purify-ts";
 
-import { InvalidStatusWordError } from "@api/command/Errors";
+import {
+  InvalidGetFirmwareMetadataResponseError,
+  InvalidStatusWordError,
+} from "@api/command/Errors";
 import { CommandResultFactory } from "@api/command/model/CommandResult";
 import { type GetOsVersionResponse } from "@api/command/os/GetOsVersionCommand";
 import { makeDeviceActionInternalApiMock } from "@api/device-action/__test-utils__/makeInternalApi";
@@ -229,7 +232,7 @@ describe("GetFirmwareMetadataTask", () => {
     );
   });
 
-  it("should fail if device version cannot be fetched", async () => {
+  it("should fail if device version cannot be fetched with InvalidGetFirmwareMetadataResponseError", async () => {
     // GIVEN
     apiMock.sendCommand.mockResolvedValueOnce(
       CommandResultFactory({ data: OS_VERSION }),
@@ -246,14 +249,12 @@ describe("GetFirmwareMetadataTask", () => {
     // THEN
     expect(result).toStrictEqual(
       CommandResultFactory({
-        error: new InvalidStatusWordError(
-          "Cannot fetch current firmware metadata",
-        ),
+        error: new InvalidGetFirmwareMetadataResponseError(),
       }),
     );
   });
 
-  it("should fail if firmware version cannot be fetched", async () => {
+  it("should fail if firmware version cannot be fetched with InvalidGetFirmwareMetadataResponseError", async () => {
     // GIVEN
     apiMock.sendCommand.mockResolvedValueOnce(
       CommandResultFactory({ data: OS_VERSION }),
@@ -270,9 +271,7 @@ describe("GetFirmwareMetadataTask", () => {
     // THEN
     expect(result).toStrictEqual(
       CommandResultFactory({
-        error: new InvalidStatusWordError(
-          "Cannot fetch current firmware metadata",
-        ),
+        error: new InvalidGetFirmwareMetadataResponseError(),
       }),
     );
   });

--- a/packages/device-management-kit/src/api/device-action/task/GetFirmwareMetadataTask.ts
+++ b/packages/device-management-kit/src/api/device-action/task/GetFirmwareMetadataTask.ts
@@ -1,4 +1,4 @@
-import { InvalidStatusWordError } from "@api/command/Errors";
+import { InvalidGetFirmwareMetadataResponseError } from "@api/command/Errors";
 import {
   type CommandResult,
   CommandResultFactory,
@@ -51,9 +51,7 @@ export class GetFirmwareMetadataTask {
       );
     if (result.isLeft()) {
       return CommandResultFactory({
-        error: new InvalidStatusWordError(
-          "Cannot fetch current firmware metadata",
-        ),
+        error: new InvalidGetFirmwareMetadataResponseError(),
       });
     }
     const { deviceVersion, currentFirmware } = result.unsafeCoerce();

--- a/packages/device-management-kit/src/api/index.ts
+++ b/packages/device-management-kit/src/api/index.ts
@@ -6,7 +6,10 @@ export { ApduParser } from "@api/apdu/utils/ApduParser";
 export * from "@api/apdu/utils/AppBuilderError";
 export { ByteArrayBuilder } from "@api/apdu/utils/ByteArrayBuilder";
 export { ByteArrayParser } from "@api/apdu/utils/ByteArrayParser";
-export { InvalidStatusWordError } from "@api/command/Errors";
+export {
+  InvalidGetFirmwareMetadataResponseError,
+  InvalidStatusWordError,
+} from "@api/command/Errors";
 export {
   CommandResultFactory,
   CommandResultStatus,


### PR DESCRIPTION
### 📝 Description

Added InvalidGetFirmwareMetadataResponseError to map the _wrong experimental provider_ case in LL

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [LIVE-22278](https://ledgerhq.atlassian.net/browse/LIVE-22278)

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[LIVE-22278]: https://ledgerhq.atlassian.net/browse/LIVE-22278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ