### PR TITLE
🐛 (rn-ble) [NO-ISSUE]: Fix BLE scan first emission delay

### DIFF
--- a/.changeset/wild-ends-smoke.md
+++ b/.changeset/wild-ends-smoke.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-transport-kit-react-native-ble": patch
+---
+
+Fix BLE scan delay: first scanned devices now appear immediately instead of being delayed by ~1s due to the throttle window being consumed by an initial empty emission

--- a/packages/transport/rn-ble/src/api/transport/RNBleTransport.ts
+++ b/packages/transport/rn-ble/src/api/transport/RNBleTransport.ts
@@ -35,6 +35,7 @@ import {
   first,
   from,
   type Observable,
+  ReplaySubject,
   retry,
   type Subscription,
   switchMap,
@@ -221,7 +222,7 @@ export class RNBleTransport implements Transport {
     this._startedScanningSubscriber = from([true])
       .pipe(
         switchMap(() => {
-          const subject = new BehaviorSubject<InternalScannedDevice[]>([]);
+          const subject = new ReplaySubject<InternalScannedDevice[]>(1);
           const devicesById = new Map<string, InternalScannedDevice>();
 
           this._logger.info("[startScanning] startDeviceScan");


### PR DESCRIPTION
### 📝 Description

Fixes a ~1 second delay before the first scanned BLE device appears in `listenToAvailableDevices()`.

**Root cause:** In `_startScanning()`, the inner subject was a `BehaviorSubject([])` which immediately emitted an empty `[]`. This consumed the leading edge of `throttleTime(1000)`, opening a 1s window that dropped the first real scan results. The first scanned device only appeared after the throttle window expired (~1s).

**Fix:** Replaced `BehaviorSubject<InternalScannedDevice[]>([])` with `ReplaySubject<InternalScannedDevice[]>(1)` for the inner scan subject.
- `ReplaySubject(1)` buffers the last value like `BehaviorSubject` (needed because the scan callback fires synchronously before `switchMap` subscribes to the returned observable) but has **no initial emission**, so the first real scan result passes through `throttleTime` immediately as the leading edge.
- Connected devices continue to be fetched immediately (from the outer `BehaviorSubject`'s initial emission) and polled every ~1s via the existing `setInterval`.

### ❓ Context

- **JIRA or GitHub link**: NO-ISSUE

### ✅ Checklist

- [x] **Covered by automatic tests** — 3 new tests added covering: (1) first scanned device appears immediately, (2) connected devices appear immediately with no scanned devices, (3) connected devices polling continues via interval
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - First scanned BLE device now appears immediately instead of being delayed by ~1s
  - Connected device polling behavior unchanged
  - No breaking changes to the public API

Made with [Cursor](https://cursor.com)