### PR TITLE
:sparkles: (rn-ble) [DSDK-946]: Use BLE advertised name as connected device name

### DIFF
--- a/.changeset/large-bears-remain.md
+++ b/.changeset/large-bears-remain.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": minor
+---
+
+Use BLE advertised name as connected device name

--- a/.changeset/plenty-signs-call.md
+++ b/.changeset/plenty-signs-call.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-transport-kit-react-native-ble": minor
+---
+
+Use BLE advertised name as connected device name

--- a/.changeset/sour-bags-know.md
+++ b/.changeset/sour-bags-know.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-transport-kit-web-ble": minor
+---
+
+Use BLE advertised name as connected device name

--- a/packages/device-management-kit/src/api/transport/model/ConnectedDevice.ts
+++ b/packages/device-management-kit/src/api/transport/model/ConnectedDevice.ts
@@ -19,16 +19,17 @@ export class ConnectedDevice {
   constructor({
     transportConnectedDevice: {
       id,
-      deviceModel: { id: deviceModelId, productName: deviceName },
+      deviceModel: { id: deviceModelId, productName },
       type,
       transport,
+      name,
     },
     sessionId,
   }: ConnectedDeviceConstructorArgs) {
     this.id = id;
     this.sessionId = sessionId;
     this.modelId = deviceModelId;
-    this.name = deviceName;
+    this.name = name ?? productName;
     this.type = type;
     this.transport = transport;
   }

--- a/packages/device-management-kit/src/api/transport/model/TransportConnectedDevice.ts
+++ b/packages/device-management-kit/src/api/transport/model/TransportConnectedDevice.ts
@@ -13,6 +13,7 @@ export type ConnectedDeviceConstructorArgs = {
   type: ConnectionType;
   transport: TransportIdentifier;
   sendApdu: SendApduFnType;
+  name?: string;
 };
 
 export class TransportConnectedDevice {
@@ -21,6 +22,7 @@ export class TransportConnectedDevice {
   public readonly sendApdu: SendApduFnType;
   public readonly type: ConnectionType;
   public readonly transport: TransportIdentifier;
+  public readonly name?: string;
 
   constructor({
     id,
@@ -28,11 +30,13 @@ export class TransportConnectedDevice {
     type,
     transport,
     sendApdu,
+    name,
   }: ConnectedDeviceConstructorArgs) {
     this.id = id;
     this.deviceModel = deviceModel;
     this.sendApdu = sendApdu;
     this.type = type;
     this.transport = transport;
+    this.name = name;
   }
 }

--- a/packages/transport/rn-ble/src/api/transport/RNBleTransport.test.ts
+++ b/packages/transport/rn-ble/src/api/transport/RNBleTransport.test.ts
@@ -1103,6 +1103,7 @@ describe("RNBleTransport", () => {
             transport: "RN_BLE",
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             sendApdu: expect.any(Function),
+            name: "name",
           }),
         ),
       );

--- a/packages/transport/rn-ble/src/api/transport/RNBleTransport.ts
+++ b/packages/transport/rn-ble/src/api/transport/RNBleTransport.ts
@@ -458,8 +458,11 @@ export class RNBleTransport implements Transport {
       this._logger.debug("[connect] Existing device connection found", {
         data: { deviceId: params.deviceId },
       });
+      const dependencies = existing.getDependencies();
       const deviceModel =
-        existing.getDependencies().internalDevice.bleDeviceInfos.deviceModel;
+        dependencies.internalDevice.bleDeviceInfos.deviceModel;
+      const deviceName =
+        dependencies.device.localName || dependencies.device.name || undefined;
       return Right(
         new TransportConnectedDevice({
           id: params.deviceId,
@@ -467,6 +470,7 @@ export class RNBleTransport implements Transport {
           type: "BLE",
           sendApdu: (...a) => existing.sendApdu(...a),
           transport: this.identifier,
+          name: deviceName,
         }),
       );
     }
@@ -601,6 +605,7 @@ export class RNBleTransport implements Transport {
           type: "BLE",
           sendApdu: (...args) => deviceConnectionStateMachine.sendApdu(...args),
           transport: this.identifier,
+          name: device.localName || device.name || undefined,
         });
       },
     ).run();

--- a/packages/transport/web-ble/src/api/transport/WebBleTransport.ts
+++ b/packages/transport/web-ble/src/api/transport/WebBleTransport.ts
@@ -99,6 +99,7 @@ export class WebBleTransport implements Transport {
           id: bluetoothDevice.id,
           deviceModel: ledgerServiceInfo.deviceModel,
           transport: webBleIdentifier,
+          name: bluetoothDevice.name || undefined,
         };
 
         this._deviceRegistryById.set(bluetoothDevice.id, {
@@ -234,6 +235,7 @@ export class WebBleTransport implements Transport {
           transport: webBleIdentifier,
           sendApdu: (...apduArgs) =>
             connectionStateMachine.sendApdu(...apduArgs),
+          name: bluetoothDevice.name || undefined,
         }),
       );
     } catch (e) {
@@ -581,6 +583,7 @@ export class WebBleTransport implements Transport {
           id: deviceId,
           deviceModel: registryEntry.ledgerServiceInfo.deviceModel,
           transport: webBleIdentifier,
+          name: registryEntry.device.name || undefined,
         });
       }
     }


### PR DESCRIPTION
### 📝 Description

Currently, the connected device name is just a generic product name such as "Ledger Stax".
For BLE transports, we can use the advertised name instead

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**:

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
