### PR TITLE
♻️ (chore) [NO-ISSUE]: Replace axios with native fetch API

### DIFF
--- a/.changeset/bold-tigers-run.md
+++ b/.changeset/bold-tigers-run.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/cal-interceptor": patch
+---
+
+Replace axios request/response interceptors with a native fetch interceptor

--- a/.changeset/brave-otters-jump.md
+++ b/.changeset/brave-otters-jump.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/context-module": patch
+---
+
+Replace axios with DmkNetworkClient across all HTTP data sources

--- a/.changeset/calm-lions-sing.md
+++ b/.changeset/calm-lions-sing.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-transport-kit-speculos": patch
+---
+
+Replace axios with DmkNetworkClient in the Speculos HTTP data source

--- a/.changeset/pretty-owls-drive.md
+++ b/.changeset/pretty-owls-drive.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/context-module": patch
+"@ledgerhq/device-management-kit": patch
+"@ledgerhq/device-transport-kit-speculos": patch
+"@ledgerhq/speculos-device-controller": patch
+"@ledgerhq/cal-interceptor": patch
+---
+
+Replace axios HTTP client with native fetch API across all packages

--- a/.changeset/pretty-owls-drive.md
+++ b/.changeset/pretty-owls-drive.md
@@ -1,9 +1,0 @@
----
-"@ledgerhq/context-module": patch
-"@ledgerhq/device-management-kit": patch
-"@ledgerhq/device-transport-kit-speculos": patch
-"@ledgerhq/speculos-device-controller": patch
-"@ledgerhq/cal-interceptor": patch
----
-
-Replace axios HTTP client with native fetch API across all packages

--- a/.changeset/quiet-pandas-dream.md
+++ b/.changeset/quiet-pandas-dream.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/speculos-device-controller": patch
+---
+
+Replace axios with DmkNetworkClient in the controller HTTP client

--- a/.changeset/swift-foxes-cheer.md
+++ b/.changeset/swift-foxes-cheer.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": minor
+---
+
+Add DmkNetworkClient HTTP client abstraction and migrate manager API data source to use it

--- a/apps/clear-signing-tester/package.json
+++ b/apps/clear-signing-tester/package.json
@@ -46,7 +46,6 @@
     "@ledgerhq/solana-tools": "workspace:^",
     "@ledgerhq/device-transport-kit-speculos": "workspace:^",
     "@ledgerhq/speculos-device-controller": "workspace:^",
-    "axios": "catalog:",
     "commander": "catalog:",
     "ethers": "catalog:",
     "inversify": "catalog:",

--- a/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpCalAdapter.ts
+++ b/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpCalAdapter.ts
@@ -1,5 +1,4 @@
 import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
-import axios, { AxiosError } from "axios";
 import { inject, injectable } from "inversify";
 
 import { TYPES } from "@root/src/di/types";
@@ -47,29 +46,33 @@ export class HttpCalAdapter implements CalAdapter {
     );
 
     try {
-      const response = await axios.request<CalldataDto[]>({
+      const url = new URL(`${CAL_BASE_URL}/dapps`);
+      url.searchParams.set("output", "descriptors_calldata");
+      url.searchParams.set("chain_id", String(chainId));
+      url.searchParams.set("contracts", contractAddress);
+      url.searchParams.set("ref", "branch:next");
+
+      const fetchResponse = await fetch(url, {
         method: "GET",
-        url: `${CAL_BASE_URL}/dapps`,
-        params: {
-          output: "descriptors_calldata",
-          chain_id: chainId,
-          contracts: contractAddress,
-          ref: "branch:next",
-        },
         headers: {
           "X-Ledger-Client-Origin": this.signerConfig.originToken,
         },
       });
 
+      if (!fetchResponse.ok)
+        throw new Error(`HTTP error ${fetchResponse.status}`);
+
+      const data = (await fetchResponse.json()) as CalldataDto[];
+
       const selectors = this.extractSelectorsFromResponse(
-        response.data,
+        data,
         contractAddress,
       );
 
       return selectors;
     } catch (error) {
-      if (error instanceof AxiosError) {
-        const errorMessage = `${error.status || "Unknown status"}: Failed to fetch selectors from ${CAL_BASE_URL}/dapps for contract ${contractAddress} on chain ${chainId}`;
+      if (error instanceof Error) {
+        const errorMessage = `Failed to fetch selectors from ${CAL_BASE_URL}/dapps for contract ${contractAddress} on chain ${chainId}: ${error.message}`;
         this.logger.error(errorMessage, {
           data: { error: error.message },
         });

--- a/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpCalAdapter.ts
+++ b/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpCalAdapter.ts
@@ -1,4 +1,7 @@
-import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
+import {
+  DmkNetworkClient,
+  LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 
 import { TYPES } from "@root/src/di/types";
@@ -27,6 +30,7 @@ type CalldataDto = {
 @injectable()
 export class HttpCalAdapter implements CalAdapter {
   private readonly logger: LoggerPublisherService;
+  private readonly http: DmkNetworkClient;
 
   constructor(
     @inject(TYPES.SignerConfig)
@@ -35,6 +39,11 @@ export class HttpCalAdapter implements CalAdapter {
     private readonly loggerFactory: (tag: string) => LoggerPublisherService,
   ) {
     this.logger = this.loggerFactory("cal-service");
+    this.http = new DmkNetworkClient({
+      headers: {
+        "X-Ledger-Client-Origin": this.signerConfig.originToken,
+      },
+    });
   }
 
   async fetchSelectors(
@@ -46,23 +55,14 @@ export class HttpCalAdapter implements CalAdapter {
     );
 
     try {
-      const url = new URL(`${CAL_BASE_URL}/dapps`);
-      url.searchParams.set("output", "descriptors_calldata");
-      url.searchParams.set("chain_id", String(chainId));
-      url.searchParams.set("contracts", contractAddress);
-      url.searchParams.set("ref", "branch:next");
-
-      const fetchResponse = await fetch(url, {
-        method: "GET",
-        headers: {
-          "X-Ledger-Client-Origin": this.signerConfig.originToken,
+      const data = (await this.http.get(`${CAL_BASE_URL}/dapps`, {
+        params: {
+          output: "descriptors_calldata",
+          chain_id: chainId,
+          contracts: contractAddress,
+          ref: "branch:next",
         },
-      });
-
-      if (!fetchResponse.ok)
-        throw new Error(`HTTP error ${fetchResponse.status}`);
-
-      const data = (await fetchResponse.json()) as CalldataDto[];
+      })) as CalldataDto[];
 
       const selectors = this.extractSelectorsFromResponse(
         data,

--- a/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpEtherscanAdapter.ts
+++ b/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpEtherscanAdapter.ts
@@ -1,5 +1,4 @@
 import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
-import axios, { AxiosError } from "axios";
 import { inject, injectable } from "inversify";
 
 import { TYPES } from "@root/src/di/types";
@@ -160,8 +159,8 @@ export class HttpEtherscanAdapter implements EtherscanAdapter {
 
       return selectedTransactions;
     } catch (error) {
-      if (error instanceof AxiosError) {
-        const errorMessage = `${error.status || "Unknown status"}: Failed to fetch transactions from Etherscan`;
+      if (error instanceof Error) {
+        const errorMessage = `Failed to fetch transactions from Etherscan: ${error.message}`;
         this.logger.error(errorMessage, {
           data: { error: error.message },
         });
@@ -199,45 +198,53 @@ export class HttpEtherscanAdapter implements EtherscanAdapter {
       data: { params },
     });
 
-    const response = await axios.get<EtherscanApiResponse>(baseUrl, {
-      params,
-      timeout: this.etherscanConfig.timeout || 30000,
+    const url = new URL(baseUrl);
+    Object.entries(params).forEach(([key, value]) => {
+      url.searchParams.set(key, String(value));
     });
+    const controller = new AbortController();
+    const timeoutMs = this.etherscanConfig.timeout || 30000;
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const fetchResponse = await fetch(url, { signal: controller.signal });
+      if (!fetchResponse.ok)
+        throw new Error(`HTTP error ${fetchResponse.status}`);
+      const data = (await fetchResponse.json()) as EtherscanApiResponse;
 
-    this.logger.debug("Etherscan API response", {
-      data: {
-        status: response.data.status,
-        message: response.data.message,
-        result: JSON.stringify(response.data.result),
-        resultCount: Array.isArray(response.data.result)
-          ? response.data.result.length
-          : 0,
-      },
-    });
+      this.logger.debug("Etherscan API response", {
+        data: {
+          status: data.status,
+          message: data.message,
+          result: JSON.stringify(data.result),
+          resultCount: Array.isArray(data.result) ? data.result.length : 0,
+        },
+      });
 
-    if (response.data.status !== "1") {
-      // Status "0" with "No transactions found" or "NOTOK" is not an error, just means no data
-      if (
-        response.data.status === "0" &&
-        (response.data.message === "No transactions found" ||
-          response.data.message === "NOTOK")
-      ) {
-        this.logger.info(
-          `No transactions found for address: ${response.data.message}`,
+      if (data.status !== "1") {
+        if (
+          data.status === "0" &&
+          (data.message === "No transactions found" ||
+            data.message === "NOTOK")
+        ) {
+          this.logger.info(
+            `No transactions found for address: ${data.message}`,
+          );
+          return [];
+        }
+        throw new Error(
+          `Etherscan API error: ${data.message || "Unknown error"}`,
         );
+      }
+
+      if (!Array.isArray(data.result)) {
+        this.logger.warn("No transactions found");
         return [];
       }
-      throw new Error(
-        `Etherscan API error: ${response.data.message || "Unknown error"}`,
-      );
-    }
 
-    if (!Array.isArray(response.data.result)) {
-      this.logger.warn("No transactions found");
-      return [];
+      return data.result;
+    } finally {
+      clearTimeout(timeoutId);
     }
-
-    return response.data.result;
   }
 
   /**

--- a/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpEtherscanAdapter.ts
+++ b/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpEtherscanAdapter.ts
@@ -223,8 +223,7 @@ export class HttpEtherscanAdapter implements EtherscanAdapter {
       if (data.status !== "1") {
         if (
           data.status === "0" &&
-          (data.message === "No transactions found" ||
-            data.message === "NOTOK")
+          (data.message === "No transactions found" || data.message === "NOTOK")
         ) {
           this.logger.info(
             `No transactions found for address: ${data.message}`,

--- a/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpEtherscanAdapter.ts
+++ b/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpEtherscanAdapter.ts
@@ -1,4 +1,7 @@
-import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
+import {
+  DmkNetworkClient,
+  LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 
 import { TYPES } from "@root/src/di/types";
@@ -51,6 +54,7 @@ type EtherscanApiResponse = {
 @injectable()
 export class HttpEtherscanAdapter implements EtherscanAdapter {
   private readonly logger: LoggerPublisherService;
+  private readonly http: DmkNetworkClient;
 
   constructor(
     @inject(TYPES.EtherscanConfig)
@@ -59,6 +63,7 @@ export class HttpEtherscanAdapter implements EtherscanAdapter {
     private readonly loggerFactory: (tag: string) => LoggerPublisherService,
   ) {
     this.logger = this.loggerFactory("etherscan-service");
+    this.http = new DmkNetworkClient();
   }
 
   async fetchRandomTransaction(
@@ -198,52 +203,39 @@ export class HttpEtherscanAdapter implements EtherscanAdapter {
       data: { params },
     });
 
-    const url = new URL(baseUrl);
-    Object.entries(params).forEach(([key, value]) => {
-      url.searchParams.set(key, String(value));
+    const data = (await this.http.get(baseUrl, {
+      params,
+      timeoutMs: this.etherscanConfig.timeout || 30000,
+    })) as EtherscanApiResponse;
+
+    this.logger.debug("Etherscan API response", {
+      data: {
+        status: data.status,
+        message: data.message,
+        result: JSON.stringify(data.result),
+        resultCount: Array.isArray(data.result) ? data.result.length : 0,
+      },
     });
-    const controller = new AbortController();
-    const timeoutMs = this.etherscanConfig.timeout || 30000;
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-    try {
-      const fetchResponse = await fetch(url, { signal: controller.signal });
-      if (!fetchResponse.ok)
-        throw new Error(`HTTP error ${fetchResponse.status}`);
-      const data = (await fetchResponse.json()) as EtherscanApiResponse;
 
-      this.logger.debug("Etherscan API response", {
-        data: {
-          status: data.status,
-          message: data.message,
-          result: JSON.stringify(data.result),
-          resultCount: Array.isArray(data.result) ? data.result.length : 0,
-        },
-      });
-
-      if (data.status !== "1") {
-        if (
-          data.status === "0" &&
-          (data.message === "No transactions found" || data.message === "NOTOK")
-        ) {
-          this.logger.info(
-            `No transactions found for address: ${data.message}`,
-          );
-          return [];
-        }
-        throw new Error(
-          `Etherscan API error: ${data.message || "Unknown error"}`,
-        );
-      }
-
-      if (!Array.isArray(data.result)) {
-        this.logger.warn("No transactions found");
+    if (data.status !== "1") {
+      if (
+        data.status === "0" &&
+        (data.message === "No transactions found" || data.message === "NOTOK")
+      ) {
+        this.logger.info(`No transactions found for address: ${data.message}`);
         return [];
       }
-
-      return data.result;
-    } finally {
-      clearTimeout(timeoutId);
+      throw new Error(
+        `Etherscan API error: ${data.message || "Unknown error"}`,
+      );
     }
+
+    if (!Array.isArray(data.result)) {
+      this.logger.warn("No transactions found");
+      return [];
+    }
+
+    return data.result;
   }
 
   /**

--- a/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpSolanaRpcAdapter.ts
+++ b/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpSolanaRpcAdapter.ts
@@ -1,5 +1,4 @@
 import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
-import axios from "axios";
 import { inject, injectable } from "inversify";
 
 import { TYPES } from "@root/src/di/types";
@@ -546,9 +545,9 @@ export class HttpSolanaRpcAdapter implements SolanaRpcAdapter {
     if (!sourceTokenAccount) return true;
 
     try {
-      const response = await axios.head(
+      const response = await fetch(
         `${METADATA_SERVICE_URL}/v2/solana/owner/${sourceTokenAccount}`,
-        { timeout: 5000, validateStatus: () => true },
+        { method: "HEAD", signal: AbortSignal.timeout(5000) },
       );
       if (response.status === 200) return false;
       this.logger.debug(
@@ -1043,24 +1042,31 @@ export class HttpSolanaRpcAdapter implements SolanaRpcAdapter {
   }
 
   private async rpcCall<T>(method: string, params: unknown[]): Promise<T> {
-    const response = await axios.post<RpcResponse<T>>(
-      this.rpcConfig.url,
-      {
+    const response = await fetch(this.rpcConfig.url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
         jsonrpc: "2.0",
         id: 1,
         method,
         params,
-      },
-      { timeout: this.rpcConfig.timeout ?? 30000 },
-    );
+      }),
+      signal: AbortSignal.timeout(this.rpcConfig.timeout ?? 30000),
+    });
 
-    if (response.data.error) {
+    if (!response.ok) {
+      throw new Error(`Solana RPC HTTP error: ${response.status}`);
+    }
+
+    const data = (await response.json()) as RpcResponse<T>;
+
+    if (data.error) {
       throw new Error(
-        `Solana RPC error: ${response.data.error.message} (code ${response.data.error.code})`,
+        `Solana RPC error: ${data.error.message} (code ${data.error.code})`,
       );
     }
 
-    return response.data.result;
+    return data.result;
   }
 
   // --- Encoding helpers ---

--- a/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpSolanaRpcAdapter.ts
+++ b/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpSolanaRpcAdapter.ts
@@ -1,4 +1,7 @@
-import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
+import {
+  DmkNetworkClient,
+  LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 
 import { TYPES } from "@root/src/di/types";
@@ -238,6 +241,8 @@ type RpcTransactionResult = {
 @injectable()
 export class HttpSolanaRpcAdapter implements SolanaRpcAdapter {
   private readonly logger: LoggerPublisherService;
+  private readonly http: DmkNetworkClient;
+  private readonly metadataHttp: DmkNetworkClient;
 
   constructor(
     @inject(TYPES.SolanaRpcConfig)
@@ -246,6 +251,8 @@ export class HttpSolanaRpcAdapter implements SolanaRpcAdapter {
     loggerFactory: (tag: string) => LoggerPublisherService,
   ) {
     this.logger = loggerFactory("solana-rpc-adapter");
+    this.http = new DmkNetworkClient();
+    this.metadataHttp = new DmkNetworkClient({ timeoutMs: 5000 });
   }
 
   async fetchClearSignableTransactions(
@@ -545,18 +552,13 @@ export class HttpSolanaRpcAdapter implements SolanaRpcAdapter {
     if (!sourceTokenAccount) return true;
 
     try {
-      const response = await fetch(
+      await this.metadataHttp.head(
         `${METADATA_SERVICE_URL}/v2/solana/owner/${sourceTokenAccount}`,
-        { method: "HEAD", signal: AbortSignal.timeout(5000) },
       );
-      if (response.status === 200) return false;
-      this.logger.debug(
-        `Skipping tx ${signature.slice(0, 12)}: token account ${sourceTokenAccount.slice(0, 12)}... not in metadata service (${response.status})`,
-      );
-      return true;
+      return false;
     } catch {
       this.logger.debug(
-        `Skipping tx ${signature.slice(0, 12)}: metadata service probe failed`,
+        `Skipping tx ${signature.slice(0, 12)}: token account ${sourceTokenAccount.slice(0, 12)}... not in metadata service`,
       );
       return true;
     }
@@ -1042,23 +1044,16 @@ export class HttpSolanaRpcAdapter implements SolanaRpcAdapter {
   }
 
   private async rpcCall<T>(method: string, params: unknown[]): Promise<T> {
-    const response = await fetch(this.rpcConfig.url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
+    const data = (await this.http.post(
+      this.rpcConfig.url,
+      {
         jsonrpc: "2.0",
         id: 1,
         method,
         params,
-      }),
-      signal: AbortSignal.timeout(this.rpcConfig.timeout ?? 30000),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Solana RPC HTTP error: ${response.status}`);
-    }
-
-    const data = (await response.json()) as RpcResponse<T>;
+      },
+      { timeoutMs: this.rpcConfig.timeout ?? 30000 },
+    )) as RpcResponse<T>;
 
     if (data.error) {
       throw new Error(

--- a/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpSolanaRpcAdapter.ts
+++ b/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpSolanaRpcAdapter.ts
@@ -240,9 +240,10 @@ type RpcTransactionResult = {
 
 @injectable()
 export class HttpSolanaRpcAdapter implements SolanaRpcAdapter {
+  private static readonly METADATA_TIMEOUT_MS = 5000;
+
   private readonly logger: LoggerPublisherService;
   private readonly http: DmkNetworkClient;
-  private readonly metadataHttp: DmkNetworkClient;
 
   constructor(
     @inject(TYPES.SolanaRpcConfig)
@@ -252,7 +253,6 @@ export class HttpSolanaRpcAdapter implements SolanaRpcAdapter {
   ) {
     this.logger = loggerFactory("solana-rpc-adapter");
     this.http = new DmkNetworkClient();
-    this.metadataHttp = new DmkNetworkClient({ timeoutMs: 5000 });
   }
 
   async fetchClearSignableTransactions(
@@ -552,8 +552,9 @@ export class HttpSolanaRpcAdapter implements SolanaRpcAdapter {
     if (!sourceTokenAccount) return true;
 
     try {
-      await this.metadataHttp.head(
+      await this.http.head(
         `${METADATA_SERVICE_URL}/v2/solana/owner/${sourceTokenAccount}`,
+        { timeoutMs: HttpSolanaRpcAdapter.METADATA_TIMEOUT_MS },
       );
       return false;
     } catch {

--- a/apps/clear-signing-tester/src/infrastructure/adapters/speculos/SpeculosScreenReader.ts
+++ b/apps/clear-signing-tester/src/infrastructure/adapters/speculos/SpeculosScreenReader.ts
@@ -1,5 +1,4 @@
 import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
-import axios from "axios";
 import { inject, injectable } from "inversify";
 
 import { TYPES } from "@root/src/di/types";
@@ -32,11 +31,13 @@ export class SpeculosScreenReader implements ScreenReader {
    */
   async readRawScreenEvents(): Promise<ScreenEvent[]> {
     try {
-      const response = await axios.get<{ events: ScreenEvent[] }>(
+      const response = await fetch(
         `${this.speculosUrl}/events?stream=false&currentscreenonly=true`,
       );
+      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+      const data = (await response.json()) as { events: ScreenEvent[] };
 
-      const rawEvents = response.data.events || [];
+      const rawEvents = data.events || [];
 
       // Convert raw API events to domain events
       const screenEvents: ScreenEvent[] = rawEvents.map((event) => ({

--- a/apps/clear-signing-tester/src/infrastructure/adapters/speculos/SpeculosScreenReader.ts
+++ b/apps/clear-signing-tester/src/infrastructure/adapters/speculos/SpeculosScreenReader.ts
@@ -1,4 +1,7 @@
-import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
+import {
+  DmkNetworkClient,
+  LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 
 import { TYPES } from "@root/src/di/types";
@@ -15,6 +18,7 @@ import { type ScreenEvent } from "@root/src/domain/models/ScreenContent";
 export class SpeculosScreenReader implements ScreenReader {
   private readonly speculosUrl: string;
   private readonly logger: LoggerPublisherService;
+  private readonly http: DmkNetworkClient;
 
   constructor(
     @inject(TYPES.SpeculosConfig) config: SpeculosConfig,
@@ -23,6 +27,7 @@ export class SpeculosScreenReader implements ScreenReader {
   ) {
     this.speculosUrl = `${config.url}:${config.port}`;
     this.logger = loggerFactory("screen-reader");
+    this.http = new DmkNetworkClient();
   }
 
   /**
@@ -31,11 +36,9 @@ export class SpeculosScreenReader implements ScreenReader {
    */
   async readRawScreenEvents(): Promise<ScreenEvent[]> {
     try {
-      const response = await fetch(
-        `${this.speculosUrl}/events?stream=false&currentscreenonly=true`,
-      );
-      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
-      const data = (await response.json()) as { events: ScreenEvent[] };
+      const data = (await this.http.get(`${this.speculosUrl}/events`, {
+        params: { stream: false, currentscreenonly: true },
+      })) as { events: ScreenEvent[] };
 
       const rawEvents = data.events || [];
 

--- a/apps/clear-signing-tester/src/infrastructure/adapters/speculos/SpeculosScreenshotSaver.ts
+++ b/apps/clear-signing-tester/src/infrastructure/adapters/speculos/SpeculosScreenshotSaver.ts
@@ -1,5 +1,4 @@
 import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
-import axios from "axios";
 import * as fs from "fs";
 import { inject, injectable } from "inversify";
 import * as path from "path";
@@ -44,12 +43,13 @@ export class SpeculosScreenshotSaver implements ScreenshotSaver {
       const filename = `screenshot_${this.counter}.png`;
       const filePath = path.join(this.screenshotPath, filename);
 
-      const response = await axios.get(`${this.speculosUrl}/screenshot`, {
+      const response = await fetch(`${this.speculosUrl}/screenshot`, {
         headers: { accept: "image/png" },
-        responseType: "arraybuffer",
       });
+      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+      const buffer = Buffer.from(await response.arrayBuffer());
 
-      fs.writeFileSync(filePath, response.data);
+      fs.writeFileSync(filePath, buffer);
       this.logger.info(`Saved screenshot: ${filePath}`);
 
       return filePath;

--- a/apps/clear-signing-tester/src/infrastructure/adapters/speculos/SpeculosScreenshotSaver.ts
+++ b/apps/clear-signing-tester/src/infrastructure/adapters/speculos/SpeculosScreenshotSaver.ts
@@ -1,4 +1,7 @@
-import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
+import {
+  DmkNetworkClient,
+  LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
 import * as fs from "fs";
 import { inject, injectable } from "inversify";
 import * as path from "path";
@@ -12,6 +15,7 @@ export class SpeculosScreenshotSaver implements ScreenshotSaver {
   private readonly speculosUrl: string;
   private readonly logger: LoggerPublisherService;
   private readonly screenshotPath: string | null;
+  private readonly http: DmkNetworkClient;
   private counter = 0;
 
   constructor(
@@ -22,6 +26,7 @@ export class SpeculosScreenshotSaver implements ScreenshotSaver {
     this.speculosUrl = `${config.url}:${config.port}`;
     this.screenshotPath = config.screenshotPath ?? null;
     this.logger = loggerFactory("screenshot-saver");
+    this.http = new DmkNetworkClient();
 
     if (config.screenshotPath && !fs.existsSync(config.screenshotPath)) {
       throw new Error(
@@ -43,11 +48,14 @@ export class SpeculosScreenshotSaver implements ScreenshotSaver {
       const filename = `screenshot_${this.counter}.png`;
       const filePath = path.join(this.screenshotPath, filename);
 
-      const response = await fetch(`${this.speculosUrl}/screenshot`, {
-        headers: { accept: "image/png" },
-      });
-      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
-      const buffer = Buffer.from(await response.arrayBuffer());
+      const arrayBuffer = (await this.http.get(
+        `${this.speculosUrl}/screenshot`,
+        {
+          headers: { accept: "image/png" },
+          responseType: "arrayBuffer",
+        },
+      )) as ArrayBuffer;
+      const buffer = Buffer.from(arrayBuffer);
 
       fs.writeFileSync(filePath, buffer);
       this.logger.info(`Saved screenshot: ${filePath}`);

--- a/packages/device-management-kit/package.json
+++ b/packages/device-management-kit/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "@noble/hashes": "^1.8.0",
     "@sentry/minimal": "catalog:",
-    "axios": "catalog:",
     "inversify": "catalog:",
     "isomorphic-ws": "catalog:",
     "purify-ts": "catalog:",

--- a/packages/device-management-kit/src/api/command/use-case/SendCommandUseCase.test.ts
+++ b/packages/device-management-kit/src/api/command/use-case/SendCommandUseCase.test.ts
@@ -9,7 +9,7 @@ import { deviceSessionStubBuilder } from "@internal/device-session/model/DeviceS
 import { DefaultDeviceSessionService } from "@internal/device-session/service/DefaultDeviceSessionService";
 import { type DeviceSessionService } from "@internal/device-session/service/DeviceSessionService";
 import { DefaultLoggerPublisherService } from "@internal/logger-publisher/service/DefaultLoggerPublisherService";
-import { AxiosManagerApiDataSource } from "@internal/manager-api/data/AxiosManagerApiDataSource";
+import { HttpManagerApiDataSource } from "@internal/manager-api/data/HttpManagerApiDataSource";
 import { type ManagerApiDataSource } from "@internal/manager-api/data/ManagerApiDataSource";
 import { DefaultManagerApiService } from "@internal/manager-api/service/DefaultManagerApiService";
 import { type ManagerApiService } from "@internal/manager-api/service/ManagerApiService";
@@ -37,7 +37,7 @@ describe("SendCommandUseCase", () => {
   beforeEach(() => {
     logger = new DefaultLoggerPublisherService([], "send-command-use-case");
     sessionService = new DefaultDeviceSessionService(() => logger);
-    managerApiDataSource = new AxiosManagerApiDataSource({} as DmkConfig);
+    managerApiDataSource = new HttpManagerApiDataSource({} as DmkConfig);
     managerApi = new DefaultManagerApiService(managerApiDataSource);
     secureChannelDataSource = new DefaultSecureChannelDataSource(
       {} as DmkConfig,

--- a/packages/device-management-kit/src/api/device-session/use-case/DisableDeviceSessionRefresher.test.ts
+++ b/packages/device-management-kit/src/api/device-session/use-case/DisableDeviceSessionRefresher.test.ts
@@ -7,7 +7,7 @@ import { DeviceSessionNotFound } from "@internal/device-session/model/Errors";
 import { DefaultDeviceSessionService } from "@internal/device-session/service/DefaultDeviceSessionService";
 import { type DeviceSessionService } from "@internal/device-session/service/DeviceSessionService";
 import { DefaultLoggerPublisherService } from "@internal/logger-publisher/service/DefaultLoggerPublisherService";
-import { AxiosManagerApiDataSource } from "@internal/manager-api/data/AxiosManagerApiDataSource";
+import { HttpManagerApiDataSource } from "@internal/manager-api/data/HttpManagerApiDataSource";
 import { DefaultManagerApiService } from "@internal/manager-api/service/DefaultManagerApiService";
 import { type ManagerApiService } from "@internal/manager-api/service/ManagerApiService";
 import { DefaultSecureChannelDataSource } from "@internal/secure-channel/data/DefaultSecureChannelDataSource";
@@ -34,7 +34,7 @@ describe("DisableDeviceSessionRefresherUseCase", () => {
     );
     sessionService = new DefaultDeviceSessionService(() => logger);
     managerApi = new DefaultManagerApiService(
-      new AxiosManagerApiDataSource({} as DmkConfig),
+      new HttpManagerApiDataSource({} as DmkConfig),
     );
     secureChannel = new DefaultSecureChannelService(
       new DefaultSecureChannelDataSource({} as DmkConfig),

--- a/packages/device-management-kit/src/api/index.ts
+++ b/packages/device-management-kit/src/api/index.ts
@@ -162,6 +162,16 @@ export { ConsoleLogger } from "@api/logger-subscriber/service/ConsoleLogger";
 export { DefaultLogTagFormatter } from "@api/logger-subscriber/service/DefaultLogTagFormatter";
 export { type LogTagFormatter } from "@api/logger-subscriber/service/LogTagFormatter";
 export { WebLogsExporterLogger } from "@api/logger-subscriber/service/WebLogsExporterLogger";
+export {
+  DmkNetworkClient,
+  type DmkNetworkClientOptions,
+  type DmkNetworkResponse,
+  type DmkQueryParams,
+  type DmkQueryParamValue,
+  type DmkRequestConfig,
+  type DmkResponseType,
+} from "@api/network/DmkNetworkClient";
+export { DmkNetworkClientError } from "@api/network/DmkNetworkClientError";
 export { ConnectedDevice } from "@api/transport/model/ConnectedDevice";
 export {
   DeviceConnectionStateMachine,

--- a/packages/device-management-kit/src/api/network/DmkNetworkClient.test.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClient.test.ts
@@ -264,12 +264,9 @@ describe("DmkNetworkClient", () => {
   describe("timeout", () => {
     it("should pass an AbortSignal when timeoutMs is configured", async () => {
       const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
-      const client = new DmkNetworkClient({
-        fetch: fetchMock,
-        timeoutMs: 1000,
-      });
+      const client = new DmkNetworkClient({ fetch: fetchMock });
 
-      await client.get("https://api.example.com/items");
+      await client.get("https://api.example.com/items", { timeoutMs: 1000 });
 
       const init = fetchMock.mock.calls[0]![1] as RequestInit;
       expect(init.signal).toBeInstanceOf(AbortSignal);
@@ -289,13 +286,10 @@ describe("DmkNetworkClient", () => {
       const timeoutError = new Error("The operation was aborted");
       timeoutError.name = "TimeoutError";
       const fetchMock = vi.fn().mockRejectedValue(timeoutError);
-      const client = new DmkNetworkClient({
-        fetch: fetchMock,
-        timeoutMs: 10,
-      });
+      const client = new DmkNetworkClient({ fetch: fetchMock });
 
       const error = await client
-        .get("https://api.example.com/items")
+        .get("https://api.example.com/items", { timeoutMs: 10 })
         .catch((e: unknown) => e);
 
       expect(error).toBeInstanceOf(DmkNetworkClientError);

--- a/packages/device-management-kit/src/api/network/DmkNetworkClient.test.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClient.test.ts
@@ -1,0 +1,349 @@
+import { DmkNetworkClient } from "./DmkNetworkClient";
+import { DmkNetworkClientError } from "./DmkNetworkClientError";
+
+describe("DmkNetworkClient", () => {
+  const jsonResponse = (body: unknown, init: ResponseInit = {}) =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      ...init,
+    });
+
+  describe("URL composition", () => {
+    it("should send requests to an absolute URL as-is", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      await client.get("https://api.example.com/items");
+
+      const [calledUrl] = fetchMock.mock.calls[0]!;
+      expect(calledUrl).toBeInstanceOf(URL);
+      expect((calledUrl as URL).toString()).toBe(
+        "https://api.example.com/items",
+      );
+    });
+
+    it("should prepend baseUrl to relative paths with slash normalization", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockImplementation(() => Promise.resolve(jsonResponse({ ok: true })));
+      const client = new DmkNetworkClient({
+        baseUrl: "https://api.example.com/",
+        fetch: fetchMock,
+      });
+
+      await client.get("/items");
+      await client.get("items");
+
+      expect((fetchMock.mock.calls[0]![0] as URL).toString()).toBe(
+        "https://api.example.com/items",
+      );
+      expect((fetchMock.mock.calls[1]![0] as URL).toString()).toBe(
+        "https://api.example.com/items",
+      );
+    });
+
+    it("should set URL search params from the config", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      await client.get("https://api.example.com/items", {
+        params: {
+          chain: 1,
+          contract: "0xabc",
+          active: true,
+          skip: null,
+          alsoSkip: undefined,
+        },
+      });
+
+      const url = fetchMock.mock.calls[0]![0] as URL;
+      expect(url.searchParams.get("chain")).toBe("1");
+      expect(url.searchParams.get("contract")).toBe("0xabc");
+      expect(url.searchParams.get("active")).toBe("true");
+      expect(url.searchParams.has("skip")).toBe(false);
+      expect(url.searchParams.has("alsoSkip")).toBe(false);
+    });
+  });
+
+  describe("headers", () => {
+    it("should merge default and per-request headers", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+      const client = new DmkNetworkClient({
+        fetch: fetchMock,
+        headers: { "X-Default": "default", "X-Shared": "from-default" },
+      });
+
+      await client.get("https://api.example.com/items", {
+        headers: { "X-Shared": "overridden", "X-Per-Request": "per" },
+      });
+
+      const init = fetchMock.mock.calls[0]![1] as RequestInit;
+      expect(init.headers).toMatchObject({
+        "X-Default": "default",
+        "X-Shared": "overridden",
+        "X-Per-Request": "per",
+      });
+    });
+  });
+
+  describe("body handling", () => {
+    it("should JSON-stringify plain-object bodies and set Content-Type", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      await client.post("https://api.example.com/items", { foo: "bar" });
+
+      const init = fetchMock.mock.calls[0]![1] as RequestInit;
+      expect(init.method).toBe("POST");
+      expect(init.body).toBe(JSON.stringify({ foo: "bar" }));
+      expect(init.headers).toMatchObject({
+        "Content-Type": "application/json",
+      });
+    });
+
+    it("should not override an explicit Content-Type header", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      await client.post(
+        "https://api.example.com/items",
+        { foo: "bar" },
+        { headers: { "content-type": "application/vnd.custom+json" } },
+      );
+
+      const init = fetchMock.mock.calls[0]![1] as RequestInit;
+      expect(init.headers).toMatchObject({
+        "content-type": "application/vnd.custom+json",
+      });
+    });
+
+    it("should pass raw BodyInit values through unchanged", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+      const formData = new FormData();
+      formData.set("field", "value");
+
+      await client.post("https://api.example.com/items", formData);
+
+      const init = fetchMock.mock.calls[0]![1] as RequestInit;
+      expect(init.body).toBe(formData);
+      expect(init.headers).not.toMatchObject({
+        "Content-Type": "application/json",
+      });
+    });
+
+    it("should not send a body on GET or HEAD", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockImplementation(() => Promise.resolve(jsonResponse({ ok: true })));
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      await client.get("https://api.example.com/items");
+      await client.head("https://api.example.com/items");
+
+      expect(fetchMock.mock.calls[0]![1]).toMatchObject({ body: undefined });
+      expect(fetchMock.mock.calls[1]![1]).toMatchObject({ body: undefined });
+    });
+  });
+
+  describe("response parsing", () => {
+    it("should return the parsed JSON body by default", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(jsonResponse({ hello: "world" }));
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      const result = await client.get("https://api.example.com/items");
+
+      expect(result).toEqual({ hello: "world" });
+    });
+
+    it("should return text when responseType is 'text'", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(new Response("plain-body", { status: 200 }));
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      const result = await client.get("https://api.example.com/items", {
+        responseType: "text",
+      });
+
+      expect(result).toBe("plain-body");
+    });
+
+    it("should resolve HEAD to void without reading the body", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(new Response(null, { status: 200 }));
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      const result = await client.head("https://api.example.com/items");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should resolve empty JSON body to undefined", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(new Response(null, { status: 204 }));
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      const result = await client.get("https://api.example.com/items");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should throw a DmkNetworkClientError on malformed JSON", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(new Response("not-json", { status: 200 }));
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      await expect(
+        client.get("https://api.example.com/items"),
+      ).rejects.toBeInstanceOf(DmkNetworkClientError);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should throw DmkNetworkClientError with status on non-2xx responses", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response("boom", {
+          status: 500,
+          statusText: "Server Error",
+        }),
+      );
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      const error = await client
+        .get("https://api.example.com/items")
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(DmkNetworkClientError);
+      const dmkError = error as DmkNetworkClientError;
+      expect(dmkError.status).toBe(500);
+      expect(dmkError.statusText).toBe("Server Error");
+      expect(dmkError.responseBody).toBe("boom");
+      expect(dmkError.isTimeout).toBe(false);
+      expect(dmkError.isAbort).toBe(false);
+    });
+
+    it("should not throw when throwOnHttpError is disabled", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(new Response("boom", { status: 500 }));
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      const response = await client.request({
+        method: "GET",
+        url: "https://api.example.com/items",
+        responseType: "text",
+        throwOnHttpError: false,
+      });
+
+      expect(response.status).toBe(500);
+      expect(response.ok).toBe(false);
+      expect(response.data).toBe("boom");
+    });
+
+    it("should wrap generic fetch failures into DmkNetworkClientError", async () => {
+      const cause = new TypeError("network down");
+      const fetchMock = vi.fn().mockRejectedValue(cause);
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      const error = await client
+        .get("https://api.example.com/items")
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(DmkNetworkClientError);
+      expect((error as DmkNetworkClientError).cause).toBe(cause);
+    });
+  });
+
+  describe("timeout", () => {
+    it("should pass an AbortSignal when timeoutMs is configured", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+      const client = new DmkNetworkClient({
+        fetch: fetchMock,
+        timeoutMs: 1000,
+      });
+
+      await client.get("https://api.example.com/items");
+
+      const init = fetchMock.mock.calls[0]![1] as RequestInit;
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it("should not pass a signal when no timeout and no external signal are set", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      await client.get("https://api.example.com/items");
+
+      const init = fetchMock.mock.calls[0]![1] as RequestInit;
+      expect(init.signal).toBeUndefined();
+    });
+
+    it("should mark the error as a timeout when fetch rejects with TimeoutError", async () => {
+      const timeoutError = new Error("The operation was aborted");
+      timeoutError.name = "TimeoutError";
+      const fetchMock = vi.fn().mockRejectedValue(timeoutError);
+      const client = new DmkNetworkClient({
+        fetch: fetchMock,
+        timeoutMs: 10,
+      });
+
+      const error = await client
+        .get("https://api.example.com/items")
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(DmkNetworkClientError);
+      expect((error as DmkNetworkClientError).isTimeout).toBe(true);
+      expect((error as DmkNetworkClientError).isAbort).toBe(false);
+    });
+
+    it("should mark the error as an abort when the caller signal is aborted", async () => {
+      const abortController = new AbortController();
+      abortController.abort();
+      const abortError = new Error("aborted");
+      abortError.name = "AbortError";
+      const fetchMock = vi.fn().mockRejectedValue(abortError);
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      const error = await client
+        .get("https://api.example.com/items", {
+          signal: abortController.signal,
+        })
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(DmkNetworkClientError);
+      expect((error as DmkNetworkClientError).isAbort).toBe(true);
+      expect((error as DmkNetworkClientError).isTimeout).toBe(false);
+    });
+  });
+
+  describe("request envelope", () => {
+    it("should expose full response metadata via request()", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ hello: "world" }), {
+          status: 201,
+          statusText: "Created",
+          headers: { "X-Custom": "1", "Content-Type": "application/json" },
+        }),
+      );
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      const response = await client.request({
+        method: "GET",
+        url: "https://api.example.com/items",
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.statusText).toBe("Created");
+      expect(response.ok).toBe(true);
+      expect(response.data).toEqual({ hello: "world" });
+      expect(response.headers.get("X-Custom")).toBe("1");
+    });
+  });
+});

--- a/packages/device-management-kit/src/api/network/DmkNetworkClient.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClient.ts
@@ -23,8 +23,8 @@ export type DmkRequestConfig = {
   /** Per-request headers merged on top of the client's default headers. */
   headers?: Record<string, string>;
   /**
-   * Per-request timeout in milliseconds. Overrides the client default.
-   * Pass `0` to disable the timeout entirely for this request.
+   * Per-request timeout in milliseconds. When unset (or `0`), the request
+   * has no timeout.
    */
   timeoutMs?: number;
   /**
@@ -64,8 +64,6 @@ export type DmkNetworkResponse = {
 export type DmkNetworkClientOptions = {
   /** Base URL prepended to relative request URLs. */
   baseUrl?: string;
-  /** Default timeout applied to every request (ms). `0` disables. */
-  timeoutMs?: number;
   /** Default headers merged into every request. */
   headers?: Record<string, string>;
   /** Injection point for tests. Defaults to `globalThis.fetch`. */
@@ -94,13 +92,11 @@ type InternalRequestConfig = DmkRequestConfig & {
  */
 export class DmkNetworkClient {
   private readonly baseUrl?: string;
-  private readonly defaultTimeoutMs?: number;
   private readonly defaultHeaders: Record<string, string>;
   private readonly fetchImpl?: typeof fetch;
 
   constructor(options: DmkNetworkClientOptions = {}) {
     this.baseUrl = options.baseUrl;
-    this.defaultTimeoutMs = options.timeoutMs;
     this.defaultHeaders = options.headers ?? {};
     this.fetchImpl = options.fetch;
   }
@@ -183,8 +179,7 @@ export class DmkNetworkClient {
       perRequestHeaders: config.headers,
     });
     const signal = buildSignal({
-      perRequestTimeoutMs: config.timeoutMs,
-      defaultTimeoutMs: this.defaultTimeoutMs,
+      timeoutMs: config.timeoutMs,
       externalSignal: config.signal,
     });
     const throwOnHttpError = config.throwOnHttpError ?? true;
@@ -202,8 +197,7 @@ export class DmkNetworkClient {
       throw wrapFetchError({
         cause,
         externalSignal: config.signal,
-        perRequestTimeoutMs: config.timeoutMs,
-        defaultTimeoutMs: this.defaultTimeoutMs,
+        timeoutMs: config.timeoutMs,
       });
     }
 

--- a/packages/device-management-kit/src/api/network/DmkNetworkClient.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClient.ts
@@ -1,14 +1,17 @@
 import { DmkNetworkClientError } from "./DmkNetworkClientError";
+import {
+  buildBodyAndHeaders,
+  buildSignal,
+  buildUrl,
+  type DmkQueryParams,
+  type DmkResponseType,
+  parseBody,
+  safeReadText,
+  wrapFetchError,
+} from "./DmkNetworkClientHelpers";
 
-/**
- * Values accepted for URL query parameters. `null`/`undefined` entries are
- * skipped so callers can build params objects conditionally without guards.
- */
-export type DmkQueryParamValue = string | number | boolean | null | undefined;
-
-export type DmkQueryParams = Record<string, DmkQueryParamValue>;
-
-export type DmkResponseType = "json" | "text" | "blob" | "arrayBuffer" | "void";
+export type { DmkQueryParamValue } from "./DmkNetworkClientHelpers";
+export type { DmkQueryParams, DmkResponseType };
 
 /**
  * Per-request configuration. Everything is optional — sensible defaults are
@@ -74,8 +77,6 @@ type InternalRequestConfig = DmkRequestConfig & {
   url: string;
   body?: unknown;
 };
-
-const JSON_CONTENT_TYPE = "application/json";
 
 /**
  * Minimal axios-like wrapper over `fetch`. Handles:
@@ -170,13 +171,22 @@ export class DmkNetworkClient {
   public async request(
     config: InternalRequestConfig,
   ): Promise<DmkNetworkResponse> {
-    const url = this.buildUrl(config.url, config.params);
-    const { body, headers } = this.buildBodyAndHeaders(
-      config.method,
-      config.body,
-      config.headers,
-    );
-    const signal = this.buildSignal(config.timeoutMs, config.signal);
+    const url = buildUrl({
+      url: config.url,
+      params: config.params,
+      baseUrl: this.baseUrl,
+    });
+    const { body, headers } = buildBodyAndHeaders({
+      method: config.method,
+      body: config.body,
+      defaultHeaders: this.defaultHeaders,
+      perRequestHeaders: config.headers,
+    });
+    const signal = buildSignal({
+      perRequestTimeoutMs: config.timeoutMs,
+      defaultTimeoutMs: this.defaultTimeoutMs,
+      externalSignal: config.signal,
+    });
     const throwOnHttpError = config.throwOnHttpError ?? true;
     const responseType: DmkResponseType = config.responseType ?? "json";
 
@@ -189,11 +199,16 @@ export class DmkNetworkClient {
         signal,
       });
     } catch (cause) {
-      throw this.wrapFetchError(cause, config.signal, config.timeoutMs);
+      throw wrapFetchError({
+        cause,
+        externalSignal: config.signal,
+        perRequestTimeoutMs: config.timeoutMs,
+        defaultTimeoutMs: this.defaultTimeoutMs,
+      });
     }
 
     if (!response.ok && throwOnHttpError) {
-      const responseBody = await this.safeReadText(response);
+      const responseBody = await safeReadText(response);
       throw new DmkNetworkClientError({
         message: `HTTP error ${response.status} ${response.statusText}`.trim(),
         status: response.status,
@@ -202,7 +217,7 @@ export class DmkNetworkClient {
       });
     }
 
-    const data = await this.parseBody(response, responseType);
+    const data = await parseBody(response, responseType);
 
     return {
       data,
@@ -211,157 +226,5 @@ export class DmkNetworkClient {
       headers: response.headers,
       ok: response.ok,
     };
-  }
-
-  private buildUrl(url: string, params?: DmkQueryParams): URL {
-    const fullUrl = /^[a-z][a-z0-9+.-]*:\/\//i.test(url)
-      ? new URL(url)
-      : this.baseUrl
-        ? new URL(this.joinPath(this.baseUrl, url))
-        : new URL(url);
-
-    if (params) {
-      for (const [key, value] of Object.entries(params)) {
-        if (value !== null && value !== undefined) {
-          fullUrl.searchParams.set(key, String(value));
-        }
-      }
-    }
-
-    return fullUrl;
-  }
-
-  private joinPath(base: string, path: string): string {
-    if (!path) return base;
-    const trimmedBase = base.endsWith("/") ? base.slice(0, -1) : base;
-    const trimmedPath = path.startsWith("/") ? path : `/${path}`;
-    return `${trimmedBase}${trimmedPath}`;
-  }
-
-  private buildBodyAndHeaders(
-    method: string,
-    body: unknown,
-    perRequestHeaders?: Record<string, string>,
-  ): { body?: BodyInit; headers: Record<string, string> } {
-    const headers: Record<string, string> = {
-      ...this.defaultHeaders,
-      ...perRequestHeaders,
-    };
-
-    if (body === undefined || method === "GET" || method === "HEAD") {
-      return { body: undefined, headers };
-    }
-
-    if (this.isRawBody(body)) {
-      return { body, headers };
-    }
-
-    if (!this.hasHeader(headers, "content-type")) {
-      headers["Content-Type"] = JSON_CONTENT_TYPE;
-    }
-    return { body: JSON.stringify(body), headers };
-  }
-
-  private isRawBody(body: unknown): body is BodyInit {
-    return (
-      typeof body === "string" ||
-      body instanceof ArrayBuffer ||
-      body instanceof Blob ||
-      body instanceof FormData ||
-      body instanceof URLSearchParams ||
-      body instanceof ReadableStream ||
-      ArrayBuffer.isView(body)
-    );
-  }
-
-  private hasHeader(headers: Record<string, string>, name: string): boolean {
-    const lower = name.toLowerCase();
-    return Object.keys(headers).some((k) => k.toLowerCase() === lower);
-  }
-
-  private buildSignal(
-    perRequestTimeoutMs: number | undefined,
-    externalSignal: AbortSignal | undefined,
-  ): AbortSignal | undefined {
-    const timeoutMs = perRequestTimeoutMs ?? this.defaultTimeoutMs;
-    const timeoutSignal =
-      timeoutMs && timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined;
-
-    if (timeoutSignal && externalSignal) {
-      return AbortSignal.any([externalSignal, timeoutSignal]);
-    }
-    return timeoutSignal ?? externalSignal;
-  }
-
-  private async parseBody(
-    response: Response,
-    responseType: DmkResponseType,
-  ): Promise<unknown> {
-    switch (responseType) {
-      case "void":
-        return undefined;
-      case "text":
-        return await response.text();
-      case "blob":
-        return await response.blob();
-      case "arrayBuffer":
-        return await response.arrayBuffer();
-      case "json":
-      default: {
-        const text = await response.text();
-        if (text.length === 0) {
-          return undefined;
-        }
-        try {
-          return JSON.parse(text);
-        } catch (cause) {
-          throw new DmkNetworkClientError({
-            message: "Failed to parse JSON response body",
-            status: response.status,
-            statusText: response.statusText,
-            responseBody: text,
-            cause,
-          });
-        }
-      }
-    }
-  }
-
-  private async safeReadText(response: Response): Promise<string | undefined> {
-    try {
-      return await response.text();
-    } catch {
-      return undefined;
-    }
-  }
-
-  private wrapFetchError(
-    cause: unknown,
-    externalSignal: AbortSignal | undefined,
-    perRequestTimeoutMs: number | undefined,
-  ): DmkNetworkClientError {
-    const timeoutMs = perRequestTimeoutMs ?? this.defaultTimeoutMs;
-    const hasTimeout = Boolean(timeoutMs && timeoutMs > 0);
-    const isAbortError =
-      cause instanceof Error &&
-      (cause.name === "AbortError" || cause.name === "TimeoutError");
-
-    if (isAbortError) {
-      const externallyAborted = externalSignal?.aborted ?? false;
-      const timedOut =
-        !externallyAborted && (cause.name === "TimeoutError" || hasTimeout);
-      return new DmkNetworkClientError({
-        message: timedOut ? `Request timed out` : "Request aborted",
-        isTimeout: timedOut,
-        isAbort: externallyAborted,
-        cause,
-      });
-    }
-
-    return new DmkNetworkClientError({
-      message:
-        cause instanceof Error ? cause.message : "Network request failed",
-      cause,
-    });
   }
 }

--- a/packages/device-management-kit/src/api/network/DmkNetworkClient.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClient.ts
@@ -1,0 +1,367 @@
+import { DmkNetworkClientError } from "./DmkNetworkClientError";
+
+/**
+ * Values accepted for URL query parameters. `null`/`undefined` entries are
+ * skipped so callers can build params objects conditionally without guards.
+ */
+export type DmkQueryParamValue = string | number | boolean | null | undefined;
+
+export type DmkQueryParams = Record<string, DmkQueryParamValue>;
+
+export type DmkResponseType = "json" | "text" | "blob" | "arrayBuffer" | "void";
+
+/**
+ * Per-request configuration. Everything is optional — sensible defaults are
+ * applied by the client.
+ */
+export type DmkRequestConfig = {
+  /** Query params merged into the URL. `null`/`undefined` entries are skipped. */
+  params?: DmkQueryParams;
+  /** Per-request headers merged on top of the client's default headers. */
+  headers?: Record<string, string>;
+  /**
+   * Per-request timeout in milliseconds. Overrides the client default.
+   * Pass `0` to disable the timeout entirely for this request.
+   */
+  timeoutMs?: number;
+  /**
+   * External abort signal. Composed with the internal timeout signal, so
+   * either one firing will abort the request.
+   */
+  signal?: AbortSignal;
+  /**
+   * How to parse the response body. Defaults to `"json"`, except for `head`
+   * which always resolves to `void`.
+   */
+  responseType?: DmkResponseType;
+  /**
+   * When `true` (default), non-2xx responses throw {@link DmkNetworkClientError}.
+   * Set to `false` to resolve normally and inspect {@link DmkNetworkResponse}
+   * via {@link DmkNetworkClient.request}.
+   */
+  throwOnHttpError?: boolean;
+};
+
+/**
+ * Full response envelope returned by {@link DmkNetworkClient.request}.
+ * The simple method helpers (`get`, `post`, …) unwrap to `data` directly.
+ *
+ * `data` is intentionally typed as `unknown`: network payloads are untrusted
+ * input, so callers must narrow it with a type guard or runtime validator
+ * (e.g. the existing DTO mappers) before use.
+ */
+export type DmkNetworkResponse = {
+  data: unknown;
+  status: number;
+  statusText: string;
+  headers: Headers;
+  ok: boolean;
+};
+
+export type DmkNetworkClientOptions = {
+  /** Base URL prepended to relative request URLs. */
+  baseUrl?: string;
+  /** Default timeout applied to every request (ms). `0` disables. */
+  timeoutMs?: number;
+  /** Default headers merged into every request. */
+  headers?: Record<string, string>;
+  /** Injection point for tests. Defaults to `globalThis.fetch`. */
+  fetch?: typeof fetch;
+};
+
+type InternalRequestConfig = DmkRequestConfig & {
+  method: string;
+  url: string;
+  body?: unknown;
+};
+
+const JSON_CONTENT_TYPE = "application/json";
+
+/**
+ * Minimal axios-like wrapper over `fetch`. Handles:
+ *
+ * - URL composition (base URL + relative path + query params from an object)
+ * - Automatic JSON body encoding and `Content-Type` header
+ * - Default and per-request headers merging
+ * - Request timeout via `AbortSignal.timeout`, composable with a caller signal
+ * - Automatic `response.ok` check with a typed {@link DmkNetworkClientError}
+ * - Typed JSON / text / blob / arrayBuffer response parsing
+ *
+ * Use the high-level helpers ({@link DmkNetworkClient.get}, {@link DmkNetworkClient.post},
+ * …) for 95% of calls and {@link DmkNetworkClient.request} when you need the
+ * full response envelope (status, headers).
+ */
+export class DmkNetworkClient {
+  private readonly baseUrl?: string;
+  private readonly defaultTimeoutMs?: number;
+  private readonly defaultHeaders: Record<string, string>;
+  private readonly fetchImpl?: typeof fetch;
+
+  constructor(options: DmkNetworkClientOptions = {}) {
+    this.baseUrl = options.baseUrl;
+    this.defaultTimeoutMs = options.timeoutMs;
+    this.defaultHeaders = options.headers ?? {};
+    this.fetchImpl = options.fetch;
+  }
+
+  private getFetch(): typeof fetch {
+    // Resolve `fetch` at call time so that spies installed on `globalThis.fetch`
+    // after the client was constructed are still honored.
+    return this.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  }
+
+  public get(url: string, config?: DmkRequestConfig): Promise<unknown> {
+    return this.request({ ...config, method: "GET", url }).then(
+      (res) => res.data,
+    );
+  }
+
+  public post(
+    url: string,
+    body?: unknown,
+    config?: DmkRequestConfig,
+  ): Promise<unknown> {
+    return this.request({ ...config, method: "POST", url, body }).then(
+      (res) => res.data,
+    );
+  }
+
+  public put(
+    url: string,
+    body?: unknown,
+    config?: DmkRequestConfig,
+  ): Promise<unknown> {
+    return this.request({ ...config, method: "PUT", url, body }).then(
+      (res) => res.data,
+    );
+  }
+
+  public patch(
+    url: string,
+    body?: unknown,
+    config?: DmkRequestConfig,
+  ): Promise<unknown> {
+    return this.request({ ...config, method: "PATCH", url, body }).then(
+      (res) => res.data,
+    );
+  }
+
+  public delete(url: string, config?: DmkRequestConfig): Promise<unknown> {
+    return this.request({ ...config, method: "DELETE", url }).then(
+      (res) => res.data,
+    );
+  }
+
+  public head(url: string, config?: DmkRequestConfig): Promise<void> {
+    return this.request({
+      ...config,
+      method: "HEAD",
+      url,
+      responseType: "void",
+    }).then(() => undefined);
+  }
+
+  /**
+   * Escape hatch returning the full response envelope (status, headers, data).
+   * Most callers should prefer {@link get}, {@link post}, etc.
+   *
+   * `data` is `unknown` by design; validate it with a type guard before use.
+   */
+  public async request(
+    config: InternalRequestConfig,
+  ): Promise<DmkNetworkResponse> {
+    const url = this.buildUrl(config.url, config.params);
+    const { body, headers } = this.buildBodyAndHeaders(
+      config.method,
+      config.body,
+      config.headers,
+    );
+    const signal = this.buildSignal(config.timeoutMs, config.signal);
+    const throwOnHttpError = config.throwOnHttpError ?? true;
+    const responseType: DmkResponseType = config.responseType ?? "json";
+
+    let response: Response;
+    try {
+      response = await this.getFetch()(url, {
+        method: config.method,
+        headers,
+        body,
+        signal,
+      });
+    } catch (cause) {
+      throw this.wrapFetchError(cause, config.signal, config.timeoutMs);
+    }
+
+    if (!response.ok && throwOnHttpError) {
+      const responseBody = await this.safeReadText(response);
+      throw new DmkNetworkClientError({
+        message: `HTTP error ${response.status} ${response.statusText}`.trim(),
+        status: response.status,
+        statusText: response.statusText,
+        responseBody,
+      });
+    }
+
+    const data = await this.parseBody(response, responseType);
+
+    return {
+      data,
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+      ok: response.ok,
+    };
+  }
+
+  private buildUrl(url: string, params?: DmkQueryParams): URL {
+    const fullUrl = /^[a-z][a-z0-9+.-]*:\/\//i.test(url)
+      ? new URL(url)
+      : this.baseUrl
+        ? new URL(this.joinPath(this.baseUrl, url))
+        : new URL(url);
+
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        if (value !== null && value !== undefined) {
+          fullUrl.searchParams.set(key, String(value));
+        }
+      }
+    }
+
+    return fullUrl;
+  }
+
+  private joinPath(base: string, path: string): string {
+    if (!path) return base;
+    const trimmedBase = base.endsWith("/") ? base.slice(0, -1) : base;
+    const trimmedPath = path.startsWith("/") ? path : `/${path}`;
+    return `${trimmedBase}${trimmedPath}`;
+  }
+
+  private buildBodyAndHeaders(
+    method: string,
+    body: unknown,
+    perRequestHeaders?: Record<string, string>,
+  ): { body?: BodyInit; headers: Record<string, string> } {
+    const headers: Record<string, string> = {
+      ...this.defaultHeaders,
+      ...perRequestHeaders,
+    };
+
+    if (body === undefined || method === "GET" || method === "HEAD") {
+      return { body: undefined, headers };
+    }
+
+    if (this.isRawBody(body)) {
+      return { body, headers };
+    }
+
+    if (!this.hasHeader(headers, "content-type")) {
+      headers["Content-Type"] = JSON_CONTENT_TYPE;
+    }
+    return { body: JSON.stringify(body), headers };
+  }
+
+  private isRawBody(body: unknown): body is BodyInit {
+    return (
+      typeof body === "string" ||
+      body instanceof ArrayBuffer ||
+      body instanceof Blob ||
+      body instanceof FormData ||
+      body instanceof URLSearchParams ||
+      body instanceof ReadableStream ||
+      ArrayBuffer.isView(body)
+    );
+  }
+
+  private hasHeader(headers: Record<string, string>, name: string): boolean {
+    const lower = name.toLowerCase();
+    return Object.keys(headers).some((k) => k.toLowerCase() === lower);
+  }
+
+  private buildSignal(
+    perRequestTimeoutMs: number | undefined,
+    externalSignal: AbortSignal | undefined,
+  ): AbortSignal | undefined {
+    const timeoutMs = perRequestTimeoutMs ?? this.defaultTimeoutMs;
+    const timeoutSignal =
+      timeoutMs && timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined;
+
+    if (timeoutSignal && externalSignal) {
+      return AbortSignal.any([externalSignal, timeoutSignal]);
+    }
+    return timeoutSignal ?? externalSignal;
+  }
+
+  private async parseBody(
+    response: Response,
+    responseType: DmkResponseType,
+  ): Promise<unknown> {
+    switch (responseType) {
+      case "void":
+        return undefined;
+      case "text":
+        return await response.text();
+      case "blob":
+        return await response.blob();
+      case "arrayBuffer":
+        return await response.arrayBuffer();
+      case "json":
+      default: {
+        const text = await response.text();
+        if (text.length === 0) {
+          return undefined;
+        }
+        try {
+          return JSON.parse(text);
+        } catch (cause) {
+          throw new DmkNetworkClientError({
+            message: "Failed to parse JSON response body",
+            status: response.status,
+            statusText: response.statusText,
+            responseBody: text,
+            cause,
+          });
+        }
+      }
+    }
+  }
+
+  private async safeReadText(response: Response): Promise<string | undefined> {
+    try {
+      return await response.text();
+    } catch {
+      return undefined;
+    }
+  }
+
+  private wrapFetchError(
+    cause: unknown,
+    externalSignal: AbortSignal | undefined,
+    perRequestTimeoutMs: number | undefined,
+  ): DmkNetworkClientError {
+    const timeoutMs = perRequestTimeoutMs ?? this.defaultTimeoutMs;
+    const hasTimeout = Boolean(timeoutMs && timeoutMs > 0);
+    const isAbortError =
+      cause instanceof Error &&
+      (cause.name === "AbortError" || cause.name === "TimeoutError");
+
+    if (isAbortError) {
+      const externallyAborted = externalSignal?.aborted ?? false;
+      const timedOut =
+        !externallyAborted && (cause.name === "TimeoutError" || hasTimeout);
+      return new DmkNetworkClientError({
+        message: timedOut ? `Request timed out` : "Request aborted",
+        isTimeout: timedOut,
+        isAbort: externallyAborted,
+        cause,
+      });
+    }
+
+    return new DmkNetworkClientError({
+      message:
+        cause instanceof Error ? cause.message : "Network request failed",
+      cause,
+    });
+  }
+}

--- a/packages/device-management-kit/src/api/network/DmkNetworkClientError.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClientError.ts
@@ -1,0 +1,43 @@
+export type DmkNetworkClientErrorParams = {
+  message: string;
+  status?: number;
+  statusText?: string;
+  responseBody?: string;
+  isTimeout?: boolean;
+  isAbort?: boolean;
+  cause?: unknown;
+};
+
+/**
+ * Error thrown by {@link DmkNetworkClient} for HTTP, timeout, abort or
+ * transport-level failures.
+ *
+ * - When the remote returned a non-2xx response, {@link status} and
+ *   {@link statusText} are populated and {@link responseBody} contains the
+ *   raw text body (best effort).
+ * - When the request timed out via the client's `timeoutMs`,
+ *   {@link isTimeout} is `true`.
+ * - When the request was aborted through the caller's `signal`,
+ *   {@link isAbort} is `true`.
+ * - For other fetch/network failures, {@link cause} carries the original
+ *   error.
+ */
+export class DmkNetworkClientError extends Error {
+  public readonly status?: number;
+  public readonly statusText?: string;
+  public readonly responseBody?: string;
+  public readonly isTimeout: boolean;
+  public readonly isAbort: boolean;
+  public override readonly cause?: unknown;
+
+  constructor(params: DmkNetworkClientErrorParams) {
+    super(params.message);
+    this.name = "DmkNetworkClientError";
+    this.status = params.status;
+    this.statusText = params.statusText;
+    this.responseBody = params.responseBody;
+    this.isTimeout = params.isTimeout ?? false;
+    this.isAbort = params.isAbort ?? false;
+    this.cause = params.cause;
+  }
+}

--- a/packages/device-management-kit/src/api/network/DmkNetworkClientHelpers.test.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClientHelpers.test.ts
@@ -191,18 +191,16 @@ describe("DmkNetworkClientHelpers", () => {
     it("should return undefined when no timeout and no external signal", () => {
       expect(
         buildSignal({
-          perRequestTimeoutMs: undefined,
-          defaultTimeoutMs: undefined,
+          timeoutMs: undefined,
           externalSignal: undefined,
         }),
       ).toBeUndefined();
     });
 
-    it("should return undefined when timeouts are zero and no external signal", () => {
+    it("should return undefined when timeout is zero and no external signal", () => {
       expect(
         buildSignal({
-          perRequestTimeoutMs: 0,
-          defaultTimeoutMs: 1000,
+          timeoutMs: 0,
           externalSignal: undefined,
         }),
       ).toBeUndefined();
@@ -211,8 +209,7 @@ describe("DmkNetworkClientHelpers", () => {
     it("should return the external signal alone when no timeout is configured", () => {
       const controller = new AbortController();
       const signal = buildSignal({
-        perRequestTimeoutMs: undefined,
-        defaultTimeoutMs: undefined,
+        timeoutMs: undefined,
         externalSignal: controller.signal,
       });
       expect(signal).toBe(controller.signal);
@@ -220,30 +217,27 @@ describe("DmkNetworkClientHelpers", () => {
 
     it("should return a timeout signal when only a timeout is configured", () => {
       const signal = buildSignal({
-        perRequestTimeoutMs: undefined,
-        defaultTimeoutMs: 1000,
+        timeoutMs: 1000,
         externalSignal: undefined,
       });
       expect(signal).toBeInstanceOf(AbortSignal);
     });
 
-    it("should prefer the per-request timeout over the default", () => {
-      const anySpy = vi.spyOn(AbortSignal, "timeout");
+    it("should use the provided timeout value for AbortSignal.timeout", () => {
+      const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
       buildSignal({
-        perRequestTimeoutMs: 50,
-        defaultTimeoutMs: 1000,
+        timeoutMs: 50,
         externalSignal: undefined,
       });
-      expect(anySpy).toHaveBeenCalledWith(50);
-      anySpy.mockRestore();
+      expect(timeoutSpy).toHaveBeenCalledWith(50);
+      timeoutSpy.mockRestore();
     });
 
     it("should compose both signals with AbortSignal.any when both are set", () => {
       const anySpy = vi.spyOn(AbortSignal, "any");
       const controller = new AbortController();
       const signal = buildSignal({
-        perRequestTimeoutMs: 100,
-        defaultTimeoutMs: undefined,
+        timeoutMs: 100,
         externalSignal: controller.signal,
       });
       expect(signal).toBeInstanceOf(AbortSignal);
@@ -326,8 +320,7 @@ describe("DmkNetworkClientHelpers", () => {
       const error = wrapFetchError({
         cause,
         externalSignal: undefined,
-        perRequestTimeoutMs: undefined,
-        defaultTimeoutMs: undefined,
+        timeoutMs: undefined,
       });
       expect(error).toBeInstanceOf(DmkNetworkClientError);
       expect(error.message).toBe("network down");
@@ -340,8 +333,7 @@ describe("DmkNetworkClientHelpers", () => {
       const error = wrapFetchError({
         cause: "something",
         externalSignal: undefined,
-        perRequestTimeoutMs: undefined,
-        defaultTimeoutMs: undefined,
+        timeoutMs: undefined,
       });
       expect(error.message).toBe("Network request failed");
       expect(error.cause).toBe("something");
@@ -353,8 +345,7 @@ describe("DmkNetworkClientHelpers", () => {
       const error = wrapFetchError({
         cause,
         externalSignal: undefined,
-        perRequestTimeoutMs: 10,
-        defaultTimeoutMs: undefined,
+        timeoutMs: 10,
       });
       expect(error.isTimeout).toBe(true);
       expect(error.isAbort).toBe(false);
@@ -367,8 +358,7 @@ describe("DmkNetworkClientHelpers", () => {
       const error = wrapFetchError({
         cause,
         externalSignal: undefined,
-        perRequestTimeoutMs: undefined,
-        defaultTimeoutMs: 1000,
+        timeoutMs: 1000,
       });
       expect(error.isTimeout).toBe(true);
       expect(error.isAbort).toBe(false);
@@ -382,8 +372,7 @@ describe("DmkNetworkClientHelpers", () => {
       const error = wrapFetchError({
         cause,
         externalSignal: controller.signal,
-        perRequestTimeoutMs: undefined,
-        defaultTimeoutMs: undefined,
+        timeoutMs: undefined,
       });
       expect(error.isAbort).toBe(true);
       expect(error.isTimeout).toBe(false);
@@ -396,8 +385,7 @@ describe("DmkNetworkClientHelpers", () => {
       const error = wrapFetchError({
         cause,
         externalSignal: undefined,
-        perRequestTimeoutMs: undefined,
-        defaultTimeoutMs: undefined,
+        timeoutMs: undefined,
       });
       expect(error.isTimeout).toBe(false);
       expect(error.isAbort).toBe(false);

--- a/packages/device-management-kit/src/api/network/DmkNetworkClientHelpers.test.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClientHelpers.test.ts
@@ -1,0 +1,407 @@
+import { DmkNetworkClientError } from "./DmkNetworkClientError";
+import {
+  buildBodyAndHeaders,
+  buildSignal,
+  buildUrl,
+  hasHeader,
+  isRawBody,
+  joinPath,
+  JSON_CONTENT_TYPE,
+  parseBody,
+  safeReadText,
+  wrapFetchError,
+} from "./DmkNetworkClientHelpers";
+
+describe("DmkNetworkClientHelpers", () => {
+  describe("joinPath", () => {
+    it("should return the base when the path is empty", () => {
+      expect(joinPath("https://api.example.com", "")).toBe(
+        "https://api.example.com",
+      );
+    });
+
+    it("should insert a single slash when neither side has one", () => {
+      expect(joinPath("https://api.example.com", "items")).toBe(
+        "https://api.example.com/items",
+      );
+    });
+
+    it("should collapse a trailing base slash with a leading path slash", () => {
+      expect(joinPath("https://api.example.com/", "/items")).toBe(
+        "https://api.example.com/items",
+      );
+    });
+
+    it("should keep a single slash when only one side has one", () => {
+      expect(joinPath("https://api.example.com/", "items")).toBe(
+        "https://api.example.com/items",
+      );
+      expect(joinPath("https://api.example.com", "/items")).toBe(
+        "https://api.example.com/items",
+      );
+    });
+  });
+
+  describe("buildUrl", () => {
+    it("should keep an absolute URL as-is", () => {
+      const url = buildUrl({ url: "https://api.example.com/items" });
+      expect(url.toString()).toBe("https://api.example.com/items");
+    });
+
+    it("should prepend the base URL to a relative path", () => {
+      const url = buildUrl({
+        url: "/items",
+        baseUrl: "https://api.example.com/",
+      });
+      expect(url.toString()).toBe("https://api.example.com/items");
+    });
+
+    it("should ignore the base URL when the input URL is absolute", () => {
+      const url = buildUrl({
+        url: "https://other.example.com/items",
+        baseUrl: "https://api.example.com",
+      });
+      expect(url.toString()).toBe("https://other.example.com/items");
+    });
+
+    it("should append query params and skip null/undefined entries", () => {
+      const url = buildUrl({
+        url: "https://api.example.com/items",
+        params: {
+          chain: 1,
+          contract: "0xabc",
+          active: true,
+          skip: null,
+          alsoSkip: undefined,
+        },
+      });
+      expect(url.searchParams.get("chain")).toBe("1");
+      expect(url.searchParams.get("contract")).toBe("0xabc");
+      expect(url.searchParams.get("active")).toBe("true");
+      expect(url.searchParams.has("skip")).toBe(false);
+      expect(url.searchParams.has("alsoSkip")).toBe(false);
+    });
+  });
+
+  describe("hasHeader", () => {
+    it("should find a header regardless of case", () => {
+      expect(hasHeader({ "Content-Type": "json" }, "content-type")).toBe(true);
+      expect(hasHeader({ "content-type": "json" }, "Content-Type")).toBe(true);
+    });
+
+    it("should return false when no matching header exists", () => {
+      expect(hasHeader({ Accept: "json" }, "content-type")).toBe(false);
+      expect(hasHeader({}, "content-type")).toBe(false);
+    });
+  });
+
+  describe("isRawBody", () => {
+    it("should accept native BodyInit values", () => {
+      expect(isRawBody("raw-string")).toBe(true);
+      expect(isRawBody(new ArrayBuffer(4))).toBe(true);
+      expect(isRawBody(new Uint8Array([1, 2, 3]))).toBe(true);
+      expect(isRawBody(new Blob(["a"]))).toBe(true);
+      expect(isRawBody(new FormData())).toBe(true);
+      expect(isRawBody(new URLSearchParams({ a: "1" }))).toBe(true);
+      expect(isRawBody(new ReadableStream())).toBe(true);
+    });
+
+    it("should reject plain objects and primitives", () => {
+      expect(isRawBody({ foo: "bar" })).toBe(false);
+      expect(isRawBody([1, 2, 3])).toBe(false);
+      expect(isRawBody(42)).toBe(false);
+      expect(isRawBody(null)).toBe(false);
+      expect(isRawBody(undefined)).toBe(false);
+    });
+  });
+
+  describe("buildBodyAndHeaders", () => {
+    it("should merge default and per-request headers with per-request winning", () => {
+      const { headers } = buildBodyAndHeaders({
+        method: "GET",
+        body: undefined,
+        defaultHeaders: { "X-Default": "default", "X-Shared": "from-default" },
+        perRequestHeaders: { "X-Shared": "overridden", "X-Per": "per" },
+      });
+      expect(headers).toEqual({
+        "X-Default": "default",
+        "X-Shared": "overridden",
+        "X-Per": "per",
+      });
+    });
+
+    it("should not emit a body on GET/HEAD even when a body is provided", () => {
+      const result = buildBodyAndHeaders({
+        method: "GET",
+        body: { foo: "bar" },
+        defaultHeaders: {},
+      });
+      expect(result.body).toBeUndefined();
+      expect(result.headers["Content-Type"]).toBeUndefined();
+    });
+
+    it("should JSON-stringify plain objects and set the Content-Type", () => {
+      const result = buildBodyAndHeaders({
+        method: "POST",
+        body: { foo: "bar" },
+        defaultHeaders: {},
+      });
+      expect(result.body).toBe(JSON.stringify({ foo: "bar" }));
+      expect(result.headers["Content-Type"]).toBe(JSON_CONTENT_TYPE);
+    });
+
+    it("should not override an explicit Content-Type header", () => {
+      const result = buildBodyAndHeaders({
+        method: "POST",
+        body: { foo: "bar" },
+        defaultHeaders: {},
+        perRequestHeaders: { "content-type": "application/vnd.custom+json" },
+      });
+      expect(result.body).toBe(JSON.stringify({ foo: "bar" }));
+      expect(result.headers["content-type"]).toBe(
+        "application/vnd.custom+json",
+      );
+      expect(result.headers["Content-Type"]).toBeUndefined();
+    });
+
+    it("should pass raw BodyInit values through unchanged without JSON headers", () => {
+      const formData = new FormData();
+      formData.set("field", "value");
+      const result = buildBodyAndHeaders({
+        method: "POST",
+        body: formData,
+        defaultHeaders: {},
+      });
+      expect(result.body).toBe(formData);
+      expect(result.headers["Content-Type"]).toBeUndefined();
+    });
+
+    it("should return an undefined body when the body itself is undefined", () => {
+      const result = buildBodyAndHeaders({
+        method: "POST",
+        body: undefined,
+        defaultHeaders: { "X-Default": "d" },
+      });
+      expect(result.body).toBeUndefined();
+      expect(result.headers).toEqual({ "X-Default": "d" });
+    });
+  });
+
+  describe("buildSignal", () => {
+    it("should return undefined when no timeout and no external signal", () => {
+      expect(
+        buildSignal({
+          perRequestTimeoutMs: undefined,
+          defaultTimeoutMs: undefined,
+          externalSignal: undefined,
+        }),
+      ).toBeUndefined();
+    });
+
+    it("should return undefined when timeouts are zero and no external signal", () => {
+      expect(
+        buildSignal({
+          perRequestTimeoutMs: 0,
+          defaultTimeoutMs: 1000,
+          externalSignal: undefined,
+        }),
+      ).toBeUndefined();
+    });
+
+    it("should return the external signal alone when no timeout is configured", () => {
+      const controller = new AbortController();
+      const signal = buildSignal({
+        perRequestTimeoutMs: undefined,
+        defaultTimeoutMs: undefined,
+        externalSignal: controller.signal,
+      });
+      expect(signal).toBe(controller.signal);
+    });
+
+    it("should return a timeout signal when only a timeout is configured", () => {
+      const signal = buildSignal({
+        perRequestTimeoutMs: undefined,
+        defaultTimeoutMs: 1000,
+        externalSignal: undefined,
+      });
+      expect(signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it("should prefer the per-request timeout over the default", () => {
+      const anySpy = vi.spyOn(AbortSignal, "timeout");
+      buildSignal({
+        perRequestTimeoutMs: 50,
+        defaultTimeoutMs: 1000,
+        externalSignal: undefined,
+      });
+      expect(anySpy).toHaveBeenCalledWith(50);
+      anySpy.mockRestore();
+    });
+
+    it("should compose both signals with AbortSignal.any when both are set", () => {
+      const anySpy = vi.spyOn(AbortSignal, "any");
+      const controller = new AbortController();
+      const signal = buildSignal({
+        perRequestTimeoutMs: 100,
+        defaultTimeoutMs: undefined,
+        externalSignal: controller.signal,
+      });
+      expect(signal).toBeInstanceOf(AbortSignal);
+      expect(anySpy).toHaveBeenCalledTimes(1);
+      anySpy.mockRestore();
+    });
+  });
+
+  describe("parseBody", () => {
+    it("should return undefined for 'void' response type without consuming the body", async () => {
+      const response = new Response("ignored");
+      const result = await parseBody(response, "void");
+      expect(result).toBeUndefined();
+      expect(response.bodyUsed).toBe(false);
+    });
+
+    it("should return text for 'text' response type", async () => {
+      const response = new Response("plain-body");
+      await expect(parseBody(response, "text")).resolves.toBe("plain-body");
+    });
+
+    it("should return a Blob for 'blob' response type", async () => {
+      const response = new Response("blob-body");
+      const result = await parseBody(response, "blob");
+      expect(result).toBeInstanceOf(Blob);
+    });
+
+    it("should return an ArrayBuffer for 'arrayBuffer' response type", async () => {
+      const response = new Response(new Uint8Array([1, 2, 3]));
+      const result = await parseBody(response, "arrayBuffer");
+      expect(result).toBeInstanceOf(ArrayBuffer);
+      expect(new Uint8Array(result as ArrayBuffer)).toEqual(
+        new Uint8Array([1, 2, 3]),
+      );
+    });
+
+    it("should parse JSON for 'json' response type", async () => {
+      const response = new Response(JSON.stringify({ hello: "world" }));
+      await expect(parseBody(response, "json")).resolves.toEqual({
+        hello: "world",
+      });
+    });
+
+    it("should resolve to undefined for an empty JSON body", async () => {
+      const response = new Response("");
+      await expect(parseBody(response, "json")).resolves.toBeUndefined();
+    });
+
+    it("should throw a DmkNetworkClientError for malformed JSON", async () => {
+      const response = new Response("not-json", {
+        status: 200,
+        statusText: "OK",
+      });
+      const error = await parseBody(response, "json").catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(DmkNetworkClientError);
+      const dmkError = error as DmkNetworkClientError;
+      expect(dmkError.status).toBe(200);
+      expect(dmkError.statusText).toBe("OK");
+      expect(dmkError.responseBody).toBe("not-json");
+      expect(dmkError.cause).toBeInstanceOf(SyntaxError);
+    });
+  });
+
+  describe("safeReadText", () => {
+    it("should return the text body", async () => {
+      await expect(safeReadText(new Response("hello"))).resolves.toBe("hello");
+    });
+
+    it("should return undefined when reading the body throws", async () => {
+      const response = {
+        text: () => Promise.reject(new Error("read failed")),
+      } as unknown as Response;
+      await expect(safeReadText(response)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("wrapFetchError", () => {
+    it("should wrap a generic Error with its message", () => {
+      const cause = new TypeError("network down");
+      const error = wrapFetchError({
+        cause,
+        externalSignal: undefined,
+        perRequestTimeoutMs: undefined,
+        defaultTimeoutMs: undefined,
+      });
+      expect(error).toBeInstanceOf(DmkNetworkClientError);
+      expect(error.message).toBe("network down");
+      expect(error.cause).toBe(cause);
+      expect(error.isTimeout).toBe(false);
+      expect(error.isAbort).toBe(false);
+    });
+
+    it("should fall back to a generic message for non-Error causes", () => {
+      const error = wrapFetchError({
+        cause: "something",
+        externalSignal: undefined,
+        perRequestTimeoutMs: undefined,
+        defaultTimeoutMs: undefined,
+      });
+      expect(error.message).toBe("Network request failed");
+      expect(error.cause).toBe("something");
+    });
+
+    it("should flag TimeoutError as a timeout", () => {
+      const cause = new Error("timed out");
+      cause.name = "TimeoutError";
+      const error = wrapFetchError({
+        cause,
+        externalSignal: undefined,
+        perRequestTimeoutMs: 10,
+        defaultTimeoutMs: undefined,
+      });
+      expect(error.isTimeout).toBe(true);
+      expect(error.isAbort).toBe(false);
+      expect(error.message).toBe("Request timed out");
+    });
+
+    it("should flag AbortError as a timeout when a timeout is configured and no external abort", () => {
+      const cause = new Error("aborted");
+      cause.name = "AbortError";
+      const error = wrapFetchError({
+        cause,
+        externalSignal: undefined,
+        perRequestTimeoutMs: undefined,
+        defaultTimeoutMs: 1000,
+      });
+      expect(error.isTimeout).toBe(true);
+      expect(error.isAbort).toBe(false);
+    });
+
+    it("should flag AbortError as an external abort when the caller signal is aborted", () => {
+      const controller = new AbortController();
+      controller.abort();
+      const cause = new Error("aborted");
+      cause.name = "AbortError";
+      const error = wrapFetchError({
+        cause,
+        externalSignal: controller.signal,
+        perRequestTimeoutMs: undefined,
+        defaultTimeoutMs: undefined,
+      });
+      expect(error.isAbort).toBe(true);
+      expect(error.isTimeout).toBe(false);
+      expect(error.message).toBe("Request aborted");
+    });
+
+    it("should treat AbortError with no timeout and no external abort as a plain abort", () => {
+      const cause = new Error("aborted");
+      cause.name = "AbortError";
+      const error = wrapFetchError({
+        cause,
+        externalSignal: undefined,
+        perRequestTimeoutMs: undefined,
+        defaultTimeoutMs: undefined,
+      });
+      expect(error.isTimeout).toBe(false);
+      expect(error.isAbort).toBe(false);
+      expect(error.message).toBe("Request aborted");
+    });
+  });
+});

--- a/packages/device-management-kit/src/api/network/DmkNetworkClientHelpers.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClientHelpers.ts
@@ -112,12 +112,10 @@ export function buildBodyAndHeaders(args: {
  * either one firing aborts the request.
  */
 export function buildSignal(args: {
-  perRequestTimeoutMs: number | undefined;
-  defaultTimeoutMs: number | undefined;
+  timeoutMs: number | undefined;
   externalSignal: AbortSignal | undefined;
 }): AbortSignal | undefined {
-  const { perRequestTimeoutMs, defaultTimeoutMs, externalSignal } = args;
-  const timeoutMs = perRequestTimeoutMs ?? defaultTimeoutMs;
+  const { timeoutMs, externalSignal } = args;
   const timeoutSignal =
     timeoutMs && timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined;
 
@@ -187,11 +185,9 @@ export async function safeReadText(
 export function wrapFetchError(args: {
   cause: unknown;
   externalSignal: AbortSignal | undefined;
-  perRequestTimeoutMs: number | undefined;
-  defaultTimeoutMs: number | undefined;
+  timeoutMs: number | undefined;
 }): DmkNetworkClientError {
-  const { cause, externalSignal, perRequestTimeoutMs, defaultTimeoutMs } = args;
-  const timeoutMs = perRequestTimeoutMs ?? defaultTimeoutMs;
+  const { cause, externalSignal, timeoutMs } = args;
   const hasTimeout = Boolean(timeoutMs && timeoutMs > 0);
   const isAbortError =
     cause instanceof Error &&

--- a/packages/device-management-kit/src/api/network/DmkNetworkClientHelpers.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClientHelpers.ts
@@ -1,0 +1,216 @@
+import { DmkNetworkClientError } from "./DmkNetworkClientError";
+
+export type DmkQueryParamValue = string | number | boolean | null | undefined;
+
+export type DmkQueryParams = Record<string, DmkQueryParamValue>;
+
+export type DmkResponseType = "json" | "text" | "blob" | "arrayBuffer" | "void";
+
+export const JSON_CONTENT_TYPE = "application/json";
+
+/**
+ * Joins a base URL with a relative path, normalizing surrounding slashes so
+ * that exactly one `/` appears between them.
+ */
+export function joinPath(base: string, path: string): string {
+  if (!path) return base;
+  const trimmedBase = base.endsWith("/") ? base.slice(0, -1) : base;
+  const trimmedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${trimmedBase}${trimmedPath}`;
+}
+
+/**
+ * Builds the final request URL from an input URL (absolute or relative), an
+ * optional base URL, and optional query params. `null`/`undefined` param
+ * values are skipped.
+ */
+export function buildUrl(args: {
+  url: string;
+  params?: DmkQueryParams;
+  baseUrl?: string;
+}): URL {
+  const { url, params, baseUrl } = args;
+  const isAbsolute = /^[a-z][a-z0-9+.-]*:\/\//i.test(url);
+  const fullUrl = isAbsolute
+    ? new URL(url)
+    : baseUrl
+      ? new URL(joinPath(baseUrl, url))
+      : new URL(url);
+
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== null && value !== undefined) {
+        fullUrl.searchParams.set(key, String(value));
+      }
+    }
+  }
+
+  return fullUrl;
+}
+
+/**
+ * Case-insensitive lookup for a header name in a plain record.
+ */
+export function hasHeader(
+  headers: Record<string, string>,
+  name: string,
+): boolean {
+  const lower = name.toLowerCase();
+  return Object.keys(headers).some((k) => k.toLowerCase() === lower);
+}
+
+/**
+ * Returns `true` when the value is already a `BodyInit` accepted by `fetch`
+ * and should be passed through without JSON serialization.
+ */
+export function isRawBody(body: unknown): body is BodyInit {
+  return (
+    typeof body === "string" ||
+    body instanceof ArrayBuffer ||
+    body instanceof Blob ||
+    body instanceof FormData ||
+    body instanceof URLSearchParams ||
+    body instanceof ReadableStream ||
+    ArrayBuffer.isView(body)
+  );
+}
+
+/**
+ * Computes the final request body and merged headers. Plain-object bodies are
+ * JSON-serialized and the `Content-Type` header is set (unless the caller
+ * already provided one). Raw `BodyInit` values pass through unchanged.
+ */
+export function buildBodyAndHeaders(args: {
+  method: string;
+  body: unknown;
+  defaultHeaders: Record<string, string>;
+  perRequestHeaders?: Record<string, string>;
+}): { body?: BodyInit; headers: Record<string, string> } {
+  const { method, body, defaultHeaders, perRequestHeaders } = args;
+  const headers: Record<string, string> = {
+    ...defaultHeaders,
+    ...perRequestHeaders,
+  };
+
+  if (body === undefined || method === "GET" || method === "HEAD") {
+    return { body: undefined, headers };
+  }
+
+  if (isRawBody(body)) {
+    return { body, headers };
+  }
+
+  if (!hasHeader(headers, "content-type")) {
+    headers["Content-Type"] = JSON_CONTENT_TYPE;
+  }
+  return { body: JSON.stringify(body), headers };
+}
+
+/**
+ * Composes the effective abort signal for a request. If both a timeout and an
+ * external signal are present, they are merged via `AbortSignal.any` so that
+ * either one firing aborts the request.
+ */
+export function buildSignal(args: {
+  perRequestTimeoutMs: number | undefined;
+  defaultTimeoutMs: number | undefined;
+  externalSignal: AbortSignal | undefined;
+}): AbortSignal | undefined {
+  const { perRequestTimeoutMs, defaultTimeoutMs, externalSignal } = args;
+  const timeoutMs = perRequestTimeoutMs ?? defaultTimeoutMs;
+  const timeoutSignal =
+    timeoutMs && timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined;
+
+  if (timeoutSignal && externalSignal) {
+    return AbortSignal.any([externalSignal, timeoutSignal]);
+  }
+  return timeoutSignal ?? externalSignal;
+}
+
+/**
+ * Parses the response body according to the requested {@link DmkResponseType}.
+ * Empty JSON bodies resolve to `undefined`; malformed JSON throws a
+ * {@link DmkNetworkClientError}.
+ */
+export async function parseBody(
+  response: Response,
+  responseType: DmkResponseType,
+): Promise<unknown> {
+  switch (responseType) {
+    case "void":
+      return undefined;
+    case "text":
+      return await response.text();
+    case "blob":
+      return await response.blob();
+    case "arrayBuffer":
+      return await response.arrayBuffer();
+    case "json":
+    default: {
+      const text = await response.text();
+      if (text.length === 0) {
+        return undefined;
+      }
+      try {
+        return JSON.parse(text);
+      } catch (cause) {
+        throw new DmkNetworkClientError({
+          message: "Failed to parse JSON response body",
+          status: response.status,
+          statusText: response.statusText,
+          responseBody: text,
+          cause,
+        });
+      }
+    }
+  }
+}
+
+/**
+ * Reads the response body as text, swallowing any error so callers can use it
+ * for best-effort diagnostics (e.g. building an error payload).
+ */
+export async function safeReadText(
+  response: Response,
+): Promise<string | undefined> {
+  try {
+    return await response.text();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Wraps a `fetch` rejection into a typed {@link DmkNetworkClientError},
+ * discriminating between external aborts, timeouts and generic failures.
+ */
+export function wrapFetchError(args: {
+  cause: unknown;
+  externalSignal: AbortSignal | undefined;
+  perRequestTimeoutMs: number | undefined;
+  defaultTimeoutMs: number | undefined;
+}): DmkNetworkClientError {
+  const { cause, externalSignal, perRequestTimeoutMs, defaultTimeoutMs } = args;
+  const timeoutMs = perRequestTimeoutMs ?? defaultTimeoutMs;
+  const hasTimeout = Boolean(timeoutMs && timeoutMs > 0);
+  const isAbortError =
+    cause instanceof Error &&
+    (cause.name === "AbortError" || cause.name === "TimeoutError");
+
+  if (isAbortError) {
+    const externallyAborted = externalSignal?.aborted ?? false;
+    const timedOut =
+      !externallyAborted && (cause.name === "TimeoutError" || hasTimeout);
+    return new DmkNetworkClientError({
+      message: timedOut ? `Request timed out` : "Request aborted",
+      isTimeout: timedOut,
+      isAbort: externallyAborted,
+      cause,
+    });
+  }
+
+  return new DmkNetworkClientError({
+    message: cause instanceof Error ? cause.message : "Network request failed",
+    cause,
+  });
+}

--- a/packages/device-management-kit/src/internal/device-session/service/DefaultDeviceSessionService.test.ts
+++ b/packages/device-management-kit/src/internal/device-session/service/DefaultDeviceSessionService.test.ts
@@ -8,7 +8,7 @@ import { type DeviceSession } from "@internal/device-session/model/DeviceSession
 import { deviceSessionStubBuilder } from "@internal/device-session/model/DeviceSession.stub";
 import { DeviceSessionNotFound } from "@internal/device-session/model/Errors";
 import { DefaultLoggerPublisherService } from "@internal/logger-publisher/service/DefaultLoggerPublisherService";
-import { AxiosManagerApiDataSource } from "@internal/manager-api/data/AxiosManagerApiDataSource";
+import { HttpManagerApiDataSource } from "@internal/manager-api/data/HttpManagerApiDataSource";
 import { type ManagerApiDataSource } from "@internal/manager-api/data/ManagerApiDataSource";
 import { DefaultManagerApiService } from "@internal/manager-api/service/DefaultManagerApiService";
 import type { ManagerApiService } from "@internal/manager-api/service/ManagerApiService";
@@ -20,7 +20,7 @@ import { type SecureChannelService } from "@internal/secure-channel/service/Secu
 import { DefaultDeviceSessionService } from "./DefaultDeviceSessionService";
 
 vi.mock("@internal/logger-publisher/service/DefaultLoggerPublisherService");
-vi.mock("@internal/manager-api/data/AxiosManagerApiDataSource");
+vi.mock("@internal/manager-api/data/HttpManagerApiDataSource");
 
 let sessionService: DefaultDeviceSessionService;
 let loggerService: DefaultLoggerPublisherService;
@@ -35,7 +35,7 @@ let secureChannel: SecureChannelService;
 describe("DefaultDeviceSessionService", () => {
   // Initialize shared resources
   loggerService = new DefaultLoggerPublisherService([], "deviceSession");
-  managerApiDataSource = new AxiosManagerApiDataSource({} as DmkConfig);
+  managerApiDataSource = new HttpManagerApiDataSource({} as DmkConfig);
   managerApi = new DefaultManagerApiService(managerApiDataSource);
   secureChannelDataSource = new DefaultSecureChannelDataSource({} as DmkConfig);
   secureChannel = new DefaultSecureChannelService(secureChannelDataSource);

--- a/packages/device-management-kit/src/internal/device-session/use-case/CloseSessionsUseCase.test.ts
+++ b/packages/device-management-kit/src/internal/device-session/use-case/CloseSessionsUseCase.test.ts
@@ -6,7 +6,7 @@ import { DefaultDeviceSessionService } from "@internal/device-session/service/De
 import { type DeviceSessionService } from "@internal/device-session/service/DeviceSessionService";
 import { CloseSessionsUseCase } from "@internal/device-session/use-case/CloseSessionsUseCase";
 import { DefaultLoggerPublisherService } from "@internal/logger-publisher/service/DefaultLoggerPublisherService";
-import { AxiosManagerApiDataSource } from "@internal/manager-api/data/AxiosManagerApiDataSource";
+import { HttpManagerApiDataSource } from "@internal/manager-api/data/HttpManagerApiDataSource";
 import { type ManagerApiDataSource } from "@internal/manager-api/data/ManagerApiDataSource";
 import { DefaultManagerApiService } from "@internal/manager-api/service/DefaultManagerApiService";
 import { type ManagerApiService } from "@internal/manager-api/service/ManagerApiService";
@@ -31,7 +31,7 @@ describe("CloseSessionsUseCase", () => {
       [],
       "close-sessions-use-case-test",
     );
-    managerApiDataSource = new AxiosManagerApiDataSource({} as DmkConfig);
+    managerApiDataSource = new HttpManagerApiDataSource({} as DmkConfig);
     managerApi = new DefaultManagerApiService(managerApiDataSource);
     secureChannelDataSource = new DefaultSecureChannelDataSource(
       {} as DmkConfig,

--- a/packages/device-management-kit/src/internal/device-session/use-case/GetDeviceSessionStateUseCase.test.ts
+++ b/packages/device-management-kit/src/internal/device-session/use-case/GetDeviceSessionStateUseCase.test.ts
@@ -6,7 +6,7 @@ import { DeviceSessionNotFound } from "@internal/device-session/model/Errors";
 import { DefaultDeviceSessionService } from "@internal/device-session/service/DefaultDeviceSessionService";
 import { type DeviceSessionService } from "@internal/device-session/service/DeviceSessionService";
 import { DefaultLoggerPublisherService } from "@internal/logger-publisher/service/DefaultLoggerPublisherService";
-import { AxiosManagerApiDataSource } from "@internal/manager-api/data/AxiosManagerApiDataSource";
+import { HttpManagerApiDataSource } from "@internal/manager-api/data/HttpManagerApiDataSource";
 import { type ManagerApiDataSource } from "@internal/manager-api/data/ManagerApiDataSource";
 import { DefaultManagerApiService } from "@internal/manager-api/service/DefaultManagerApiService";
 import { type ManagerApiService } from "@internal/manager-api/service/ManagerApiService";
@@ -17,7 +17,7 @@ import { type SecureChannelService } from "@internal/secure-channel/service/Secu
 
 import { GetDeviceSessionStateUseCase } from "./GetDeviceSessionStateUseCase";
 
-vi.mock("@internal/manager-api/data/AxiosManagerApiDataSource");
+vi.mock("@internal/manager-api/data/HttpManagerApiDataSource");
 
 let logger: LoggerPublisherService;
 let sessionService: DeviceSessionService;
@@ -34,7 +34,7 @@ describe("GetDeviceSessionStateUseCase", () => {
       [],
       "get-connected-device-use-case-test",
     );
-    managerApiDataSource = new AxiosManagerApiDataSource({} as DmkConfig);
+    managerApiDataSource = new HttpManagerApiDataSource({} as DmkConfig);
     managerApi = new DefaultManagerApiService(managerApiDataSource);
     secureChannelDataSource = new DefaultSecureChannelDataSource(
       {} as DmkConfig,

--- a/packages/device-management-kit/src/internal/discovery/use-case/DisconnectUseCase.test.ts
+++ b/packages/device-management-kit/src/internal/discovery/use-case/DisconnectUseCase.test.ts
@@ -9,7 +9,7 @@ import { deviceSessionStubBuilder } from "@internal/device-session/model/DeviceS
 import { DeviceSessionNotFound } from "@internal/device-session/model/Errors";
 import { DefaultDeviceSessionService } from "@internal/device-session/service/DefaultDeviceSessionService";
 import { DefaultLoggerPublisherService } from "@internal/logger-publisher/service/DefaultLoggerPublisherService";
-import { AxiosManagerApiDataSource } from "@internal/manager-api/data/AxiosManagerApiDataSource";
+import { HttpManagerApiDataSource } from "@internal/manager-api/data/HttpManagerApiDataSource";
 import { type ManagerApiDataSource } from "@internal/manager-api/data/ManagerApiDataSource";
 import { DefaultManagerApiService } from "@internal/manager-api/service/DefaultManagerApiService";
 import { type ManagerApiService } from "@internal/manager-api/service/ManagerApiService";
@@ -56,7 +56,7 @@ describe("DisconnectUseCase", () => {
   it("should disconnect from a device", async () => {
     // Given
     const connectedDevice = connectedDeviceStubBuilder();
-    managerApiDataSource = new AxiosManagerApiDataSource({} as DmkConfig);
+    managerApiDataSource = new HttpManagerApiDataSource({} as DmkConfig);
     managerApi = new DefaultManagerApiService(managerApiDataSource);
     secureChannelDataSource = new DefaultSecureChannelDataSource(
       {} as DmkConfig,

--- a/packages/device-management-kit/src/internal/discovery/use-case/GetConnectedDeviceUseCase.test.ts
+++ b/packages/device-management-kit/src/internal/discovery/use-case/GetConnectedDeviceUseCase.test.ts
@@ -6,7 +6,7 @@ import { deviceSessionStubBuilder } from "@internal/device-session/model/DeviceS
 import { DefaultDeviceSessionService } from "@internal/device-session/service/DefaultDeviceSessionService";
 import { type DeviceSessionService } from "@internal/device-session/service/DeviceSessionService";
 import { DefaultLoggerPublisherService } from "@internal/logger-publisher/service/DefaultLoggerPublisherService";
-import { AxiosManagerApiDataSource } from "@internal/manager-api/data/AxiosManagerApiDataSource";
+import { HttpManagerApiDataSource } from "@internal/manager-api/data/HttpManagerApiDataSource";
 import { type ManagerApiDataSource } from "@internal/manager-api/data/ManagerApiDataSource";
 import { DefaultManagerApiService } from "@internal/manager-api/service/DefaultManagerApiService";
 import { type ManagerApiService } from "@internal/manager-api/service/ManagerApiService";
@@ -17,7 +17,7 @@ import { type SecureChannelService } from "@internal/secure-channel/service/Secu
 
 import { GetConnectedDeviceUseCase } from "./GetConnectedDeviceUseCase";
 
-vi.mock("@internal/manager-api/data/AxiosManagerApiDataSource");
+vi.mock("@internal/manager-api/data/HttpManagerApiDataSource");
 
 let logger: LoggerPublisherService;
 let sessionService: DeviceSessionService;
@@ -34,7 +34,7 @@ describe("GetConnectedDevice", () => {
       [],
       "get-connected-device-use-case",
     );
-    managerApiDataSource = new AxiosManagerApiDataSource({} as DmkConfig);
+    managerApiDataSource = new HttpManagerApiDataSource({} as DmkConfig);
     managerApi = new DefaultManagerApiService(managerApiDataSource);
     secureChannelDataSource = new DefaultSecureChannelDataSource(
       {} as DmkConfig,

--- a/packages/device-management-kit/src/internal/discovery/use-case/ListConnectedDevicesUseCase.test.ts
+++ b/packages/device-management-kit/src/internal/discovery/use-case/ListConnectedDevicesUseCase.test.ts
@@ -6,7 +6,7 @@ import { DefaultDeviceSessionService } from "@internal/device-session/service/De
 import { type DeviceSessionService } from "@internal/device-session/service/DeviceSessionService";
 import { ListConnectedDevicesUseCase } from "@internal/discovery/use-case/ListConnectedDevicesUseCase";
 import { DefaultLoggerPublisherService } from "@internal/logger-publisher/service/DefaultLoggerPublisherService";
-import { AxiosManagerApiDataSource } from "@internal/manager-api/data/AxiosManagerApiDataSource";
+import { HttpManagerApiDataSource } from "@internal/manager-api/data/HttpManagerApiDataSource";
 import { type ManagerApiDataSource } from "@internal/manager-api/data/ManagerApiDataSource";
 import { DefaultManagerApiService } from "@internal/manager-api/service/DefaultManagerApiService";
 import { type ManagerApiService } from "@internal/manager-api/service/ManagerApiService";
@@ -29,7 +29,7 @@ describe("ListDeviceSessionsUseCase", () => {
       [],
       "list-device-sessions-use-case-test",
     );
-    managerApiDataSource = new AxiosManagerApiDataSource({} as DmkConfig);
+    managerApiDataSource = new HttpManagerApiDataSource({} as DmkConfig);
     managerApi = new DefaultManagerApiService(managerApiDataSource);
     secureChannelDataSource = new DefaultSecureChannelDataSource(
       {} as DmkConfig,

--- a/packages/device-management-kit/src/internal/discovery/use-case/ListenToConnectedDeviceUseCase.test.ts
+++ b/packages/device-management-kit/src/internal/discovery/use-case/ListenToConnectedDeviceUseCase.test.ts
@@ -8,7 +8,7 @@ import { DefaultDeviceSessionService } from "@internal/device-session/service/De
 import { type DeviceSessionService } from "@internal/device-session/service/DeviceSessionService";
 import { ListenToConnectedDeviceUseCase } from "@internal/discovery/use-case/ListenToConnectedDeviceUseCase";
 import { DefaultLoggerPublisherService } from "@internal/logger-publisher/service/DefaultLoggerPublisherService";
-import { AxiosManagerApiDataSource } from "@internal/manager-api/data/AxiosManagerApiDataSource";
+import { HttpManagerApiDataSource } from "@internal/manager-api/data/HttpManagerApiDataSource";
 import { type ManagerApiDataSource } from "@internal/manager-api/data/ManagerApiDataSource";
 import { DefaultManagerApiService } from "@internal/manager-api/service/DefaultManagerApiService";
 import { type ManagerApiService } from "@internal/manager-api/service/ManagerApiService";
@@ -17,7 +17,7 @@ import { type SecureChannelDataSource } from "@internal/secure-channel/data/Secu
 import { DefaultSecureChannelService } from "@internal/secure-channel/service/DefaultSecureChannelService";
 import { type SecureChannelService } from "@internal/secure-channel/service/SecureChannelService";
 
-vi.mock("@internal/manager-api/data/AxiosManagerApiDataSource");
+vi.mock("@internal/manager-api/data/HttpManagerApiDataSource");
 
 let logger: LoggerPublisherService;
 let sessionService: DeviceSessionService;
@@ -34,7 +34,7 @@ describe("ListenToConnectedDevice", () => {
       [],
       "listen-to-connected-device-use-case",
     );
-    managerApiDataSource = new AxiosManagerApiDataSource({} as DmkConfig);
+    managerApiDataSource = new HttpManagerApiDataSource({} as DmkConfig);
     managerApi = new DefaultManagerApiService(managerApiDataSource);
     secureChannelDataSource = new DefaultSecureChannelDataSource(
       {} as DmkConfig,

--- a/packages/device-management-kit/src/internal/manager-api/data/AxiosManagerApiDataSource.test.ts
+++ b/packages/device-management-kit/src/internal/manager-api/data/AxiosManagerApiDataSource.test.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { Left, Right } from "purify-ts";
 
 import {
@@ -14,21 +13,23 @@ import { HttpFetchApiError } from "@internal/manager-api/model/Errors";
 import { AxiosManagerApiDataSource } from "./AxiosManagerApiDataSource";
 import { type ManagerApiDataSource } from "./ManagerApiDataSource";
 
-vi.mock("axios");
-
 describe("AxiosManagerApiDataSource", () => {
   describe("getAppList", () => {
     let api: ManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({} as DmkConfig);
+      api = new AxiosManagerApiDataSource({
+        managerApiUrl: "http://localhost",
+      } as DmkConfig);
     });
     afterEach(() => {
-      vi.clearAllMocks();
+      vi.restoreAllMocks();
     });
     it("should return a list of applications", async () => {
       // given
       const apps = [BTC_APP_METADATA, ETH_APP_METADATA];
-      vi.spyOn(axios, "get").mockResolvedValue({ data: apps });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(apps)),
+      );
 
       // when
       const response = await api.getAppList({
@@ -43,7 +44,9 @@ describe("AxiosManagerApiDataSource", () => {
       // given
       const { versionId, ...rest } = BTC_APP_METADATA;
       const apps = [{ versionId: "invalidVersion", ...rest }];
-      vi.spyOn(axios, "get").mockResolvedValue({ data: apps });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(apps)),
+      );
 
       // when
       const response = await api.getAppList({
@@ -57,7 +60,7 @@ describe("AxiosManagerApiDataSource", () => {
     it("should return an error if the request fails", async () => {
       // given
       const error = new Error("fetch error");
-      vi.spyOn(axios, "get").mockRejectedValue(error);
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(error);
 
       // when
       const response = await api.getAppList({
@@ -73,15 +76,17 @@ describe("AxiosManagerApiDataSource", () => {
     describe("success cases", () => {
       let api: ManagerApiDataSource;
       beforeEach(() => {
-        api = new AxiosManagerApiDataSource({} as DmkConfig);
+        api = new AxiosManagerApiDataSource({
+          managerApiUrl: "http://localhost",
+        } as DmkConfig);
       });
       afterEach(() => {
-        vi.clearAllMocks();
+        vi.restoreAllMocks();
       });
       it("with BTC app, should return the metadata", async () => {
-        vi.spyOn(axios, "post").mockResolvedValue({
-          data: [BTC_APP_METADATA],
-        });
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(JSON.stringify([BTC_APP_METADATA])),
+        );
 
         const hashes = [BTC_APP.appFullHash];
 
@@ -91,9 +96,9 @@ describe("AxiosManagerApiDataSource", () => {
       });
 
       it("with no apps, should return an empty list", async () => {
-        vi.spyOn(axios, "post").mockResolvedValue({
-          data: [],
-        });
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(JSON.stringify([])),
+        );
 
         const hashes: string[] = [];
 
@@ -103,9 +108,14 @@ describe("AxiosManagerApiDataSource", () => {
       });
 
       it("with BTC app and custom lock screen, should return the metadata", async () => {
-        vi.spyOn(axios, "post").mockResolvedValue({
-          data: [BTC_APP_METADATA, CUSTOM_LOCK_SCREEN_APP_METADATA],
-        });
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(
+            JSON.stringify([
+              BTC_APP_METADATA,
+              CUSTOM_LOCK_SCREEN_APP_METADATA,
+            ]),
+          ),
+        );
 
         const hashes = [
           BTC_APP.appFullHash,
@@ -123,16 +133,20 @@ describe("AxiosManagerApiDataSource", () => {
     describe("error cases", () => {
       let api: ManagerApiDataSource;
       beforeEach(() => {
-        api = new AxiosManagerApiDataSource({} as DmkConfig);
+        api = new AxiosManagerApiDataSource({
+          managerApiUrl: "http://localhost",
+        } as DmkConfig);
       });
       afterEach(() => {
-        vi.clearAllMocks();
+        vi.restoreAllMocks();
       });
       it("with BTC app, should fail if payload don't match the dto", async () => {
         const { versionId, ...rest } = BTC_APP_METADATA;
-        vi.spyOn(axios, "post").mockResolvedValue({
-          data: [{ versionId: "invalidVersion", ...rest }],
-        });
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(
+            JSON.stringify([{ versionId: "invalidVersion", ...rest }]),
+          ),
+        );
 
         const hashes = [BTC_APP.appFullHash];
 
@@ -143,10 +157,12 @@ describe("AxiosManagerApiDataSource", () => {
 
       it("should throw an error if the request fails", async () => {
         // given
-        const api = new AxiosManagerApiDataSource({} as DmkConfig);
+        const api = new AxiosManagerApiDataSource({
+          managerApiUrl: "http://localhost",
+        } as DmkConfig);
 
         const err = new Error("fetch error");
-        vi.spyOn(axios, "post").mockRejectedValue(err);
+        vi.spyOn(globalThis, "fetch").mockRejectedValue(err);
 
         const hashes = [BTC_APP.appFullHash];
 
@@ -162,19 +178,23 @@ describe("AxiosManagerApiDataSource", () => {
   describe("getDeviceVersion", () => {
     let api: ManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({} as DmkConfig);
+      api = new AxiosManagerApiDataSource({
+        managerApiUrl: "http://localhost",
+      } as DmkConfig);
     });
     afterEach(() => {
-      vi.clearAllMocks();
+      vi.restoreAllMocks();
     });
     it("should return a complete device version", async () => {
       // given
-      vi.spyOn(axios, "get").mockResolvedValue({
-        data: {
-          id: 17,
-          target_id: "857735172",
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            id: 17,
+            target_id: "857735172",
+          }),
+        ),
+      );
 
       // when
       const response = await api.getDeviceVersion({
@@ -187,11 +207,13 @@ describe("AxiosManagerApiDataSource", () => {
 
     it("should return an error if payload don't match dto", async () => {
       // given
-      vi.spyOn(axios, "get").mockResolvedValue({
-        data: {
-          target_id: "857735172",
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            target_id: "857735172",
+          }),
+        ),
+      );
 
       // when
       const response = await api.getDeviceVersion({
@@ -206,7 +228,7 @@ describe("AxiosManagerApiDataSource", () => {
       // given
 
       const error = new Error("fetch error");
-      vi.spyOn(axios, "get").mockRejectedValue(error);
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(error);
 
       // when
       const response = await api.getDeviceVersion({
@@ -221,25 +243,29 @@ describe("AxiosManagerApiDataSource", () => {
   describe("getFirmwareVersion", () => {
     let api: ManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({} as DmkConfig);
+      api = new AxiosManagerApiDataSource({
+        managerApiUrl: "http://localhost",
+      } as DmkConfig);
     });
     afterEach(() => {
-      vi.clearAllMocks();
+      vi.restoreAllMocks();
     });
     it("should return a complete firmware version", async () => {
       // given
-      vi.spyOn(axios, "get").mockResolvedValue({
-        data: {
-          id: 361,
-          version: "1.6.0",
-          perso: "perso_11",
-          firmware: null,
-          firmware_key: "testKey",
-          hash: "hash",
-          bytes: 194,
-          mcu_versions: [1, 5, 7],
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            id: 361,
+            version: "1.6.0",
+            perso: "perso_11",
+            firmware: null,
+            firmware_key: "testKey",
+            hash: "hash",
+            bytes: 194,
+            mcu_versions: [1, 5, 7],
+          }),
+        ),
+      );
 
       // when
       const response = await api.getFirmwareVersion({
@@ -263,18 +289,20 @@ describe("AxiosManagerApiDataSource", () => {
     });
     it("should return an error if payload don't match the dto", async () => {
       // given
-      vi.spyOn(axios, "get").mockResolvedValue({
-        data: {
-          id: "invalidId",
-          version: "1.6.0",
-          perso: "perso_11",
-          firmware: null,
-          firmware_key: "testKey",
-          hash: "hash",
-          bytes: 194,
-          mcu_versions: [1, 5, 7],
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            id: "invalidId",
+            version: "1.6.0",
+            perso: "perso_11",
+            firmware: null,
+            firmware_key: "testKey",
+            hash: "hash",
+            bytes: 194,
+            mcu_versions: [1, 5, 7],
+          }),
+        ),
+      );
 
       // when
       const response = await api.getFirmwareVersion({
@@ -288,7 +316,7 @@ describe("AxiosManagerApiDataSource", () => {
     it("should return an error if the request fails", async () => {
       // given
       const error = new Error("fetch error");
-      vi.spyOn(axios, "get").mockRejectedValue(error);
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(error);
 
       // when
       const response = await api.getFirmwareVersion({
@@ -356,25 +384,29 @@ describe("AxiosManagerApiDataSource", () => {
   describe("getFirmwareVersionById", () => {
     let api: ManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({} as DmkConfig);
+      api = new AxiosManagerApiDataSource({
+        managerApiUrl: "http://localhost",
+      } as DmkConfig);
     });
     afterEach(() => {
-      vi.clearAllMocks();
+      vi.restoreAllMocks();
     });
     it("should return a complete firmware version", async () => {
       // given
-      vi.spyOn(axios, "get").mockResolvedValue({
-        data: {
-          id: 361,
-          version: "1.6.0",
-          perso: "perso_11",
-          firmware: null,
-          firmware_key: "testKey",
-          hash: "hash",
-          bytes: 194,
-          mcu_versions: [1, 5, 7],
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            id: 361,
+            version: "1.6.0",
+            perso: "perso_11",
+            firmware: null,
+            firmware_key: "testKey",
+            hash: "hash",
+            bytes: 194,
+            mcu_versions: [1, 5, 7],
+          }),
+        ),
+      );
 
       // when
       const response = await api.getFirmwareVersionById(42);
@@ -398,26 +430,30 @@ describe("AxiosManagerApiDataSource", () => {
   describe("getLatestFirmwareVersion", () => {
     let api: ManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({} as DmkConfig);
+      api = new AxiosManagerApiDataSource({
+        managerApiUrl: "http://localhost",
+      } as DmkConfig);
     });
     afterEach(() => {
-      vi.clearAllMocks();
+      vi.restoreAllMocks();
     });
     it("should return the latest firmware version", async () => {
       // given
-      vi.spyOn(axios, "get").mockResolvedValue({
-        data: {
-          result: "success",
-          se_firmware_osu_version: {
-            id: 361,
-            perso: "perso_11",
-            firmware: "test",
-            firmware_key: "testKey",
-            hash: "hash",
-            next_se_firmware_final_version: 567,
-          },
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            result: "success",
+            se_firmware_osu_version: {
+              id: 361,
+              perso: "perso_11",
+              firmware: "test",
+              firmware_key: "testKey",
+              hash: "hash",
+              next_se_firmware_final_version: 567,
+            },
+          }),
+        ),
+      );
 
       // when
       const response = await api.getLatestFirmwareVersion({
@@ -439,12 +475,14 @@ describe("AxiosManagerApiDataSource", () => {
     });
     it("should return an error if result is not success", async () => {
       // given
-      vi.spyOn(axios, "get").mockResolvedValue({
-        data: {
-          result: "failed",
-          se_firmware_osu_version: null,
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            result: "failed",
+            se_firmware_osu_version: null,
+          }),
+        ),
+      );
 
       // when
       const response = await api.getLatestFirmwareVersion({
@@ -457,19 +495,21 @@ describe("AxiosManagerApiDataSource", () => {
     });
     it("should return an error if payload don't match the dto", async () => {
       // given
-      vi.spyOn(axios, "get").mockResolvedValue({
-        data: {
-          result: "success",
-          se_firmware_osu_version: {
-            id: "InvalidId",
-            perso: "perso_11",
-            firmware: "test",
-            firmware_key: "testKey",
-            hash: "hash",
-            next_se_firmware_final_version: 567,
-          },
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            result: "success",
+            se_firmware_osu_version: {
+              id: "InvalidId",
+              perso: "perso_11",
+              firmware: "test",
+              firmware_key: "testKey",
+              hash: "hash",
+              next_se_firmware_final_version: 567,
+            },
+          }),
+        ),
+      );
 
       // when
       const response = await api.getLatestFirmwareVersion({
@@ -483,7 +523,7 @@ describe("AxiosManagerApiDataSource", () => {
     it("should return an error if the request fails", async () => {
       // given
       const error = new Error("fetch error");
-      vi.spyOn(axios, "get").mockRejectedValue(error);
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(error);
 
       // when
       const response = await api.getLatestFirmwareVersion({
@@ -499,23 +539,27 @@ describe("AxiosManagerApiDataSource", () => {
   describe("getOsuFirmwareVersion", () => {
     let api: ManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({} as DmkConfig);
+      api = new AxiosManagerApiDataSource({
+        managerApiUrl: "http://localhost",
+      } as DmkConfig);
     });
     afterEach(() => {
-      vi.clearAllMocks();
+      vi.restoreAllMocks();
     });
     it("should return a complete OSU firmware version", async () => {
       // given
-      vi.spyOn(axios, "get").mockResolvedValue({
-        data: {
-          id: 361,
-          perso: "perso_11",
-          firmware: "test",
-          firmware_key: "testKey",
-          hash: "hash",
-          next_se_firmware_final_version: 567,
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            id: 361,
+            perso: "perso_11",
+            firmware: "test",
+            firmware_key: "testKey",
+            hash: "hash",
+            next_se_firmware_final_version: 567,
+          }),
+        ),
+      );
 
       // when
       const response = await api.getOsuFirmwareVersion({
@@ -537,16 +581,18 @@ describe("AxiosManagerApiDataSource", () => {
     });
     it("should return an error if payload don't match the dto", async () => {
       // given
-      vi.spyOn(axios, "get").mockResolvedValue({
-        data: {
-          id: "invalidId",
-          perso: "perso_11",
-          firmware: "test",
-          firmware_key: "testKey",
-          hash: "hash",
-          next_se_firmware_final_version: 567,
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            id: "invalidId",
+            perso: "perso_11",
+            firmware: "test",
+            firmware_key: "testKey",
+            hash: "hash",
+            next_se_firmware_final_version: 567,
+          }),
+        ),
+      );
 
       // when
       const response = await api.getOsuFirmwareVersion({
@@ -560,7 +606,7 @@ describe("AxiosManagerApiDataSource", () => {
     it("should return an error if the request fails", async () => {
       // given
       const error = new Error("fetch error");
-      vi.spyOn(axios, "get").mockRejectedValue(error);
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(error);
 
       // when
       const response = await api.getOsuFirmwareVersion({
@@ -576,47 +622,51 @@ describe("AxiosManagerApiDataSource", () => {
   describe("getLanguagePackages", () => {
     let api: ManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({} as DmkConfig);
+      api = new AxiosManagerApiDataSource({
+        managerApiUrl: "http://localhost",
+      } as DmkConfig);
     });
     afterEach(() => {
-      vi.clearAllMocks();
+      vi.restoreAllMocks();
     });
     it("should return the langage packages version", async () => {
       // given
-      vi.spyOn(axios, "get").mockResolvedValue({
-        data: [
-          {
-            language: "turkish",
-            languagePackageVersionId: 474,
-            version: "0.0.4",
-            language_package_id: 57,
-            apdu_install_url:
-              "https://download.languages.ledger.com/stax/turkish/bolos_1.6.2_pack_0.0.4_tr.apdu",
-            apdu_uninstall_url:
-              "https://download.languages.ledger.com/stax/turkish/bolos_1.6.2_pack_0.0.4_tr_del.apdu",
-            device_versions: [17],
-            se_firmware_final_versions: [432],
-            bytes: 20800,
-            date_creation: "2025-03-04T10:48:27.910630Z",
-            date_last_modified: "2025-03-04T10:48:27.910630Z",
-          },
-          {
-            language: "russian",
-            languagePackageVersionId: 470,
-            version: "0.0.4",
-            language_package_id: 56,
-            apdu_install_url:
-              "https://download.languages.ledger.com/stax/russian/bolos_1.6.2_pack_0.0.4_ru.apdu",
-            apdu_uninstall_url:
-              "https://download.languages.ledger.com/stax/russian/bolos_1.6.2_pack_0.0.4_ru_del.apdu",
-            device_versions: [17],
-            se_firmware_final_versions: [432],
-            bytes: 46592,
-            date_creation: "2025-03-04T10:48:26.218729Z",
-            date_last_modified: "2025-03-04T10:48:26.218729Z",
-          },
-        ],
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify([
+            {
+              language: "turkish",
+              languagePackageVersionId: 474,
+              version: "0.0.4",
+              language_package_id: 57,
+              apdu_install_url:
+                "https://download.languages.ledger.com/stax/turkish/bolos_1.6.2_pack_0.0.4_tr.apdu",
+              apdu_uninstall_url:
+                "https://download.languages.ledger.com/stax/turkish/bolos_1.6.2_pack_0.0.4_tr_del.apdu",
+              device_versions: [17],
+              se_firmware_final_versions: [432],
+              bytes: 20800,
+              date_creation: "2025-03-04T10:48:27.910630Z",
+              date_last_modified: "2025-03-04T10:48:27.910630Z",
+            },
+            {
+              language: "russian",
+              languagePackageVersionId: 470,
+              version: "0.0.4",
+              language_package_id: 56,
+              apdu_install_url:
+                "https://download.languages.ledger.com/stax/russian/bolos_1.6.2_pack_0.0.4_ru.apdu",
+              apdu_uninstall_url:
+                "https://download.languages.ledger.com/stax/russian/bolos_1.6.2_pack_0.0.4_ru_del.apdu",
+              device_versions: [17],
+              se_firmware_final_versions: [432],
+              bytes: 46592,
+              date_creation: "2025-03-04T10:48:26.218729Z",
+              date_last_modified: "2025-03-04T10:48:26.218729Z",
+            },
+          ]),
+        ),
+      );
 
       // when
       const response = await api.getLanguagePackages({
@@ -658,15 +708,17 @@ describe("AxiosManagerApiDataSource", () => {
     });
     it("should return an error if payload don't match the dto", async () => {
       // given
-      vi.spyOn(axios, "get").mockResolvedValue({
-        data: [
-          {
-            language: "turkish",
-            version: "0.0.4",
-            language_package_id: "invalid",
-          },
-        ],
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify([
+            {
+              language: "turkish",
+              version: "0.0.4",
+              language_package_id: "invalid",
+            },
+          ]),
+        ),
+      );
 
       // when
       const response = await api.getLanguagePackages({
@@ -680,7 +732,7 @@ describe("AxiosManagerApiDataSource", () => {
     it("should return an error if the request fails", async () => {
       // given
       const error = new Error("fetch error");
-      vi.spyOn(axios, "get").mockRejectedValue(error);
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(error);
 
       // when
       const response = await api.getLanguagePackages({
@@ -696,43 +748,47 @@ describe("AxiosManagerApiDataSource", () => {
   describe("getMcuList", () => {
     let api: ManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({} as DmkConfig);
+      api = new AxiosManagerApiDataSource({
+        managerApiUrl: "http://localhost",
+      } as DmkConfig);
     });
     afterEach(() => {
-      vi.clearAllMocks();
+      vi.restoreAllMocks();
     });
     it("should return a the list of MCUs", async () => {
       // given
-      vi.spyOn(axios, "get").mockResolvedValue({
-        data: [
-          {
-            id: 1,
-            mcu: 1,
-            name: "1.0",
-            description: null,
-            providers: [],
-            device_versions: [1, 2],
-            from_bootloader_version: "",
-            from_bootloader_version_id: 2,
-            se_firmware_final_versions: [7, 12, 13, 14, 15],
-            date_creation: "2018-09-20T13:30:50.156394Z",
-            date_last_modified: "2018-09-20T13:30:50.156453Z",
-          },
-          {
-            id: 2,
-            mcu: 1,
-            name: "1.1",
-            description: null,
-            providers: [],
-            device_versions: [1, 2],
-            from_bootloader_version: "",
-            from_bootloader_version_id: 2,
-            se_firmware_final_versions: [7, 12, 13, 14, 15],
-            date_creation: "2018-09-20T13:30:50.339966Z",
-            date_last_modified: "2018-09-20T13:30:50.340031Z",
-          },
-        ],
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify([
+            {
+              id: 1,
+              mcu: 1,
+              name: "1.0",
+              description: null,
+              providers: [],
+              device_versions: [1, 2],
+              from_bootloader_version: "",
+              from_bootloader_version_id: 2,
+              se_firmware_final_versions: [7, 12, 13, 14, 15],
+              date_creation: "2018-09-20T13:30:50.156394Z",
+              date_last_modified: "2018-09-20T13:30:50.156453Z",
+            },
+            {
+              id: 2,
+              mcu: 1,
+              name: "1.1",
+              description: null,
+              providers: [],
+              device_versions: [1, 2],
+              from_bootloader_version: "",
+              from_bootloader_version_id: 2,
+              se_firmware_final_versions: [7, 12, 13, 14, 15],
+              date_creation: "2018-09-20T13:30:50.339966Z",
+              date_last_modified: "2018-09-20T13:30:50.340031Z",
+            },
+          ]),
+        ),
+      );
 
       // when
       const response = await api.getMcuList();
@@ -754,20 +810,22 @@ describe("AxiosManagerApiDataSource", () => {
 
     it("should return an error when the payload don't match the dto", async () => {
       // given
-      vi.spyOn(axios, "get").mockResolvedValue({
-        data: [
-          {
-            id: "invalid id",
-            mcu: 1,
-            name: "1.0",
-            description: null,
-            providers: [],
-            se_firmware_final_versions: [7, 12, 13, 14, 15],
-            date_creation: "2018-09-20T13:30:50.156394Z",
-            date_last_modified: "2018-09-20T13:30:50.156453Z",
-          },
-        ],
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify([
+            {
+              id: "invalid id",
+              mcu: 1,
+              name: "1.0",
+              description: null,
+              providers: [],
+              se_firmware_final_versions: [7, 12, 13, 14, 15],
+              date_creation: "2018-09-20T13:30:50.156394Z",
+              date_last_modified: "2018-09-20T13:30:50.156453Z",
+            },
+          ]),
+        ),
+      );
 
       // when
       const response = await api.getMcuList();
@@ -779,7 +837,7 @@ describe("AxiosManagerApiDataSource", () => {
     it("should return an error if the request fails", async () => {
       // given
       const error = new Error("fetch error");
-      vi.spyOn(axios, "get").mockRejectedValue(error);
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(error);
 
       // when
       const response = await api.getMcuList();
@@ -797,7 +855,7 @@ describe("AxiosManagerApiDataSource", () => {
       } as DmkConfig);
     });
     afterEach(() => {
-      vi.clearAllMocks();
+      vi.restoreAllMocks();
     });
 
     it("should return the initial provider", () => {

--- a/packages/device-management-kit/src/internal/manager-api/data/AxiosManagerApiDataSource.test.ts
+++ b/packages/device-management-kit/src/internal/manager-api/data/AxiosManagerApiDataSource.test.ts
@@ -110,10 +110,7 @@ describe("AxiosManagerApiDataSource", () => {
       it("with BTC app and custom lock screen, should return the metadata", async () => {
         vi.spyOn(globalThis, "fetch").mockResolvedValue(
           new Response(
-            JSON.stringify([
-              BTC_APP_METADATA,
-              CUSTOM_LOCK_SCREEN_APP_METADATA,
-            ]),
+            JSON.stringify([BTC_APP_METADATA, CUSTOM_LOCK_SCREEN_APP_METADATA]),
           ),
         );
 

--- a/packages/device-management-kit/src/internal/manager-api/data/AxiosManagerApiDataSource.ts
+++ b/packages/device-management-kit/src/internal/manager-api/data/AxiosManagerApiDataSource.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { EitherAsync } from "purify-ts";
 
@@ -70,31 +69,27 @@ export class AxiosManagerApiDataSource implements ManagerApiDataSource {
     params: GetAppListParams,
   ): EitherAsync<HttpFetchApiError, Array<Application>> {
     const { targetId, firmwareVersionName } = params;
-    return EitherAsync(() =>
-      axios.get<Array<ApplicationDto>>(
-        `${this._managerApiBaseUrl}/v2/apps/by-target`,
-        {
-          params: {
-            target_id: targetId,
-            provider: this._provider,
-            firmware_version_name: firmwareVersionName,
-          },
-        },
-      ),
-    )
-      .map((res) => res.data)
+    return EitherAsync(async () => {
+      const url = new URL(`${this._managerApiBaseUrl}/v2/apps/by-target`);
+      url.searchParams.set("target_id", String(targetId));
+      url.searchParams.set("provider", String(this._provider));
+      url.searchParams.set("firmware_version_name", firmwareVersionName);
+      const response = await fetch(url);
+      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+      return (await response.json()) as Array<ApplicationDto>;
+    })
       .chain((apps) => this.mapApplicationDtoToApplication(apps))
       .mapLeft((error) => new HttpFetchApiError(error));
   }
 
   getMcuList(): EitherAsync<HttpFetchApiError, Array<McuFirmware>> {
-    return EitherAsync(() =>
-      axios.get<Array<McuVersionDto>>(
+    return EitherAsync(async () => {
+      const response = await fetch(
         `${this._managerApiBaseUrl}/mcu_versions`,
-        {},
-      ),
-    )
-      .map((res) => res.data)
+      );
+      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+      return (await response.json()) as Array<McuVersionDto>;
+    })
       .chain((mcus) => this.mapMcuDtoToMcu(mcus))
       .mapLeft((error) => new HttpFetchApiError(error));
   }
@@ -103,18 +98,14 @@ export class AxiosManagerApiDataSource implements ManagerApiDataSource {
     params: GetDeviceVersionParams,
   ): EitherAsync<HttpFetchApiError, DeviceVersion> {
     const { targetId } = params;
-    return EitherAsync(() =>
-      axios.get<DeviceVersionDto>(
-        `${this._managerApiBaseUrl}/get_device_version`,
-        {
-          params: {
-            target_id: targetId,
-            provider: this._provider,
-          },
-        },
-      ),
-    )
-      .map((res) => res.data)
+    return EitherAsync(async () => {
+      const url = new URL(`${this._managerApiBaseUrl}/get_device_version`);
+      url.searchParams.set("target_id", String(targetId));
+      url.searchParams.set("provider", String(this._provider));
+      const response = await fetch(url);
+      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+      return (await response.json()) as DeviceVersionDto;
+    })
       .chain((deviceVersion) => this.mapDeviceVersionDto(deviceVersion))
       .mapLeft((error) => new HttpFetchApiError(error));
   }
@@ -123,19 +114,17 @@ export class AxiosManagerApiDataSource implements ManagerApiDataSource {
     params: GetFirmwareVersionParams,
   ): EitherAsync<HttpFetchApiError, FinalFirmware> {
     const { deviceId, version } = params;
-    return EitherAsync(() =>
-      axios.get<FirmwareFinalVersionDto>(
+    return EitherAsync(async () => {
+      const url = new URL(
         `${this._managerApiBaseUrl}/get_firmware_version`,
-        {
-          params: {
-            device_version: deviceId,
-            version_name: version,
-            provider: this._provider,
-          },
-        },
-      ),
-    )
-      .map((res) => res.data)
+      );
+      url.searchParams.set("device_version", String(deviceId));
+      url.searchParams.set("version_name", version);
+      url.searchParams.set("provider", String(this._provider));
+      const response = await fetch(url);
+      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+      return (await response.json()) as FirmwareFinalVersionDto;
+    })
       .chain((finalFirmware) => this.mapFinalFirmwareDto(finalFirmware))
       .mapLeft((error) => new HttpFetchApiError(error));
   }
@@ -143,13 +132,13 @@ export class AxiosManagerApiDataSource implements ManagerApiDataSource {
   getFirmwareVersionById(
     finalFirmwareId: number,
   ): EitherAsync<HttpFetchApiError, FinalFirmware> {
-    return EitherAsync(() =>
-      axios.get<FirmwareFinalVersionDto>(
+    return EitherAsync(async () => {
+      const response = await fetch(
         `${this._managerApiBaseUrl}/firmware_final_versions/${finalFirmwareId}`,
-        {},
-      ),
-    )
-      .map((res) => res.data)
+      );
+      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+      return (await response.json()) as FirmwareFinalVersionDto;
+    })
       .chain((finalFirmware) => this.mapFinalFirmwareDto(finalFirmware))
       .mapLeft((error) => new HttpFetchApiError(error));
   }
@@ -158,19 +147,15 @@ export class AxiosManagerApiDataSource implements ManagerApiDataSource {
     params: GetFirmwareVersionParams,
   ): EitherAsync<HttpFetchApiError, OsuFirmware> {
     const { deviceId, version } = params;
-    return EitherAsync(() =>
-      axios.get<FirmwareOsuVersionDto>(
-        `${this._managerApiBaseUrl}/get_osu_version`,
-        {
-          params: {
-            device_version: deviceId,
-            version_name: version,
-            provider: this._provider,
-          },
-        },
-      ),
-    )
-      .map((res) => res.data)
+    return EitherAsync(async () => {
+      const url = new URL(`${this._managerApiBaseUrl}/get_osu_version`);
+      url.searchParams.set("device_version", String(deviceId));
+      url.searchParams.set("version_name", version);
+      url.searchParams.set("provider", String(this._provider));
+      const response = await fetch(url);
+      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+      return (await response.json()) as FirmwareOsuVersionDto;
+    })
       .chain((osuFirmware) => this.mapOsuFirmwareDto(osuFirmware))
       .mapLeft((error) => new HttpFetchApiError(error));
   }
@@ -180,21 +165,22 @@ export class AxiosManagerApiDataSource implements ManagerApiDataSource {
   ): EitherAsync<HttpFetchApiError, OsuFirmware> {
     const livecommonversion = "34.27.0"; // Legacy parameter that should just be a too old
     const { currentFinalFirmwareId, deviceId } = params;
-    return EitherAsync(() =>
-      axios.get<LatestFirmwareOsuVersionResponseDto>(
+    return EitherAsync(async () => {
+      const url = new URL(
         `${this._managerApiBaseUrl}/get_latest_firmware`,
-        {
-          params: {
-            current_se_firmware_final_version: currentFinalFirmwareId,
-            device_version: deviceId,
-            provider: this._provider,
-            salt: this._firmwareDistributionSalt,
-            livecommonversion,
-          },
-        },
-      ),
-    )
-      .map((res) => res.data)
+      );
+      url.searchParams.set(
+        "current_se_firmware_final_version",
+        String(currentFinalFirmwareId),
+      );
+      url.searchParams.set("device_version", String(deviceId));
+      url.searchParams.set("provider", String(this._provider));
+      url.searchParams.set("salt", this._firmwareDistributionSalt);
+      url.searchParams.set("livecommonversion", livecommonversion);
+      const response = await fetch(url);
+      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+      return (await response.json()) as LatestFirmwareOsuVersionResponseDto;
+    })
       .chain((latestFirmware) => this.mapLatestFirmwareDto(latestFirmware))
       .mapLeft((error) => new HttpFetchApiError(error));
   }
@@ -203,13 +189,18 @@ export class AxiosManagerApiDataSource implements ManagerApiDataSource {
     params: GetAppByHashParams,
   ): EitherAsync<HttpFetchApiError, Array<Application | null>> {
     const { hashes } = params;
-    return EitherAsync(() =>
-      axios.post<Array<ApplicationDto | null>>(
+    return EitherAsync(async () => {
+      const response = await fetch(
         `${this._managerApiBaseUrl}/v2/apps/hash`,
-        hashes,
-      ),
-    )
-      .map((res) => res.data)
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(hashes),
+        },
+      );
+      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+      return (await response.json()) as Array<ApplicationDto | null>;
+    })
       .chain((apps) => this.mapNullableApplicationDtoToApplication(apps))
       .mapLeft((error) => new HttpFetchApiError(error));
   }
@@ -218,18 +209,17 @@ export class AxiosManagerApiDataSource implements ManagerApiDataSource {
     params: GetLanguagePackagesParams,
   ): EitherAsync<HttpFetchApiError, Array<LanguagePackage>> {
     const { deviceId, currentFinalFirmwareId } = params;
-    return EitherAsync(() =>
-      axios.get<Array<LanguagePackageVersionDto>>(
-        `${this._managerApiBaseUrl}/language-packages`,
-        {
-          params: {
-            device_version: deviceId,
-            current_se_firmware_final_version: currentFinalFirmwareId,
-          },
-        },
-      ),
-    )
-      .map((res) => res.data)
+    return EitherAsync(async () => {
+      const url = new URL(`${this._managerApiBaseUrl}/language-packages`);
+      url.searchParams.set("device_version", String(deviceId));
+      url.searchParams.set(
+        "current_se_firmware_final_version",
+        String(currentFinalFirmwareId),
+      );
+      const response = await fetch(url);
+      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+      return (await response.json()) as Array<LanguagePackageVersionDto>;
+    })
       .chain((apps) => this.mapLanguagesDtoToLanguages(apps))
       .mapLeft((error) => new HttpFetchApiError(error));
   }

--- a/packages/device-management-kit/src/internal/manager-api/data/AxiosManagerApiDataSource.ts
+++ b/packages/device-management-kit/src/internal/manager-api/data/AxiosManagerApiDataSource.ts
@@ -84,9 +84,7 @@ export class AxiosManagerApiDataSource implements ManagerApiDataSource {
 
   getMcuList(): EitherAsync<HttpFetchApiError, Array<McuFirmware>> {
     return EitherAsync(async () => {
-      const response = await fetch(
-        `${this._managerApiBaseUrl}/mcu_versions`,
-      );
+      const response = await fetch(`${this._managerApiBaseUrl}/mcu_versions`);
       if (!response.ok) throw new Error(`HTTP error ${response.status}`);
       return (await response.json()) as Array<McuVersionDto>;
     })
@@ -115,9 +113,7 @@ export class AxiosManagerApiDataSource implements ManagerApiDataSource {
   ): EitherAsync<HttpFetchApiError, FinalFirmware> {
     const { deviceId, version } = params;
     return EitherAsync(async () => {
-      const url = new URL(
-        `${this._managerApiBaseUrl}/get_firmware_version`,
-      );
+      const url = new URL(`${this._managerApiBaseUrl}/get_firmware_version`);
       url.searchParams.set("device_version", String(deviceId));
       url.searchParams.set("version_name", version);
       url.searchParams.set("provider", String(this._provider));
@@ -166,9 +162,7 @@ export class AxiosManagerApiDataSource implements ManagerApiDataSource {
     const livecommonversion = "34.27.0"; // Legacy parameter that should just be a too old
     const { currentFinalFirmwareId, deviceId } = params;
     return EitherAsync(async () => {
-      const url = new URL(
-        `${this._managerApiBaseUrl}/get_latest_firmware`,
-      );
+      const url = new URL(`${this._managerApiBaseUrl}/get_latest_firmware`);
       url.searchParams.set(
         "current_se_firmware_final_version",
         String(currentFinalFirmwareId),
@@ -190,14 +184,11 @@ export class AxiosManagerApiDataSource implements ManagerApiDataSource {
   ): EitherAsync<HttpFetchApiError, Array<Application | null>> {
     const { hashes } = params;
     return EitherAsync(async () => {
-      const response = await fetch(
-        `${this._managerApiBaseUrl}/v2/apps/hash`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(hashes),
-        },
-      );
+      const response = await fetch(`${this._managerApiBaseUrl}/v2/apps/hash`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(hashes),
+      });
       if (!response.ok) throw new Error(`HTTP error ${response.status}`);
       return (await response.json()) as Array<ApplicationDto | null>;
     })

--- a/packages/device-management-kit/src/internal/manager-api/data/HttpManagerApiDataSource.test.ts
+++ b/packages/device-management-kit/src/internal/manager-api/data/HttpManagerApiDataSource.test.ts
@@ -10,14 +10,14 @@ import {
 import { type DmkConfig } from "@api/DmkConfig";
 import { HttpFetchApiError } from "@internal/manager-api/model/Errors";
 
-import { AxiosManagerApiDataSource } from "./AxiosManagerApiDataSource";
+import { HttpManagerApiDataSource } from "./HttpManagerApiDataSource";
 import { type ManagerApiDataSource } from "./ManagerApiDataSource";
 
-describe("AxiosManagerApiDataSource", () => {
+describe("HttpManagerApiDataSource", () => {
   describe("getAppList", () => {
     let api: ManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({
+      api = new HttpManagerApiDataSource({
         managerApiUrl: "http://localhost",
       } as DmkConfig);
     });
@@ -76,7 +76,7 @@ describe("AxiosManagerApiDataSource", () => {
     describe("success cases", () => {
       let api: ManagerApiDataSource;
       beforeEach(() => {
-        api = new AxiosManagerApiDataSource({
+        api = new HttpManagerApiDataSource({
           managerApiUrl: "http://localhost",
         } as DmkConfig);
       });
@@ -130,7 +130,7 @@ describe("AxiosManagerApiDataSource", () => {
     describe("error cases", () => {
       let api: ManagerApiDataSource;
       beforeEach(() => {
-        api = new AxiosManagerApiDataSource({
+        api = new HttpManagerApiDataSource({
           managerApiUrl: "http://localhost",
         } as DmkConfig);
       });
@@ -154,7 +154,7 @@ describe("AxiosManagerApiDataSource", () => {
 
       it("should throw an error if the request fails", async () => {
         // given
-        const api = new AxiosManagerApiDataSource({
+        const api = new HttpManagerApiDataSource({
           managerApiUrl: "http://localhost",
         } as DmkConfig);
 
@@ -175,7 +175,7 @@ describe("AxiosManagerApiDataSource", () => {
   describe("getDeviceVersion", () => {
     let api: ManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({
+      api = new HttpManagerApiDataSource({
         managerApiUrl: "http://localhost",
       } as DmkConfig);
     });
@@ -240,7 +240,7 @@ describe("AxiosManagerApiDataSource", () => {
   describe("getFirmwareVersion", () => {
     let api: ManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({
+      api = new HttpManagerApiDataSource({
         managerApiUrl: "http://localhost",
       } as DmkConfig);
     });
@@ -327,9 +327,9 @@ describe("AxiosManagerApiDataSource", () => {
   });
 
   describe("setProvider", () => {
-    let api: AxiosManagerApiDataSource;
+    let api: HttpManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({
+      api = new HttpManagerApiDataSource({
         managerApiUrl: "http://fake-url.com",
         provider: 1,
       } as DmkConfig);
@@ -381,7 +381,7 @@ describe("AxiosManagerApiDataSource", () => {
   describe("getFirmwareVersionById", () => {
     let api: ManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({
+      api = new HttpManagerApiDataSource({
         managerApiUrl: "http://localhost",
       } as DmkConfig);
     });
@@ -427,7 +427,7 @@ describe("AxiosManagerApiDataSource", () => {
   describe("getLatestFirmwareVersion", () => {
     let api: ManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({
+      api = new HttpManagerApiDataSource({
         managerApiUrl: "http://localhost",
       } as DmkConfig);
     });
@@ -536,7 +536,7 @@ describe("AxiosManagerApiDataSource", () => {
   describe("getOsuFirmwareVersion", () => {
     let api: ManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({
+      api = new HttpManagerApiDataSource({
         managerApiUrl: "http://localhost",
       } as DmkConfig);
     });
@@ -619,7 +619,7 @@ describe("AxiosManagerApiDataSource", () => {
   describe("getLanguagePackages", () => {
     let api: ManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({
+      api = new HttpManagerApiDataSource({
         managerApiUrl: "http://localhost",
       } as DmkConfig);
     });
@@ -745,7 +745,7 @@ describe("AxiosManagerApiDataSource", () => {
   describe("getMcuList", () => {
     let api: ManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({
+      api = new HttpManagerApiDataSource({
         managerApiUrl: "http://localhost",
       } as DmkConfig);
     });
@@ -844,9 +844,9 @@ describe("AxiosManagerApiDataSource", () => {
     });
   });
   describe("getProvider", () => {
-    let api: AxiosManagerApiDataSource;
+    let api: HttpManagerApiDataSource;
     beforeEach(() => {
-      api = new AxiosManagerApiDataSource({
+      api = new HttpManagerApiDataSource({
         managerApiUrl: "http://fake-url.com",
         provider: 123,
       } as DmkConfig);

--- a/packages/device-management-kit/src/internal/manager-api/data/HttpManagerApiDataSource.ts
+++ b/packages/device-management-kit/src/internal/manager-api/data/HttpManagerApiDataSource.ts
@@ -2,6 +2,8 @@ import { inject, injectable } from "inversify";
 import { EitherAsync } from "purify-ts";
 
 import { type DmkConfig } from "@api/DmkConfig";
+import { DmkNetworkClient } from "@api/network/DmkNetworkClient";
+import { DmkNetworkClientError } from "@api/network/DmkNetworkClientError";
 import { managerApiTypes } from "@internal/manager-api/di/managerApiTypes";
 import {
   type Application,
@@ -38,9 +40,19 @@ import {
   McuVersionDto,
 } from "./ManagerApiDto";
 
+const toHttpFetchApiError = (error: unknown): HttpFetchApiError => {
+  // The network client wraps fetch errors in DmkNetworkClientError. Unwrap the
+  // original cause when available so consumers (and tests) keep seeing the
+  // underlying error.
+  if (error instanceof DmkNetworkClientError && error.cause !== undefined) {
+    return new HttpFetchApiError(error.cause);
+  }
+  return new HttpFetchApiError(error);
+};
+
 @injectable()
-export class AxiosManagerApiDataSource implements ManagerApiDataSource {
-  private readonly _managerApiBaseUrl: string;
+export class HttpManagerApiDataSource implements ManagerApiDataSource {
+  private readonly http: DmkNetworkClient;
   private _provider: number = DEFAULT_PROVIDER;
   private _firmwareDistributionSalt: string =
     DEFAULT_FIRMWARE_DISTRIBUTION_SALT;
@@ -49,7 +61,7 @@ export class AxiosManagerApiDataSource implements ManagerApiDataSource {
     @inject(managerApiTypes.DmkConfig)
     { managerApiUrl, provider, firmwareDistributionSalt }: DmkConfig,
   ) {
-    this._managerApiBaseUrl = managerApiUrl;
+    this.http = new DmkNetworkClient({ baseUrl: managerApiUrl });
     this._provider = provider;
     this._firmwareDistributionSalt = firmwareDistributionSalt;
   }
@@ -69,91 +81,90 @@ export class AxiosManagerApiDataSource implements ManagerApiDataSource {
     params: GetAppListParams,
   ): EitherAsync<HttpFetchApiError, Array<Application>> {
     const { targetId, firmwareVersionName } = params;
-    return EitherAsync(async () => {
-      const url = new URL(`${this._managerApiBaseUrl}/v2/apps/by-target`);
-      url.searchParams.set("target_id", String(targetId));
-      url.searchParams.set("provider", String(this._provider));
-      url.searchParams.set("firmware_version_name", firmwareVersionName);
-      const response = await fetch(url);
-      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
-      return (await response.json()) as Array<ApplicationDto>;
-    })
-      .chain((apps) => this.mapApplicationDtoToApplication(apps))
-      .mapLeft((error) => new HttpFetchApiError(error));
+    return EitherAsync(() =>
+      this.http.get("/v2/apps/by-target", {
+        params: {
+          target_id: targetId,
+          provider: this._provider,
+          firmware_version_name: firmwareVersionName,
+        },
+      }),
+    )
+      .chain((apps) =>
+        this.mapApplicationDtoToApplication(apps as Array<ApplicationDto>),
+      )
+      .mapLeft(toHttpFetchApiError);
   }
 
   getMcuList(): EitherAsync<HttpFetchApiError, Array<McuFirmware>> {
-    return EitherAsync(async () => {
-      const response = await fetch(`${this._managerApiBaseUrl}/mcu_versions`);
-      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
-      return (await response.json()) as Array<McuVersionDto>;
-    })
-      .chain((mcus) => this.mapMcuDtoToMcu(mcus))
-      .mapLeft((error) => new HttpFetchApiError(error));
+    return EitherAsync(() => this.http.get("/mcu_versions"))
+      .chain((mcus) => this.mapMcuDtoToMcu(mcus as Array<McuVersionDto>))
+      .mapLeft(toHttpFetchApiError);
   }
 
   getDeviceVersion(
     params: GetDeviceVersionParams,
   ): EitherAsync<HttpFetchApiError, DeviceVersion> {
     const { targetId } = params;
-    return EitherAsync(async () => {
-      const url = new URL(`${this._managerApiBaseUrl}/get_device_version`);
-      url.searchParams.set("target_id", String(targetId));
-      url.searchParams.set("provider", String(this._provider));
-      const response = await fetch(url);
-      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
-      return (await response.json()) as DeviceVersionDto;
-    })
-      .chain((deviceVersion) => this.mapDeviceVersionDto(deviceVersion))
-      .mapLeft((error) => new HttpFetchApiError(error));
+    return EitherAsync(() =>
+      this.http.get("/get_device_version", {
+        params: { target_id: targetId, provider: this._provider },
+      }),
+    )
+      .chain((deviceVersion) =>
+        this.mapDeviceVersionDto(deviceVersion as DeviceVersionDto),
+      )
+      .mapLeft(toHttpFetchApiError);
   }
 
   getFirmwareVersion(
     params: GetFirmwareVersionParams,
   ): EitherAsync<HttpFetchApiError, FinalFirmware> {
     const { deviceId, version } = params;
-    return EitherAsync(async () => {
-      const url = new URL(`${this._managerApiBaseUrl}/get_firmware_version`);
-      url.searchParams.set("device_version", String(deviceId));
-      url.searchParams.set("version_name", version);
-      url.searchParams.set("provider", String(this._provider));
-      const response = await fetch(url);
-      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
-      return (await response.json()) as FirmwareFinalVersionDto;
-    })
-      .chain((finalFirmware) => this.mapFinalFirmwareDto(finalFirmware))
-      .mapLeft((error) => new HttpFetchApiError(error));
+    return EitherAsync(() =>
+      this.http.get("/get_firmware_version", {
+        params: {
+          device_version: deviceId,
+          version_name: version,
+          provider: this._provider,
+        },
+      }),
+    )
+      .chain((finalFirmware) =>
+        this.mapFinalFirmwareDto(finalFirmware as FirmwareFinalVersionDto),
+      )
+      .mapLeft(toHttpFetchApiError);
   }
 
   getFirmwareVersionById(
     finalFirmwareId: number,
   ): EitherAsync<HttpFetchApiError, FinalFirmware> {
-    return EitherAsync(async () => {
-      const response = await fetch(
-        `${this._managerApiBaseUrl}/firmware_final_versions/${finalFirmwareId}`,
-      );
-      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
-      return (await response.json()) as FirmwareFinalVersionDto;
-    })
-      .chain((finalFirmware) => this.mapFinalFirmwareDto(finalFirmware))
-      .mapLeft((error) => new HttpFetchApiError(error));
+    return EitherAsync(() =>
+      this.http.get(`/firmware_final_versions/${finalFirmwareId}`),
+    )
+      .chain((finalFirmware) =>
+        this.mapFinalFirmwareDto(finalFirmware as FirmwareFinalVersionDto),
+      )
+      .mapLeft(toHttpFetchApiError);
   }
 
   getOsuFirmwareVersion(
     params: GetFirmwareVersionParams,
   ): EitherAsync<HttpFetchApiError, OsuFirmware> {
     const { deviceId, version } = params;
-    return EitherAsync(async () => {
-      const url = new URL(`${this._managerApiBaseUrl}/get_osu_version`);
-      url.searchParams.set("device_version", String(deviceId));
-      url.searchParams.set("version_name", version);
-      url.searchParams.set("provider", String(this._provider));
-      const response = await fetch(url);
-      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
-      return (await response.json()) as FirmwareOsuVersionDto;
-    })
-      .chain((osuFirmware) => this.mapOsuFirmwareDto(osuFirmware))
-      .mapLeft((error) => new HttpFetchApiError(error));
+    return EitherAsync(() =>
+      this.http.get("/get_osu_version", {
+        params: {
+          device_version: deviceId,
+          version_name: version,
+          provider: this._provider,
+        },
+      }),
+    )
+      .chain((osuFirmware) =>
+        this.mapOsuFirmwareDto(osuFirmware as FirmwareOsuVersionDto),
+      )
+      .mapLeft(toHttpFetchApiError);
   }
 
   getLatestFirmwareVersion(
@@ -161,58 +172,56 @@ export class AxiosManagerApiDataSource implements ManagerApiDataSource {
   ): EitherAsync<HttpFetchApiError, OsuFirmware> {
     const livecommonversion = "34.27.0"; // Legacy parameter that should just be a too old
     const { currentFinalFirmwareId, deviceId } = params;
-    return EitherAsync(async () => {
-      const url = new URL(`${this._managerApiBaseUrl}/get_latest_firmware`);
-      url.searchParams.set(
-        "current_se_firmware_final_version",
-        String(currentFinalFirmwareId),
-      );
-      url.searchParams.set("device_version", String(deviceId));
-      url.searchParams.set("provider", String(this._provider));
-      url.searchParams.set("salt", this._firmwareDistributionSalt);
-      url.searchParams.set("livecommonversion", livecommonversion);
-      const response = await fetch(url);
-      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
-      return (await response.json()) as LatestFirmwareOsuVersionResponseDto;
-    })
-      .chain((latestFirmware) => this.mapLatestFirmwareDto(latestFirmware))
-      .mapLeft((error) => new HttpFetchApiError(error));
+    return EitherAsync(() =>
+      this.http.get("/get_latest_firmware", {
+        params: {
+          current_se_firmware_final_version: currentFinalFirmwareId,
+          device_version: deviceId,
+          provider: this._provider,
+          salt: this._firmwareDistributionSalt,
+          livecommonversion,
+        },
+      }),
+    )
+      .chain((latestFirmware) =>
+        this.mapLatestFirmwareDto(
+          latestFirmware as LatestFirmwareOsuVersionResponseDto,
+        ),
+      )
+      .mapLeft(toHttpFetchApiError);
   }
 
   getAppsByHash(
     params: GetAppByHashParams,
   ): EitherAsync<HttpFetchApiError, Array<Application | null>> {
     const { hashes } = params;
-    return EitherAsync(async () => {
-      const response = await fetch(`${this._managerApiBaseUrl}/v2/apps/hash`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(hashes),
-      });
-      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
-      return (await response.json()) as Array<ApplicationDto | null>;
-    })
-      .chain((apps) => this.mapNullableApplicationDtoToApplication(apps))
-      .mapLeft((error) => new HttpFetchApiError(error));
+    return EitherAsync(() => this.http.post("/v2/apps/hash", hashes))
+      .chain((apps) =>
+        this.mapNullableApplicationDtoToApplication(
+          apps as Array<ApplicationDto | null>,
+        ),
+      )
+      .mapLeft(toHttpFetchApiError);
   }
 
   getLanguagePackages(
     params: GetLanguagePackagesParams,
   ): EitherAsync<HttpFetchApiError, Array<LanguagePackage>> {
     const { deviceId, currentFinalFirmwareId } = params;
-    return EitherAsync(async () => {
-      const url = new URL(`${this._managerApiBaseUrl}/language-packages`);
-      url.searchParams.set("device_version", String(deviceId));
-      url.searchParams.set(
-        "current_se_firmware_final_version",
-        String(currentFinalFirmwareId),
-      );
-      const response = await fetch(url);
-      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
-      return (await response.json()) as Array<LanguagePackageVersionDto>;
-    })
-      .chain((apps) => this.mapLanguagesDtoToLanguages(apps))
-      .mapLeft((error) => new HttpFetchApiError(error));
+    return EitherAsync(() =>
+      this.http.get("/language-packages", {
+        params: {
+          device_version: deviceId,
+          current_se_firmware_final_version: currentFinalFirmwareId,
+        },
+      }),
+    )
+      .chain((apps) =>
+        this.mapLanguagesDtoToLanguages(
+          apps as Array<LanguagePackageVersionDto>,
+        ),
+      )
+      .mapLeft(toHttpFetchApiError);
   }
 
   private mapAppTypeDtoToAppType(appType: AppTypeDto | null): AppType | null {

--- a/packages/device-management-kit/src/internal/manager-api/data/__mocks__/HttpManagerApiDataSource.ts
+++ b/packages/device-management-kit/src/internal/manager-api/data/__mocks__/HttpManagerApiDataSource.ts
@@ -1,6 +1,6 @@
 import { type ManagerApiDataSource } from "@internal/manager-api/data/ManagerApiDataSource";
 
-export class AxiosManagerApiDataSource implements ManagerApiDataSource {
+export class HttpManagerApiDataSource implements ManagerApiDataSource {
   getAppList = vi.fn();
   getDeviceVersion = vi.fn();
   getFirmwareVersion = vi.fn();

--- a/packages/device-management-kit/src/internal/manager-api/di/managerApiModule.test.ts
+++ b/packages/device-management-kit/src/internal/manager-api/di/managerApiModule.test.ts
@@ -1,7 +1,7 @@
 import { Container } from "inversify";
 
 import { type DmkConfig } from "@api/DmkConfig";
-import { AxiosManagerApiDataSource } from "@internal/manager-api/data/AxiosManagerApiDataSource";
+import { HttpManagerApiDataSource } from "@internal/manager-api/data/HttpManagerApiDataSource";
 import { DefaultManagerApiService } from "@internal/manager-api/service/DefaultManagerApiService";
 import { StubUseCase } from "@root/src/di.stub";
 
@@ -33,7 +33,7 @@ describe("managerApiModuleFactory", () => {
       const managerApiDataSource = container.get(
         managerApiTypes.ManagerApiDataSource,
       );
-      expect(managerApiDataSource).toBeInstanceOf(AxiosManagerApiDataSource);
+      expect(managerApiDataSource).toBeInstanceOf(HttpManagerApiDataSource);
 
       const managerApiService = container.get(
         managerApiTypes.ManagerApiService,

--- a/packages/device-management-kit/src/internal/manager-api/di/managerApiModule.ts
+++ b/packages/device-management-kit/src/internal/manager-api/di/managerApiModule.ts
@@ -1,7 +1,7 @@
 import { ContainerModule } from "inversify";
 
 import { type DmkConfig } from "@api/DmkConfig";
-import { AxiosManagerApiDataSource } from "@internal/manager-api/data/AxiosManagerApiDataSource";
+import { HttpManagerApiDataSource } from "@internal/manager-api/data/HttpManagerApiDataSource";
 import { DefaultManagerApiService } from "@internal/manager-api/service/DefaultManagerApiService";
 import { SetProviderUseCase } from "@internal/manager-api/use-case/SetProviderUseCase";
 import { StubUseCase } from "@root/src/di.stub";
@@ -18,7 +18,7 @@ export const managerApiModuleFactory = ({ stub, config }: FactoryProps) =>
     bind(managerApiTypes.DmkConfig).toConstantValue(config);
 
     bind(managerApiTypes.ManagerApiDataSource)
-      .to(AxiosManagerApiDataSource)
+      .to(HttpManagerApiDataSource)
       .inSingletonScope();
     bind(managerApiTypes.ManagerApiService)
       .to(DefaultManagerApiService)

--- a/packages/device-management-kit/src/internal/manager-api/service/DefaultManagerApiService.test.ts
+++ b/packages/device-management-kit/src/internal/manager-api/service/DefaultManagerApiService.test.ts
@@ -10,7 +10,7 @@ import {
   ETH_APP_METADATA,
 } from "@api/device-action/__test-utils__/data";
 import { type DmkConfig } from "@api/DmkConfig";
-import { AxiosManagerApiDataSource } from "@internal/manager-api/data/AxiosManagerApiDataSource";
+import { HttpManagerApiDataSource } from "@internal/manager-api/data/HttpManagerApiDataSource";
 import { HttpFetchApiError } from "@internal/manager-api/model/Errors";
 import {
   type FinalFirmware,
@@ -20,14 +20,14 @@ import {
 import { DefaultManagerApiService } from "./DefaultManagerApiService";
 import { type ManagerApiService } from "./ManagerApiService";
 
-vi.mock("@internal/manager-api/data/AxiosManagerApiDataSource");
-let dataSource: Mocked<AxiosManagerApiDataSource>;
+vi.mock("@internal/manager-api/data/HttpManagerApiDataSource");
+let dataSource: Mocked<HttpManagerApiDataSource>;
 let service: ManagerApiService;
 describe("ManagerApiService", () => {
   beforeEach(() => {
-    dataSource = new AxiosManagerApiDataSource(
+    dataSource = new HttpManagerApiDataSource(
       {} as DmkConfig,
-    ) as Mocked<AxiosManagerApiDataSource>;
+    ) as Mocked<HttpManagerApiDataSource>;
     service = new DefaultManagerApiService(dataSource);
   });
 

--- a/packages/signer/context-module/package.json
+++ b/packages/signer/context-module/package.json
@@ -49,7 +49,6 @@
     "ts-node": "catalog:"
   },
   "dependencies": {
-    "axios": "catalog:",
     "crypto-js": "catalog:",
     "ethers": "catalog:",
     "inversify": "catalog:",

--- a/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.test.ts
+++ b/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.test.ts
@@ -1,4 +1,3 @@
-import axios, { AxiosError, type AxiosResponse } from "axios";
 import { Left, Right } from "purify-ts";
 
 import { AccountOwnershipError } from "@/account-ownership/data/AccountOwnershipError";
@@ -11,26 +10,21 @@ import PACKAGE from "@root/package.json";
 
 import { HttpAccountOwnershipDataSource } from "./HttpAccountOwnershipDataSource";
 
-vi.mock("axios");
-
-function makeAxiosError(
-  status: number,
-  data: unknown,
-  message = "Request failed",
-): AxiosError {
-  const err = new AxiosError(message);
-  err.message = message;
-  err.response = {
-    status,
-    data,
-    statusText: "",
-    headers: {},
-    config: {} as never,
-  } as AxiosResponse;
-  return err;
+function mockFetchResponse(body: unknown, status = 200): void {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(typeof body === "string" ? body : JSON.stringify(body), {
+      status,
+    }),
+  );
 }
 
-function makeInterceptedError(status: number, message: string): Error {
+function mockFetchRawResponse(body: string, status: number): void {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(body, { status }),
+  );
+}
+
+function makeStatusError(status: number, message: string): Error {
   const err = new Error(message);
   (err as unknown as { status: number }).status = status;
   return err;
@@ -59,63 +53,54 @@ describe("HttpAccountOwnershipDataSource", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.spyOn(axios, "isAxiosError").mockImplementation(
-      (value: unknown): value is AxiosError => value instanceof AxiosError,
-    );
   });
 
   describe("getDescriptor", () => {
     it("should return descriptor on successful request", async () => {
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: validDto,
-      });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validDto)));
 
       const result = await new HttpAccountOwnershipDataSource(
         config,
       ).getDescriptor(baseParams);
 
-      expect(axios.request).toHaveBeenCalledWith({
-        method: "GET",
-        url: "https://nft.api.live.ledger-test.com/v2/concordium/owner/abcdef1234567890/3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
-        params: {
-          challenge: "0xabcdef",
-          network: "mainnet",
-        },
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: "test-origin-token",
-        },
-      });
+      const calledUrl = new URL(fetchSpy.mock.calls[0]![0]!.toString());
+      expect(calledUrl.pathname).toBe(
+        `/v2/concordium/owner/${baseParams.publicKey}/${baseParams.address}`,
+      );
+      expect(calledUrl.searchParams.get("challenge")).toBe(
+        baseParams.challenge,
+      );
+      expect(calledUrl.searchParams.get("network")).toBe(baseParams.network);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(URL),
+        expect.objectContaining({
+          headers: {
+            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+            [LEDGER_ORIGIN_TOKEN_HEADER]: "test-origin-token",
+          },
+        }),
+      );
       expect(result).toEqual(Right(validDto));
     });
 
     it("should pass testnet network parameter", async () => {
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: validDto,
-      });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validDto)));
 
       await new HttpAccountOwnershipDataSource(config).getDescriptor({
         ...baseParams,
         network: "testnet",
       });
 
-      expect(axios.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          params: {
-            challenge: "0xabcdef",
-            network: "testnet",
-          },
-        }),
-      );
+      const calledUrl = new URL(fetchSpy.mock.calls[0]![0]!.toString());
+      expect(calledUrl.searchParams.get("network")).toBe("testnet");
     });
 
     it("should classify empty response as service_unavailable", async () => {
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: null,
-      });
+      mockFetchResponse(null);
 
       const result = await new HttpAccountOwnershipDataSource(
         config,
@@ -139,7 +124,7 @@ describe("HttpAccountOwnershipDataSource", () => {
     ])(
       "should classify malformed response (%s) as service_unavailable",
       async (_label, data) => {
-        vi.spyOn(axios, "request").mockResolvedValue({ status: 200, data });
+        mockFetchResponse(data);
 
         const result = await new HttpAccountOwnershipDataSource(
           config,
@@ -156,9 +141,7 @@ describe("HttpAccountOwnershipDataSource", () => {
     it("should classify 422 with { message } body as verification_failed and forward backend message", async () => {
       const backendMessage =
         "Address ByteVector(32 bytes, 0xa63c) is not associated with the given public key ByteVector(32 bytes, 0x9dc1) on the network Testnet";
-      vi.spyOn(axios, "request").mockRejectedValue(
-        makeAxiosError(422, { message: backendMessage }),
-      );
+      mockFetchResponse({ message: backendMessage }, 422);
 
       const result = await new HttpAccountOwnershipDataSource(
         config,
@@ -174,9 +157,7 @@ describe("HttpAccountOwnershipDataSource", () => {
     it.each([400, 401, 403, 404, 429])(
       "should classify HTTP %s as verification_failed",
       async (status) => {
-        vi.spyOn(axios, "request").mockRejectedValue(
-          makeAxiosError(status, { message: "refused" }),
-        );
+        mockFetchResponse({ message: "refused" }, status);
 
         const result = await new HttpAccountOwnershipDataSource(
           config,
@@ -189,9 +170,7 @@ describe("HttpAccountOwnershipDataSource", () => {
     );
 
     it("should classify 500 as service_unavailable with status prefix", async () => {
-      vi.spyOn(axios, "request").mockRejectedValue(
-        makeAxiosError(500, { message: "internal error" }),
-      );
+      mockFetchResponse({ message: "internal error" }, 500);
 
       const result = await new HttpAccountOwnershipDataSource(
         config,
@@ -206,9 +185,7 @@ describe("HttpAccountOwnershipDataSource", () => {
     it.each([502, 503, 504])(
       "should classify HTTP %s as service_unavailable",
       async (status) => {
-        vi.spyOn(axios, "request").mockRejectedValue(
-          makeAxiosError(status, { message: "down" }),
-        );
+        mockFetchResponse({ message: "down" }, status);
 
         const result = await new HttpAccountOwnershipDataSource(
           config,
@@ -219,10 +196,8 @@ describe("HttpAccountOwnershipDataSource", () => {
       },
     );
 
-    it("should accept string body and forward it as message on 4xx", async () => {
-      vi.spyOn(axios, "request").mockRejectedValue(
-        makeAxiosError(422, "plain text reason"),
-      );
+    it("should accept plain-text body and forward it as message on 4xx", async () => {
+      mockFetchRawResponse("plain text reason", 422);
 
       const result = await new HttpAccountOwnershipDataSource(
         config,
@@ -233,10 +208,8 @@ describe("HttpAccountOwnershipDataSource", () => {
       expect(err.message).toBe("plain text reason");
     });
 
-    it("should fall back to axios error message when body has no message", async () => {
-      vi.spyOn(axios, "request").mockRejectedValue(
-        makeAxiosError(422, {}, "Request failed with status code 422"),
-      );
+    it("should fall back to 'Unknown error' when body has no message", async () => {
+      mockFetchResponse({}, 422);
 
       const result = await new HttpAccountOwnershipDataSource(
         config,
@@ -244,17 +217,11 @@ describe("HttpAccountOwnershipDataSource", () => {
 
       const err = result.extract() as AccountOwnershipError;
       expect(err.kind).toBe("verification_failed");
-      expect(err.message).toBe("Request failed with status code 422");
+      expect(err.message).toBe("Unknown error");
     });
 
-    it("should fall back to axios error message when body message is empty", async () => {
-      vi.spyOn(axios, "request").mockRejectedValue(
-        makeAxiosError(
-          422,
-          { message: "" },
-          "Request failed with status code 422",
-        ),
-      );
+    it("should fall back to 'Unknown error' when body message is empty", async () => {
+      mockFetchResponse({ message: "" }, 422);
 
       const result = await new HttpAccountOwnershipDataSource(
         config,
@@ -262,11 +229,13 @@ describe("HttpAccountOwnershipDataSource", () => {
 
       const err = result.extract() as AccountOwnershipError;
       expect(err.kind).toBe("verification_failed");
-      expect(err.message).toBe("Request failed with status code 422");
+      expect(err.message).toBe("Unknown error");
     });
 
-    it("should classify non-axios / network errors as service_unavailable", async () => {
-      vi.spyOn(axios, "request").mockRejectedValue(new Error("ECONNREFUSED"));
+    it("should classify network errors as service_unavailable", async () => {
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(
+        new Error("ECONNREFUSED"),
+      );
 
       const result = await new HttpAccountOwnershipDataSource(
         config,
@@ -282,18 +251,17 @@ describe("HttpAccountOwnershipDataSource", () => {
       );
     });
 
-    // Consumers may install a global axios interceptor that replaces
-    // AxiosError with a custom class, preserving the HTTP status on
-    // `.status` and dropping `.response`. The datasource must still
-    // classify these.
-    describe("intercepted error shape (numeric .status on the error)", () => {
+    // A wrapping HTTP client may surface failures as plain errors carrying a
+    // numeric `.status` field instead of an HTTP Response. The datasource
+    // must still classify these.
+    describe("errors with numeric .status", () => {
       it.each([400, 401, 403, 404, 422, 429])(
         "should classify HTTP %s on .status as verification_failed and forward message",
         async (status) => {
           const backendMessage =
             "Address ByteVector(...) is not associated with the given public key ByteVector(...)";
-          vi.spyOn(axios, "request").mockRejectedValue(
-            makeInterceptedError(status, backendMessage),
+          vi.spyOn(globalThis, "fetch").mockRejectedValue(
+            makeStatusError(status, backendMessage),
           );
 
           const result = await new HttpAccountOwnershipDataSource(
@@ -309,8 +277,8 @@ describe("HttpAccountOwnershipDataSource", () => {
       it.each([500, 502, 503, 504])(
         "should classify HTTP %s on .status as service_unavailable with status prefix",
         async (status) => {
-          vi.spyOn(axios, "request").mockRejectedValue(
-            makeInterceptedError(status, "down"),
+          vi.spyOn(globalThis, "fetch").mockRejectedValue(
+            makeStatusError(status, "down"),
           );
 
           const result = await new HttpAccountOwnershipDataSource(
@@ -327,7 +295,7 @@ describe("HttpAccountOwnershipDataSource", () => {
       it("should ignore non-numeric .status and fall through to service_unavailable fallback", async () => {
         const err = new Error("bad");
         (err as unknown as { status: string }).status = "422";
-        vi.spyOn(axios, "request").mockRejectedValue(err);
+        vi.spyOn(globalThis, "fetch").mockRejectedValue(err);
 
         const result = await new HttpAccountOwnershipDataSource(
           config,
@@ -344,7 +312,7 @@ describe("HttpAccountOwnershipDataSource", () => {
       });
 
       it("should forward .message from plain object errors (not Error instances)", async () => {
-        vi.spyOn(axios, "request").mockRejectedValue({
+        vi.spyOn(globalThis, "fetch").mockRejectedValue({
           status: 422,
           message: "plain object message",
         });
@@ -359,7 +327,7 @@ describe("HttpAccountOwnershipDataSource", () => {
       });
 
       it("should use an 'Unknown error' fallback when the object has no usable message", async () => {
-        vi.spyOn(axios, "request").mockRejectedValue({ status: 422 });
+        vi.spyOn(globalThis, "fetch").mockRejectedValue({ status: 422 });
 
         const result = await new HttpAccountOwnershipDataSource(
           config,
@@ -378,18 +346,21 @@ describe("HttpAccountOwnershipDataSource", () => {
         },
         originToken: "custom-token",
       } as ContextModuleServiceConfig;
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: validDto,
-      });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validDto)));
 
       await new HttpAccountOwnershipDataSource(customConfig).getDescriptor(
         baseParams,
       );
 
-      expect(axios.request).toHaveBeenCalledWith(
+      const calledUrl = fetchSpy.mock.calls[0]![0]!.toString();
+      expect(calledUrl).toContain(
+        "https://custom-metadata.example.com/v2/concordium/owner/abcdef1234567890/3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
+      );
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(URL),
         expect.objectContaining({
-          url: "https://custom-metadata.example.com/v2/concordium/owner/abcdef1234567890/3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
           headers: expect.objectContaining({
             [LEDGER_ORIGIN_TOKEN_HEADER]: "custom-token",
           }),

--- a/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.test.ts
+++ b/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.test.ts
@@ -24,12 +24,6 @@ function mockFetchRawResponse(body: string, status: number): void {
   );
 }
 
-function makeStatusError(status: number, message: string): Error {
-  const err = new Error(message);
-  (err as unknown as { status: number }).status = status;
-  return err;
-}
-
 describe("HttpAccountOwnershipDataSource", () => {
   const config: ContextModuleServiceConfig = {
     metadataServiceDomain: {
@@ -76,10 +70,10 @@ describe("HttpAccountOwnershipDataSource", () => {
       expect(fetchSpy).toHaveBeenCalledWith(
         expect.any(URL),
         expect.objectContaining({
-          headers: {
+          headers: expect.objectContaining({
             [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
             [LEDGER_ORIGIN_TOKEN_HEADER]: "test-origin-token",
-          },
+          }),
         }),
       );
       expect(result).toEqual(Right(validDto));
@@ -208,30 +202,6 @@ describe("HttpAccountOwnershipDataSource", () => {
       expect(err.message).toBe("plain text reason");
     });
 
-    it("should fall back to 'Unknown error' when body has no message", async () => {
-      mockFetchResponse({}, 422);
-
-      const result = await new HttpAccountOwnershipDataSource(
-        config,
-      ).getDescriptor(baseParams);
-
-      const err = result.extract() as AccountOwnershipError;
-      expect(err.kind).toBe("verification_failed");
-      expect(err.message).toBe("Unknown error");
-    });
-
-    it("should fall back to 'Unknown error' when body message is empty", async () => {
-      mockFetchResponse({ message: "" }, 422);
-
-      const result = await new HttpAccountOwnershipDataSource(
-        config,
-      ).getDescriptor(baseParams);
-
-      const err = result.extract() as AccountOwnershipError;
-      expect(err.kind).toBe("verification_failed");
-      expect(err.message).toBe("Unknown error");
-    });
-
     it("should classify network errors as service_unavailable", async () => {
       vi.spyOn(globalThis, "fetch").mockRejectedValue(
         new Error("ECONNREFUSED"),
@@ -249,94 +219,6 @@ describe("HttpAccountOwnershipDataSource", () => {
           ),
         ),
       );
-    });
-
-    // A wrapping HTTP client may surface failures as plain errors carrying a
-    // numeric `.status` field instead of an HTTP Response. The datasource
-    // must still classify these.
-    describe("errors with numeric .status", () => {
-      it.each([400, 401, 403, 404, 422, 429])(
-        "should classify HTTP %s on .status as verification_failed and forward message",
-        async (status) => {
-          const backendMessage =
-            "Address ByteVector(...) is not associated with the given public key ByteVector(...)";
-          vi.spyOn(globalThis, "fetch").mockRejectedValue(
-            makeStatusError(status, backendMessage),
-          );
-
-          const result = await new HttpAccountOwnershipDataSource(
-            config,
-          ).getDescriptor(baseParams);
-
-          const err = result.extract() as AccountOwnershipError;
-          expect(err.kind).toBe("verification_failed");
-          expect(err.message).toBe(backendMessage);
-        },
-      );
-
-      it.each([500, 502, 503, 504])(
-        "should classify HTTP %s on .status as service_unavailable with status prefix",
-        async (status) => {
-          vi.spyOn(globalThis, "fetch").mockRejectedValue(
-            makeStatusError(status, "down"),
-          );
-
-          const result = await new HttpAccountOwnershipDataSource(
-            config,
-          ).getDescriptor(baseParams);
-
-          const err = result.extract() as AccountOwnershipError;
-          expect(err.kind).toBe("service_unavailable");
-          expect(err.message).toContain(`backend ${status}`);
-          expect(err.message).toContain("down");
-        },
-      );
-
-      it("should ignore non-numeric .status and fall through to service_unavailable fallback", async () => {
-        const err = new Error("bad");
-        (err as unknown as { status: string }).status = "422";
-        vi.spyOn(globalThis, "fetch").mockRejectedValue(err);
-
-        const result = await new HttpAccountOwnershipDataSource(
-          config,
-        ).getDescriptor(baseParams);
-
-        expect(result).toEqual(
-          Left(
-            new AccountOwnershipError(
-              "service_unavailable",
-              "[ContextModule] HttpAccountOwnershipDataSource: Failed to fetch account ownership descriptor",
-            ),
-          ),
-        );
-      });
-
-      it("should forward .message from plain object errors (not Error instances)", async () => {
-        vi.spyOn(globalThis, "fetch").mockRejectedValue({
-          status: 422,
-          message: "plain object message",
-        });
-
-        const result = await new HttpAccountOwnershipDataSource(
-          config,
-        ).getDescriptor(baseParams);
-
-        const err = result.extract() as AccountOwnershipError;
-        expect(err.kind).toBe("verification_failed");
-        expect(err.message).toBe("plain object message");
-      });
-
-      it("should use an 'Unknown error' fallback when the object has no usable message", async () => {
-        vi.spyOn(globalThis, "fetch").mockRejectedValue({ status: 422 });
-
-        const result = await new HttpAccountOwnershipDataSource(
-          config,
-        ).getDescriptor(baseParams);
-
-        const err = result.extract() as AccountOwnershipError;
-        expect(err.kind).toBe("verification_failed");
-        expect(err.message).toBe("Unknown error");
-      });
     });
 
     it("should use correct metadata service URL from config", async () => {

--- a/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.test.ts
+++ b/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.test.ts
@@ -1,27 +1,30 @@
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
 
 import { AccountOwnershipError } from "@/account-ownership/data/AccountOwnershipError";
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
 
 import { HttpAccountOwnershipDataSource } from "./HttpAccountOwnershipDataSource";
 
-function mockFetchResponse(body: unknown, status = 200): void {
-  vi.spyOn(globalThis, "fetch").mockResolvedValue(
-    new Response(typeof body === "string" ? body : JSON.stringify(body), {
-      status,
-    }),
-  );
-}
-
-function mockFetchRawResponse(body: string, status: number): void {
-  vi.spyOn(globalThis, "fetch").mockResolvedValue(
-    new Response(body, { status }),
-  );
+/**
+ * Build an error that quacks like a {@link DmkNetworkClientError}: a real
+ * `Error` with numeric `.status` and raw `.responseBody` text. Callers can
+ * omit fields to simulate specific shapes.
+ */
+function makeHttpError(options: {
+  status?: number;
+  message?: string;
+  responseBody?: string;
+}): Error {
+  const err = new Error(options.message ?? "HTTP error");
+  if (options.status !== undefined) {
+    (err as unknown as { status: number }).status = options.status;
+  }
+  if (options.responseBody !== undefined) {
+    (err as unknown as { responseBody: string }).responseBody =
+      options.responseBody;
+  }
+  return err;
 }
 
 describe("HttpAccountOwnershipDataSource", () => {
@@ -45,60 +48,50 @@ describe("HttpAccountOwnershipDataSource", () => {
     network: "mainnet" as const,
   };
 
+  let httpMock: { get: ReturnType<typeof vi.fn> };
+  let datasource: HttpAccountOwnershipDataSource;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    httpMock = { get: vi.fn() };
+    datasource = new HttpAccountOwnershipDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
   });
 
   describe("getDescriptor", () => {
     it("should return descriptor on successful request", async () => {
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validDto)));
+      httpMock.get.mockResolvedValue(validDto);
 
-      const result = await new HttpAccountOwnershipDataSource(
-        config,
-      ).getDescriptor(baseParams);
+      const result = await datasource.getDescriptor(baseParams);
 
-      const calledUrl = new URL(fetchSpy.mock.calls[0]![0]!.toString());
-      expect(calledUrl.pathname).toBe(
-        `/v2/concordium/owner/${baseParams.publicKey}/${baseParams.address}`,
-      );
-      expect(calledUrl.searchParams.get("challenge")).toBe(
-        baseParams.challenge,
-      );
-      expect(calledUrl.searchParams.get("network")).toBe(baseParams.network);
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.any(URL),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            [LEDGER_ORIGIN_TOKEN_HEADER]: "test-origin-token",
-          }),
-        }),
+      expect(httpMock.get).toHaveBeenCalledWith(
+        `${config.metadataServiceDomain.url}/v2/concordium/owner/${baseParams.publicKey}/${baseParams.address}`,
+        {
+          params: {
+            challenge: baseParams.challenge,
+            network: baseParams.network,
+          },
+        },
       );
       expect(result).toEqual(Right(validDto));
     });
 
     it("should pass testnet network parameter", async () => {
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validDto)));
+      httpMock.get.mockResolvedValue(validDto);
 
-      await new HttpAccountOwnershipDataSource(config).getDescriptor({
-        ...baseParams,
-        network: "testnet",
+      await datasource.getDescriptor({ ...baseParams, network: "testnet" });
+
+      expect(httpMock.get).toHaveBeenCalledWith(expect.any(String), {
+        params: { challenge: baseParams.challenge, network: "testnet" },
       });
-
-      const calledUrl = new URL(fetchSpy.mock.calls[0]![0]!.toString());
-      expect(calledUrl.searchParams.get("network")).toBe("testnet");
     });
 
     it("should classify empty response as service_unavailable", async () => {
-      mockFetchResponse(null);
+      httpMock.get.mockResolvedValue(null);
 
-      const result = await new HttpAccountOwnershipDataSource(
-        config,
-      ).getDescriptor(baseParams);
+      const result = await datasource.getDescriptor(baseParams);
 
       expect(result.isLeft()).toBe(true);
       const err = result.extract() as AccountOwnershipError;
@@ -118,11 +111,9 @@ describe("HttpAccountOwnershipDataSource", () => {
     ])(
       "should classify malformed response (%s) as service_unavailable",
       async (_label, data) => {
-        mockFetchResponse(data);
+        httpMock.get.mockResolvedValue(data);
 
-        const result = await new HttpAccountOwnershipDataSource(
-          config,
-        ).getDescriptor(baseParams);
+        const result = await datasource.getDescriptor(baseParams);
 
         expect(result.isLeft()).toBe(true);
         const err = result.extract() as AccountOwnershipError;
@@ -135,11 +126,15 @@ describe("HttpAccountOwnershipDataSource", () => {
     it("should classify 422 with { message } body as verification_failed and forward backend message", async () => {
       const backendMessage =
         "Address ByteVector(32 bytes, 0xa63c) is not associated with the given public key ByteVector(32 bytes, 0x9dc1) on the network Testnet";
-      mockFetchResponse({ message: backendMessage }, 422);
+      httpMock.get.mockRejectedValue(
+        makeHttpError({
+          status: 422,
+          message: "HTTP error 422",
+          responseBody: JSON.stringify({ message: backendMessage }),
+        }),
+      );
 
-      const result = await new HttpAccountOwnershipDataSource(
-        config,
-      ).getDescriptor(baseParams);
+      const result = await datasource.getDescriptor(baseParams);
 
       expect(result.isLeft()).toBe(true);
       const err = result.extract() as AccountOwnershipError;
@@ -149,13 +144,17 @@ describe("HttpAccountOwnershipDataSource", () => {
     });
 
     it.each([400, 401, 403, 404, 429])(
-      "should classify HTTP %s as verification_failed",
+      "should classify HTTP %s as verification_failed with forwarded message",
       async (status) => {
-        mockFetchResponse({ message: "refused" }, status);
+        httpMock.get.mockRejectedValue(
+          makeHttpError({
+            status,
+            message: `HTTP error ${status}`,
+            responseBody: JSON.stringify({ message: "refused" }),
+          }),
+        );
 
-        const result = await new HttpAccountOwnershipDataSource(
-          config,
-        ).getDescriptor(baseParams);
+        const result = await datasource.getDescriptor(baseParams);
 
         const err = result.extract() as AccountOwnershipError;
         expect(err.kind).toBe("verification_failed");
@@ -164,11 +163,15 @@ describe("HttpAccountOwnershipDataSource", () => {
     );
 
     it("should classify 500 as service_unavailable with status prefix", async () => {
-      mockFetchResponse({ message: "internal error" }, 500);
+      httpMock.get.mockRejectedValue(
+        makeHttpError({
+          status: 500,
+          message: "HTTP error 500",
+          responseBody: JSON.stringify({ message: "internal error" }),
+        }),
+      );
 
-      const result = await new HttpAccountOwnershipDataSource(
-        config,
-      ).getDescriptor(baseParams);
+      const result = await datasource.getDescriptor(baseParams);
 
       const err = result.extract() as AccountOwnershipError;
       expect(err.kind).toBe("service_unavailable");
@@ -179,37 +182,59 @@ describe("HttpAccountOwnershipDataSource", () => {
     it.each([502, 503, 504])(
       "should classify HTTP %s as service_unavailable",
       async (status) => {
-        mockFetchResponse({ message: "down" }, status);
+        httpMock.get.mockRejectedValue(
+          makeHttpError({
+            status,
+            message: `HTTP error ${status}`,
+            responseBody: JSON.stringify({ message: "down" }),
+          }),
+        );
 
-        const result = await new HttpAccountOwnershipDataSource(
-          config,
-        ).getDescriptor(baseParams);
+        const result = await datasource.getDescriptor(baseParams);
 
         const err = result.extract() as AccountOwnershipError;
         expect(err.kind).toBe("service_unavailable");
+        expect(err.message).toContain(`backend ${status}`);
+        expect(err.message).toContain("down");
       },
     );
 
-    it("should accept plain-text body and forward it as message on 4xx", async () => {
-      mockFetchRawResponse("plain text reason", 422);
+    it("should accept plain-text response body and forward it on 4xx", async () => {
+      httpMock.get.mockRejectedValue(
+        makeHttpError({
+          status: 422,
+          message: "HTTP error 422",
+          responseBody: "plain text reason",
+        }),
+      );
 
-      const result = await new HttpAccountOwnershipDataSource(
-        config,
-      ).getDescriptor(baseParams);
+      const result = await datasource.getDescriptor(baseParams);
 
       const err = result.extract() as AccountOwnershipError;
       expect(err.kind).toBe("verification_failed");
       expect(err.message).toBe("plain text reason");
     });
 
-    it("should classify network errors as service_unavailable", async () => {
-      vi.spyOn(globalThis, "fetch").mockRejectedValue(
-        new Error("ECONNREFUSED"),
+    it("should fall back to the client error message when response body is empty", async () => {
+      httpMock.get.mockRejectedValue(
+        makeHttpError({
+          status: 422,
+          message: "HTTP error 422",
+          responseBody: "",
+        }),
       );
 
-      const result = await new HttpAccountOwnershipDataSource(
-        config,
-      ).getDescriptor(baseParams);
+      const result = await datasource.getDescriptor(baseParams);
+
+      const err = result.extract() as AccountOwnershipError;
+      expect(err.kind).toBe("verification_failed");
+      expect(err.message).toBe("HTTP error 422");
+    });
+
+    it("should classify network errors (no status) as service_unavailable", async () => {
+      httpMock.get.mockRejectedValue(new Error("Network error"));
+
+      const result = await datasource.getDescriptor(baseParams);
 
       expect(result).toEqual(
         Left(
@@ -221,6 +246,84 @@ describe("HttpAccountOwnershipDataSource", () => {
       );
     });
 
+    // Errors surfaced by the network client (or any wrapping layer) that
+    // expose a numeric `.status` field must still be classified, even if
+    // they are not true `DmkNetworkClientError` instances.
+    describe("errors with numeric .status", () => {
+      it.each([400, 401, 403, 404, 422, 429])(
+        "should classify HTTP %s on .status as verification_failed and forward .message",
+        async (status) => {
+          const backendMessage =
+            "Address ByteVector(...) is not associated with the given public key ByteVector(...)";
+          httpMock.get.mockRejectedValue(
+            makeHttpError({ status, message: backendMessage }),
+          );
+
+          const result = await datasource.getDescriptor(baseParams);
+
+          const err = result.extract() as AccountOwnershipError;
+          expect(err.kind).toBe("verification_failed");
+          expect(err.message).toBe(backendMessage);
+        },
+      );
+
+      it.each([500, 502, 503, 504])(
+        "should classify HTTP %s on .status as service_unavailable with status prefix",
+        async (status) => {
+          httpMock.get.mockRejectedValue(
+            makeHttpError({ status, message: "down" }),
+          );
+
+          const result = await datasource.getDescriptor(baseParams);
+
+          const err = result.extract() as AccountOwnershipError;
+          expect(err.kind).toBe("service_unavailable");
+          expect(err.message).toContain(`backend ${status}`);
+          expect(err.message).toContain("down");
+        },
+      );
+
+      it("should ignore non-numeric .status and fall through to service_unavailable fallback", async () => {
+        const err = new Error("bad");
+        (err as unknown as { status: string }).status = "422";
+        httpMock.get.mockRejectedValue(err);
+
+        const result = await datasource.getDescriptor(baseParams);
+
+        expect(result).toEqual(
+          Left(
+            new AccountOwnershipError(
+              "service_unavailable",
+              "[ContextModule] HttpAccountOwnershipDataSource: Failed to fetch account ownership descriptor",
+            ),
+          ),
+        );
+      });
+
+      it("should forward .message from plain object errors (not Error instances)", async () => {
+        httpMock.get.mockRejectedValue({
+          status: 422,
+          message: "plain object message",
+        });
+
+        const result = await datasource.getDescriptor(baseParams);
+
+        const err = result.extract() as AccountOwnershipError;
+        expect(err.kind).toBe("verification_failed");
+        expect(err.message).toBe("plain object message");
+      });
+
+      it("should use an 'Unknown error' fallback when the object has no usable message", async () => {
+        httpMock.get.mockRejectedValue({ status: 422 });
+
+        const result = await datasource.getDescriptor(baseParams);
+
+        const err = result.extract() as AccountOwnershipError;
+        expect(err.kind).toBe("verification_failed");
+        expect(err.message).toBe("Unknown error");
+      });
+    });
+
     it("should use correct metadata service URL from config", async () => {
       const customConfig: ContextModuleServiceConfig = {
         metadataServiceDomain: {
@@ -228,25 +331,17 @@ describe("HttpAccountOwnershipDataSource", () => {
         },
         originToken: "custom-token",
       } as ContextModuleServiceConfig;
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validDto)));
-
-      await new HttpAccountOwnershipDataSource(customConfig).getDescriptor(
-        baseParams,
+      const customDatasource = new HttpAccountOwnershipDataSource(
+        customConfig,
+        httpMock as unknown as DmkNetworkClient,
       );
+      httpMock.get.mockResolvedValue(validDto);
 
-      const calledUrl = fetchSpy.mock.calls[0]![0]!.toString();
-      expect(calledUrl).toContain(
+      await customDatasource.getDescriptor(baseParams);
+
+      expect(httpMock.get).toHaveBeenCalledWith(
         "https://custom-metadata.example.com/v2/concordium/owner/abcdef1234567890/3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
-      );
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.any(URL),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            [LEDGER_ORIGIN_TOKEN_HEADER]: "custom-token",
-          }),
-        }),
+        expect.anything(),
       );
     });
   });

--- a/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.ts
+++ b/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.ts
@@ -11,31 +11,18 @@ import { AccountOwnershipError } from "@/account-ownership/data/AccountOwnership
 import { type AccountOwnershipDto } from "@/account-ownership/data/dto/AccountOwnershipDto";
 import { configTypes } from "@/config/di/configTypes";
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
+import { networkTypes } from "@/network/di/networkTypes";
 
 @injectable()
 export class HttpAccountOwnershipDataSource
   implements AccountOwnershipDataSource
 {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-        ...(this.config.originToken && {
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-        }),
-      },
-    });
-  }
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
+  ) {}
 
   async getDescriptor({
     publicKey,
@@ -130,6 +117,10 @@ export class HttpAccountOwnershipDataSource
   }
 
   private extractErrorMessage(value: unknown): string {
+    const fromBody = this.extractResponseBodyMessage(value);
+    if (fromBody !== null) {
+      return fromBody;
+    }
     if (
       typeof value === "object" &&
       value !== null &&
@@ -138,10 +129,6 @@ export class HttpAccountOwnershipDataSource
       (value as { message: string }).message.length > 0
     ) {
       return (value as { message: string }).message;
-    }
-    const fromBody = this.extractResponseBodyMessage(value);
-    if (fromBody !== null) {
-      return fromBody;
     }
     if (typeof value === "string") {
       return value;

--- a/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.ts
+++ b/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { type Either, Left, Right } from "purify-ts";
 
@@ -35,20 +34,24 @@ export class HttpAccountOwnershipDataSource
     Either<Error, AccountOwnershipDescriptor>
   > {
     try {
-      const response = await axios.request<AccountOwnershipDto>({
-        method: "GET",
-        url: `${this.config.metadataServiceDomain.url}/v2/concordium/owner/${publicKey}/${address}`,
-        params: {
-          challenge,
-          network,
-        },
+      const url = new URL(
+        `${this.config.metadataServiceDomain.url}/v2/concordium/owner/${publicKey}/${address}`,
+      );
+      url.searchParams.set("challenge", challenge);
+      url.searchParams.set("network", network);
+      const response = await fetch(url, {
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
           [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
         },
       });
+      if (!response.ok) {
+        const message = await this.readErrorMessage(response);
+        throw Object.assign(new Error(message), { status: response.status });
+      }
+      const data = (await response.json()) as AccountOwnershipDto | null;
 
-      if (!response.data) {
+      if (!data) {
         return Left(
           new AccountOwnershipError(
             "service_unavailable",
@@ -57,7 +60,7 @@ export class HttpAccountOwnershipDataSource
         );
       }
 
-      if (!this.isAccountOwnershipDto(response.data)) {
+      if (!this.isAccountOwnershipDto(data)) {
         return Left(
           new AccountOwnershipError(
             "service_unavailable",
@@ -67,9 +70,9 @@ export class HttpAccountOwnershipDataSource
       }
 
       return Right({
-        signedDescriptor: response.data.signedDescriptor,
-        keyId: response.data.keyId,
-        keyUsage: response.data.keyUsage,
+        signedDescriptor: data.signedDescriptor,
+        keyId: data.keyId,
+        keyUsage: data.keyUsage,
       });
     } catch (error) {
       return Left(this.classifyError(error));
@@ -82,25 +85,13 @@ export class HttpAccountOwnershipDataSource
    * as `verification_failed`; everything else (network failure, 5xx,
    * unrecognized errors) is marked as `service_unavailable`.
    *
-   * Two shapes are recognized:
-   * - Vanilla {@link AxiosError} with `.response` (standalone axios usage).
-   * - Any error carrying a numeric `.status` field. Consumers may install a
-   *   global axios interceptor that replaces {@link AxiosError} with a
-   *   custom class, typically stripping `.response` but preserving the HTTP
-   *   status on a top-level `.status` field. The duck-typed branch keeps
-   *   classification correct on those paths without coupling to any
-   *   host-specific class.
+   * Errors with a numeric `.status` field are treated as HTTP-shaped failures
+   * (thrown above when the fetch response is not ok, or surfaced by a
+   * wrapping client that preserves the HTTP status on a top-level `.status`
+   * field). Anything else falls through to the canonical
+   * `service_unavailable` message.
    */
   private classifyError(error: unknown): AccountOwnershipError {
-    if (axios.isAxiosError(error) && error.response) {
-      const status = error.response.status;
-      const backendMessage = this.extractBackendMessage(
-        error.response.data,
-        error.message,
-      );
-      return this.classifyFromStatus(status, backendMessage);
-    }
-
     if (this.hasNumericStatus(error)) {
       const status = error.status;
       const message = this.extractErrorMessage(error);
@@ -140,7 +131,8 @@ export class HttpAccountOwnershipDataSource
       typeof value === "object" &&
       value !== null &&
       "message" in value &&
-      typeof (value as { message: unknown }).message === "string"
+      typeof (value as { message: unknown }).message === "string" &&
+      (value as { message: string }).message.length > 0
     ) {
       return (value as { message: string }).message;
     }
@@ -150,20 +142,26 @@ export class HttpAccountOwnershipDataSource
     return "Unknown error";
   }
 
-  private extractBackendMessage(data: unknown, fallback: string): string {
-    if (typeof data === "string" && data.length > 0) {
-      return data;
+  private async readErrorMessage(response: Response): Promise<string> {
+    const text = await response.text().catch(() => "");
+    if (!text) {
+      return "Unknown error";
     }
-    if (
-      typeof data === "object" &&
-      data !== null &&
-      "message" in data &&
-      typeof (data as { message: unknown }).message === "string" &&
-      (data as { message: string }).message.length > 0
-    ) {
-      return (data as { message: string }).message;
+    try {
+      const parsed = JSON.parse(text) as unknown;
+      if (
+        typeof parsed === "object" &&
+        parsed !== null &&
+        "message" in parsed &&
+        typeof (parsed as { message: unknown }).message === "string" &&
+        (parsed as { message: string }).message.length > 0
+      ) {
+        return (parsed as { message: string }).message;
+      }
+    } catch {
+      // body is not JSON; use the raw text below
     }
-    return fallback;
+    return text;
   }
 
   private isAccountOwnershipDto(value: unknown): value is AccountOwnershipDto {

--- a/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.ts
+++ b/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.ts
@@ -1,3 +1,4 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { type Either, Left, Right } from "purify-ts";
 
@@ -20,10 +21,19 @@ import PACKAGE from "@root/package.json";
 export class HttpAccountOwnershipDataSource
   implements AccountOwnershipDataSource
 {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {}
+  ) {
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+        [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+      },
+    });
+  }
 
   async getDescriptor({
     publicKey,
@@ -34,22 +44,12 @@ export class HttpAccountOwnershipDataSource
     Either<Error, AccountOwnershipDescriptor>
   > {
     try {
-      const url = new URL(
+      const data = (await this.http.get(
         `${this.config.metadataServiceDomain.url}/v2/concordium/owner/${publicKey}/${address}`,
-      );
-      url.searchParams.set("challenge", challenge);
-      url.searchParams.set("network", network);
-      const response = await fetch(url, {
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+        {
+          params: { challenge, network },
         },
-      });
-      if (!response.ok) {
-        const message = await this.readErrorMessage(response);
-        throw Object.assign(new Error(message), { status: response.status });
-      }
-      const data = (await response.json()) as AccountOwnershipDto | null;
+      )) as AccountOwnershipDto | null;
 
       if (!data) {
         return Left(
@@ -85,11 +85,12 @@ export class HttpAccountOwnershipDataSource
    * as `verification_failed`; everything else (network failure, 5xx,
    * unrecognized errors) is marked as `service_unavailable`.
    *
-   * Errors with a numeric `.status` field are treated as HTTP-shaped failures
-   * (thrown above when the fetch response is not ok, or surfaced by a
-   * wrapping client that preserves the HTTP status on a top-level `.status`
-   * field). Anything else falls through to the canonical
-   * `service_unavailable` message.
+   * Errors with a numeric `.status` field are treated as HTTP-shaped
+   * failures. `DmkNetworkClientError` exposes `.status` and a raw
+   * `.responseBody` string; the backend's human-readable message is
+   * extracted from the error's own `.message` first, then from the JSON
+   * body on `.responseBody`, and finally from the raw body as a
+   * last resort.
    */
   private classifyError(error: unknown): AccountOwnershipError {
     if (this.hasNumericStatus(error)) {
@@ -136,19 +137,31 @@ export class HttpAccountOwnershipDataSource
     ) {
       return (value as { message: string }).message;
     }
+    const fromBody = this.extractResponseBodyMessage(value);
+    if (fromBody !== null) {
+      return fromBody;
+    }
     if (typeof value === "string") {
       return value;
     }
     return "Unknown error";
   }
 
-  private async readErrorMessage(response: Response): Promise<string> {
-    const text = await response.text().catch(() => "");
-    if (!text) {
-      return "Unknown error";
+  private extractResponseBodyMessage(value: unknown): string | null {
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      !("responseBody" in value) ||
+      typeof (value as { responseBody: unknown }).responseBody !== "string"
+    ) {
+      return null;
+    }
+    const body = (value as { responseBody: string }).responseBody;
+    if (body.length === 0) {
+      return null;
     }
     try {
-      const parsed = JSON.parse(text) as unknown;
+      const parsed = JSON.parse(body) as unknown;
       if (
         typeof parsed === "object" &&
         parsed !== null &&
@@ -159,9 +172,9 @@ export class HttpAccountOwnershipDataSource
         return (parsed as { message: string }).message;
       }
     } catch {
-      // body is not JSON; use the raw text below
+      // body is not JSON; fall through to use it as plain text
     }
-    return text;
+    return body;
   }
 
   private isAccountOwnershipDto(value: unknown): value is AccountOwnershipDto {

--- a/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.ts
+++ b/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.ts
@@ -30,7 +30,9 @@ export class HttpAccountOwnershipDataSource
     this.http = new DmkNetworkClient({
       headers: {
         [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-        [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+        ...(this.config.originToken && {
+          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+        }),
       },
     });
   }

--- a/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.test.ts
+++ b/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.test.ts
@@ -1,5 +1,4 @@
 import { DeviceModelId } from "@ledgerhq/device-management-kit";
-import axios from "axios";
 import { Left } from "purify-ts";
 
 import type {
@@ -19,7 +18,6 @@ import PACKAGE from "@root/package.json";
 
 import { HttpCalldataDescriptorDataSource } from "./HttpCalldataDescriptorDataSource";
 
-vi.mock("axios");
 const config = {
   cal: {
     url: "https://crypto-assets-service.api.ledger.com/v1",
@@ -358,11 +356,12 @@ describe("HttpCalldataDescriptorDataSource", () => {
     };
   }
 
-  it("should call axios with the ledger client version header", async () => {
+  it("should call fetch with the ledger client version header", async () => {
     // GIVEN
     const version = `context-module/${PACKAGE.version}`;
-    const requestSpy = vi.fn(() => Promise.resolve({ data: [] }));
-    vi.spyOn(axios, "request").mockImplementation(requestSpy);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -376,7 +375,8 @@ describe("HttpCalldataDescriptorDataSource", () => {
     });
 
     // THEN
-    expect(requestSpy).toHaveBeenCalledWith(
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.any(URL),
       expect.objectContaining({
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: version,
@@ -387,11 +387,12 @@ describe("HttpCalldataDescriptorDataSource", () => {
   });
 
   it.each([["dapps"], ["tokens"]])(
-    "should call axios with the correct url for endpoint '%s'",
+    "should call fetch with the correct url for endpoint '%s'",
     async (endpoint) => {
       // GIVEN
-      const requestSpy = vi.fn(() => Promise.resolve({ data: [] }));
-      vi.spyOn(axios, "request").mockImplementation(requestSpy);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify([])),
+      );
       const customDataSource = new HttpCalldataDescriptorDataSource(
         config,
         certificateLoaderMock as unknown as PkiCertificateLoader,
@@ -407,17 +408,16 @@ describe("HttpCalldataDescriptorDataSource", () => {
       });
 
       // THEN
-      expect(requestSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: `https://crypto-assets-service.api.ledger.com/v1/${endpoint}`,
-        }),
+      const calledUrl = vi.mocked(globalThis.fetch).mock.calls[0]![0] as URL;
+      expect(calledUrl.pathname).toBe(
+        `/v1/${endpoint}`,
       );
     },
   );
 
-  it("should return an error when axios throws an error", async () => {
+  it("should return an error when fetch throws an error", async () => {
     // GIVEN
-    vi.spyOn(axios, "request").mockRejectedValue(new Error());
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error());
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -442,8 +442,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
 
   it("should return an error when no payload is returned", async () => {
     // GIVEN
-    const response = { data: { test: "" } };
-    vi.spyOn(axios, "request").mockResolvedValue(response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ test: "" })),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -468,7 +469,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
 
   it("should return an error when an empty array is returned", async () => {
     // GIVEN
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -494,7 +497,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
   it("should return an error when selector is not found", async () => {
     // GIVEN
     const calldataDTO = createCalldata(transactionInfo, enums, [fieldToken]);
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -525,7 +528,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       fieldNft,
       fieldEnum,
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -634,7 +637,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
         0x01, 0x02, 0x03, 0x04, 0x15, 0x04, 0x05, 0x06, 0x07, 0x08,
       ]),
     };
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValueOnce(
       certificate,
     );
@@ -742,7 +745,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       [],
       [fieldAmount, fieldDatetime, fieldUnit, fieldDuration],
     );
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -788,9 +791,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
       [],
       [fieldAmount, fieldDatetime, fieldUnit, fieldDuration],
     );
-    vi.spyOn(axios, "request").mockResolvedValue({
-      data: [{}, {}, calldataDTO],
-    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([{}, {}, calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -844,7 +847,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       [],
       [fieldAmount, fieldDatetime, fieldUnit, fieldDuration],
     );
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -934,7 +937,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
         "0001010112416d6f756e7420746f2065786368616e6765020102033b0001010115000101010101020120030a00010101020000040103021f0001010101050201140514ae7ab96520de3a18e5e111b5eaab095312d7fe84",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1020,7 +1023,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
         "0001010112416d6f756e7420746f2065786368616e6765020102033b0001010115000101010101020120030a00010101020000040103021f00010101010502011405147d2768de32b0b80b7a3454c06bdac94a69ddc7a9",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1054,7 +1057,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
   it("Calldata with CALLDATA fields references", async () => {
     // GIVEN
     const calldataDTO = createCalldata(transactionInfo, [], [fieldCalldata]);
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1175,7 +1178,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       [],
       [fieldCalldataMinimal],
     );
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1244,7 +1247,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
         },
       },
     };
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1281,7 +1284,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       enums,
       [fieldToken],
     );
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1311,7 +1314,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       ["badEnum"] as unknown as CalldataEnumV1,
       [fieldToken],
     );
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1341,7 +1344,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       { 0: { 1: { data: "1234" } } } as unknown as CalldataEnumV1,
       [fieldToken],
     );
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1380,7 +1383,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       },
       [fieldToken],
     );
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1410,7 +1413,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       [],
       [{ descriptor: 3 }],
     );
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1447,7 +1450,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       descriptor: "000100010c546f20726563697069667",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1484,7 +1487,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       descriptor: "000100010c546f20726563697069667",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1527,7 +1530,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       descriptor: "000100010c546f20726563697069667",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1564,7 +1567,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       descriptor: "000100010c546f20726563697069667",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [calldataDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1587,9 +1590,11 @@ describe("HttpCalldataDescriptorDataSource", () => {
     );
   });
 
-  it("should call axios with the correct headers", async () => {
+  it("should call fetch with the correct headers", async () => {
     // GIVEN
-    vi.spyOn(axios, "request").mockResolvedValueOnce({ data: {} });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({})),
+    );
 
     // WHEN
     await datasource.getCalldataDescriptors({
@@ -1600,7 +1605,8 @@ describe("HttpCalldataDescriptorDataSource", () => {
     });
 
     // THEN
-    expect(axios.request).toHaveBeenCalledWith(
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.any(URL),
       expect.objectContaining({
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,

--- a/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.test.ts
+++ b/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.test.ts
@@ -1,4 +1,7 @@
-import { DeviceModelId } from "@ledgerhq/device-management-kit";
+import {
+  DeviceModelId,
+  type DmkNetworkClient,
+} from "@ledgerhq/device-management-kit";
 import { Left } from "purify-ts";
 
 import type {
@@ -10,11 +13,6 @@ import type { ContextModuleServiceConfig } from "@/config/model/ContextModuleCon
 import { type CalldataDescriptorDataSource } from "@/index";
 import { type PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
 import { type PkiCertificate } from "@/pki/model/PkiCertificate";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
 
 import { HttpCalldataDescriptorDataSource } from "./HttpCalldataDescriptorDataSource";
 
@@ -29,6 +27,7 @@ const config = {
 
 describe("HttpCalldataDescriptorDataSource", () => {
   let datasource: CalldataDescriptorDataSource;
+  let httpMock: { get: ReturnType<typeof vi.fn> };
   let transactionInfo: CalldataTransactionInfoV1;
   let enums: CalldataEnumV1;
   let fieldToken: CalldataFieldV1;
@@ -44,13 +43,18 @@ describe("HttpCalldataDescriptorDataSource", () => {
     loadCertificate: vi.fn(),
   };
 
-  beforeAll(() => {
-    vi.clearAllMocks();
+  beforeEach(() => {
+    httpMock = { get: vi.fn() };
     datasource = new HttpCalldataDescriptorDataSource(
       config,
       certificateLoaderMock as unknown as PkiCertificateLoader,
       "dapps",
+      httpMock as unknown as DmkNetworkClient,
     );
+  });
+
+  beforeAll(() => {
+    vi.clearAllMocks();
 
     transactionInfo = {
       descriptor: {
@@ -356,47 +360,16 @@ describe("HttpCalldataDescriptorDataSource", () => {
     };
   }
 
-  it("should call fetch with the ledger client version header", async () => {
-    // GIVEN
-    const version = `context-module/${PACKAGE.version}`;
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([])),
-    );
-    vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
-      undefined,
-    );
-
-    // WHEN
-    await datasource.getCalldataDescriptors({
-      deviceModelId: DeviceModelId.FLEX,
-      chainId: 1,
-      address: "0x0abc",
-      selector: "0x01ff",
-    });
-
-    // THEN
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.any(URL),
-      expect.objectContaining({
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: version,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
-        },
-      }),
-    );
-  });
-
   it.each([["dapps"], ["tokens"]])(
-    "should call fetch with the correct url for endpoint '%s'",
+    "should call http.get with the correct url for endpoint '%s'",
     async (endpoint) => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify([])),
-      );
+      httpMock.get.mockResolvedValue([]);
       const customDataSource = new HttpCalldataDescriptorDataSource(
         config,
         certificateLoaderMock as unknown as PkiCertificateLoader,
         endpoint,
+        httpMock as unknown as DmkNetworkClient,
       );
 
       // WHEN
@@ -408,14 +381,24 @@ describe("HttpCalldataDescriptorDataSource", () => {
       });
 
       // THEN
-      const calledUrl = vi.mocked(globalThis.fetch).mock.calls[0]![0] as URL;
-      expect(calledUrl.pathname).toBe(`/v1/${endpoint}`);
+      expect(httpMock.get).toHaveBeenCalledWith(
+        `${config.cal.url}/${endpoint}`,
+        {
+          params: {
+            output: "descriptors_calldata",
+            chain_id: 1,
+            contracts: "0x0abc",
+            contract_address: "0x0abc",
+            ref: `branch:${config.cal.branch}`,
+          },
+        },
+      );
     },
   );
 
-  it("should return an error when fetch throws an error", async () => {
+  it("should return an error when http.get throws an error", async () => {
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error());
+    httpMock.get.mockRejectedValue(new Error("boom"));
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -432,7 +415,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
     expect(result).toEqual(
       Left(
         new Error(
-          "[ContextModule] HttpCalldataDescriptorDataSource: Failed to fetch calldata descriptors: DmkNetworkClientError",
+          "[ContextModule] HttpCalldataDescriptorDataSource: Failed to fetch calldata descriptors: Error: boom",
         ),
       ),
     );
@@ -440,9 +423,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
 
   it("should return an error when no payload is returned", async () => {
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ test: "" })),
-    );
+    httpMock.get.mockResolvedValue({ test: "" });
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -467,9 +448,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
 
   it("should return an error when an empty array is returned", async () => {
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([])),
-    );
+    httpMock.get.mockResolvedValue([]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -495,9 +474,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
   it("should return an error when selector is not found", async () => {
     // GIVEN
     const calldataDTO = createCalldata(transactionInfo, enums, [fieldToken]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -528,9 +505,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       fieldNft,
       fieldEnum,
     ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -639,9 +614,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
         0x01, 0x02, 0x03, 0x04, 0x15, 0x04, 0x05, 0x06, 0x07, 0x08,
       ]),
     };
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValueOnce(
       certificate,
     );
@@ -749,9 +722,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       [],
       [fieldAmount, fieldDatetime, fieldUnit, fieldDuration],
     );
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -797,9 +768,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       [],
       [fieldAmount, fieldDatetime, fieldUnit, fieldDuration],
     );
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([{}, {}, calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([{}, {}, calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -853,9 +822,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       [],
       [fieldAmount, fieldDatetime, fieldUnit, fieldDuration],
     );
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -945,9 +912,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
         "0001010112416d6f756e7420746f2065786368616e6765020102033b0001010115000101010101020120030a00010101020000040103021f0001010101050201140514ae7ab96520de3a18e5e111b5eaab095312d7fe84",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1033,9 +998,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
         "0001010112416d6f756e7420746f2065786368616e6765020102033b0001010115000101010101020120030a00010101020000040103021f00010101010502011405147d2768de32b0b80b7a3454c06bdac94a69ddc7a9",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1069,9 +1032,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
   it("Calldata with CALLDATA fields references", async () => {
     // GIVEN
     const calldataDTO = createCalldata(transactionInfo, [], [fieldCalldata]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1192,9 +1153,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       [],
       [fieldCalldataMinimal],
     );
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1263,9 +1222,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
         },
       },
     };
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1302,9 +1259,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       enums,
       [fieldToken],
     );
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1334,9 +1289,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       ["badEnum"] as unknown as CalldataEnumV1,
       [fieldToken],
     );
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1366,9 +1319,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       { 0: { 1: { data: "1234" } } } as unknown as CalldataEnumV1,
       [fieldToken],
     );
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1407,9 +1358,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       },
       [fieldToken],
     );
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1439,9 +1388,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       [],
       [{ descriptor: 3 }],
     );
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1478,9 +1425,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       descriptor: "000100010c546f20726563697069667",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1517,9 +1462,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       descriptor: "000100010c546f20726563697069667",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1562,9 +1505,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       descriptor: "000100010c546f20726563697069667",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1601,9 +1542,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
       descriptor: "000100010c546f20726563697069667",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([calldataDTO])),
-    );
+    httpMock.get.mockResolvedValue([calldataDTO]);
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1623,32 +1562,6 @@ describe("HttpCalldataDescriptorDataSource", () => {
           "[ContextModule] HttpCalldataDescriptorDataSource: Invalid response for contract 0x7d2768de32b0b80b7a3454c06bdac94a69ddc7a9 and selector 0x69328dec",
         ),
       ),
-    );
-  });
-
-  it("should call fetch with the correct headers", async () => {
-    // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({})),
-    );
-
-    // WHEN
-    await datasource.getCalldataDescriptors({
-      deviceModelId: DeviceModelId.FLEX,
-      chainId: 1,
-      address: "0x7d2768de32b0b80b7a3454c06bdac94a69ddc7a9",
-      selector: "0x69328dec",
-    });
-
-    // THEN
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.any(URL),
-      expect.objectContaining({
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
-        },
-      }),
     );
   });
 });

--- a/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.test.ts
+++ b/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.test.ts
@@ -409,9 +409,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
 
       // THEN
       const calledUrl = vi.mocked(globalThis.fetch).mock.calls[0]![0] as URL;
-      expect(calledUrl.pathname).toBe(
-        `/v1/${endpoint}`,
-      );
+      expect(calledUrl.pathname).toBe(`/v1/${endpoint}`);
     },
   );
 
@@ -497,7 +495,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
   it("should return an error when selector is not found", async () => {
     // GIVEN
     const calldataDTO = createCalldata(transactionInfo, enums, [fieldToken]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -528,7 +528,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
       fieldNft,
       fieldEnum,
     ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -637,7 +639,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
         0x01, 0x02, 0x03, 0x04, 0x15, 0x04, 0x05, 0x06, 0x07, 0x08,
       ]),
     };
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValueOnce(
       certificate,
     );
@@ -745,7 +749,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
       [],
       [fieldAmount, fieldDatetime, fieldUnit, fieldDuration],
     );
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -847,7 +853,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
       [],
       [fieldAmount, fieldDatetime, fieldUnit, fieldDuration],
     );
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -937,7 +945,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
         "0001010112416d6f756e7420746f2065786368616e6765020102033b0001010115000101010101020120030a00010101020000040103021f0001010101050201140514ae7ab96520de3a18e5e111b5eaab095312d7fe84",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1023,7 +1033,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
         "0001010112416d6f756e7420746f2065786368616e6765020102033b0001010115000101010101020120030a00010101020000040103021f00010101010502011405147d2768de32b0b80b7a3454c06bdac94a69ddc7a9",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1057,7 +1069,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
   it("Calldata with CALLDATA fields references", async () => {
     // GIVEN
     const calldataDTO = createCalldata(transactionInfo, [], [fieldCalldata]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1178,7 +1192,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
       [],
       [fieldCalldataMinimal],
     );
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1247,7 +1263,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
         },
       },
     };
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1284,7 +1302,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
       enums,
       [fieldToken],
     );
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1314,7 +1334,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
       ["badEnum"] as unknown as CalldataEnumV1,
       [fieldToken],
     );
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1344,7 +1366,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
       { 0: { 1: { data: "1234" } } } as unknown as CalldataEnumV1,
       [fieldToken],
     );
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1383,7 +1407,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
       },
       [fieldToken],
     );
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1413,7 +1439,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
       [],
       [{ descriptor: 3 }],
     );
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1450,7 +1478,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
       descriptor: "000100010c546f20726563697069667",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1487,7 +1517,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
       descriptor: "000100010c546f20726563697069667",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1530,7 +1562,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
       descriptor: "000100010c546f20726563697069667",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );
@@ -1567,7 +1601,9 @@ describe("HttpCalldataDescriptorDataSource", () => {
       descriptor: "000100010c546f20726563697069667",
     };
     const calldataDTO = createCalldata(transactionInfo, [], [field]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([calldataDTO])));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([calldataDTO])),
+    );
     vi.spyOn(certificateLoaderMock, "loadCertificate").mockResolvedValue(
       undefined,
     );

--- a/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.test.ts
+++ b/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.test.ts
@@ -432,7 +432,7 @@ describe("HttpCalldataDescriptorDataSource", () => {
     expect(result).toEqual(
       Left(
         new Error(
-          "[ContextModule] HttpCalldataDescriptorDataSource: Failed to fetch calldata descriptors: Error",
+          "[ContextModule] HttpCalldataDescriptorDataSource: Failed to fetch calldata descriptors: DmkNetworkClientError",
         ),
       ),
     );

--- a/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.ts
+++ b/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -72,22 +71,22 @@ export class HttpCalldataDescriptorDataSource
   > {
     let dto: CalldataDto[] | undefined;
     try {
-      const response = await axios.request<CalldataDto[]>({
-        method: "GET",
-        url: `${this.config.cal.url}/${this.endpoint}`,
-        params: {
-          output: "descriptors_calldata",
-          chain_id: chainId,
-          contracts: address, // used for dapps
-          contract_address: address, // used for tokens
-          ref: `branch:${this.config.cal.branch}`,
-        },
+      const url = new URL(`${this.config.cal.url}/${this.endpoint}`);
+      url.searchParams.set("output", "descriptors_calldata");
+      url.searchParams.set("chain_id", String(chainId));
+      url.searchParams.set("contracts", address);
+      url.searchParams.set("contract_address", address);
+      url.searchParams.set("ref", `branch:${this.config.cal.branch}`);
+      const response = await fetch(url, {
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+          ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
         },
       });
-      dto = response.data;
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      dto = (await response.json()) as CalldataDto[];
     } catch (error) {
       return Left(
         new Error(

--- a/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.ts
+++ b/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.ts
@@ -7,16 +7,13 @@ import {
   type ContextModuleCalMode,
   type ContextModuleServiceConfig,
 } from "@/config/model/ContextModuleConfig";
+import { networkTypes } from "@/network/di/networkTypes";
 import { pkiTypes } from "@/pki/di/pkiTypes";
 import { type PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
 import { KeyId } from "@/pki/model/KeyId";
 import { KeyUsage } from "@/pki/model/KeyUsage";
 import { PkiCertificate } from "@/pki/model/PkiCertificate";
 import { PkiCertificateInfo } from "@/pki/model/PkiCertificateInfo";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
 import {
   ClearSignContextReference,
   ClearSignContextReferenceType,
@@ -26,7 +23,6 @@ import {
 import { GenericPath } from "@/shared/model/GenericPath";
 import { INFO_SIGNATURE_TAG } from "@/shared/model/SignatureTags";
 import { HexStringUtils } from "@/shared/utils/HexStringUtils";
-import PACKAGE from "@root/package.json";
 
 import {
   CalldataDescriptor,
@@ -54,24 +50,15 @@ import {
 export class HttpCalldataDescriptorDataSource
   implements CalldataDescriptorDataSource
 {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
     @inject(pkiTypes.PkiCertificateLoader)
     private readonly _certificateLoader: PkiCertificateLoader,
     private readonly endpoint: string,
-  ) {
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-        ...(this.config.originToken && {
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-        }),
-      },
-    });
-  }
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
+  ) {}
 
   public async getCalldataDescriptors({
     chainId,

--- a/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.ts
+++ b/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.ts
@@ -80,7 +80,9 @@ export class HttpCalldataDescriptorDataSource
       const response = await fetch(url, {
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
+          ...(this.config.originToken && {
+            [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+          }),
         },
       });
       if (!response.ok) {

--- a/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.ts
+++ b/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.ts
@@ -1,3 +1,4 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -53,13 +54,24 @@ import {
 export class HttpCalldataDescriptorDataSource
   implements CalldataDescriptorDataSource
 {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
     @inject(pkiTypes.PkiCertificateLoader)
     private readonly _certificateLoader: PkiCertificateLoader,
     private readonly endpoint: string,
-  ) {}
+  ) {
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+        ...(this.config.originToken && {
+          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+        }),
+      },
+    });
+  }
 
   public async getCalldataDescriptors({
     chainId,
@@ -71,24 +83,15 @@ export class HttpCalldataDescriptorDataSource
   > {
     let dto: CalldataDto[] | undefined;
     try {
-      const url = new URL(`${this.config.cal.url}/${this.endpoint}`);
-      url.searchParams.set("output", "descriptors_calldata");
-      url.searchParams.set("chain_id", String(chainId));
-      url.searchParams.set("contracts", address);
-      url.searchParams.set("contract_address", address);
-      url.searchParams.set("ref", `branch:${this.config.cal.branch}`);
-      const response = await fetch(url, {
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          ...(this.config.originToken && {
-            [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-          }),
+      dto = (await this.http.get(`${this.config.cal.url}/${this.endpoint}`, {
+        params: {
+          output: "descriptors_calldata",
+          chain_id: chainId,
+          contracts: address,
+          contract_address: address,
+          ref: `branch:${this.config.cal.branch}`,
         },
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      dto = (await response.json()) as CalldataDto[];
+      })) as CalldataDto[];
     } catch (error) {
       return Left(
         new Error(

--- a/packages/signer/context-module/src/calldata/di/calldataModuleFactory.ts
+++ b/packages/signer/context-module/src/calldata/di/calldataModuleFactory.ts
@@ -4,6 +4,7 @@ import { HttpCalldataDescriptorDataSource } from "@/calldata/data/HttpCalldataDe
 import { calldataTypes } from "@/calldata/di/calldataTypes";
 import { CalldataContextLoader } from "@/calldata/domain/CalldataContextLoader";
 import { configTypes } from "@/config/di/configTypes";
+import { networkTypes } from "@/network/di/networkTypes";
 import { pkiTypes } from "@/pki/di/pkiTypes";
 
 export const calldataModuleFactory = () =>
@@ -14,6 +15,7 @@ export const calldataModuleFactory = () =>
           context.get(configTypes.Config),
           context.get(pkiTypes.PkiCertificateLoader),
           "dapps",
+          context.get(networkTypes.NetworkClient),
         ),
     );
     bind(calldataTypes.TokenCalldataDescriptorDataSource).toDynamicValue(
@@ -22,6 +24,7 @@ export const calldataModuleFactory = () =>
           context.get(configTypes.Config),
           context.get(pkiTypes.PkiCertificateLoader),
           "tokens",
+          context.get(networkTypes.NetworkClient),
         ),
     );
     bind(calldataTypes.CalldataContextLoader).to(CalldataContextLoader);

--- a/packages/signer/context-module/src/di.ts
+++ b/packages/signer/context-module/src/di.ts
@@ -12,6 +12,7 @@ import {
 import { dynamicNetworkModuleFactory } from "@/dynamic-network/di/dynamicNetworkModuleFactory";
 import { externalPluginModuleFactory } from "@/external-plugin/di/externalPluginModuleFactory";
 import { gatedSigningModuleFactory } from "@/gated-signing/di/gatedSigningModuleFactory";
+import { networkModuleFactory } from "@/network/di/networkModuleFactory";
 import { nftModuleFactory } from "@/nft/di/nftModuleFactory";
 import { nanoPkiModuleFactory } from "@/pki/di/pkiModuleFactory";
 import { proxyModuleFactory } from "@/proxy/di/proxyModuleFactory";
@@ -41,6 +42,7 @@ export const makeContainer = ({ config }: MakeContainerArgs) => {
 
   container.loadSync(
     configModuleFactory(config),
+    networkModuleFactory(config),
     accountOwnershipModuleFactory(),
     externalPluginModuleFactory(),
     dynamicNetworkModuleFactory(),

--- a/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.test.ts
+++ b/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.test.ts
@@ -1,12 +1,9 @@
-import axios from "axios";
 import { Left, Right } from "purify-ts";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 
 import { HttpDynamicNetworkDataSource } from "./HttpDynamicNetworkDataSource";
-
-vi.mock("axios");
 
 describe("HttpNetworkDataSource", () => {
   let datasource: HttpDynamicNetworkDataSource;
@@ -18,33 +15,31 @@ describe("HttpNetworkDataSource", () => {
     },
   } as ContextModuleServiceConfig;
 
-  const mockNetworkResponse = {
-    data: [
-      {
-        id: "ethereum",
-        descriptors: {
-          flex: {
-            data: "0x010108020101510101230800000000000000895207506f6c79676f6e2403504f4c",
-            descriptorType: "network",
-            descriptorVersion: "v1",
-            signatures: {
-              prod: "3045022100c116b5470c266c2947b92aa9eadbe3da03305efc6b8fee041e04e8484a9834af022041d5b82b359614ea8dd94a542dfd87b0ae6f3b4a075aad9a53a030064ab42cd0",
-              test: "3045022100f78bac5c9c3f2ceeea26680aaea17be61fce84ae7ec983a8194e68275f4fe5900220231afbe39fcec63edfea2b4e787a72d79ce53d6a4c408f24b5a116905a9082d3",
-            },
+  const mockNetworkData = [
+    {
+      id: "ethereum",
+      descriptors: {
+        flex: {
+          data: "0x010108020101510101230800000000000000895207506f6c79676f6e2403504f4c",
+          descriptorType: "network",
+          descriptorVersion: "v1",
+          signatures: {
+            prod: "3045022100c116b5470c266c2947b92aa9eadbe3da03305efc6b8fee041e04e8484a9834af022041d5b82b359614ea8dd94a542dfd87b0ae6f3b4a075aad9a53a030064ab42cd0",
+            test: "3045022100f78bac5c9c3f2ceeea26680aaea17be61fce84ae7ec983a8194e68275f4fe5900220231afbe39fcec63edfea2b4e787a72d79ce53d6a4c408f24b5a116905a9082d3",
           },
-          stax: {
-            data: "0x010108020101510101230800000000000000895207506f6c79676f6e2403504f4c53204aa5034d2fd4c46647d382aa64d0a03d06b185512bb7942390318bda18d0423a",
-            descriptorType: "network",
-            descriptorVersion: "v1",
-            signatures: {
-              prod: "3045022100cf42c039c16fc95dc97c09f15cdd93bed0e63ee45cf5c38c2b30bb8a3bc17f8d022053a96c9e51695c3c1c1a31f5cbf84bd6febadc97f4bb02bdc67cf3e24ad0c32d",
-              test: "304402207e1e1b8f99b45c95b0cf1e90f46cf07e6a90f82c49ccdb6e2e95ab0c1e2f5a370220784e1fac16bb01c5d096733e1cbf067d616e4de659fda2c388f8c3502e7f7f80",
-            },
+        },
+        stax: {
+          data: "0x010108020101510101230800000000000000895207506f6c79676f6e2403504f4c53204aa5034d2fd4c46647d382aa64d0a03d06b185512bb7942390318bda18d0423a",
+          descriptorType: "network",
+          descriptorVersion: "v1",
+          signatures: {
+            prod: "3045022100cf42c039c16fc95dc97c09f15cdd93bed0e63ee45cf5c38c2b30bb8a3bc17f8d022053a96c9e51695c3c1c1a31f5cbf84bd6febadc97f4bb02bdc67cf3e24ad0c32d",
+            test: "304402207e1e1b8f99b45c95b0cf1e90f46cf07e6a90f82c49ccdb6e2e95ab0c1e2f5a370220784e1fac16bb01c5d096733e1cbf067d616e4de659fda2c388f8c3502e7f7f80",
           },
         },
       },
-    ],
-  };
+    },
+  ];
 
   beforeAll(() => {
     datasource = new HttpDynamicNetworkDataSource(mockConfig);
@@ -56,11 +51,13 @@ describe("HttpNetworkDataSource", () => {
 
   describe("getNetworkConfiguration", () => {
     it("should return network configuration successfully", async () => {
-      vi.mocked(axios.get).mockResolvedValue(mockNetworkResponse);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(mockNetworkData)),
+      );
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
-      expect(axios.get).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
         "https://crypto-assets-service.api.ledger.com/networks?output=id,descriptors,icons&chain_id=1",
         expect.objectContaining({
           headers: expect.any(Object) as Record<string, string>,
@@ -97,7 +94,9 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should return error when network data is not found", async () => {
-      vi.mocked(axios.get).mockResolvedValue({ data: [] });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify([])),
+      );
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -107,7 +106,7 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should return error when network data is undefined", async () => {
-      vi.mocked(axios.get).mockResolvedValue({ data: undefined });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("null"));
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -116,16 +115,18 @@ describe("HttpNetworkDataSource", () => {
       );
     });
 
-    it("should return error when axios throws an error", async () => {
-      vi.mocked(axios.get).mockRejectedValue(new Error("Network error"));
+    it("should return error when fetch throws an error", async () => {
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(
+        new Error("Network error"),
+      );
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
       expect(result).toEqual(Left(new Error("Network error")));
     });
 
-    it("should return generic error when axios throws non-Error", async () => {
-      vi.mocked(axios.get).mockRejectedValue("String error");
+    it("should return generic error when fetch throws non-Error", async () => {
+      vi.spyOn(globalThis, "fetch").mockRejectedValue("String error");
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -135,15 +136,15 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should handle invalid data - missing id", async () => {
-      const invalidResponse = {
-        data: [
-          {
-            // Missing id
-            descriptors: {},
-          },
-        ],
-      };
-      vi.mocked(axios.get).mockResolvedValue(invalidResponse);
+      const invalidData = [
+        {
+          // Missing id
+          descriptors: {},
+        },
+      ];
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidData)),
+      );
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -155,15 +156,15 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should handle invalid data - missing descriptors", async () => {
-      const invalidResponse = {
-        data: [
-          {
-            id: "ethereum",
-            // Missing descriptors
-          },
-        ],
-      };
-      vi.mocked(axios.get).mockResolvedValue(invalidResponse);
+      const invalidData = [
+        {
+          id: "ethereum",
+          // Missing descriptors
+        },
+      ];
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidData)),
+      );
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -175,22 +176,22 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should handle invalid descriptor - missing data field", async () => {
-      const invalidResponse = {
-        data: [
-          {
-            id: "ethereum",
-            descriptors: {
-              flex: {
-                // Missing data
-                descriptorType: "network",
-                descriptorVersion: "v1",
-                signatures: { prod: "sig1", test: "sig2" },
-              },
+      const invalidData = [
+        {
+          id: "ethereum",
+          descriptors: {
+            flex: {
+              // Missing data
+              descriptorType: "network",
+              descriptorVersion: "v1",
+              signatures: { prod: "sig1", test: "sig2" },
             },
           },
-        ],
-      };
-      vi.mocked(axios.get).mockResolvedValue(invalidResponse);
+        },
+      ];
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidData)),
+      );
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -202,22 +203,22 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should handle invalid descriptor - missing signatures", async () => {
-      const invalidResponse = {
-        data: [
-          {
-            id: "ethereum",
-            descriptors: {
-              flex: {
-                data: "0x0101",
-                descriptorType: "network",
-                descriptorVersion: "v1",
-                // Missing signatures
-              },
+      const invalidData = [
+        {
+          id: "ethereum",
+          descriptors: {
+            flex: {
+              data: "0x0101",
+              descriptorType: "network",
+              descriptorVersion: "v1",
+              // Missing signatures
             },
           },
-        ],
-      };
-      vi.mocked(axios.get).mockResolvedValue(invalidResponse);
+        },
+      ];
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidData)),
+      );
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -229,25 +230,25 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should handle invalid signatures - missing prod", async () => {
-      const invalidResponse = {
-        data: [
-          {
-            id: "ethereum",
-            descriptors: {
-              flex: {
-                data: "0x0101",
-                descriptorType: "network",
-                descriptorVersion: "v1",
-                signatures: {
-                  // Missing prod
-                  test: "sig2",
-                },
+      const invalidData = [
+        {
+          id: "ethereum",
+          descriptors: {
+            flex: {
+              data: "0x0101",
+              descriptorType: "network",
+              descriptorVersion: "v1",
+              signatures: {
+                // Missing prod
+                test: "sig2",
               },
             },
           },
-        ],
-      };
-      vi.mocked(axios.get).mockResolvedValue(invalidResponse);
+        },
+      ];
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidData)),
+      );
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -259,38 +260,38 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should include icons when available", async () => {
-      const responseWithIcons = {
-        data: [
-          {
-            id: "ethereum",
-            descriptors: {
-              flex: {
-                data: "0x0101",
-                descriptorType: "network",
-                descriptorVersion: "v1",
-                signatures: {
-                  prod: "sig1",
-                  test: "sig2",
-                },
-              },
-              stax: {
-                data: "0x0102",
-                descriptorType: "network",
-                descriptorVersion: "v1",
-                signatures: {
-                  prod: "sig3",
-                  test: "sig4",
-                },
+      const dataWithIcons = [
+        {
+          id: "ethereum",
+          descriptors: {
+            flex: {
+              data: "0x0101",
+              descriptorType: "network",
+              descriptorVersion: "v1",
+              signatures: {
+                prod: "sig1",
+                test: "sig2",
               },
             },
-            icons: {
-              flex: "icon1",
-              stax: "icon2",
+            stax: {
+              data: "0x0102",
+              descriptorType: "network",
+              descriptorVersion: "v1",
+              signatures: {
+                prod: "sig3",
+                test: "sig4",
+              },
             },
           },
-        ],
-      };
-      vi.mocked(axios.get).mockResolvedValue(responseWithIcons);
+          icons: {
+            flex: "icon1",
+            stax: "icon2",
+          },
+        },
+      ];
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(dataWithIcons)),
+      );
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -301,11 +302,13 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should transform data correctly for Polygon chain ID", async () => {
-      vi.mocked(axios.get).mockResolvedValue(mockNetworkResponse);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(mockNetworkData)),
+      );
 
       const result = await datasource.getDynamicNetworkConfiguration(137);
 
-      expect(axios.get).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
         "https://crypto-assets-service.api.ledger.com/networks?output=id,descriptors,icons&chain_id=137",
         expect.objectContaining({
           headers: expect.any(Object) as Record<string, string>,
@@ -318,10 +321,10 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should handle invalid data - null data", async () => {
-      const invalidResponse = {
-        data: [null],
-      };
-      vi.mocked(axios.get).mockResolvedValue(invalidResponse);
+      const invalidData = [null];
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidData)),
+      );
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -331,10 +334,10 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should handle invalid data - non-object data", async () => {
-      const invalidResponse = {
-        data: ["string_instead_of_object"],
-      };
-      vi.mocked(axios.get).mockResolvedValue(invalidResponse);
+      const invalidData = ["string_instead_of_object"];
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidData)),
+      );
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -346,26 +349,26 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should handle invalid data - icons as string instead of object", async () => {
-      const invalidResponse = {
-        data: [
-          {
-            id: "ethereum",
-            descriptors: {
-              flex: {
-                data: "0x0101",
-                descriptorType: "network",
-                descriptorVersion: "v1",
-                signatures: {
-                  prod: "sig1",
-                  test: "sig2",
-                },
+      const invalidData = [
+        {
+          id: "ethereum",
+          descriptors: {
+            flex: {
+              data: "0x0101",
+              descriptorType: "network",
+              descriptorVersion: "v1",
+              signatures: {
+                prod: "sig1",
+                test: "sig2",
               },
             },
-            icons: "should_be_object_not_string",
           },
-        ],
-      };
-      vi.mocked(axios.get).mockResolvedValue(invalidResponse);
+          icons: "should_be_object_not_string",
+        },
+      ];
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidData)),
+      );
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -377,26 +380,26 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should handle invalid data - icons as number instead of object (line 93)", async () => {
-      const invalidResponse = {
-        data: [
-          {
-            id: "ethereum",
-            descriptors: {
-              flex: {
-                data: "0x0101",
-                descriptorType: "network",
-                descriptorVersion: "v1",
-                signatures: {
-                  prod: "sig1",
-                  test: "sig2",
-                },
+      const invalidData = [
+        {
+          id: "ethereum",
+          descriptors: {
+            flex: {
+              data: "0x0101",
+              descriptorType: "network",
+              descriptorVersion: "v1",
+              signatures: {
+                prod: "sig1",
+                test: "sig2",
               },
             },
-            icons: 123,
           },
-        ],
-      };
-      vi.mocked(axios.get).mockResolvedValue(invalidResponse);
+          icons: 123,
+        },
+      ];
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidData)),
+      );
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -408,17 +411,17 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should handle invalid descriptor - null descriptor (line 103)", async () => {
-      const invalidResponse = {
-        data: [
-          {
-            id: "ethereum",
-            descriptors: {
-              flex: null,
-            },
+      const invalidData = [
+        {
+          id: "ethereum",
+          descriptors: {
+            flex: null,
           },
-        ],
-      };
-      vi.mocked(axios.get).mockResolvedValue(invalidResponse);
+        },
+      ];
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidData)),
+      );
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -430,17 +433,17 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should handle invalid descriptor - non-object descriptor (line 103)", async () => {
-      const invalidResponse = {
-        data: [
-          {
-            id: "ethereum",
-            descriptors: {
-              flex: "should_be_object_not_string",
-            },
+      const invalidData = [
+        {
+          id: "ethereum",
+          descriptors: {
+            flex: "should_be_object_not_string",
           },
-        ],
-      };
-      vi.mocked(axios.get).mockResolvedValue(invalidResponse);
+        },
+      ];
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidData)),
+      );
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 

--- a/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.test.ts
+++ b/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.test.ts
@@ -58,7 +58,9 @@ describe("HttpNetworkDataSource", () => {
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "https://crypto-assets-service.api.ledger.com/networks?output=id,descriptors,icons&chain_id=1",
+        expect.objectContaining({
+          href: "https://crypto-assets-service.api.ledger.com/networks?output=id%2Cdescriptors%2Cicons&chain_id=1",
+        }),
         expect.objectContaining({
           headers: expect.any(Object) as Record<string, string>,
         }),
@@ -130,9 +132,7 @@ describe("HttpNetworkDataSource", () => {
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
-      expect(result).toEqual(
-        Left(new Error("Failed to fetch network configuration")),
-      );
+      expect(result).toEqual(Left(new Error("Network request failed")));
     });
 
     it("should handle invalid data - missing id", async () => {
@@ -309,7 +309,9 @@ describe("HttpNetworkDataSource", () => {
       const result = await datasource.getDynamicNetworkConfiguration(137);
 
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "https://crypto-assets-service.api.ledger.com/networks?output=id,descriptors,icons&chain_id=137",
+        expect.objectContaining({
+          href: "https://crypto-assets-service.api.ledger.com/networks?output=id%2Cdescriptors%2Cicons&chain_id=137",
+        }),
         expect.objectContaining({
           headers: expect.any(Object) as Record<string, string>,
         }),

--- a/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.test.ts
+++ b/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.test.ts
@@ -1,5 +1,6 @@
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 
@@ -7,6 +8,7 @@ import { HttpDynamicNetworkDataSource } from "./HttpDynamicNetworkDataSource";
 
 describe("HttpNetworkDataSource", () => {
   let datasource: HttpDynamicNetworkDataSource;
+  let httpMock: { get: ReturnType<typeof vi.fn> };
   const mockConfig: ContextModuleServiceConfig = {
     cal: {
       url: "https://crypto-assets-service.api.ledger.com",
@@ -41,29 +43,29 @@ describe("HttpNetworkDataSource", () => {
     },
   ];
 
-  beforeAll(() => {
-    datasource = new HttpDynamicNetworkDataSource(mockConfig);
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
+    httpMock = { get: vi.fn() };
+    datasource = new HttpDynamicNetworkDataSource(
+      mockConfig,
+      httpMock as unknown as DmkNetworkClient,
+    );
   });
 
   describe("getNetworkConfiguration", () => {
     it("should return network configuration successfully", async () => {
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(mockNetworkData)),
-      );
+      httpMock.get.mockResolvedValue(mockNetworkData);
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.objectContaining({
-          href: "https://crypto-assets-service.api.ledger.com/networks?output=id%2Cdescriptors%2Cicons&chain_id=1",
-        }),
-        expect.objectContaining({
-          headers: expect.any(Object) as Record<string, string>,
-        }),
+      expect(httpMock.get).toHaveBeenCalledWith(
+        `${mockConfig.cal.url}/networks`,
+        {
+          params: {
+            output: "id,descriptors,icons",
+            chain_id: 1,
+          },
+        },
       );
 
       expect(result).toEqual(
@@ -96,9 +98,7 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should return error when network data is not found", async () => {
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify([])),
-      );
+      httpMock.get.mockResolvedValue([]);
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -108,7 +108,7 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should return error when network data is undefined", async () => {
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("null"));
+      httpMock.get.mockResolvedValue(null);
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -117,22 +117,22 @@ describe("HttpNetworkDataSource", () => {
       );
     });
 
-    it("should return error when fetch throws an error", async () => {
-      vi.spyOn(globalThis, "fetch").mockRejectedValue(
-        new Error("Network error"),
-      );
+    it("should return error when http.get throws an error", async () => {
+      httpMock.get.mockRejectedValue(new Error("Network error"));
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
       expect(result).toEqual(Left(new Error("Network error")));
     });
 
-    it("should return generic error when fetch throws non-Error", async () => {
-      vi.spyOn(globalThis, "fetch").mockRejectedValue("String error");
+    it("should return generic error when http.get throws non-Error", async () => {
+      httpMock.get.mockRejectedValue("String error");
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
-      expect(result).toEqual(Left(new Error("Network request failed")));
+      expect(result).toEqual(
+        Left(new Error("Failed to fetch network configuration")),
+      );
     });
 
     it("should handle invalid data - missing id", async () => {
@@ -142,9 +142,7 @@ describe("HttpNetworkDataSource", () => {
           descriptors: {},
         },
       ];
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidData)),
-      );
+      httpMock.get.mockResolvedValue(invalidData);
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -162,9 +160,7 @@ describe("HttpNetworkDataSource", () => {
           // Missing descriptors
         },
       ];
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidData)),
-      );
+      httpMock.get.mockResolvedValue(invalidData);
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -189,9 +185,7 @@ describe("HttpNetworkDataSource", () => {
           },
         },
       ];
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidData)),
-      );
+      httpMock.get.mockResolvedValue(invalidData);
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -216,9 +210,7 @@ describe("HttpNetworkDataSource", () => {
           },
         },
       ];
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidData)),
-      );
+      httpMock.get.mockResolvedValue(invalidData);
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -246,9 +238,7 @@ describe("HttpNetworkDataSource", () => {
           },
         },
       ];
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidData)),
-      );
+      httpMock.get.mockResolvedValue(invalidData);
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -289,9 +279,7 @@ describe("HttpNetworkDataSource", () => {
           },
         },
       ];
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(dataWithIcons)),
-      );
+      httpMock.get.mockResolvedValue(dataWithIcons);
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -302,19 +290,18 @@ describe("HttpNetworkDataSource", () => {
     });
 
     it("should transform data correctly for Polygon chain ID", async () => {
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(mockNetworkData)),
-      );
+      httpMock.get.mockResolvedValue(mockNetworkData);
 
       const result = await datasource.getDynamicNetworkConfiguration(137);
 
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.objectContaining({
-          href: "https://crypto-assets-service.api.ledger.com/networks?output=id%2Cdescriptors%2Cicons&chain_id=137",
-        }),
-        expect.objectContaining({
-          headers: expect.any(Object) as Record<string, string>,
-        }),
+      expect(httpMock.get).toHaveBeenCalledWith(
+        `${mockConfig.cal.url}/networks`,
+        {
+          params: {
+            output: "id,descriptors,icons",
+            chain_id: 137,
+          },
+        },
       );
 
       expect(result.isRight()).toBe(true);
@@ -324,9 +311,7 @@ describe("HttpNetworkDataSource", () => {
 
     it("should handle invalid data - null data", async () => {
       const invalidData = [null];
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidData)),
-      );
+      httpMock.get.mockResolvedValue(invalidData);
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -337,9 +322,7 @@ describe("HttpNetworkDataSource", () => {
 
     it("should handle invalid data - non-object data", async () => {
       const invalidData = ["string_instead_of_object"];
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidData)),
-      );
+      httpMock.get.mockResolvedValue(invalidData);
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -368,9 +351,7 @@ describe("HttpNetworkDataSource", () => {
           icons: "should_be_object_not_string",
         },
       ];
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidData)),
-      );
+      httpMock.get.mockResolvedValue(invalidData);
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -399,9 +380,7 @@ describe("HttpNetworkDataSource", () => {
           icons: 123,
         },
       ];
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidData)),
-      );
+      httpMock.get.mockResolvedValue(invalidData);
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -421,9 +400,7 @@ describe("HttpNetworkDataSource", () => {
           },
         },
       ];
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidData)),
-      );
+      httpMock.get.mockResolvedValue(invalidData);
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 
@@ -443,9 +420,7 @@ describe("HttpNetworkDataSource", () => {
           },
         },
       ];
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidData)),
-      );
+      httpMock.get.mockResolvedValue(invalidData);
 
       const result = await datasource.getDynamicNetworkConfiguration(1);
 

--- a/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.ts
+++ b/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.ts
@@ -11,8 +11,7 @@ import {
   type DynamicNetworkConfiguration,
   type DynamicNetworkDescriptor,
 } from "@/dynamic-network/model/DynamicNetworkConfiguration";
-import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
+import { networkTypes } from "@/network/di/networkTypes";
 
 import { type DynamicNetworkApiResponseDto } from "./dto/DynamicNetworkApiResponseDto";
 import { type DynamicNetworkDataSource } from "./DynamicNetworkDataSource";
@@ -29,18 +28,12 @@ const LOWERCASE_KEY_TO_DEVICE_MODEL_ID: Record<string, DeviceModelId> = {
 
 @injectable()
 export class HttpDynamicNetworkDataSource implements DynamicNetworkDataSource {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-      },
-    });
-  }
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
+  ) {}
 
   async getDynamicNetworkConfiguration(
     chainId: number,

--- a/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.ts
+++ b/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.ts
@@ -1,4 +1,7 @@
-import { DeviceModelId } from "@ledgerhq/device-management-kit";
+import {
+  DeviceModelId,
+  DmkNetworkClient,
+} from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -26,10 +29,18 @@ const LOWERCASE_KEY_TO_DEVICE_MODEL_ID: Record<string, DeviceModelId> = {
 
 @injectable()
 export class HttpDynamicNetworkDataSource implements DynamicNetworkDataSource {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {}
+  ) {
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+      },
+    });
+  }
 
   async getDynamicNetworkConfiguration(
     chainId: number,
@@ -37,22 +48,16 @@ export class HttpDynamicNetworkDataSource implements DynamicNetworkDataSource {
     let response: DynamicNetworkApiResponseDto;
 
     try {
-      const fetchResponse = await fetch(
-        `${this.config.cal.url}/networks?output=id,descriptors,icons&chain_id=${chainId}`,
-        {
-          headers: {
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          },
+      response = (await this.http.get(`${this.config.cal.url}/networks`, {
+        params: {
+          output: "id,descriptors,icons",
+          chain_id: chainId,
         },
-      );
-      if (!fetchResponse.ok) {
-        throw new Error(`HTTP error ${fetchResponse.status}`);
-      }
-      response = (await fetchResponse.json()) as DynamicNetworkApiResponseDto;
+      })) as DynamicNetworkApiResponseDto;
     } catch (error) {
       return Left(
         error instanceof Error
-          ? error
+          ? new Error(error.message)
           : new Error("Failed to fetch network configuration"),
       );
     }

--- a/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.ts
+++ b/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.ts
@@ -1,5 +1,4 @@
 import { DeviceModelId } from "@ledgerhq/device-management-kit";
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -38,7 +37,7 @@ export class HttpDynamicNetworkDataSource implements DynamicNetworkDataSource {
     let response: DynamicNetworkApiResponseDto;
 
     try {
-      const axiosResponse = await axios.get<DynamicNetworkApiResponseDto>(
+      const fetchResponse = await fetch(
         `${this.config.cal.url}/networks?output=id,descriptors,icons&chain_id=${chainId}`,
         {
           headers: {
@@ -46,7 +45,10 @@ export class HttpDynamicNetworkDataSource implements DynamicNetworkDataSource {
           },
         },
       );
-      response = axiosResponse.data;
+      if (!fetchResponse.ok) {
+        throw new Error(`HTTP error ${fetchResponse.status}`);
+      }
+      response = (await fetchResponse.json()) as DynamicNetworkApiResponseDto;
     } catch (error) {
       return Left(
         error instanceof Error

--- a/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.test.ts
+++ b/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.test.ts
@@ -1,3 +1,5 @@
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
+
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import ABI from "@/external-plugin/__tests__/abi.json";
 import {
@@ -8,15 +10,6 @@ import {
 } from "@/external-plugin/data/DAppDto";
 import { type ExternalPluginDataSource } from "@/external-plugin/data/ExternalPluginDataSource";
 import { HttpExternalPluginDataSource } from "@/external-plugin/data/HttpExternalPluginDataSource";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
-
-const fetchResponseBuilder = (dto: Partial<DAppDto>[]) => {
-  return new Response(JSON.stringify(dto));
-};
 
 const config = {
   web3checks: {
@@ -30,6 +23,7 @@ const config = {
 
 describe("HttpExternalPuginDataSource", () => {
   let datasource: ExternalPluginDataSource;
+  let httpMock: { get: ReturnType<typeof vi.fn> };
   const exampleB2c: B2c = {
     blockchainName: "ethereum",
     chainId: 1,
@@ -77,17 +71,20 @@ describe("HttpExternalPuginDataSource", () => {
     },
   };
 
-  beforeAll(() => {
-    datasource = new HttpExternalPluginDataSource(config);
+  beforeEach(() => {
     vi.clearAllMocks();
+    httpMock = { get: vi.fn() };
+    datasource = new HttpExternalPluginDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
   });
 
-  it("should call fetch with the ledger client version header", async () => {
+  const dappDtoResponse = (dto: Partial<DAppDto>[]) => dto as DAppDto[];
+
+  it("should call the expected CAL URL with query params", async () => {
     // GIVEN
-    const version = `context-module/${PACKAGE.version}`;
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([])),
-    );
+    httpMock.get.mockResolvedValue([]);
 
     // WHEN
     await datasource.getDappInfos({
@@ -97,23 +94,25 @@ describe("HttpExternalPuginDataSource", () => {
     });
 
     // THEN
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.any(URL),
-      expect.objectContaining({
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: version,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
+    expect(httpMock.get).toHaveBeenCalledWith(
+      "https://crypto-assets-service.api.ledger.com/v1/dapps",
+      {
+        params: {
+          output: "b2c,b2c_signatures,abis",
+          chain_id: 1,
+          contracts: "0x0abc",
         },
-      }),
+      },
     );
   });
 
   it("should return undefined when no abis is undefined", async () => {
     // GIVEN
-    const response = fetchResponseBuilder([
-      { b2c: exampleB2c, b2c_signatures: exampleB2cSignatures },
-    ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+    httpMock.get.mockResolvedValue(
+      dappDtoResponse([
+        { b2c: exampleB2c, b2c_signatures: exampleB2cSignatures },
+      ]),
+    );
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -128,10 +127,11 @@ describe("HttpExternalPuginDataSource", () => {
 
   it("should return undefined when no selectors", async () => {
     // GIVEN
-    const response = fetchResponseBuilder([
-      { abis: exampleAbis, b2c_signatures: exampleB2cSignatures },
-    ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+    httpMock.get.mockResolvedValue(
+      dappDtoResponse([
+        { abis: exampleAbis, b2c_signatures: exampleB2cSignatures },
+      ]),
+    );
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -146,10 +146,11 @@ describe("HttpExternalPuginDataSource", () => {
 
   it("should return undefined when no abis data", async () => {
     // GIVEN
-    const response = fetchResponseBuilder([
-      { abis: {}, b2c: exampleB2c, b2c_signatures: exampleB2cSignatures },
-    ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+    httpMock.get.mockResolvedValue(
+      dappDtoResponse([
+        { abis: {}, b2c: exampleB2c, b2c_signatures: exampleB2cSignatures },
+      ]),
+    );
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -162,12 +163,13 @@ describe("HttpExternalPuginDataSource", () => {
     expect(result.extract()).toEqual(undefined);
   });
 
-  it("should return undefined when no abis data", async () => {
+  it("should return undefined when no abis data (duplicate case)", async () => {
     // GIVEN
-    const response = fetchResponseBuilder([
-      { abis: {}, b2c: exampleB2c, b2c_signatures: exampleB2cSignatures },
-    ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+    httpMock.get.mockResolvedValue(
+      dappDtoResponse([
+        { abis: {}, b2c: exampleB2c, b2c_signatures: exampleB2cSignatures },
+      ]),
+    );
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -183,10 +185,11 @@ describe("HttpExternalPuginDataSource", () => {
   it("should return undefined when no abis data for the contract address", async () => {
     // GIVEN
     const abis: Abis = { "0x1": ABI };
-    const response = fetchResponseBuilder([
-      { abis, b2c: exampleB2c, b2c_signatures: exampleB2cSignatures },
-    ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+    httpMock.get.mockResolvedValue(
+      dappDtoResponse([
+        { abis, b2c: exampleB2c, b2c_signatures: exampleB2cSignatures },
+      ]),
+    );
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -201,10 +204,9 @@ describe("HttpExternalPuginDataSource", () => {
 
   it("should return undefined when no b2c signature", async () => {
     // GIVEN
-    const response = fetchResponseBuilder([
-      { b2c: exampleB2c, abis: exampleAbis },
-    ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+    httpMock.get.mockResolvedValue(
+      dappDtoResponse([{ b2c: exampleB2c, abis: exampleAbis }]),
+    );
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -233,10 +235,11 @@ describe("HttpExternalPuginDataSource", () => {
       ],
       name: "test",
     } as unknown as B2c;
-    const response = fetchResponseBuilder([
-      { b2c, abis: exampleAbis, b2c_signatures: exampleB2cSignatures },
-    ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+    httpMock.get.mockResolvedValue(
+      dappDtoResponse([
+        { b2c, abis: exampleAbis, b2c_signatures: exampleB2cSignatures },
+      ]),
+    );
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -265,10 +268,11 @@ describe("HttpExternalPuginDataSource", () => {
       ],
       name: "test",
     } as unknown as B2c;
-    const response = fetchResponseBuilder([
-      { b2c, abis: exampleAbis, b2c_signatures: exampleB2cSignatures },
-    ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+    httpMock.get.mockResolvedValue(
+      dappDtoResponse([
+        { b2c, abis: exampleAbis, b2c_signatures: exampleB2cSignatures },
+      ]),
+    );
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -297,42 +301,11 @@ describe("HttpExternalPuginDataSource", () => {
       ],
       name: "test",
     } as unknown as B2c;
-    const response = fetchResponseBuilder([
-      { b2c, abis: exampleAbis, b2c_signatures: exampleB2cSignatures },
-    ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
-
-    // WHEN
-    const result = await datasource.getDappInfos({
-      chainId: 1,
-      address: "0x0abc",
-      selector: "0x01ff",
-    });
-
-    // THEN
-    expect(result.extract()).toEqual(undefined);
-  });
-
-  it("should return undefined when no method", async () => {
-    // GIVEN
-    const b2c = {
-      blockchainName: "ethereum",
-      chainId: 1,
-      contracts: [
-        {
-          address: "0x0abc",
-          contractName: "name",
-          selectors: {
-            "0x01ff": { erc20OfInterest: ["fromToken"], plugin: "plugin" },
-          },
-        },
-      ],
-      name: "test",
-    } as unknown as B2c;
-    const response = fetchResponseBuilder([
-      { b2c, abis: exampleAbis, b2c_signatures: exampleB2cSignatures },
-    ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+    httpMock.get.mockResolvedValue(
+      dappDtoResponse([
+        { b2c, abis: exampleAbis, b2c_signatures: exampleB2cSignatures },
+      ]),
+    );
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -350,12 +323,11 @@ describe("HttpExternalPuginDataSource", () => {
     const B2CSignature = {
       "0x0abc": { "0x01ff": { plugin: "plugin", serialized_data: "0x001" } },
     } as unknown as B2cSignatures;
-
-    // FIXME
-    const response = fetchResponseBuilder([
-      { b2c: exampleB2c, abis: exampleAbis, b2c_signatures: B2CSignature },
-    ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+    httpMock.get.mockResolvedValue(
+      dappDtoResponse([
+        { b2c: exampleB2c, abis: exampleAbis, b2c_signatures: B2CSignature },
+      ]),
+    );
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -373,12 +345,11 @@ describe("HttpExternalPuginDataSource", () => {
     const B2CSignature = {
       "0x0abc": { "0x01ff": { plugin: "plugin", signature: "0x002" } },
     } as unknown as B2cSignatures;
-
-    // FIXME
-    const response = fetchResponseBuilder([
-      { b2c: exampleB2c, abis: exampleAbis, b2c_signatures: B2CSignature },
-    ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+    httpMock.get.mockResolvedValue(
+      dappDtoResponse([
+        { b2c: exampleB2c, abis: exampleAbis, b2c_signatures: B2CSignature },
+      ]),
+    );
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -393,14 +364,15 @@ describe("HttpExternalPuginDataSource", () => {
 
   it("should return a correct response", async () => {
     // GIVEN
-    const response = fetchResponseBuilder([
-      {
-        b2c: exampleB2c,
-        abis: exampleAbis,
-        b2c_signatures: exampleB2cSignatures,
-      },
-    ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+    httpMock.get.mockResolvedValue(
+      dappDtoResponse([
+        {
+          b2c: exampleB2c,
+          abis: exampleAbis,
+          b2c_signatures: exampleB2cSignatures,
+        },
+      ]),
+    );
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -424,14 +396,15 @@ describe("HttpExternalPuginDataSource", () => {
 
   it("should normalize the address and selector", async () => {
     // GIVEN
-    const response = fetchResponseBuilder([
-      {
-        b2c: exampleB2c,
-        abis: exampleAbis,
-        b2c_signatures: exampleB2cSignatures,
-      },
-    ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+    httpMock.get.mockResolvedValue(
+      dappDtoResponse([
+        {
+          b2c: exampleB2c,
+          abis: exampleAbis,
+          b2c_signatures: exampleB2cSignatures,
+        },
+      ]),
+    );
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -453,9 +426,9 @@ describe("HttpExternalPuginDataSource", () => {
     });
   });
 
-  it("should return an error when fetch throws an error", async () => {
+  it("should return an error when network client throws an error", async () => {
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("error"));
+    httpMock.get.mockRejectedValue(new Error("error"));
 
     // WHEN
     const result = await datasource.getDappInfos({

--- a/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.test.ts
+++ b/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.test.ts
@@ -1,5 +1,3 @@
-import axios from "axios";
-
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import ABI from "@/external-plugin/__tests__/abi.json";
 import {
@@ -16,10 +14,8 @@ import {
 } from "@/shared/constant/HttpHeaders";
 import PACKAGE from "@root/package.json";
 
-vi.mock("axios");
-
-const axiosResponseBuilder = (dto: Partial<DAppDto>[]) => {
-  return { data: dto };
+const fetchResponseBuilder = (dto: Partial<DAppDto>[]) => {
+  return new Response(JSON.stringify(dto));
 };
 
 const config = {
@@ -86,11 +82,12 @@ describe("HttpExternalPuginDataSource", () => {
     vi.clearAllMocks();
   });
 
-  it("should call axios with the ledger client version header", async () => {
+  it("should call fetch with the ledger client version header", async () => {
     // GIVEN
     const version = `context-module/${PACKAGE.version}`;
-    const requestSpy = vi.fn(() => Promise.resolve({ data: [] }));
-    vi.spyOn(axios, "request").mockImplementation(requestSpy);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([])),
+    );
 
     // WHEN
     await datasource.getDappInfos({
@@ -100,7 +97,8 @@ describe("HttpExternalPuginDataSource", () => {
     });
 
     // THEN
-    expect(requestSpy).toHaveBeenCalledWith(
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.any(URL),
       expect.objectContaining({
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: version,
@@ -112,10 +110,10 @@ describe("HttpExternalPuginDataSource", () => {
 
   it("should return undefined when no abis is undefined", async () => {
     // GIVEN
-    const response = axiosResponseBuilder([
+    const response = fetchResponseBuilder([
       { b2c: exampleB2c, b2c_signatures: exampleB2cSignatures },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue(response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -130,10 +128,10 @@ describe("HttpExternalPuginDataSource", () => {
 
   it("should return undefined when no selectors", async () => {
     // GIVEN
-    const response = axiosResponseBuilder([
+    const response = fetchResponseBuilder([
       { abis: exampleAbis, b2c_signatures: exampleB2cSignatures },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue(response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -148,10 +146,10 @@ describe("HttpExternalPuginDataSource", () => {
 
   it("should return undefined when no abis data", async () => {
     // GIVEN
-    const response = axiosResponseBuilder([
+    const response = fetchResponseBuilder([
       { abis: {}, b2c: exampleB2c, b2c_signatures: exampleB2cSignatures },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue(response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -166,10 +164,10 @@ describe("HttpExternalPuginDataSource", () => {
 
   it("should return undefined when no abis data", async () => {
     // GIVEN
-    const response = axiosResponseBuilder([
+    const response = fetchResponseBuilder([
       { abis: {}, b2c: exampleB2c, b2c_signatures: exampleB2cSignatures },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue(response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -185,10 +183,10 @@ describe("HttpExternalPuginDataSource", () => {
   it("should return undefined when no abis data for the contract address", async () => {
     // GIVEN
     const abis: Abis = { "0x1": ABI };
-    const response = axiosResponseBuilder([
+    const response = fetchResponseBuilder([
       { abis, b2c: exampleB2c, b2c_signatures: exampleB2cSignatures },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue(response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -203,10 +201,10 @@ describe("HttpExternalPuginDataSource", () => {
 
   it("should return undefined when no b2c signature", async () => {
     // GIVEN
-    const response = axiosResponseBuilder([
+    const response = fetchResponseBuilder([
       { b2c: exampleB2c, abis: exampleAbis },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue(response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -235,10 +233,10 @@ describe("HttpExternalPuginDataSource", () => {
       ],
       name: "test",
     } as unknown as B2c;
-    const response = axiosResponseBuilder([
+    const response = fetchResponseBuilder([
       { b2c, abis: exampleAbis, b2c_signatures: exampleB2cSignatures },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue(response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -267,10 +265,10 @@ describe("HttpExternalPuginDataSource", () => {
       ],
       name: "test",
     } as unknown as B2c;
-    const response = axiosResponseBuilder([
+    const response = fetchResponseBuilder([
       { b2c, abis: exampleAbis, b2c_signatures: exampleB2cSignatures },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue(response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -299,10 +297,10 @@ describe("HttpExternalPuginDataSource", () => {
       ],
       name: "test",
     } as unknown as B2c;
-    const response = axiosResponseBuilder([
+    const response = fetchResponseBuilder([
       { b2c, abis: exampleAbis, b2c_signatures: exampleB2cSignatures },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue(response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -331,10 +329,10 @@ describe("HttpExternalPuginDataSource", () => {
       ],
       name: "test",
     } as unknown as B2c;
-    const response = axiosResponseBuilder([
+    const response = fetchResponseBuilder([
       { b2c, abis: exampleAbis, b2c_signatures: exampleB2cSignatures },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue(response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -354,10 +352,10 @@ describe("HttpExternalPuginDataSource", () => {
     } as unknown as B2cSignatures;
 
     // FIXME
-    const response = axiosResponseBuilder([
+    const response = fetchResponseBuilder([
       { b2c: exampleB2c, abis: exampleAbis, b2c_signatures: B2CSignature },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue(response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -377,10 +375,10 @@ describe("HttpExternalPuginDataSource", () => {
     } as unknown as B2cSignatures;
 
     // FIXME
-    const response = axiosResponseBuilder([
+    const response = fetchResponseBuilder([
       { b2c: exampleB2c, abis: exampleAbis, b2c_signatures: B2CSignature },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue(response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -395,14 +393,14 @@ describe("HttpExternalPuginDataSource", () => {
 
   it("should return a correct response", async () => {
     // GIVEN
-    const response = axiosResponseBuilder([
+    const response = fetchResponseBuilder([
       {
         b2c: exampleB2c,
         abis: exampleAbis,
         b2c_signatures: exampleB2cSignatures,
       },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue(response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -426,14 +424,14 @@ describe("HttpExternalPuginDataSource", () => {
 
   it("should normalize the address and selector", async () => {
     // GIVEN
-    const response = axiosResponseBuilder([
+    const response = fetchResponseBuilder([
       {
         b2c: exampleB2c,
         abis: exampleAbis,
         b2c_signatures: exampleB2cSignatures,
       },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue(response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
 
     // WHEN
     const result = await datasource.getDappInfos({
@@ -455,9 +453,9 @@ describe("HttpExternalPuginDataSource", () => {
     });
   });
 
-  it("should return an error when axios throws an error", async () => {
+  it("should return an error when fetch throws an error", async () => {
     // GIVEN
-    vi.spyOn(axios, "request").mockRejectedValue(new Error("error"));
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("error"));
 
     // WHEN
     const result = await datasource.getDappInfos({

--- a/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.ts
+++ b/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -30,21 +29,22 @@ export class HttpExternalPluginDataSource implements ExternalPluginDataSource {
     selector,
   }: GetDappInfos): Promise<Either<Error, DappInfos | undefined>> {
     try {
-      const dappInfos = await axios.request<DAppDto[]>({
-        method: "GET",
-        url: `${this.config.cal.url}/dapps`,
-        params: {
-          output: "b2c,b2c_signatures,abis",
-          chain_id: chainId,
-          contracts: address,
-        },
+      const url = new URL(`${this.config.cal.url}/dapps`);
+      url.searchParams.set("output", "b2c,b2c_signatures,abis");
+      url.searchParams.set("chain_id", String(chainId));
+      url.searchParams.set("contracts", address);
+      const response = await fetch(url, {
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+          ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
         },
       });
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      const dappInfos = (await response.json()) as DAppDto[];
 
-      if (!dappInfos.data[0]) {
+      if (!dappInfos[0]) {
         return Right(undefined);
       }
 
@@ -53,10 +53,10 @@ export class HttpExternalPluginDataSource implements ExternalPluginDataSource {
       selector = `0x${selector.slice(2).toLowerCase()}`;
 
       const { erc20OfInterest, method, plugin } =
-        dappInfos.data[0].b2c?.contracts?.find((c) => c.address === address)
+        dappInfos[0].b2c?.contracts?.find((c) => c.address === address)
           ?.selectors?.[selector] || {};
       const { signature, serialized_data: serializedData } =
-        dappInfos.data[0].b2c_signatures?.[address]?.[selector] || {};
+        dappInfos[0].b2c_signatures?.[address]?.[selector] || {};
 
       if (
         !erc20OfInterest ||
@@ -68,7 +68,7 @@ export class HttpExternalPluginDataSource implements ExternalPluginDataSource {
         return Right(undefined);
       }
 
-      const abi = dappInfos.data[0].abis?.[address];
+      const abi = dappInfos[0].abis?.[address];
 
       if (!abi) {
         return Right(undefined);

--- a/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.ts
+++ b/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.ts
@@ -36,7 +36,9 @@ export class HttpExternalPluginDataSource implements ExternalPluginDataSource {
       const response = await fetch(url, {
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
+          ...(this.config.originToken && {
+            [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+          }),
         },
       });
       if (!response.ok) {

--- a/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.ts
+++ b/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.ts
@@ -1,3 +1,4 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -18,10 +19,21 @@ import PACKAGE from "@root/package.json";
 
 @injectable()
 export class HttpExternalPluginDataSource implements ExternalPluginDataSource {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {}
+  ) {
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+        ...(this.config.originToken && {
+          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+        }),
+      },
+    });
+  }
 
   async getDappInfos({
     chainId,
@@ -29,22 +41,13 @@ export class HttpExternalPluginDataSource implements ExternalPluginDataSource {
     selector,
   }: GetDappInfos): Promise<Either<Error, DappInfos | undefined>> {
     try {
-      const url = new URL(`${this.config.cal.url}/dapps`);
-      url.searchParams.set("output", "b2c,b2c_signatures,abis");
-      url.searchParams.set("chain_id", String(chainId));
-      url.searchParams.set("contracts", address);
-      const response = await fetch(url, {
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          ...(this.config.originToken && {
-            [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-          }),
+      const dappInfos = (await this.http.get(`${this.config.cal.url}/dapps`, {
+        params: {
+          output: "b2c,b2c_signatures,abis",
+          chain_id: chainId,
+          contracts: address,
         },
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      const dappInfos = (await response.json()) as DAppDto[];
+      })) as DAppDto[];
 
       if (!dappInfos[0]) {
         return Right(undefined);

--- a/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.ts
+++ b/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.ts
@@ -11,29 +11,16 @@ import {
 } from "@/external-plugin/data/ExternalPluginDataSource";
 import { DappInfos } from "@/external-plugin/model/DappInfos";
 import { SelectorDetails } from "@/external-plugin/model/SelectorDetails";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
+import { networkTypes } from "@/network/di/networkTypes";
 
 @injectable()
 export class HttpExternalPluginDataSource implements ExternalPluginDataSource {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-        ...(this.config.originToken && {
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-        }),
-      },
-    });
-  }
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
+  ) {}
 
   async getDappInfos({
     chainId,

--- a/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.test.ts
+++ b/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.test.ts
@@ -209,7 +209,7 @@ describe("HttpGatedDescriptorDataSource", () => {
       expect(result).toEqual(
         Left(
           new Error(
-            "[ContextModule] HttpGatedDescriptorDataSource: Failed to fetch gated descriptors: Error: Network error",
+            "[ContextModule] HttpGatedDescriptorDataSource: Failed to fetch gated descriptors: DmkNetworkClientError: Network error",
           ),
         ),
       );
@@ -536,7 +536,7 @@ describe("HttpGatedDescriptorDataSource", () => {
       expect(result).toEqual(
         Left(
           new Error(
-            "[ContextModule] HttpGatedDescriptorDataSource: Failed to fetch gated descriptors: Error: Network error",
+            "[ContextModule] HttpGatedDescriptorDataSource: Failed to fetch gated descriptors: DmkNetworkClientError: Network error",
           ),
         ),
       );

--- a/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.test.ts
+++ b/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.test.ts
@@ -1,12 +1,8 @@
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { HttpGatedDescriptorDataSource } from "@/gated-signing/data/HttpGatedDescriptorDataSource";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
 
 describe("HttpGatedDescriptorDataSource", () => {
   const config: ContextModuleServiceConfig = {
@@ -44,44 +40,38 @@ describe("HttpGatedDescriptorDataSource", () => {
   // signedDescriptor = payload + SIGNATURE_TAG("15") + length(01) + signature("00")
   const expectedSignedDescriptor = `${descriptorPayload}150100`;
 
+  let httpMock: { get: ReturnType<typeof vi.fn> };
+  let dataSource: HttpGatedDescriptorDataSource;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    httpMock = { get: vi.fn() };
+    dataSource = new HttpGatedDescriptorDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
   });
 
   describe("getGatedDescriptor", () => {
     it("should return descriptor on successful request with correct URL and params", async () => {
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(
-          new Response(JSON.stringify(validGatedDappsResponse)),
-        );
+      httpMock.get.mockResolvedValue(validGatedDappsResponse);
 
-      const result = await new HttpGatedDescriptorDataSource(
-        config,
-      ).getGatedDescriptor({
+      const result = await dataSource.getGatedDescriptor({
         contractAddress,
         selector,
         chainId,
       });
 
-      const calledUrl = new URL(fetchSpy.mock.calls[0]![0]!.toString());
-      expect(calledUrl.origin + calledUrl.pathname).toBe(
-        "https://crypto-assets-service.api.ledger.com/v1/gated_dapps",
-      );
-      expect(calledUrl.searchParams.get("ref")).toBe("branch:next");
-      expect(calledUrl.searchParams.get("output")).toBe(
-        "gated_descriptors,app,category",
-      );
-      expect(calledUrl.searchParams.get("contracts")).toBe(contractAddress);
-      expect(calledUrl.searchParams.get("chain_id")).toBe(String(chainId));
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.any(URL),
-        expect.objectContaining({
-          headers: {
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            [LEDGER_ORIGIN_TOKEN_HEADER]: "test-origin-token",
+      expect(httpMock.get).toHaveBeenCalledWith(
+        `${config.cal.url}/gated_dapps`,
+        {
+          params: {
+            ref: "branch:next",
+            output: "gated_descriptors,app,category",
+            contracts: contractAddress,
+            chain_id: chainId,
           },
-        }),
+        },
       );
       expect(result).toEqual(
         Right({
@@ -91,13 +81,9 @@ describe("HttpGatedDescriptorDataSource", () => {
     });
 
     it("should find descriptor when API response has selector key without 0x prefix", async () => {
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(validGatedDappsResponse)),
-      );
+      httpMock.get.mockResolvedValue(validGatedDappsResponse);
 
-      const result = await new HttpGatedDescriptorDataSource(
-        config,
-      ).getGatedDescriptor({
+      const result = await dataSource.getGatedDescriptor({
         contractAddress,
         selector: "0xa1251d75",
         chainId,
@@ -111,13 +97,9 @@ describe("HttpGatedDescriptorDataSource", () => {
     });
 
     it("should return Left when response is not an array", async () => {
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify({ gated_descriptors: {} })),
-      );
+      httpMock.get.mockResolvedValue({ gated_descriptors: {} });
 
-      const result = await new HttpGatedDescriptorDataSource(
-        config,
-      ).getGatedDescriptor({
+      const result = await dataSource.getGatedDescriptor({
         contractAddress,
         selector,
         chainId,
@@ -133,13 +115,9 @@ describe("HttpGatedDescriptorDataSource", () => {
     });
 
     it("should return Left when response is empty array", async () => {
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify([])),
-      );
+      httpMock.get.mockResolvedValue([]);
 
-      const result = await new HttpGatedDescriptorDataSource(
-        config,
-      ).getGatedDescriptor({
+      const result = await dataSource.getGatedDescriptor({
         contractAddress,
         selector,
         chainId,
@@ -155,30 +133,24 @@ describe("HttpGatedDescriptorDataSource", () => {
     });
 
     it("should return Left when no descriptor matches contract and selector", async () => {
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(
-          JSON.stringify([
-            {
-              gated_descriptors: {
-                "0xothercontract": {
-                  a1251d75: {
-                    descriptor: "some-descriptor",
-                    network: "ethereum",
-                    chain_id: 1,
-                    address: "0xother",
-                    selector: "a1251d75",
-                    version: "v1",
-                  },
-                },
+      httpMock.get.mockResolvedValue([
+        {
+          gated_descriptors: {
+            "0xothercontract": {
+              a1251d75: {
+                descriptor: "some-descriptor",
+                network: "ethereum",
+                chain_id: 1,
+                address: "0xother",
+                selector: "a1251d75",
+                version: "v1",
               },
             },
-          ]),
-        ),
-      );
+          },
+        },
+      ]);
 
-      const result = await new HttpGatedDescriptorDataSource(
-        config,
-      ).getGatedDescriptor({
+      const result = await dataSource.getGatedDescriptor({
         contractAddress,
         selector,
         chainId,
@@ -193,14 +165,10 @@ describe("HttpGatedDescriptorDataSource", () => {
       );
     });
 
-    it("should return Left when fetch request fails", async () => {
-      vi.spyOn(globalThis, "fetch").mockRejectedValue(
-        new Error("Network error"),
-      );
+    it("should return Left when http.get request fails", async () => {
+      httpMock.get.mockRejectedValue(new Error("Network error"));
 
-      const result = await new HttpGatedDescriptorDataSource(
-        config,
-      ).getGatedDescriptor({
+      const result = await dataSource.getGatedDescriptor({
         contractAddress,
         selector,
         chainId,
@@ -209,7 +177,7 @@ describe("HttpGatedDescriptorDataSource", () => {
       expect(result).toEqual(
         Left(
           new Error(
-            "[ContextModule] HttpGatedDescriptorDataSource: Failed to fetch gated descriptors: DmkNetworkClientError: Network error",
+            "[ContextModule] HttpGatedDescriptorDataSource: Failed to fetch gated descriptors: Error: Network error",
           ),
         ),
       );
@@ -220,20 +188,24 @@ describe("HttpGatedDescriptorDataSource", () => {
         ...config,
         cal: { ...config.cal!, branch: "main" },
       } as ContextModuleServiceConfig;
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(
-          new Response(JSON.stringify(validGatedDappsResponse)),
-        );
+      httpMock.get.mockResolvedValue(validGatedDappsResponse);
 
-      await new HttpGatedDescriptorDataSource(configMain).getGatedDescriptor({
+      const mainDataSource = new HttpGatedDescriptorDataSource(
+        configMain,
+        httpMock as unknown as DmkNetworkClient,
+      );
+      await mainDataSource.getGatedDescriptor({
         contractAddress,
         selector,
         chainId,
       });
 
-      const calledUrl = new URL(fetchSpy.mock.calls[0]![0]!.toString());
-      expect(calledUrl.searchParams.get("ref")).toBe("branch:main");
+      expect(httpMock.get).toHaveBeenCalledWith(
+        `${config.cal.url}/gated_dapps`,
+        expect.objectContaining({
+          params: expect.objectContaining({ ref: "branch:main" }),
+        }),
+      );
     });
 
     describe("when response fails DTO validation", () => {
@@ -242,13 +214,9 @@ describe("HttpGatedDescriptorDataSource", () => {
       );
 
       it("should return Left when array item has no gated_descriptors", async () => {
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(
-          new Response(JSON.stringify([{}])),
-        );
+        httpMock.get.mockResolvedValue([{}]);
 
-        const result = await new HttpGatedDescriptorDataSource(
-          config,
-        ).getGatedDescriptor({
+        const result = await dataSource.getGatedDescriptor({
           contractAddress,
           selector,
           chainId,
@@ -258,15 +226,11 @@ describe("HttpGatedDescriptorDataSource", () => {
       });
 
       it("should return Left when gated_descriptors is not an object", async () => {
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(
-          new Response(
-            JSON.stringify([{ gated_descriptors: "not-an-object" }]),
-          ),
-        );
+        httpMock.get.mockResolvedValue([
+          { gated_descriptors: "not-an-object" },
+        ]);
 
-        const result = await new HttpGatedDescriptorDataSource(
-          config,
-        ).getGatedDescriptor({
+        const result = await dataSource.getGatedDescriptor({
           contractAddress,
           selector,
           chainId,
@@ -276,30 +240,24 @@ describe("HttpGatedDescriptorDataSource", () => {
       });
 
       it("should return Left when entry is missing required field (descriptor)", async () => {
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(
-          new Response(
-            JSON.stringify([
-              {
-                gated_descriptors: {
-                  [contractAddress]: {
-                    a1251d75: {
-                      network: "ethereum",
-                      chain_id: 1,
-                      address: contractAddress,
-                      selector: "a1251d75",
-                      version: "v1",
-                      // descriptor missing
-                    },
-                  },
+        httpMock.get.mockResolvedValue([
+          {
+            gated_descriptors: {
+              [contractAddress]: {
+                a1251d75: {
+                  network: "ethereum",
+                  chain_id: 1,
+                  address: contractAddress,
+                  selector: "a1251d75",
+                  version: "v1",
+                  // descriptor missing
                 },
               },
-            ]),
-          ),
-        );
+            },
+          },
+        ]);
 
-        const result = await new HttpGatedDescriptorDataSource(
-          config,
-        ).getGatedDescriptor({
+        const result = await dataSource.getGatedDescriptor({
           contractAddress,
           selector,
           chainId,
@@ -309,31 +267,25 @@ describe("HttpGatedDescriptorDataSource", () => {
       });
 
       it("should return Left when entry has wrong type for chain_id", async () => {
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(
-          new Response(
-            JSON.stringify([
-              {
-                gated_descriptors: {
-                  [contractAddress]: {
-                    a1251d75: {
-                      network: "ethereum",
-                      chain_id: "1", // string instead of number
-                      address: contractAddress,
-                      selector: "a1251d75",
-                      version: "v1",
-                      descriptor: descriptorPayload,
-                      signatures: { prod: "00", test: "00" },
-                    },
-                  },
+        httpMock.get.mockResolvedValue([
+          {
+            gated_descriptors: {
+              [contractAddress]: {
+                a1251d75: {
+                  network: "ethereum",
+                  chain_id: "1", // string instead of number
+                  address: contractAddress,
+                  selector: "a1251d75",
+                  version: "v1",
+                  descriptor: descriptorPayload,
+                  signatures: { prod: "00", test: "00" },
                 },
               },
-            ]),
-          ),
-        );
+            },
+          },
+        ]);
 
-        const result = await new HttpGatedDescriptorDataSource(
-          config,
-        ).getGatedDescriptor({
+        const result = await dataSource.getGatedDescriptor({
           contractAddress,
           selector,
           chainId,
@@ -343,31 +295,25 @@ describe("HttpGatedDescriptorDataSource", () => {
       });
 
       it("should return Left when entry signatures contains non-string value", async () => {
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(
-          new Response(
-            JSON.stringify([
-              {
-                gated_descriptors: {
-                  [contractAddress]: {
-                    a1251d75: {
-                      network: "ethereum",
-                      chain_id: 1,
-                      address: contractAddress,
-                      selector: "a1251d75",
-                      version: "v1",
-                      descriptor: descriptorPayload,
-                      signatures: { prod: 123 }, // number instead of string
-                    },
-                  },
+        httpMock.get.mockResolvedValue([
+          {
+            gated_descriptors: {
+              [contractAddress]: {
+                a1251d75: {
+                  network: "ethereum",
+                  chain_id: 1,
+                  address: contractAddress,
+                  selector: "a1251d75",
+                  version: "v1",
+                  descriptor: descriptorPayload,
+                  signatures: { prod: 123 }, // number instead of string
                 },
               },
-            ]),
-          ),
-        );
+            },
+          },
+        ]);
 
-        const result = await new HttpGatedDescriptorDataSource(
-          config,
-        ).getGatedDescriptor({
+        const result = await dataSource.getGatedDescriptor({
           contractAddress,
           selector,
           chainId,
@@ -377,13 +323,9 @@ describe("HttpGatedDescriptorDataSource", () => {
       });
 
       it("should return Left when array item is null", async () => {
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(
-          new Response(JSON.stringify([null])),
-        );
+        httpMock.get.mockResolvedValue([null]);
 
-        const result = await new HttpGatedDescriptorDataSource(
-          config,
-        ).getGatedDescriptor({
+        const result = await dataSource.getGatedDescriptor({
           contractAddress,
           selector,
           chainId,
@@ -393,21 +335,15 @@ describe("HttpGatedDescriptorDataSource", () => {
       });
 
       it("should return Left when selectors map value is not an object", async () => {
-        vi.spyOn(globalThis, "fetch").mockResolvedValue(
-          new Response(
-            JSON.stringify([
-              {
-                gated_descriptors: {
-                  [contractAddress]: "not-a-selectors-map",
-                },
-              },
-            ]),
-          ),
-        );
+        httpMock.get.mockResolvedValue([
+          {
+            gated_descriptors: {
+              [contractAddress]: "not-a-selectors-map",
+            },
+          },
+        ]);
 
-        const result = await new HttpGatedDescriptorDataSource(
-          config,
-        ).getGatedDescriptor({
+        const result = await dataSource.getGatedDescriptor({
           contractAddress,
           selector,
           chainId,
@@ -443,36 +379,24 @@ describe("HttpGatedDescriptorDataSource", () => {
     const expectedSignedDescriptorTypedData = `${descriptorPayloadTypedData}150100`;
 
     it("should return descriptor on successful request when keyed by schema hash", async () => {
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(
-          new Response(JSON.stringify(validTypedDataResponse)),
-        );
+      httpMock.get.mockResolvedValue(validTypedDataResponse);
 
-      const result = await new HttpGatedDescriptorDataSource(
-        config,
-      ).getGatedDescriptorForTypedData({
+      const result = await dataSource.getGatedDescriptorForTypedData({
         contractAddress,
         schemaHash,
         chainId,
       });
 
-      const calledUrl = new URL(fetchSpy.mock.calls[0]![0]!.toString());
-      expect(calledUrl.origin + calledUrl.pathname).toBe(
-        "https://crypto-assets-service.api.ledger.com/v1/gated_dapps",
-      );
-      expect(calledUrl.searchParams.get("ref")).toBe("branch:next");
-      expect(calledUrl.searchParams.get("output")).toBe("gated_descriptors");
-      expect(calledUrl.searchParams.get("contracts")).toBe(contractAddress);
-      expect(calledUrl.searchParams.get("chain_id")).toBe(String(chainId));
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.any(URL),
-        expect.objectContaining({
-          headers: {
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            [LEDGER_ORIGIN_TOKEN_HEADER]: "test-origin-token",
+      expect(httpMock.get).toHaveBeenCalledWith(
+        `${config.cal.url}/gated_dapps`,
+        {
+          params: {
+            ref: "branch:next",
+            output: "gated_descriptors",
+            contracts: contractAddress,
+            chain_id: chainId,
           },
-        }),
+        },
       );
       expect(result).toEqual(
         Right({
@@ -482,30 +406,24 @@ describe("HttpGatedDescriptorDataSource", () => {
     });
 
     it("should return Left when no descriptor matches contract and schema hash", async () => {
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(
-          JSON.stringify([
-            {
-              gated_descriptors: {
-                [contractAddress]: {
-                  other_schema_hash: {
-                    descriptor: "some-descriptor",
-                    network: "ethereum",
-                    chain_id: 1,
-                    address: contractAddress,
-                    selector: "eip712",
-                    version: "v1",
-                  },
-                },
+      httpMock.get.mockResolvedValue([
+        {
+          gated_descriptors: {
+            [contractAddress]: {
+              other_schema_hash: {
+                descriptor: "some-descriptor",
+                network: "ethereum",
+                chain_id: 1,
+                address: contractAddress,
+                selector: "eip712",
+                version: "v1",
               },
             },
-          ]),
-        ),
-      );
+          },
+        },
+      ]);
 
-      const result = await new HttpGatedDescriptorDataSource(
-        config,
-      ).getGatedDescriptorForTypedData({
+      const result = await dataSource.getGatedDescriptorForTypedData({
         contractAddress,
         schemaHash,
         chainId,
@@ -520,14 +438,10 @@ describe("HttpGatedDescriptorDataSource", () => {
       );
     });
 
-    it("should return Left when fetch request fails", async () => {
-      vi.spyOn(globalThis, "fetch").mockRejectedValue(
-        new Error("Network error"),
-      );
+    it("should return Left when http.get request fails", async () => {
+      httpMock.get.mockRejectedValue(new Error("Network error"));
 
-      const result = await new HttpGatedDescriptorDataSource(
-        config,
-      ).getGatedDescriptorForTypedData({
+      const result = await dataSource.getGatedDescriptorForTypedData({
         contractAddress,
         schemaHash,
         chainId,
@@ -536,7 +450,7 @@ describe("HttpGatedDescriptorDataSource", () => {
       expect(result).toEqual(
         Left(
           new Error(
-            "[ContextModule] HttpGatedDescriptorDataSource: Failed to fetch gated descriptors: DmkNetworkClientError: Network error",
+            "[ContextModule] HttpGatedDescriptorDataSource: Failed to fetch gated descriptors: Error: Network error",
           ),
         ),
       );

--- a/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.test.ts
+++ b/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.test.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { Left, Right } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
@@ -8,8 +7,6 @@ import {
   LEDGER_ORIGIN_TOKEN_HEADER,
 } from "@/shared/constant/HttpHeaders";
 import PACKAGE from "@root/package.json";
-
-vi.mock("axios");
 
 describe("HttpGatedDescriptorDataSource", () => {
   const config: ContextModuleServiceConfig = {
@@ -53,10 +50,11 @@ describe("HttpGatedDescriptorDataSource", () => {
 
   describe("getGatedDescriptor", () => {
     it("should return descriptor on successful request with correct URL and params", async () => {
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: validGatedDappsResponse,
-      });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(
+          new Response(JSON.stringify(validGatedDappsResponse)),
+        );
 
       const result = await new HttpGatedDescriptorDataSource(
         config,
@@ -66,20 +64,25 @@ describe("HttpGatedDescriptorDataSource", () => {
         chainId,
       });
 
-      expect(axios.request).toHaveBeenCalledWith({
-        method: "GET",
-        url: "https://crypto-assets-service.api.ledger.com/v1/gated_dapps",
-        params: {
-          ref: "branch:next",
-          output: "gated_descriptors,app,category",
-          contracts: contractAddress,
-          chain_id: chainId,
-        },
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: "test-origin-token",
-        },
-      });
+      const calledUrl = new URL(fetchSpy.mock.calls[0]![0]!.toString());
+      expect(calledUrl.origin + calledUrl.pathname).toBe(
+        "https://crypto-assets-service.api.ledger.com/v1/gated_dapps",
+      );
+      expect(calledUrl.searchParams.get("ref")).toBe("branch:next");
+      expect(calledUrl.searchParams.get("output")).toBe(
+        "gated_descriptors,app,category",
+      );
+      expect(calledUrl.searchParams.get("contracts")).toBe(contractAddress);
+      expect(calledUrl.searchParams.get("chain_id")).toBe(String(chainId));
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(URL),
+        expect.objectContaining({
+          headers: {
+            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+            [LEDGER_ORIGIN_TOKEN_HEADER]: "test-origin-token",
+          },
+        }),
+      );
       expect(result).toEqual(
         Right({
           signedDescriptor: expectedSignedDescriptor,
@@ -88,10 +91,9 @@ describe("HttpGatedDescriptorDataSource", () => {
     });
 
     it("should find descriptor when API response has selector key without 0x prefix", async () => {
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: validGatedDappsResponse,
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(validGatedDappsResponse)),
+      );
 
       const result = await new HttpGatedDescriptorDataSource(
         config,
@@ -109,10 +111,9 @@ describe("HttpGatedDescriptorDataSource", () => {
     });
 
     it("should return Left when response is not an array", async () => {
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: { gated_descriptors: {} },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ gated_descriptors: {} })),
+      );
 
       const result = await new HttpGatedDescriptorDataSource(
         config,
@@ -132,10 +133,9 @@ describe("HttpGatedDescriptorDataSource", () => {
     });
 
     it("should return Left when response is empty array", async () => {
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: [],
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify([])),
+      );
 
       const result = await new HttpGatedDescriptorDataSource(
         config,
@@ -155,25 +155,26 @@ describe("HttpGatedDescriptorDataSource", () => {
     });
 
     it("should return Left when no descriptor matches contract and selector", async () => {
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: [
-          {
-            gated_descriptors: {
-              "0xothercontract": {
-                a1251d75: {
-                  descriptor: "some-descriptor",
-                  network: "ethereum",
-                  chain_id: 1,
-                  address: "0xother",
-                  selector: "a1251d75",
-                  version: "v1",
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify([
+            {
+              gated_descriptors: {
+                "0xothercontract": {
+                  a1251d75: {
+                    descriptor: "some-descriptor",
+                    network: "ethereum",
+                    chain_id: 1,
+                    address: "0xother",
+                    selector: "a1251d75",
+                    version: "v1",
+                  },
                 },
               },
             },
-          },
-        ],
-      });
+          ]),
+        ),
+      );
 
       const result = await new HttpGatedDescriptorDataSource(
         config,
@@ -192,8 +193,10 @@ describe("HttpGatedDescriptorDataSource", () => {
       );
     });
 
-    it("should return Left when axios request fails", async () => {
-      vi.spyOn(axios, "request").mockRejectedValue(new Error("Network error"));
+    it("should return Left when fetch request fails", async () => {
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(
+        new Error("Network error"),
+      );
 
       const result = await new HttpGatedDescriptorDataSource(
         config,
@@ -217,10 +220,11 @@ describe("HttpGatedDescriptorDataSource", () => {
         ...config,
         cal: { ...config.cal!, branch: "main" },
       } as ContextModuleServiceConfig;
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: validGatedDappsResponse,
-      });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(
+          new Response(JSON.stringify(validGatedDappsResponse)),
+        );
 
       await new HttpGatedDescriptorDataSource(configMain).getGatedDescriptor({
         contractAddress,
@@ -228,13 +232,8 @@ describe("HttpGatedDescriptorDataSource", () => {
         chainId,
       });
 
-      expect(axios.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          params: expect.objectContaining({
-            ref: "branch:main",
-          }),
-        }),
-      );
+      const calledUrl = new URL(fetchSpy.mock.calls[0]![0]!.toString());
+      expect(calledUrl.searchParams.get("ref")).toBe("branch:main");
     });
 
     describe("when response fails DTO validation", () => {
@@ -243,10 +242,9 @@ describe("HttpGatedDescriptorDataSource", () => {
       );
 
       it("should return Left when array item has no gated_descriptors", async () => {
-        vi.spyOn(axios, "request").mockResolvedValue({
-          status: 200,
-          data: [{}],
-        });
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(JSON.stringify([{}])),
+        );
 
         const result = await new HttpGatedDescriptorDataSource(
           config,
@@ -260,10 +258,11 @@ describe("HttpGatedDescriptorDataSource", () => {
       });
 
       it("should return Left when gated_descriptors is not an object", async () => {
-        vi.spyOn(axios, "request").mockResolvedValue({
-          status: 200,
-          data: [{ gated_descriptors: "not-an-object" }],
-        });
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(
+            JSON.stringify([{ gated_descriptors: "not-an-object" }]),
+          ),
+        );
 
         const result = await new HttpGatedDescriptorDataSource(
           config,
@@ -277,25 +276,26 @@ describe("HttpGatedDescriptorDataSource", () => {
       });
 
       it("should return Left when entry is missing required field (descriptor)", async () => {
-        vi.spyOn(axios, "request").mockResolvedValue({
-          status: 200,
-          data: [
-            {
-              gated_descriptors: {
-                [contractAddress]: {
-                  a1251d75: {
-                    network: "ethereum",
-                    chain_id: 1,
-                    address: contractAddress,
-                    selector: "a1251d75",
-                    version: "v1",
-                    // descriptor missing
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(
+            JSON.stringify([
+              {
+                gated_descriptors: {
+                  [contractAddress]: {
+                    a1251d75: {
+                      network: "ethereum",
+                      chain_id: 1,
+                      address: contractAddress,
+                      selector: "a1251d75",
+                      version: "v1",
+                      // descriptor missing
+                    },
                   },
                 },
               },
-            },
-          ],
-        });
+            ]),
+          ),
+        );
 
         const result = await new HttpGatedDescriptorDataSource(
           config,
@@ -309,26 +309,27 @@ describe("HttpGatedDescriptorDataSource", () => {
       });
 
       it("should return Left when entry has wrong type for chain_id", async () => {
-        vi.spyOn(axios, "request").mockResolvedValue({
-          status: 200,
-          data: [
-            {
-              gated_descriptors: {
-                [contractAddress]: {
-                  a1251d75: {
-                    network: "ethereum",
-                    chain_id: "1", // string instead of number
-                    address: contractAddress,
-                    selector: "a1251d75",
-                    version: "v1",
-                    descriptor: descriptorPayload,
-                    signatures: { prod: "00", test: "00" },
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(
+            JSON.stringify([
+              {
+                gated_descriptors: {
+                  [contractAddress]: {
+                    a1251d75: {
+                      network: "ethereum",
+                      chain_id: "1", // string instead of number
+                      address: contractAddress,
+                      selector: "a1251d75",
+                      version: "v1",
+                      descriptor: descriptorPayload,
+                      signatures: { prod: "00", test: "00" },
+                    },
                   },
                 },
               },
-            },
-          ],
-        });
+            ]),
+          ),
+        );
 
         const result = await new HttpGatedDescriptorDataSource(
           config,
@@ -342,26 +343,27 @@ describe("HttpGatedDescriptorDataSource", () => {
       });
 
       it("should return Left when entry signatures contains non-string value", async () => {
-        vi.spyOn(axios, "request").mockResolvedValue({
-          status: 200,
-          data: [
-            {
-              gated_descriptors: {
-                [contractAddress]: {
-                  a1251d75: {
-                    network: "ethereum",
-                    chain_id: 1,
-                    address: contractAddress,
-                    selector: "a1251d75",
-                    version: "v1",
-                    descriptor: descriptorPayload,
-                    signatures: { prod: 123 }, // number instead of string
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(
+            JSON.stringify([
+              {
+                gated_descriptors: {
+                  [contractAddress]: {
+                    a1251d75: {
+                      network: "ethereum",
+                      chain_id: 1,
+                      address: contractAddress,
+                      selector: "a1251d75",
+                      version: "v1",
+                      descriptor: descriptorPayload,
+                      signatures: { prod: 123 }, // number instead of string
+                    },
                   },
                 },
               },
-            },
-          ],
-        });
+            ]),
+          ),
+        );
 
         const result = await new HttpGatedDescriptorDataSource(
           config,
@@ -375,10 +377,9 @@ describe("HttpGatedDescriptorDataSource", () => {
       });
 
       it("should return Left when array item is null", async () => {
-        vi.spyOn(axios, "request").mockResolvedValue({
-          status: 200,
-          data: [null],
-        });
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(JSON.stringify([null])),
+        );
 
         const result = await new HttpGatedDescriptorDataSource(
           config,
@@ -392,16 +393,17 @@ describe("HttpGatedDescriptorDataSource", () => {
       });
 
       it("should return Left when selectors map value is not an object", async () => {
-        vi.spyOn(axios, "request").mockResolvedValue({
-          status: 200,
-          data: [
-            {
-              gated_descriptors: {
-                [contractAddress]: "not-a-selectors-map",
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+          new Response(
+            JSON.stringify([
+              {
+                gated_descriptors: {
+                  [contractAddress]: "not-a-selectors-map",
+                },
               },
-            },
-          ],
-        });
+            ]),
+          ),
+        );
 
         const result = await new HttpGatedDescriptorDataSource(
           config,
@@ -441,10 +443,11 @@ describe("HttpGatedDescriptorDataSource", () => {
     const expectedSignedDescriptorTypedData = `${descriptorPayloadTypedData}150100`;
 
     it("should return descriptor on successful request when keyed by schema hash", async () => {
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: validTypedDataResponse,
-      });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(
+          new Response(JSON.stringify(validTypedDataResponse)),
+        );
 
       const result = await new HttpGatedDescriptorDataSource(
         config,
@@ -454,20 +457,23 @@ describe("HttpGatedDescriptorDataSource", () => {
         chainId,
       });
 
-      expect(axios.request).toHaveBeenCalledWith({
-        method: "GET",
-        url: "https://crypto-assets-service.api.ledger.com/v1/gated_dapps",
-        params: {
-          ref: "branch:next",
-          output: "gated_descriptors",
-          contracts: contractAddress,
-          chain_id: chainId,
-        },
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: "test-origin-token",
-        },
-      });
+      const calledUrl = new URL(fetchSpy.mock.calls[0]![0]!.toString());
+      expect(calledUrl.origin + calledUrl.pathname).toBe(
+        "https://crypto-assets-service.api.ledger.com/v1/gated_dapps",
+      );
+      expect(calledUrl.searchParams.get("ref")).toBe("branch:next");
+      expect(calledUrl.searchParams.get("output")).toBe("gated_descriptors");
+      expect(calledUrl.searchParams.get("contracts")).toBe(contractAddress);
+      expect(calledUrl.searchParams.get("chain_id")).toBe(String(chainId));
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(URL),
+        expect.objectContaining({
+          headers: {
+            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+            [LEDGER_ORIGIN_TOKEN_HEADER]: "test-origin-token",
+          },
+        }),
+      );
       expect(result).toEqual(
         Right({
           signedDescriptor: expectedSignedDescriptorTypedData,
@@ -476,25 +482,26 @@ describe("HttpGatedDescriptorDataSource", () => {
     });
 
     it("should return Left when no descriptor matches contract and schema hash", async () => {
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: [
-          {
-            gated_descriptors: {
-              [contractAddress]: {
-                other_schema_hash: {
-                  descriptor: "some-descriptor",
-                  network: "ethereum",
-                  chain_id: 1,
-                  address: contractAddress,
-                  selector: "eip712",
-                  version: "v1",
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify([
+            {
+              gated_descriptors: {
+                [contractAddress]: {
+                  other_schema_hash: {
+                    descriptor: "some-descriptor",
+                    network: "ethereum",
+                    chain_id: 1,
+                    address: contractAddress,
+                    selector: "eip712",
+                    version: "v1",
+                  },
                 },
               },
             },
-          },
-        ],
-      });
+          ]),
+        ),
+      );
 
       const result = await new HttpGatedDescriptorDataSource(
         config,
@@ -513,8 +520,10 @@ describe("HttpGatedDescriptorDataSource", () => {
       );
     });
 
-    it("should return Left when axios request fails", async () => {
-      vi.spyOn(axios, "request").mockRejectedValue(new Error("Network error"));
+    it("should return Left when fetch request fails", async () => {
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(
+        new Error("Network error"),
+      );
 
       const result = await new HttpGatedDescriptorDataSource(
         config,

--- a/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.ts
+++ b/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.ts
@@ -4,13 +4,9 @@ import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
+import { networkTypes } from "@/network/di/networkTypes";
 import { SIGNATURE_TAG } from "@/shared/model/SignatureTags";
 import { HexStringUtils } from "@/shared/utils/HexStringUtils";
-import PACKAGE from "@root/package.json";
 
 import {
   type GatedDappsDto,
@@ -28,19 +24,12 @@ import {
 export class HttpGatedDescriptorDataSource
   implements GatedDescriptorDataSource
 {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-        [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-      },
-    });
-  }
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
+  ) {}
 
   async getGatedDescriptor({
     contractAddress,

--- a/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.ts
+++ b/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.ts
@@ -1,3 +1,4 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -27,10 +28,19 @@ import {
 export class HttpGatedDescriptorDataSource
   implements GatedDescriptorDataSource
 {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {}
+  ) {
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+        [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+      },
+    });
+  }
 
   async getGatedDescriptor({
     contractAddress,
@@ -41,21 +51,14 @@ export class HttpGatedDescriptorDataSource
   > {
     let dto: GatedDappsDto | undefined;
     try {
-      const url = new URL(`${this.config.cal.url}/gated_dapps`);
-      url.searchParams.set("ref", `branch:${this.config.cal.branch}`);
-      url.searchParams.set("output", "gated_descriptors,app,category");
-      url.searchParams.set("contracts", contractAddress);
-      url.searchParams.set("chain_id", String(chainId));
-      const response = await fetch(url, {
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+      dto = (await this.http.get(`${this.config.cal.url}/gated_dapps`, {
+        params: {
+          ref: `branch:${this.config.cal.branch}`,
+          output: "gated_descriptors,app,category",
+          contracts: contractAddress,
+          chain_id: chainId,
         },
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      dto = (await response.json()) as GatedDappsDto;
+      })) as GatedDappsDto;
     } catch (error) {
       return Left(
         new Error(
@@ -113,21 +116,14 @@ export class HttpGatedDescriptorDataSource
   > {
     let dto: GatedDappsDto | undefined;
     try {
-      const url = new URL(`${this.config.cal.url}/gated_dapps`);
-      url.searchParams.set("ref", `branch:${this.config.cal.branch}`);
-      url.searchParams.set("output", "gated_descriptors");
-      url.searchParams.set("contracts", contractAddress);
-      url.searchParams.set("chain_id", String(chainId));
-      const response = await fetch(url, {
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+      dto = (await this.http.get(`${this.config.cal.url}/gated_dapps`, {
+        params: {
+          ref: `branch:${this.config.cal.branch}`,
+          output: "gated_descriptors",
+          contracts: contractAddress,
+          chain_id: chainId,
         },
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      dto = (await response.json()) as GatedDappsDto;
+      })) as GatedDappsDto;
     } catch (error) {
       return Left(
         new Error(

--- a/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.ts
+++ b/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -42,21 +41,21 @@ export class HttpGatedDescriptorDataSource
   > {
     let dto: GatedDappsDto | undefined;
     try {
-      const response = await axios.request<GatedDappsDto>({
-        method: "GET",
-        url: `${this.config.cal.url}/gated_dapps`,
-        params: {
-          ref: `branch:${this.config.cal.branch}`,
-          output: "gated_descriptors,app,category",
-          contracts: contractAddress,
-          chain_id: chainId,
-        },
+      const url = new URL(`${this.config.cal.url}/gated_dapps`);
+      url.searchParams.set("ref", `branch:${this.config.cal.branch}`);
+      url.searchParams.set("output", "gated_descriptors,app,category");
+      url.searchParams.set("contracts", contractAddress);
+      url.searchParams.set("chain_id", String(chainId));
+      const response = await fetch(url, {
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
           [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
         },
       });
-      dto = response.data;
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      dto = (await response.json()) as GatedDappsDto;
     } catch (error) {
       return Left(
         new Error(
@@ -114,21 +113,21 @@ export class HttpGatedDescriptorDataSource
   > {
     let dto: GatedDappsDto | undefined;
     try {
-      const response = await axios.request<GatedDappsDto>({
-        method: "GET",
-        url: `${this.config.cal.url}/gated_dapps`,
-        params: {
-          ref: `branch:${this.config.cal.branch}`,
-          output: "gated_descriptors",
-          contracts: contractAddress,
-          chain_id: chainId,
-        },
+      const url = new URL(`${this.config.cal.url}/gated_dapps`);
+      url.searchParams.set("ref", `branch:${this.config.cal.branch}`);
+      url.searchParams.set("output", "gated_descriptors");
+      url.searchParams.set("contracts", contractAddress);
+      url.searchParams.set("chain_id", String(chainId));
+      const response = await fetch(url, {
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
           [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
         },
       });
-      dto = response.data;
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      dto = (await response.json()) as GatedDappsDto;
     } catch (error) {
       return Left(
         new Error(

--- a/packages/signer/context-module/src/network/di/networkModuleFactory.ts
+++ b/packages/signer/context-module/src/network/di/networkModuleFactory.ts
@@ -1,0 +1,24 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
+import { ContainerModule } from "inversify";
+
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
+import { networkTypes } from "@/network/di/networkTypes";
+import {
+  LEDGER_CLIENT_VERSION_HEADER,
+  LEDGER_ORIGIN_TOKEN_HEADER,
+} from "@/shared/constant/HttpHeaders";
+import PACKAGE from "@root/package.json";
+
+export const networkModuleFactory = (config: ContextModuleServiceConfig) =>
+  new ContainerModule(({ bind }) => {
+    bind<DmkNetworkClient>(networkTypes.NetworkClient).toConstantValue(
+      new DmkNetworkClient({
+        headers: {
+          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+          ...(config.originToken && {
+            [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
+          }),
+        },
+      }),
+    );
+  });

--- a/packages/signer/context-module/src/network/di/networkTypes.ts
+++ b/packages/signer/context-module/src/network/di/networkTypes.ts
@@ -1,0 +1,3 @@
+export const networkTypes = {
+  NetworkClient: Symbol.for("networkClient"),
+};

--- a/packages/signer/context-module/src/nft/data/HttpNftDataSource.test.ts
+++ b/packages/signer/context-module/src/nft/data/HttpNftDataSource.test.ts
@@ -1,5 +1,3 @@
-import axios from "axios";
-
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
@@ -9,8 +7,6 @@ import PACKAGE from "@root/package.json";
 
 import { HttpNftDataSource } from "./HttpNftDataSource";
 import { type NftDataSource } from "./NftDataSource";
-
-vi.mock("axios");
 
 const config = {
   web3checks: {
@@ -29,11 +25,12 @@ describe("HttpNftDataSource", () => {
     vi.clearAllMocks();
   });
 
-  it("should call axios with the ledger client version and origin Token header", async () => {
+  it("should call fetch with the ledger client version and origin Token header", async () => {
     // GIVEN
     const version = `context-module/${PACKAGE.version}`;
-    const requestSpy = vi.fn(() => Promise.resolve({ data: [] }));
-    vi.spyOn(axios, "request").mockImplementation(requestSpy);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([])),
+    );
 
     // WHEN
     await datasource.getNftInfosPayload({ address: "0x00", chainId: 1 });
@@ -44,8 +41,9 @@ describe("HttpNftDataSource", () => {
     });
 
     // THEN
-    expect(requestSpy).toHaveBeenNthCalledWith(
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
       1,
+      expect.any(String),
       expect.objectContaining({
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: version,
@@ -53,8 +51,9 @@ describe("HttpNftDataSource", () => {
         },
       }),
     );
-    expect(requestSpy).toHaveBeenNthCalledWith(
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
       2,
+      expect.any(String),
       expect.objectContaining({
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: version,
@@ -65,9 +64,9 @@ describe("HttpNftDataSource", () => {
   });
 
   describe("getNftInfosPayload", () => {
-    it("should return an error when axios throws an error", async () => {
+    it("should return an error when fetch throws an error", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockRejectedValue(new Error("error"));
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("error"));
 
       // WHEN
       const result = await datasource.getNftInfosPayload({
@@ -85,8 +84,9 @@ describe("HttpNftDataSource", () => {
 
     it("should return an error when the response is empty", async () => {
       // GIVEN
-      const response = { data: {} };
-      vi.spyOn(axios, "request").mockResolvedValue(response);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({})),
+      );
 
       // WHEN
       const result = await datasource.getNftInfosPayload({
@@ -102,8 +102,9 @@ describe("HttpNftDataSource", () => {
 
     it("should return the payload", async () => {
       // GIVEN
-      const response = { data: { payload: "payload" } };
-      vi.spyOn(axios, "request").mockResolvedValue(response);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ payload: "payload" })),
+      );
 
       // WHEN
       const result = await datasource.getNftInfosPayload({
@@ -117,9 +118,9 @@ describe("HttpNftDataSource", () => {
   });
 
   describe("getSetPluginPayload", () => {
-    it("should return an error when axios throws an error", async () => {
+    it("should return an error when fetch throws an error", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockRejectedValue(new Error("error"));
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("error"));
 
       // WHEN
       const result = await datasource.getSetPluginPayload({
@@ -138,8 +139,9 @@ describe("HttpNftDataSource", () => {
 
     it("should return an error when the response is empty", async () => {
       // GIVEN
-      const response = { data: {} };
-      vi.spyOn(axios, "request").mockResolvedValue(response);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({})),
+      );
 
       // WHEN
       const result = await datasource.getSetPluginPayload({
@@ -158,8 +160,9 @@ describe("HttpNftDataSource", () => {
 
     it("should return the payload", async () => {
       // GIVEN
-      const response = { data: { payload: "payload" } };
-      vi.spyOn(axios, "request").mockResolvedValue(response);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ payload: "payload" })),
+      );
 
       // WHEN
       const result = await datasource.getSetPluginPayload({

--- a/packages/signer/context-module/src/nft/data/HttpNftDataSource.test.ts
+++ b/packages/signer/context-module/src/nft/data/HttpNftDataSource.test.ts
@@ -43,7 +43,7 @@ describe("HttpNftDataSource", () => {
     // THEN
     expect(globalThis.fetch).toHaveBeenNthCalledWith(
       1,
-      expect.any(String),
+      expect.any(URL),
       expect.objectContaining({
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: version,
@@ -53,7 +53,7 @@ describe("HttpNftDataSource", () => {
     );
     expect(globalThis.fetch).toHaveBeenNthCalledWith(
       2,
-      expect.any(String),
+      expect.any(URL),
       expect.objectContaining({
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: version,

--- a/packages/signer/context-module/src/nft/data/HttpNftDataSource.test.ts
+++ b/packages/signer/context-module/src/nft/data/HttpNftDataSource.test.ts
@@ -1,9 +1,6 @@
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
+
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
 
 import { HttpNftDataSource } from "./HttpNftDataSource";
 import { type NftDataSource } from "./NftDataSource";
@@ -17,64 +14,38 @@ const config = {
   },
   originToken: "originToken",
 } as ContextModuleServiceConfig;
+
 describe("HttpNftDataSource", () => {
   let datasource: NftDataSource;
+  let httpMock: { get: ReturnType<typeof vi.fn> };
 
-  beforeAll(() => {
-    datasource = new HttpNftDataSource(config);
-    vi.clearAllMocks();
-  });
-
-  it("should call fetch with the ledger client version and origin Token header", async () => {
-    // GIVEN
-    const version = `context-module/${PACKAGE.version}`;
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([])),
-    );
-
-    // WHEN
-    await datasource.getNftInfosPayload({ address: "0x00", chainId: 1 });
-    await datasource.getSetPluginPayload({
-      address: "0x00",
-      chainId: 1,
-      selector: "0x00",
-    });
-
-    // THEN
-    expect(globalThis.fetch).toHaveBeenNthCalledWith(
-      1,
-      expect.any(URL),
-      expect.objectContaining({
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: version,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
-        },
-      }),
-    );
-    expect(globalThis.fetch).toHaveBeenNthCalledWith(
-      2,
-      expect.any(URL),
-      expect.objectContaining({
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: version,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
-        },
-      }),
+  beforeEach(() => {
+    httpMock = { get: vi.fn() };
+    datasource = new HttpNftDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
     );
   });
 
   describe("getNftInfosPayload", () => {
-    it("should return an error when fetch throws an error", async () => {
-      // GIVEN
-      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("error"));
+    it("should call the expected metadata service URL", async () => {
+      httpMock.get.mockResolvedValue({ payload: "payload" });
 
-      // WHEN
+      await datasource.getNftInfosPayload({ address: "0x00", chainId: 1 });
+
+      expect(httpMock.get).toHaveBeenCalledWith(
+        "https://nft.api.live.ledger.com/v1/ethereum/1/contracts/0x00",
+      );
+    });
+
+    it("should return an error when the network client throws", async () => {
+      httpMock.get.mockRejectedValue(new Error("error"));
+
       const result = await datasource.getNftInfosPayload({
         address: "0x00",
         chainId: 1,
       });
 
-      // THEN
       expect(result.extract()).toEqual(
         new Error(
           "[ContextModule] HttpNftDataSource: Failed to fetch nft informations",
@@ -82,54 +53,55 @@ describe("HttpNftDataSource", () => {
       );
     });
 
-    it("should return an error when the response is empty", async () => {
-      // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify({})),
-      );
+    it("should return an error when the response has no payload", async () => {
+      httpMock.get.mockResolvedValue({});
 
-      // WHEN
       const result = await datasource.getNftInfosPayload({
         address: "0x00",
         chainId: 1,
       });
 
-      // THEN
       expect(result.extract()).toEqual(
         new Error("[ContextModule] HttpNftDataSource: no nft metadata"),
       );
     });
 
     it("should return the payload", async () => {
-      // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify({ payload: "payload" })),
-      );
+      httpMock.get.mockResolvedValue({ payload: "payload" });
 
-      // WHEN
       const result = await datasource.getNftInfosPayload({
         address: "0x00",
         chainId: 1,
       });
 
-      // THEN
       expect(result.extract()).toEqual("payload");
     });
   });
 
   describe("getSetPluginPayload", () => {
-    it("should return an error when fetch throws an error", async () => {
-      // GIVEN
-      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("error"));
+    it("should call the expected metadata service URL", async () => {
+      httpMock.get.mockResolvedValue({ payload: "payload" });
 
-      // WHEN
+      await datasource.getSetPluginPayload({
+        address: "0x00",
+        chainId: 1,
+        selector: "0x00",
+      });
+
+      expect(httpMock.get).toHaveBeenCalledWith(
+        "https://nft.api.live.ledger.com/v1/ethereum/1/contracts/0x00/plugin-selector/0x00",
+      );
+    });
+
+    it("should return an error when the network client throws", async () => {
+      httpMock.get.mockRejectedValue(new Error("error"));
+
       const result = await datasource.getSetPluginPayload({
         address: "0x00",
         chainId: 1,
         selector: "0x00",
       });
 
-      // THEN
       expect(result.extract()).toEqual(
         new Error(
           "[ContextModule] HttpNftDataSource: Failed to fetch set plugin payload",
@@ -137,20 +109,15 @@ describe("HttpNftDataSource", () => {
       );
     });
 
-    it("should return an error when the response is empty", async () => {
-      // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify({})),
-      );
+    it("should return an error when the response has no payload", async () => {
+      httpMock.get.mockResolvedValue({});
 
-      // WHEN
       const result = await datasource.getSetPluginPayload({
         address: "0x00",
         chainId: 1,
         selector: "0x00",
       });
 
-      // THEN
       expect(result.extract()).toEqual(
         new Error(
           "[ContextModule] HttpNftDataSource: unexpected empty response",
@@ -159,19 +126,14 @@ describe("HttpNftDataSource", () => {
     });
 
     it("should return the payload", async () => {
-      // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify({ payload: "payload" })),
-      );
+      httpMock.get.mockResolvedValue({ payload: "payload" });
 
-      // WHEN
       const result = await datasource.getSetPluginPayload({
         address: "0x00",
         chainId: 1,
         selector: "0x00",
       });
 
-      // THEN
       expect(result.extract()).toEqual("payload");
     });
   });

--- a/packages/signer/context-module/src/nft/data/HttpNftDataSource.ts
+++ b/packages/signer/context-module/src/nft/data/HttpNftDataSource.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -28,17 +27,22 @@ export class HttpNftDataSource implements NftDataSource {
     selector,
   }: GetSetPluginPayloadParams): Promise<Either<Error, string>> {
     try {
-      const response = await axios.request<{ payload: string }>({
-        method: "GET",
-        url: `${this.config.metadataServiceDomain.url}/v1/ethereum/${chainId}/contracts/${address}/plugin-selector/${selector}`,
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+      const response = await fetch(
+        `${this.config.metadataServiceDomain.url}/v1/ethereum/${chainId}/contracts/${address}/plugin-selector/${selector}`,
+        {
+          headers: {
+            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+            ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
+          },
         },
-      });
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      const data = (await response.json()) as { payload: string };
 
-      return response.data.payload
-        ? Right(response.data.payload)
+      return data.payload
+        ? Right(data.payload)
         : Left(
             new Error(
               "[ContextModule] HttpNftDataSource: unexpected empty response",
@@ -58,17 +62,22 @@ export class HttpNftDataSource implements NftDataSource {
     address,
   }: GetNftInformationsParams): Promise<Either<Error, string>> {
     try {
-      const response = await axios.request<{ payload: string }>({
-        method: "GET",
-        url: `${this.config.metadataServiceDomain.url}/v1/ethereum/${chainId}/contracts/${address}`,
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+      const response = await fetch(
+        `${this.config.metadataServiceDomain.url}/v1/ethereum/${chainId}/contracts/${address}`,
+        {
+          headers: {
+            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+            ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
+          },
         },
-      });
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      const data = (await response.json()) as { payload: string };
 
-      return response.data.payload
-        ? Right(response.data.payload)
+      return data.payload
+        ? Right(data.payload)
         : Left(new Error("[ContextModule] HttpNftDataSource: no nft metadata"));
     } catch (_error) {
       return Left(

--- a/packages/signer/context-module/src/nft/data/HttpNftDataSource.ts
+++ b/packages/signer/context-module/src/nft/data/HttpNftDataSource.ts
@@ -32,7 +32,9 @@ export class HttpNftDataSource implements NftDataSource {
         {
           headers: {
             [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
+            ...(this.config.originToken && {
+              [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+            }),
           },
         },
       );
@@ -67,7 +69,9 @@ export class HttpNftDataSource implements NftDataSource {
         {
           headers: {
             [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
+            ...(this.config.originToken && {
+              [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+            }),
           },
         },
       );

--- a/packages/signer/context-module/src/nft/data/HttpNftDataSource.ts
+++ b/packages/signer/context-module/src/nft/data/HttpNftDataSource.ts
@@ -1,3 +1,4 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -16,10 +17,21 @@ import PACKAGE from "@root/package.json";
 
 @injectable()
 export class HttpNftDataSource implements NftDataSource {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {}
+  ) {
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+        ...(this.config.originToken && {
+          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+        }),
+      },
+    });
+  }
 
   public async getSetPluginPayload({
     chainId,
@@ -27,21 +39,9 @@ export class HttpNftDataSource implements NftDataSource {
     selector,
   }: GetSetPluginPayloadParams): Promise<Either<Error, string>> {
     try {
-      const response = await fetch(
+      const data = (await this.http.get(
         `${this.config.metadataServiceDomain.url}/v1/ethereum/${chainId}/contracts/${address}/plugin-selector/${selector}`,
-        {
-          headers: {
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            ...(this.config.originToken && {
-              [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-            }),
-          },
-        },
-      );
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      const data = (await response.json()) as { payload: string };
+      )) as { payload: string };
 
       return data.payload
         ? Right(data.payload)
@@ -64,21 +64,9 @@ export class HttpNftDataSource implements NftDataSource {
     address,
   }: GetNftInformationsParams): Promise<Either<Error, string>> {
     try {
-      const response = await fetch(
+      const data = (await this.http.get(
         `${this.config.metadataServiceDomain.url}/v1/ethereum/${chainId}/contracts/${address}`,
-        {
-          headers: {
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            ...(this.config.originToken && {
-              [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-            }),
-          },
-        },
-      );
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      const data = (await response.json()) as { payload: string };
+      )) as { payload: string };
 
       return data.payload
         ? Right(data.payload)

--- a/packages/signer/context-module/src/nft/data/HttpNftDataSource.ts
+++ b/packages/signer/context-module/src/nft/data/HttpNftDataSource.ts
@@ -4,34 +4,21 @@ import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
+import { networkTypes } from "@/network/di/networkTypes";
 import {
   GetNftInformationsParams,
   GetSetPluginPayloadParams,
   NftDataSource,
 } from "@/nft/data/NftDataSource";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
 
 @injectable()
 export class HttpNftDataSource implements NftDataSource {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-        ...(this.config.originToken && {
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-        }),
-      },
-    });
-  }
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
+  ) {}
 
   public async getSetPluginPayload({
     chainId,

--- a/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.test.ts
+++ b/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.test.ts
@@ -1,3 +1,4 @@
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
@@ -14,6 +15,18 @@ describe("HttpPkiCertificateDataSource", () => {
     },
   } as ContextModuleServiceConfig;
 
+  let httpMock: { get: ReturnType<typeof vi.fn> };
+  let datasource: HttpPkiCertificateDataSource;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    httpMock = { get: vi.fn() };
+    datasource = new HttpPkiCertificateDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
+  });
+
   describe("fetchCertificate", () => {
     it("should return certificate", async () => {
       // GIVEN
@@ -22,25 +35,19 @@ describe("HttpPkiCertificateDataSource", () => {
         keyUsage: KeyUsage.Calldata,
         keyId: "keyId",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(
-          JSON.stringify([
-            {
-              descriptor: {
-                data: "01020304",
-                signatures: {
-                  test: "05060708",
-                },
-              },
+      httpMock.get.mockResolvedValue([
+        {
+          descriptor: {
+            data: "01020304",
+            signatures: {
+              test: "05060708",
             },
-          ]),
-        ),
-      );
+          },
+        },
+      ]);
 
       // WHEN
-      const result = await new HttpPkiCertificateDataSource(
-        config,
-      ).fetchCertificate(pkiCertificateInfo);
+      const result = await datasource.fetchCertificate(pkiCertificateInfo);
 
       // THEN
       expect(result).toEqual(
@@ -53,6 +60,33 @@ describe("HttpPkiCertificateDataSource", () => {
       );
     });
 
+    it("should call the network client with the expected URL and params", async () => {
+      // GIVEN
+      const pkiCertificateInfo: PkiCertificateInfo = {
+        targetDevice: "targetDevice",
+        keyUsage: KeyUsage.Calldata,
+        keyId: "keyId",
+      };
+      httpMock.get.mockResolvedValue([]);
+
+      // WHEN
+      await datasource.fetchCertificate(pkiCertificateInfo);
+
+      // THEN
+      expect(httpMock.get).toHaveBeenCalledWith(
+        "https://cal.com/certificates",
+        {
+          params: {
+            output: "descriptor",
+            target_device: "targetDevice",
+            latest: true,
+            public_key_id: "keyId",
+            public_key_usage: KeyUsage.Calldata,
+          },
+        },
+      );
+    });
+
     it("should return an error when certificate is not found", async () => {
       // GIVEN
       const pkiCertificateInfo: PkiCertificateInfo = {
@@ -60,14 +94,10 @@ describe("HttpPkiCertificateDataSource", () => {
         keyUsage: KeyUsage.Calldata,
         keyId: "keyId",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify([])),
-      );
+      httpMock.get.mockResolvedValue([]);
 
       // WHEN
-      const result = await new HttpPkiCertificateDataSource(
-        config,
-      ).fetchCertificate(pkiCertificateInfo);
+      const result = await datasource.fetchCertificate(pkiCertificateInfo);
 
       // THEN
       expect(result).toEqual(
@@ -79,19 +109,17 @@ describe("HttpPkiCertificateDataSource", () => {
       );
     });
 
-    it("should return an error when fetch request fails", async () => {
+    it("should return an error when network client throws", async () => {
       // GIVEN
       const pkiCertificateInfo: PkiCertificateInfo = {
         targetDevice: "targetDevice",
         keyUsage: KeyUsage.Calldata,
         keyId: "keyId",
       };
-      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("error"));
+      httpMock.get.mockRejectedValue(new Error("error"));
 
       // WHEN
-      const result = await new HttpPkiCertificateDataSource(
-        config,
-      ).fetchCertificate(pkiCertificateInfo);
+      const result = await datasource.fetchCertificate(pkiCertificateInfo);
 
       // THEN
       expect(result).toEqual(
@@ -110,25 +138,19 @@ describe("HttpPkiCertificateDataSource", () => {
         keyUsage: KeyUsage.Calldata,
         keyId: "keyId",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(
-          JSON.stringify([
-            {
-              descriptor: {
-                data: "corrupteddata",
-                signatures: {
-                  test: "05060708",
-                },
-              },
+      httpMock.get.mockResolvedValue([
+        {
+          descriptor: {
+            data: "corrupteddata",
+            signatures: {
+              test: "05060708",
             },
-          ]),
-        ),
-      );
+          },
+        },
+      ]);
 
       // WHEN
-      const result = await new HttpPkiCertificateDataSource(
-        config,
-      ).fetchCertificate(pkiCertificateInfo);
+      const result = await datasource.fetchCertificate(pkiCertificateInfo);
 
       // THEN
       expect(result).toEqual(

--- a/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.test.ts
+++ b/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.test.ts
@@ -1,12 +1,9 @@
-import axios from "axios";
 import { Left, Right } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { HttpPkiCertificateDataSource } from "@/pki/data/HttpPkiCertificateDataSource";
 import { KeyUsage } from "@/pki/model/KeyUsage";
 import { type PkiCertificateInfo } from "@/pki/model/PkiCertificateInfo";
-
-vi.mock("axios");
 
 describe("HttpPkiCertificateDataSource", () => {
   const config = {
@@ -25,19 +22,20 @@ describe("HttpPkiCertificateDataSource", () => {
         keyUsage: KeyUsage.Calldata,
         keyId: "keyId",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: [
-          {
-            descriptor: {
-              data: "01020304",
-              signatures: {
-                test: "05060708",
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify([
+            {
+              descriptor: {
+                data: "01020304",
+                signatures: {
+                  test: "05060708",
+                },
               },
             },
-          },
-        ],
-      });
+          ]),
+        ),
+      );
 
       // WHEN
       const result = await new HttpPkiCertificateDataSource(
@@ -62,10 +60,9 @@ describe("HttpPkiCertificateDataSource", () => {
         keyUsage: KeyUsage.Calldata,
         keyId: "keyId",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: [],
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify([])),
+      );
 
       // WHEN
       const result = await new HttpPkiCertificateDataSource(
@@ -82,14 +79,14 @@ describe("HttpPkiCertificateDataSource", () => {
       );
     });
 
-    it("should return an error when axios request fails", async () => {
+    it("should return an error when fetch request fails", async () => {
       // GIVEN
       const pkiCertificateInfo: PkiCertificateInfo = {
         targetDevice: "targetDevice",
         keyUsage: KeyUsage.Calldata,
         keyId: "keyId",
       };
-      vi.spyOn(axios, "request").mockRejectedValue(new Error("error"));
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("error"));
 
       // WHEN
       const result = await new HttpPkiCertificateDataSource(
@@ -113,19 +110,20 @@ describe("HttpPkiCertificateDataSource", () => {
         keyUsage: KeyUsage.Calldata,
         keyId: "keyId",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: [
-          {
-            descriptor: {
-              data: "corrupteddata",
-              signatures: {
-                test: "05060708",
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify([
+            {
+              descriptor: {
+                data: "corrupteddata",
+                signatures: {
+                  test: "05060708",
+                },
               },
             },
-          },
-        ],
-      });
+          ]),
+        ),
+      );
 
       // WHEN
       const result = await new HttpPkiCertificateDataSource(

--- a/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.ts
+++ b/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.ts
@@ -1,4 +1,7 @@
-import { hexaStringToBuffer } from "@ledgerhq/device-management-kit";
+import {
+  DmkNetworkClient,
+  hexaStringToBuffer,
+} from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -23,10 +26,18 @@ import {
 
 @injectable()
 export class HttpPkiCertificateDataSource implements PkiCertificateDataSource {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {}
+  ) {
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+      },
+    });
+  }
 
   async fetchCertificate(
     pkiCertificateInfo: PkiCertificateInfo,
@@ -40,21 +51,15 @@ export class HttpPkiCertificateDataSource implements PkiCertificateDataSource {
     };
 
     try {
-      const url = new URL(`${this.config.cal.url}/certificates`);
-      url.searchParams.set("output", requestDto.output);
-      url.searchParams.set("target_device", requestDto.target_device);
-      url.searchParams.set("latest", String(requestDto.latest));
-      url.searchParams.set("public_key_id", String(requestDto.public_key_id));
-      url.searchParams.set("public_key_usage", requestDto.public_key_usage);
-      const response = await fetch(url, {
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+      const data = (await this.http.get(`${this.config.cal.url}/certificates`, {
+        params: {
+          output: requestDto.output,
+          target_device: requestDto.target_device,
+          latest: requestDto.latest,
+          public_key_id: requestDto.public_key_id,
+          public_key_usage: requestDto.public_key_usage,
         },
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      const data = (await response.json()) as PkiCertificateResponseDto[];
+      })) as PkiCertificateResponseDto[];
 
       if (
         data !== undefined &&

--- a/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.ts
+++ b/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.ts
@@ -1,5 +1,4 @@
 import { hexaStringToBuffer } from "@ledgerhq/device-management-kit";
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -41,32 +40,31 @@ export class HttpPkiCertificateDataSource implements PkiCertificateDataSource {
     };
 
     try {
-      const pkiCertificateResponse = await axios.request<
-        PkiCertificateResponseDto[]
-      >({
-        method: "GET",
-        url: `${this.config.cal.url}/certificates`,
-        params: requestDto,
+      const url = new URL(`${this.config.cal.url}/certificates`);
+      url.searchParams.set("output", requestDto.output);
+      url.searchParams.set("target_device", requestDto.target_device);
+      url.searchParams.set("latest", String(requestDto.latest));
+      url.searchParams.set("public_key_id", String(requestDto.public_key_id));
+      url.searchParams.set("public_key_usage", requestDto.public_key_usage);
+      const response = await fetch(url, {
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
         },
       });
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      const data = (await response.json()) as PkiCertificateResponseDto[];
 
       if (
-        pkiCertificateResponse.status == 200 &&
-        pkiCertificateResponse.data !== undefined &&
-        pkiCertificateResponse.data.length > 0 &&
-        this.isValidPkiCertificateResponse(
-          pkiCertificateResponse.data[0],
-          this.config.cal.mode,
-        )
+        data !== undefined &&
+        data.length > 0 &&
+        this.isValidPkiCertificateResponse(data[0], this.config.cal.mode)
       ) {
         const payload = hexaStringToBuffer(
           HexStringUtils.appendSignatureToPayload(
-            pkiCertificateResponse.data[0].descriptor.data,
-            pkiCertificateResponse.data[0].descriptor.signatures[
-              this.config.cal.mode
-            ],
+            data[0].descriptor.data,
+            data[0].descriptor.signatures[this.config.cal.mode],
             SIGNATURE_TAG,
           ),
         );

--- a/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.ts
+++ b/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.ts
@@ -100,27 +100,20 @@ export class HttpPkiCertificateDataSource implements PkiCertificateDataSource {
     value: unknown,
     mode: ContextModuleCalMode,
   ): value is PkiCertificateResponseDto {
+    if (!this.isRecord(value) || !this.isRecord(value["descriptor"])) {
+      return false;
+    }
+    const descriptor = value["descriptor"];
     if (
-      typeof value !== "object" ||
-      value === null ||
-      !("descriptor" in value) ||
-      typeof value.descriptor !== "object" ||
-      value.descriptor === null
+      typeof descriptor["data"] !== "string" ||
+      !this.isRecord(descriptor["signatures"])
     ) {
       return false;
     }
-    const { descriptor } = value;
-    if (
-      !("data" in descriptor) ||
-      typeof descriptor.data !== "string" ||
-      !("signatures" in descriptor) ||
-      typeof descriptor.signatures !== "object" ||
-      descriptor.signatures === null ||
-      !(mode in descriptor.signatures)
-    ) {
-      return false;
-    }
-    const signature = (descriptor.signatures as Record<string, unknown>)[mode];
-    return typeof signature === "string";
+    return typeof descriptor["signatures"][mode] === "string";
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
   }
 }

--- a/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.ts
+++ b/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.ts
@@ -51,7 +51,7 @@ export class HttpPkiCertificateDataSource implements PkiCertificateDataSource {
     };
 
     try {
-      const data = (await this.http.get(`${this.config.cal.url}/certificates`, {
+      const data = await this.http.get(`${this.config.cal.url}/certificates`, {
         params: {
           output: requestDto.output,
           target_device: requestDto.target_device,
@@ -59,10 +59,10 @@ export class HttpPkiCertificateDataSource implements PkiCertificateDataSource {
           public_key_id: requestDto.public_key_id,
           public_key_usage: requestDto.public_key_usage,
         },
-      })) as PkiCertificateResponseDto[];
+      });
 
       if (
-        data !== undefined &&
+        Array.isArray(data) &&
         data.length > 0 &&
         this.isValidPkiCertificateResponse(data[0], this.config.cal.mode)
       ) {
@@ -107,20 +107,27 @@ export class HttpPkiCertificateDataSource implements PkiCertificateDataSource {
     value: unknown,
     mode: ContextModuleCalMode,
   ): value is PkiCertificateResponseDto {
-    return (
-      typeof value === "object" &&
-      value !== null &&
-      "descriptor" in value &&
-      typeof value.descriptor === "object" &&
-      value.descriptor !== null &&
-      "data" in value.descriptor &&
-      typeof value.descriptor.data === "string" &&
-      "signatures" in value.descriptor &&
-      typeof value.descriptor.signatures === "object" &&
-      value.descriptor.signatures !== null &&
-      mode in value.descriptor.signatures &&
-      typeof (value.descriptor.signatures as Record<string, unknown>)[mode] ===
-        "string"
-    );
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      !("descriptor" in value) ||
+      typeof value.descriptor !== "object" ||
+      value.descriptor === null
+    ) {
+      return false;
+    }
+    const { descriptor } = value;
+    if (
+      !("data" in descriptor) ||
+      typeof descriptor.data !== "string" ||
+      !("signatures" in descriptor) ||
+      typeof descriptor.signatures !== "object" ||
+      descriptor.signatures === null ||
+      !(mode in descriptor.signatures)
+    ) {
+      return false;
+    }
+    const signature = (descriptor.signatures as Record<string, unknown>)[mode];
+    return typeof signature === "string";
   }
 }

--- a/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.ts
+++ b/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.ts
@@ -10,13 +10,12 @@ import type {
   ContextModuleCalMode,
   ContextModuleServiceConfig,
 } from "@/config/model/ContextModuleConfig";
+import { networkTypes } from "@/network/di/networkTypes";
 import { PkiCertificate } from "@/pki/model/PkiCertificate";
 import { PkiCertificateInfo } from "@/pki/model/PkiCertificateInfo";
-import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import { SIGNATURE_TAG } from "@/shared/model/SignatureTags";
 import { HexStringUtils } from "@/shared/utils/HexStringUtils";
 import { KeyUsageMapper } from "@/shared/utils/KeyUsageMapper";
-import PACKAGE from "@root/package.json";
 
 import { type PkiCertificateDataSource } from "./PkiCertificateDataSource";
 import {
@@ -26,18 +25,12 @@ import {
 
 @injectable()
 export class HttpPkiCertificateDataSource implements PkiCertificateDataSource {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-      },
-    });
-  }
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
+  ) {}
 
   async fetchCertificate(
     pkiCertificateInfo: PkiCertificateInfo,

--- a/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.test.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.test.ts
@@ -1,5 +1,3 @@
-import axios from "axios";
-
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { KeyId } from "@/pki/model/KeyId";
 import { KeyUsage } from "@/pki/model/KeyUsage";
@@ -12,8 +10,6 @@ import PACKAGE from "@root/package.json";
 import { type ProxyDelegateCallDto } from "./dto/ProxyDelegateCallDto";
 import { HttpProxyDataSource } from "./HttpProxyDataSource";
 import { type ProxyDataSource } from "./ProxyDataSource";
-
-vi.mock("axios");
 
 const config = {
   metadataServiceDomain: {
@@ -47,34 +43,40 @@ describe("HttpProxyDataSource", () => {
   };
 
   describe("getProxyImplementationAddress", () => {
-    it("should call axios with correct URL, headers, and data", async () => {
+    it("should call fetch with correct URL, headers, and body", async () => {
       // GIVEN
       const version = `context-module/${PACKAGE.version}`;
-      const requestSpy = vi.fn(() => Promise.resolve({ data: validDto }));
-      vi.spyOn(axios, "request").mockImplementation(requestSpy);
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validDto)));
 
       // WHEN
       await datasource.getProxyImplementationAddress(validParams);
 
       // THEN
-      expect(requestSpy).toHaveBeenCalledWith({
-        method: "POST",
-        url: `${config.metadataServiceDomain.url}/v2/ethereum/${validParams.chainId}/contract/proxy/delegate`,
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: version,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${config.metadataServiceDomain.url}/v2/ethereum/${validParams.chainId}/contract/proxy/delegate`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            [LEDGER_CLIENT_VERSION_HEADER]: version,
+            [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
+          },
+          body: JSON.stringify({
+            proxy: validParams.proxyAddress,
+            data: validParams.calldata,
+            challenge: validParams.challenge,
+          }),
         },
-        data: {
-          proxy: validParams.proxyAddress,
-          data: validParams.calldata,
-          challenge: validParams.challenge,
-        },
-      });
+      );
     });
 
     it("should return Right with proxy implementation data when request succeeds with valid DTO", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockResolvedValue({ data: validDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(validDto)),
+      );
 
       // WHEN
       const result =
@@ -99,9 +101,9 @@ describe("HttpProxyDataSource", () => {
         ],
         signedDescriptor: "signed-descriptor-data",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        data: dtoWithMultipleAddresses,
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(dtoWithMultipleAddresses)),
+      );
 
       // WHEN
       const result =
@@ -117,9 +119,11 @@ describe("HttpProxyDataSource", () => {
       });
     });
 
-    it("should return Left with error when axios throws an error", async () => {
+    it("should return Left with error when fetch throws an error", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockRejectedValue(new Error("Network error"));
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(
+        new Error("Network error"),
+      );
 
       // WHEN
       const result =
@@ -136,7 +140,10 @@ describe("HttpProxyDataSource", () => {
 
     it("should return Left with error when response data is undefined", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockResolvedValue({ data: undefined });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(undefined),
+      } as Response);
 
       // WHEN
       const result =
@@ -153,7 +160,7 @@ describe("HttpProxyDataSource", () => {
 
     it("should return Left with error when response data is null", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockResolvedValue({ data: null });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("null"));
 
       // WHEN
       const result =
@@ -171,7 +178,9 @@ describe("HttpProxyDataSource", () => {
     it("should return Left with error when addresses field is missing", async () => {
       // GIVEN
       const { addresses: _, ...invalidDto } = validDto;
-      vi.spyOn(axios, "request").mockResolvedValue({ data: invalidDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidDto)),
+      );
 
       // WHEN
       const result =
@@ -189,7 +198,9 @@ describe("HttpProxyDataSource", () => {
     it("should return Left with error when signedDescriptor is missing", async () => {
       // GIVEN
       const { signedDescriptor: _, ...invalidDto } = validDto;
-      vi.spyOn(axios, "request").mockResolvedValue({ data: invalidDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidDto)),
+      );
 
       // WHEN
       const result =
@@ -207,7 +218,9 @@ describe("HttpProxyDataSource", () => {
     it("should return Left with error when addresses is not an array", async () => {
       // GIVEN
       const invalidDto = { ...validDto, addresses: "not-an-array" };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: invalidDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidDto)),
+      );
 
       // WHEN
       const result =
@@ -225,7 +238,9 @@ describe("HttpProxyDataSource", () => {
     it("should return Left with error when addresses array contains non-string values", async () => {
       // GIVEN
       const invalidDto = { ...validDto, addresses: [123, "valid-address"] };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: invalidDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidDto)),
+      );
 
       // WHEN
       const result =
@@ -243,7 +258,9 @@ describe("HttpProxyDataSource", () => {
     it("should return Left with error when signedDescriptor is not a string", async () => {
       // GIVEN
       const invalidDto = { ...validDto, signedDescriptor: 123 };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: invalidDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidDto)),
+      );
 
       // WHEN
       const result =
@@ -264,7 +281,9 @@ describe("HttpProxyDataSource", () => {
         addresses: [],
         signedDescriptor: "signed-descriptor-data",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: invalidDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidDto)),
+      );
 
       // WHEN
       const result =
@@ -281,7 +300,9 @@ describe("HttpProxyDataSource", () => {
 
     it("should return Left with error when response is not an object", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockResolvedValue({ data: "not an object" });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify("not an object")),
+      );
 
       // WHEN
       const result =
@@ -299,7 +320,9 @@ describe("HttpProxyDataSource", () => {
     it("should handle different chainId values correctly", async () => {
       // GIVEN
       const paramsWithDifferentChainId = { ...validParams, chainId: 137 };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: validDto });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validDto)));
 
       // WHEN
       const result = await datasource.getProxyImplementationAddress(
@@ -308,10 +331,9 @@ describe("HttpProxyDataSource", () => {
 
       // THEN
       expect(result.isRight()).toBe(true);
-      expect(axios.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: `${config.metadataServiceDomain.url}/v2/ethereum/137/contract/proxy/delegate`,
-        }),
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${config.metadataServiceDomain.url}/v2/ethereum/137/contract/proxy/delegate`,
+        expect.anything(),
       );
     });
 
@@ -323,7 +345,9 @@ describe("HttpProxyDataSource", () => {
         ...validParams,
         proxyAddress: differentProxyAddress,
       };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: validDto });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validDto)));
 
       // WHEN
       const result = await datasource.getProxyImplementationAddress(
@@ -332,11 +356,12 @@ describe("HttpProxyDataSource", () => {
 
       // THEN
       expect(result.isRight()).toBe(true);
-      expect(axios.request).toHaveBeenCalledWith(
+      const calledBody = JSON.parse(
+        (fetchSpy.mock.calls[0]![1] as { body: string }).body,
+      );
+      expect(calledBody).toEqual(
         expect.objectContaining({
-          data: expect.objectContaining({
-            proxy: differentProxyAddress,
-          }),
+          proxy: differentProxyAddress,
         }),
       );
     });
@@ -348,7 +373,9 @@ describe("HttpProxyDataSource", () => {
         ...validParams,
         calldata: customCalldata,
       };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: validDto });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validDto)));
 
       // WHEN
       const result = await datasource.getProxyImplementationAddress(
@@ -357,11 +384,12 @@ describe("HttpProxyDataSource", () => {
 
       // THEN
       expect(result.isRight()).toBe(true);
-      expect(axios.request).toHaveBeenCalledWith(
+      const calledBody = JSON.parse(
+        (fetchSpy.mock.calls[0]![1] as { body: string }).body,
+      );
+      expect(calledBody).toEqual(
         expect.objectContaining({
-          data: expect.objectContaining({
-            data: customCalldata,
-          }),
+          data: customCalldata,
         }),
       );
     });
@@ -373,7 +401,9 @@ describe("HttpProxyDataSource", () => {
         ...validParams,
         challenge: customChallenge,
       };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: validDto });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validDto)));
 
       // WHEN
       const result = await datasource.getProxyImplementationAddress(
@@ -382,11 +412,12 @@ describe("HttpProxyDataSource", () => {
 
       // THEN
       expect(result.isRight()).toBe(true);
-      expect(axios.request).toHaveBeenCalledWith(
+      const calledBody = JSON.parse(
+        (fetchSpy.mock.calls[0]![1] as { body: string }).body,
+      );
+      expect(calledBody).toEqual(
         expect.objectContaining({
-          data: expect.objectContaining({
-            challenge: customChallenge,
-          }),
+          challenge: customChallenge,
         }),
       );
     });

--- a/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.test.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.test.ts
@@ -55,8 +55,10 @@ describe("HttpProxyDataSource", () => {
 
       // THEN
       expect(fetchSpy).toHaveBeenCalledWith(
-        `${config.metadataServiceDomain.url}/v2/ethereum/${validParams.chainId}/contract/proxy/delegate`,
-        {
+        expect.objectContaining({
+          href: `${config.metadataServiceDomain.url}/v2/ethereum/${validParams.chainId}/contract/proxy/delegate`,
+        }),
+        expect.objectContaining({
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -68,7 +70,7 @@ describe("HttpProxyDataSource", () => {
             data: validParams.calldata,
             challenge: validParams.challenge,
           }),
-        },
+        }),
       );
     });
 
@@ -140,10 +142,7 @@ describe("HttpProxyDataSource", () => {
 
     it("should return Left with error when response data is undefined", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(undefined),
-      } as Response);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(""));
 
       // WHEN
       const result =
@@ -332,7 +331,9 @@ describe("HttpProxyDataSource", () => {
       // THEN
       expect(result.isRight()).toBe(true);
       expect(fetchSpy).toHaveBeenCalledWith(
-        `${config.metadataServiceDomain.url}/v2/ethereum/137/contract/proxy/delegate`,
+        expect.objectContaining({
+          href: `${config.metadataServiceDomain.url}/v2/ethereum/137/contract/proxy/delegate`,
+        }),
         expect.anything(),
       );
     });

--- a/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.test.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.test.ts
@@ -1,11 +1,8 @@
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
+
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { KeyId } from "@/pki/model/KeyId";
 import { KeyUsage } from "@/pki/model/KeyUsage";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
 
 import { type ProxyDelegateCallDto } from "./dto/ProxyDelegateCallDto";
 import { HttpProxyDataSource } from "./HttpProxyDataSource";
@@ -20,14 +17,15 @@ const config = {
 
 describe("HttpProxyDataSource", () => {
   let datasource: ProxyDataSource;
-
-  beforeAll(() => {
-    datasource = new HttpProxyDataSource(config);
-    vi.clearAllMocks();
-  });
+  let httpMock: { post: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    httpMock = { post: vi.fn() };
+    datasource = new HttpProxyDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
   });
 
   const validParams = {
@@ -43,42 +41,27 @@ describe("HttpProxyDataSource", () => {
   };
 
   describe("getProxyImplementationAddress", () => {
-    it("should call fetch with correct URL, headers, and body", async () => {
+    it("should call network client post with correct URL and body", async () => {
       // GIVEN
-      const version = `context-module/${PACKAGE.version}`;
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validDto)));
+      httpMock.post.mockResolvedValue(validDto);
 
       // WHEN
       await datasource.getProxyImplementationAddress(validParams);
 
       // THEN
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          href: `${config.metadataServiceDomain.url}/v2/ethereum/${validParams.chainId}/contract/proxy/delegate`,
-        }),
-        expect.objectContaining({
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            [LEDGER_CLIENT_VERSION_HEADER]: version,
-            [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
-          },
-          body: JSON.stringify({
-            proxy: validParams.proxyAddress,
-            data: validParams.calldata,
-            challenge: validParams.challenge,
-          }),
-        }),
+      expect(httpMock.post).toHaveBeenCalledWith(
+        `${config.metadataServiceDomain.url}/v2/ethereum/${validParams.chainId}/contract/proxy/delegate`,
+        {
+          proxy: validParams.proxyAddress,
+          data: validParams.calldata,
+          challenge: validParams.challenge,
+        },
       );
     });
 
     it("should return Right with proxy implementation data when request succeeds with valid DTO", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(validDto)),
-      );
+      httpMock.post.mockResolvedValue(validDto);
 
       // WHEN
       const result =
@@ -103,9 +86,7 @@ describe("HttpProxyDataSource", () => {
         ],
         signedDescriptor: "signed-descriptor-data",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(dtoWithMultipleAddresses)),
-      );
+      httpMock.post.mockResolvedValue(dtoWithMultipleAddresses);
 
       // WHEN
       const result =
@@ -121,11 +102,9 @@ describe("HttpProxyDataSource", () => {
       });
     });
 
-    it("should return Left with error when fetch throws an error", async () => {
+    it("should return Left with error when network client throws", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockRejectedValue(
-        new Error("Network error"),
-      );
+      httpMock.post.mockRejectedValue(new Error("Network error"));
 
       // WHEN
       const result =
@@ -142,7 +121,7 @@ describe("HttpProxyDataSource", () => {
 
     it("should return Left with error when response data is undefined", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(""));
+      httpMock.post.mockResolvedValue(undefined);
 
       // WHEN
       const result =
@@ -159,7 +138,7 @@ describe("HttpProxyDataSource", () => {
 
     it("should return Left with error when response data is null", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("null"));
+      httpMock.post.mockResolvedValue(null);
 
       // WHEN
       const result =
@@ -177,9 +156,7 @@ describe("HttpProxyDataSource", () => {
     it("should return Left with error when addresses field is missing", async () => {
       // GIVEN
       const { addresses: _, ...invalidDto } = validDto;
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidDto)),
-      );
+      httpMock.post.mockResolvedValue(invalidDto);
 
       // WHEN
       const result =
@@ -197,9 +174,7 @@ describe("HttpProxyDataSource", () => {
     it("should return Left with error when signedDescriptor is missing", async () => {
       // GIVEN
       const { signedDescriptor: _, ...invalidDto } = validDto;
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidDto)),
-      );
+      httpMock.post.mockResolvedValue(invalidDto);
 
       // WHEN
       const result =
@@ -217,9 +192,7 @@ describe("HttpProxyDataSource", () => {
     it("should return Left with error when addresses is not an array", async () => {
       // GIVEN
       const invalidDto = { ...validDto, addresses: "not-an-array" };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidDto)),
-      );
+      httpMock.post.mockResolvedValue(invalidDto);
 
       // WHEN
       const result =
@@ -237,9 +210,7 @@ describe("HttpProxyDataSource", () => {
     it("should return Left with error when addresses array contains non-string values", async () => {
       // GIVEN
       const invalidDto = { ...validDto, addresses: [123, "valid-address"] };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidDto)),
-      );
+      httpMock.post.mockResolvedValue(invalidDto);
 
       // WHEN
       const result =
@@ -257,9 +228,7 @@ describe("HttpProxyDataSource", () => {
     it("should return Left with error when signedDescriptor is not a string", async () => {
       // GIVEN
       const invalidDto = { ...validDto, signedDescriptor: 123 };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidDto)),
-      );
+      httpMock.post.mockResolvedValue(invalidDto);
 
       // WHEN
       const result =
@@ -280,9 +249,7 @@ describe("HttpProxyDataSource", () => {
         addresses: [],
         signedDescriptor: "signed-descriptor-data",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidDto)),
-      );
+      httpMock.post.mockResolvedValue(invalidDto);
 
       // WHEN
       const result =
@@ -299,9 +266,7 @@ describe("HttpProxyDataSource", () => {
 
     it("should return Left with error when response is not an object", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify("not an object")),
-      );
+      httpMock.post.mockResolvedValue("not an object");
 
       // WHEN
       const result =
@@ -319,9 +284,7 @@ describe("HttpProxyDataSource", () => {
     it("should handle different chainId values correctly", async () => {
       // GIVEN
       const paramsWithDifferentChainId = { ...validParams, chainId: 137 };
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validDto)));
+      httpMock.post.mockResolvedValue(validDto);
 
       // WHEN
       const result = await datasource.getProxyImplementationAddress(
@@ -330,10 +293,8 @@ describe("HttpProxyDataSource", () => {
 
       // THEN
       expect(result.isRight()).toBe(true);
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          href: `${config.metadataServiceDomain.url}/v2/ethereum/137/contract/proxy/delegate`,
-        }),
+      expect(httpMock.post).toHaveBeenCalledWith(
+        `${config.metadataServiceDomain.url}/v2/ethereum/137/contract/proxy/delegate`,
         expect.anything(),
       );
     });
@@ -346,9 +307,7 @@ describe("HttpProxyDataSource", () => {
         ...validParams,
         proxyAddress: differentProxyAddress,
       };
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validDto)));
+      httpMock.post.mockResolvedValue(validDto);
 
       // WHEN
       const result = await datasource.getProxyImplementationAddress(
@@ -357,10 +316,8 @@ describe("HttpProxyDataSource", () => {
 
       // THEN
       expect(result.isRight()).toBe(true);
-      const calledBody = JSON.parse(
-        (fetchSpy.mock.calls[0]![1] as { body: string }).body,
-      );
-      expect(calledBody).toEqual(
+      expect(httpMock.post).toHaveBeenCalledWith(
+        expect.any(String),
         expect.objectContaining({
           proxy: differentProxyAddress,
         }),
@@ -374,9 +331,7 @@ describe("HttpProxyDataSource", () => {
         ...validParams,
         calldata: customCalldata,
       };
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validDto)));
+      httpMock.post.mockResolvedValue(validDto);
 
       // WHEN
       const result = await datasource.getProxyImplementationAddress(
@@ -385,10 +340,8 @@ describe("HttpProxyDataSource", () => {
 
       // THEN
       expect(result.isRight()).toBe(true);
-      const calledBody = JSON.parse(
-        (fetchSpy.mock.calls[0]![1] as { body: string }).body,
-      );
-      expect(calledBody).toEqual(
+      expect(httpMock.post).toHaveBeenCalledWith(
+        expect.any(String),
         expect.objectContaining({
           data: customCalldata,
         }),
@@ -402,9 +355,7 @@ describe("HttpProxyDataSource", () => {
         ...validParams,
         challenge: customChallenge,
       };
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validDto)));
+      httpMock.post.mockResolvedValue(validDto);
 
       // WHEN
       const result = await datasource.getProxyImplementationAddress(
@@ -413,10 +364,8 @@ describe("HttpProxyDataSource", () => {
 
       // THEN
       expect(result.isRight()).toBe(true);
-      const calledBody = JSON.parse(
-        (fetchSpy.mock.calls[0]![1] as { body: string }).body,
-      );
-      expect(calledBody).toEqual(
+      expect(httpMock.post).toHaveBeenCalledWith(
+        expect.any(String),
         expect.objectContaining({
           challenge: customChallenge,
         }),

--- a/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.ts
@@ -4,13 +4,9 @@ import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
+import { networkTypes } from "@/network/di/networkTypes";
 import { KeyId } from "@/pki/model/KeyId";
 import { KeyUsage } from "@/pki/model/KeyUsage";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
 
 import { ProxyDelegateCallDto } from "./dto/ProxyDelegateCallDto";
 import {
@@ -21,21 +17,12 @@ import {
 
 @injectable()
 export class HttpProxyDataSource implements ProxyDataSource {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-        ...(this.config.originToken && {
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-        }),
-      },
-    });
-  }
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
+  ) {}
 
   async getProxyImplementationAddress({
     proxyAddress,

--- a/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -36,20 +35,28 @@ export class HttpProxyDataSource implements ProxyDataSource {
   > {
     let dto: ProxyDelegateCallDto | undefined;
     try {
-      const response = await axios.request<ProxyDelegateCallDto>({
-        method: "POST",
-        url: `${this.config.metadataServiceDomain.url}/v2/ethereum/${chainId}/contract/proxy/delegate`,
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+      const response = await fetch(
+        `${this.config.metadataServiceDomain.url}/v2/ethereum/${chainId}/contract/proxy/delegate`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+            ...(this.config.originToken && {
+              [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+            }),
+          },
+          body: JSON.stringify({
+            proxy: proxyAddress,
+            data: calldata,
+            challenge,
+          }),
         },
-        data: {
-          proxy: proxyAddress,
-          data: calldata,
-          challenge,
-        },
-      });
-      dto = response.data;
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      dto = (await response.json()) as ProxyDelegateCallDto;
     } catch (_error) {
       return Left(
         new Error(

--- a/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.ts
@@ -1,3 +1,4 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -20,10 +21,21 @@ import {
 
 @injectable()
 export class HttpProxyDataSource implements ProxyDataSource {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {}
+  ) {
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+        ...(this.config.originToken && {
+          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+        }),
+      },
+    });
+  }
 
   async getProxyImplementationAddress({
     proxyAddress,
@@ -35,28 +47,14 @@ export class HttpProxyDataSource implements ProxyDataSource {
   > {
     let dto: ProxyDelegateCallDto | undefined;
     try {
-      const response = await fetch(
+      dto = (await this.http.post(
         `${this.config.metadataServiceDomain.url}/v2/ethereum/${chainId}/contract/proxy/delegate`,
         {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            ...(this.config.originToken && {
-              [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-            }),
-          },
-          body: JSON.stringify({
-            proxy: proxyAddress,
-            data: calldata,
-            challenge,
-          }),
+          proxy: proxyAddress,
+          data: calldata,
+          challenge,
         },
-      );
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      dto = (await response.json()) as ProxyDelegateCallDto;
+      )) as ProxyDelegateCallDto;
     } catch (_error) {
       return Left(
         new Error(

--- a/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.test.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.test.ts
@@ -1,5 +1,3 @@
-import axios from "axios";
-
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
@@ -10,8 +8,6 @@ import PACKAGE from "@root/package.json";
 import { type SafeProxyImplementationAddressDto } from "./dto/SafeProxyImplementationAddressDto";
 import { HttpSafeProxyDataSource } from "./HttpSafeProxyDataSource";
 import { type ProxyDataSource } from "./ProxyDataSource";
-
-vi.mock("axios");
 
 const config = {
   metadataServiceDomain: {
@@ -50,33 +46,39 @@ describe("HttpSafeProxyDataSource", () => {
   };
 
   describe("getProxyImplementationAddress", () => {
-    it("should call axios with correct URL, headers, and parameters", async () => {
+    it("should call fetch with correct URL, headers, and parameters", async () => {
       // GIVEN
       const version = `context-module/${PACKAGE.version}`;
-      const requestSpy = vi.fn(() => Promise.resolve({ data: validDto }));
-      vi.spyOn(axios, "request").mockImplementation(requestSpy);
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validDto)));
 
       // WHEN
       await datasource.getProxyImplementationAddress(validParams);
 
       // THEN
-      expect(requestSpy).toHaveBeenCalledWith({
-        method: "GET",
-        url: `${config.metadataServiceDomain.url}/v3/ethereum/${validParams.chainId}/contract/proxy/${validParams.proxyAddress}`,
+      expect(fetchSpy).toHaveBeenCalled();
+      const calledUrl = new URL(fetchSpy.mock.calls[0]![0]!.toString());
+      expect(calledUrl.origin + calledUrl.pathname).toBe(
+        `${config.metadataServiceDomain.url}/v3/ethereum/${validParams.chainId}/contract/proxy/${validParams.proxyAddress}`,
+      );
+      expect(calledUrl.searchParams.get("challenge")).toBe(
+        validParams.challenge,
+      );
+      expect(calledUrl.searchParams.get("resolver")).toBe("SAFE_GATEWAY");
+      expect(fetchSpy.mock.calls[0]![1]).toEqual({
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: version,
           [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
-        },
-        params: {
-          challenge: validParams.challenge,
-          resolver: "SAFE_GATEWAY",
         },
       });
     });
 
     it("should return Right with proxy implementation data when request succeeds with valid DTO", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockResolvedValue({ data: validDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(validDto)),
+      );
 
       // WHEN
       const result =
@@ -92,9 +94,11 @@ describe("HttpSafeProxyDataSource", () => {
       });
     });
 
-    it("should return Left with error when axios throws an error", async () => {
+    it("should return Left with error when fetch throws an error", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockRejectedValue(new Error("Network error"));
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(
+        new Error("Network error"),
+      );
 
       // WHEN
       const result =
@@ -111,7 +115,10 @@ describe("HttpSafeProxyDataSource", () => {
 
     it("should return Left with error when response data is undefined", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockResolvedValue({ data: undefined });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(undefined),
+      } as Response);
 
       // WHEN
       const result =
@@ -128,7 +135,7 @@ describe("HttpSafeProxyDataSource", () => {
 
     it("should return Left with error when response data is null", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockResolvedValue({ data: null });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("null"));
 
       // WHEN
       const result =
@@ -146,7 +153,9 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when proxyAddress is missing", async () => {
       // GIVEN
       const { proxyAddress: _, ...invalidDto } = validDto;
-      vi.spyOn(axios, "request").mockResolvedValue({ data: invalidDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidDto)),
+      );
 
       // WHEN
       const result =
@@ -164,7 +173,9 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when implementationAddress is missing", async () => {
       // GIVEN
       const { implementationAddress: _, ...invalidDto } = validDto;
-      vi.spyOn(axios, "request").mockResolvedValue({ data: invalidDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidDto)),
+      );
 
       // WHEN
       const result =
@@ -182,7 +193,9 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when standard is missing", async () => {
       // GIVEN
       const { standard: _, ...invalidDto } = validDto;
-      vi.spyOn(axios, "request").mockResolvedValue({ data: invalidDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidDto)),
+      );
 
       // WHEN
       const result =
@@ -200,7 +213,9 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when signedDescriptor is missing", async () => {
       // GIVEN
       const { signedDescriptor: _, ...invalidDto } = validDto;
-      vi.spyOn(axios, "request").mockResolvedValue({ data: invalidDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidDto)),
+      );
 
       // WHEN
       const result =
@@ -218,7 +233,9 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when providedBy is missing", async () => {
       // GIVEN
       const { providedBy: _, ...invalidDto } = validDto;
-      vi.spyOn(axios, "request").mockResolvedValue({ data: invalidDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidDto)),
+      );
 
       // WHEN
       const result =
@@ -236,7 +253,9 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when proxyAddress is not a string", async () => {
       // GIVEN
       const invalidDto = { ...validDto, proxyAddress: 123 };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: invalidDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidDto)),
+      );
 
       // WHEN
       const result =
@@ -254,7 +273,9 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when implementationAddress is not a string", async () => {
       // GIVEN
       const invalidDto = { ...validDto, implementationAddress: null };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: invalidDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidDto)),
+      );
 
       // WHEN
       const result =
@@ -272,7 +293,9 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when standard is not a string", async () => {
       // GIVEN
       const invalidDto = { ...validDto, standard: [] };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: invalidDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidDto)),
+      );
 
       // WHEN
       const result =
@@ -290,7 +313,9 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when signedDescriptor is not a string", async () => {
       // GIVEN
       const invalidDto = { ...validDto, signedDescriptor: {} };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: invalidDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidDto)),
+      );
 
       // WHEN
       const result =
@@ -308,7 +333,9 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when providedBy is not a string", async () => {
       // GIVEN
       const invalidDto = { ...validDto, providedBy: true };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: invalidDto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(invalidDto)),
+      );
 
       // WHEN
       const result =
@@ -325,7 +352,9 @@ describe("HttpSafeProxyDataSource", () => {
 
     it("should return Left with error when response is not an object", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockResolvedValue({ data: "not an object" });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify("not an object")),
+      );
 
       // WHEN
       const result =
@@ -342,7 +371,7 @@ describe("HttpSafeProxyDataSource", () => {
 
     it("should return Left with error when response is null", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockResolvedValue({ data: null });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("null"));
 
       // WHEN
       const result =
@@ -360,7 +389,9 @@ describe("HttpSafeProxyDataSource", () => {
     it("should handle different chainId values correctly", async () => {
       // GIVEN
       const paramsWithDifferentChainId = { ...validParams, chainId: 137 };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: validDto });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validDto)));
 
       // WHEN
       const result = await datasource.getProxyImplementationAddress(
@@ -369,10 +400,9 @@ describe("HttpSafeProxyDataSource", () => {
 
       // THEN
       expect(result.isRight()).toBe(true);
-      expect(axios.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: `${config.metadataServiceDomain.url}/v3/ethereum/137/contract/proxy/${validParams.proxyAddress}`,
-        }),
+      const calledUrl = fetchSpy.mock.calls[0]![0]!.toString();
+      expect(calledUrl).toContain(
+        `${config.metadataServiceDomain.url}/v3/ethereum/137/contract/proxy/${validParams.proxyAddress}`,
       );
     });
 
@@ -384,7 +414,9 @@ describe("HttpSafeProxyDataSource", () => {
         ...validParams,
         proxyAddress: differentProxyAddress,
       };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: validDto });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validDto)));
 
       // WHEN
       const result = await datasource.getProxyImplementationAddress(
@@ -393,10 +425,9 @@ describe("HttpSafeProxyDataSource", () => {
 
       // THEN
       expect(result.isRight()).toBe(true);
-      expect(axios.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: `${config.metadataServiceDomain.url}/v3/ethereum/${validParams.chainId}/contract/proxy/${differentProxyAddress}`,
-        }),
+      const calledUrl = fetchSpy.mock.calls[0]![0]!.toString();
+      expect(calledUrl).toContain(
+        `${config.metadataServiceDomain.url}/v3/ethereum/${validParams.chainId}/contract/proxy/${differentProxyAddress}`,
       );
     });
 
@@ -407,7 +438,9 @@ describe("HttpSafeProxyDataSource", () => {
         ...validParams,
         challenge: customChallenge,
       };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: validDto });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validDto)));
 
       // WHEN
       const result = await datasource.getProxyImplementationAddress(
@@ -416,14 +449,9 @@ describe("HttpSafeProxyDataSource", () => {
 
       // THEN
       expect(result.isRight()).toBe(true);
-      expect(axios.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          params: {
-            challenge: customChallenge,
-            resolver: "SAFE_GATEWAY",
-          },
-        }),
-      );
+      const calledUrl = new URL(fetchSpy.mock.calls[0]![0]!.toString());
+      expect(calledUrl.searchParams.get("challenge")).toBe(customChallenge);
+      expect(calledUrl.searchParams.get("resolver")).toBe("SAFE_GATEWAY");
     });
   });
 });

--- a/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.test.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.test.ts
@@ -1,9 +1,6 @@
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
+
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
 
 import { type SafeProxyImplementationAddressDto } from "./dto/SafeProxyImplementationAddressDto";
 import { HttpSafeProxyDataSource } from "./HttpSafeProxyDataSource";
@@ -18,14 +15,15 @@ const config = {
 
 describe("HttpSafeProxyDataSource", () => {
   let datasource: ProxyDataSource;
-
-  beforeAll(() => {
-    datasource = new HttpSafeProxyDataSource(config);
-    vi.clearAllMocks();
-  });
+  let httpMock: { get: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    httpMock = { get: vi.fn() };
+    datasource = new HttpSafeProxyDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
   });
 
   const validParams = {
@@ -46,42 +44,28 @@ describe("HttpSafeProxyDataSource", () => {
   };
 
   describe("getProxyImplementationAddress", () => {
-    it("should call fetch with correct URL, headers, and parameters", async () => {
+    it("should call the network client with correct URL and parameters", async () => {
       // GIVEN
-      const version = `context-module/${PACKAGE.version}`;
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validDto)));
+      httpMock.get.mockResolvedValue(validDto);
 
       // WHEN
       await datasource.getProxyImplementationAddress(validParams);
 
       // THEN
-      expect(fetchSpy).toHaveBeenCalled();
-      const calledUrl = new URL(fetchSpy.mock.calls[0]![0]!.toString());
-      expect(calledUrl.origin + calledUrl.pathname).toBe(
+      expect(httpMock.get).toHaveBeenCalledWith(
         `${config.metadataServiceDomain.url}/v3/ethereum/${validParams.chainId}/contract/proxy/${validParams.proxyAddress}`,
-      );
-      expect(calledUrl.searchParams.get("challenge")).toBe(
-        validParams.challenge,
-      );
-      expect(calledUrl.searchParams.get("resolver")).toBe("SAFE_GATEWAY");
-      expect(fetchSpy.mock.calls[0]![1]).toEqual(
-        expect.objectContaining({
-          method: "GET",
-          headers: {
-            [LEDGER_CLIENT_VERSION_HEADER]: version,
-            [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
+        {
+          params: {
+            challenge: validParams.challenge,
+            resolver: "SAFE_GATEWAY",
           },
-        }),
+        },
       );
     });
 
     it("should return Right with proxy implementation data when request succeeds with valid DTO", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(validDto)),
-      );
+      httpMock.get.mockResolvedValue(validDto);
 
       // WHEN
       const result =
@@ -97,11 +81,9 @@ describe("HttpSafeProxyDataSource", () => {
       });
     });
 
-    it("should return Left with error when fetch throws an error", async () => {
+    it("should return Left with error when network client throws", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockRejectedValue(
-        new Error("Network error"),
-      );
+      httpMock.get.mockRejectedValue(new Error("Network error"));
 
       // WHEN
       const result =
@@ -118,7 +100,7 @@ describe("HttpSafeProxyDataSource", () => {
 
     it("should return Left with error when response data is undefined", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(""));
+      httpMock.get.mockResolvedValue(undefined);
 
       // WHEN
       const result =
@@ -135,7 +117,7 @@ describe("HttpSafeProxyDataSource", () => {
 
     it("should return Left with error when response data is null", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("null"));
+      httpMock.get.mockResolvedValue(null);
 
       // WHEN
       const result =
@@ -153,9 +135,7 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when proxyAddress is missing", async () => {
       // GIVEN
       const { proxyAddress: _, ...invalidDto } = validDto;
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidDto)),
-      );
+      httpMock.get.mockResolvedValue(invalidDto);
 
       // WHEN
       const result =
@@ -173,9 +153,7 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when implementationAddress is missing", async () => {
       // GIVEN
       const { implementationAddress: _, ...invalidDto } = validDto;
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidDto)),
-      );
+      httpMock.get.mockResolvedValue(invalidDto);
 
       // WHEN
       const result =
@@ -193,9 +171,7 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when standard is missing", async () => {
       // GIVEN
       const { standard: _, ...invalidDto } = validDto;
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidDto)),
-      );
+      httpMock.get.mockResolvedValue(invalidDto);
 
       // WHEN
       const result =
@@ -213,9 +189,7 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when signedDescriptor is missing", async () => {
       // GIVEN
       const { signedDescriptor: _, ...invalidDto } = validDto;
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidDto)),
-      );
+      httpMock.get.mockResolvedValue(invalidDto);
 
       // WHEN
       const result =
@@ -233,9 +207,7 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when providedBy is missing", async () => {
       // GIVEN
       const { providedBy: _, ...invalidDto } = validDto;
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidDto)),
-      );
+      httpMock.get.mockResolvedValue(invalidDto);
 
       // WHEN
       const result =
@@ -253,9 +225,7 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when proxyAddress is not a string", async () => {
       // GIVEN
       const invalidDto = { ...validDto, proxyAddress: 123 };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidDto)),
-      );
+      httpMock.get.mockResolvedValue(invalidDto);
 
       // WHEN
       const result =
@@ -273,9 +243,7 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when implementationAddress is not a string", async () => {
       // GIVEN
       const invalidDto = { ...validDto, implementationAddress: null };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidDto)),
-      );
+      httpMock.get.mockResolvedValue(invalidDto);
 
       // WHEN
       const result =
@@ -293,9 +261,7 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when standard is not a string", async () => {
       // GIVEN
       const invalidDto = { ...validDto, standard: [] };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidDto)),
-      );
+      httpMock.get.mockResolvedValue(invalidDto);
 
       // WHEN
       const result =
@@ -313,9 +279,7 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when signedDescriptor is not a string", async () => {
       // GIVEN
       const invalidDto = { ...validDto, signedDescriptor: {} };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidDto)),
-      );
+      httpMock.get.mockResolvedValue(invalidDto);
 
       // WHEN
       const result =
@@ -333,9 +297,7 @@ describe("HttpSafeProxyDataSource", () => {
     it("should return Left with error when providedBy is not a string", async () => {
       // GIVEN
       const invalidDto = { ...validDto, providedBy: true };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(invalidDto)),
-      );
+      httpMock.get.mockResolvedValue(invalidDto);
 
       // WHEN
       const result =
@@ -352,9 +314,7 @@ describe("HttpSafeProxyDataSource", () => {
 
     it("should return Left with error when response is not an object", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify("not an object")),
-      );
+      httpMock.get.mockResolvedValue("not an object");
 
       // WHEN
       const result =
@@ -371,7 +331,7 @@ describe("HttpSafeProxyDataSource", () => {
 
     it("should return Left with error when response is null", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("null"));
+      httpMock.get.mockResolvedValue(null);
 
       // WHEN
       const result =
@@ -389,9 +349,7 @@ describe("HttpSafeProxyDataSource", () => {
     it("should handle different chainId values correctly", async () => {
       // GIVEN
       const paramsWithDifferentChainId = { ...validParams, chainId: 137 };
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validDto)));
+      httpMock.get.mockResolvedValue(validDto);
 
       // WHEN
       const result = await datasource.getProxyImplementationAddress(
@@ -400,9 +358,9 @@ describe("HttpSafeProxyDataSource", () => {
 
       // THEN
       expect(result.isRight()).toBe(true);
-      const calledUrl = fetchSpy.mock.calls[0]![0]!.toString();
-      expect(calledUrl).toContain(
+      expect(httpMock.get).toHaveBeenCalledWith(
         `${config.metadataServiceDomain.url}/v3/ethereum/137/contract/proxy/${validParams.proxyAddress}`,
+        expect.anything(),
       );
     });
 
@@ -414,9 +372,7 @@ describe("HttpSafeProxyDataSource", () => {
         ...validParams,
         proxyAddress: differentProxyAddress,
       };
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validDto)));
+      httpMock.get.mockResolvedValue(validDto);
 
       // WHEN
       const result = await datasource.getProxyImplementationAddress(
@@ -425,9 +381,9 @@ describe("HttpSafeProxyDataSource", () => {
 
       // THEN
       expect(result.isRight()).toBe(true);
-      const calledUrl = fetchSpy.mock.calls[0]![0]!.toString();
-      expect(calledUrl).toContain(
+      expect(httpMock.get).toHaveBeenCalledWith(
         `${config.metadataServiceDomain.url}/v3/ethereum/${validParams.chainId}/contract/proxy/${differentProxyAddress}`,
+        expect.anything(),
       );
     });
 
@@ -438,9 +394,7 @@ describe("HttpSafeProxyDataSource", () => {
         ...validParams,
         challenge: customChallenge,
       };
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validDto)));
+      httpMock.get.mockResolvedValue(validDto);
 
       // WHEN
       const result = await datasource.getProxyImplementationAddress(
@@ -449,9 +403,9 @@ describe("HttpSafeProxyDataSource", () => {
 
       // THEN
       expect(result.isRight()).toBe(true);
-      const calledUrl = new URL(fetchSpy.mock.calls[0]![0]!.toString());
-      expect(calledUrl.searchParams.get("challenge")).toBe(customChallenge);
-      expect(calledUrl.searchParams.get("resolver")).toBe("SAFE_GATEWAY");
+      expect(httpMock.get).toHaveBeenCalledWith(expect.any(String), {
+        params: { challenge: customChallenge, resolver: "SAFE_GATEWAY" },
+      });
     });
   });
 });

--- a/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.test.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.test.ts
@@ -66,12 +66,15 @@ describe("HttpSafeProxyDataSource", () => {
         validParams.challenge,
       );
       expect(calledUrl.searchParams.get("resolver")).toBe("SAFE_GATEWAY");
-      expect(fetchSpy.mock.calls[0]![1]).toEqual({
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: version,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
-        },
-      });
+      expect(fetchSpy.mock.calls[0]![1]).toEqual(
+        expect.objectContaining({
+          method: "GET",
+          headers: {
+            [LEDGER_CLIENT_VERSION_HEADER]: version,
+            [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
+          },
+        }),
+      );
     });
 
     it("should return Right with proxy implementation data when request succeeds with valid DTO", async () => {
@@ -115,10 +118,7 @@ describe("HttpSafeProxyDataSource", () => {
 
     it("should return Left with error when response data is undefined", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(undefined),
-      } as Response);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(""));
 
       // WHEN
       const result =

--- a/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -33,19 +32,21 @@ export class HttpSafeProxyDataSource implements ProxyDataSource {
   > {
     let dto: SafeProxyImplementationAddressDto | undefined;
     try {
-      const response = await axios.request<SafeProxyImplementationAddressDto>({
-        method: "GET",
-        url: `${this.config.metadataServiceDomain.url}/v3/ethereum/${chainId}/contract/proxy/${proxyAddress}`,
+      const url = new URL(
+        `${this.config.metadataServiceDomain.url}/v3/ethereum/${chainId}/contract/proxy/${proxyAddress}`,
+      );
+      url.searchParams.set("challenge", challenge);
+      url.searchParams.set("resolver", "SAFE_GATEWAY");
+      const response = await fetch(url, {
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-        },
-        params: {
-          challenge,
-          resolver: "SAFE_GATEWAY",
+          ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
         },
       });
-      dto = response.data;
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      dto = (await response.json()) as SafeProxyImplementationAddressDto;
     } catch (_error) {
       return Left(
         new Error(

--- a/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.ts
@@ -4,11 +4,7 @@ import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
+import { networkTypes } from "@/network/di/networkTypes";
 
 import { SafeProxyImplementationAddressDto } from "./dto/SafeProxyImplementationAddressDto";
 import {
@@ -19,21 +15,12 @@ import {
 
 @injectable()
 export class HttpSafeProxyDataSource implements ProxyDataSource {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-        ...(this.config.originToken && {
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-        }),
-      },
-    });
-  }
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
+  ) {}
 
   async getProxyImplementationAddress({
     proxyAddress,

--- a/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.ts
@@ -1,3 +1,4 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -18,10 +19,21 @@ import {
 
 @injectable()
 export class HttpSafeProxyDataSource implements ProxyDataSource {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {}
+  ) {
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+        ...(this.config.originToken && {
+          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+        }),
+      },
+    });
+  }
 
   async getProxyImplementationAddress({
     proxyAddress,
@@ -32,23 +44,15 @@ export class HttpSafeProxyDataSource implements ProxyDataSource {
   > {
     let dto: SafeProxyImplementationAddressDto | undefined;
     try {
-      const url = new URL(
+      dto = (await this.http.get(
         `${this.config.metadataServiceDomain.url}/v3/ethereum/${chainId}/contract/proxy/${proxyAddress}`,
-      );
-      url.searchParams.set("challenge", challenge);
-      url.searchParams.set("resolver", "SAFE_GATEWAY");
-      const response = await fetch(url, {
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          ...(this.config.originToken && {
-            [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-          }),
+        {
+          params: {
+            challenge,
+            resolver: "SAFE_GATEWAY",
+          },
         },
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      dto = (await response.json()) as SafeProxyImplementationAddressDto;
+      )) as SafeProxyImplementationAddressDto;
     } catch (_error) {
       return Left(
         new Error(

--- a/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.ts
@@ -40,7 +40,9 @@ export class HttpSafeProxyDataSource implements ProxyDataSource {
       const response = await fetch(url, {
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
+          ...(this.config.originToken && {
+            [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+          }),
         },
       });
       if (!response.ok) {

--- a/packages/signer/context-module/src/proxy/di/proxyModuleFactory.test.ts
+++ b/packages/signer/context-module/src/proxy/di/proxyModuleFactory.test.ts
@@ -1,7 +1,9 @@
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { Container } from "inversify";
 
 import { configTypes } from "@/config/di/configTypes";
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
+import { networkTypes } from "@/network/di/networkTypes";
 import { pkiTypes } from "@/pki/di/pkiTypes";
 import { type PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
 import { HttpProxyDataSource } from "@/proxy/data/HttpProxyDataSource";
@@ -30,6 +32,10 @@ describe("proxyModuleFactory", () => {
     container
       .bind(pkiTypes.PkiCertificateLoader)
       .toConstantValue(mockPkiCertificateLoader);
+    container.bind(networkTypes.NetworkClient).toConstantValue({
+      get: vi.fn(),
+      post: vi.fn(),
+    } as unknown as DmkNetworkClient);
   });
 
   describe("when datasource config is undefined", () => {

--- a/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.test.ts
+++ b/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.test.ts
@@ -1,3 +1,4 @@
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
@@ -10,11 +11,6 @@ import {
   ClearSigningType,
 } from "@/reporter/model/BlindSigningEvent";
 import { BlindSigningModelId } from "@/reporter/model/BlindSigningModelId";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
 
 describe("HttpBlindSigningReporterDatasource", () => {
   const config = {
@@ -41,19 +37,24 @@ describe("HttpBlindSigningReporterDatasource", () => {
     },
   };
 
+  let httpMock: { post: ReturnType<typeof vi.fn> };
+  let dataSource: HttpBlindSigningReporterDatasource;
+
   beforeEach(() => {
     vi.resetAllMocks();
+    httpMock = { post: vi.fn() };
+    dataSource = new HttpBlindSigningReporterDatasource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
   });
 
   describe("report", () => {
     it("should return Right(undefined) on success", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-        new Response(null, { status: 200 }),
-      );
+      httpMock.post.mockResolvedValueOnce(undefined);
 
       // WHEN
-      const dataSource = new HttpBlindSigningReporterDatasource(config);
       const result = await dataSource.report(params);
 
       // THEN
@@ -62,12 +63,9 @@ describe("HttpBlindSigningReporterDatasource", () => {
 
     it("should return Left(Error) when the request fails", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(
-        new Error("network error"),
-      );
+      httpMock.post.mockRejectedValueOnce(new Error("network error"));
 
       // WHEN
-      const dataSource = new HttpBlindSigningReporterDatasource(config);
       const result = await dataSource.report(params);
 
       // THEN
@@ -80,69 +78,24 @@ describe("HttpBlindSigningReporterDatasource", () => {
       );
     });
 
-    it("should call fetch with the correct URL and method", async () => {
+    it("should call http.post with the correct URL, body and options", async () => {
       // GIVEN
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValueOnce(new Response(null, { status: 200 }));
+      httpMock.post.mockResolvedValueOnce(undefined);
 
       // WHEN
-      const dataSource = new HttpBlindSigningReporterDatasource(config);
       await dataSource.report(params);
 
       // THEN
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          href: `${config.reporter!.url}/blind-signing-events`,
-        }),
-        expect.objectContaining({ method: "POST" }),
-      );
-    });
-
-    it("should call fetch with the correct headers", async () => {
-      // GIVEN
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValueOnce(new Response(null, { status: 200 }));
-
-      // WHEN
-      const dataSource = new HttpBlindSigningReporterDatasource(config);
-      await dataSource.report(params);
-
-      // THEN
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.any(URL),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
-          }),
-        }),
-      );
-    });
-
-    it("should call fetch with the event payload and injected source as body", async () => {
-      // GIVEN
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValueOnce(new Response(null, { status: 200 }));
-
-      // WHEN
-      const dataSource = new HttpBlindSigningReporterDatasource(config);
-      await dataSource.report(params);
-
-      // THEN
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.any(URL),
-        expect.objectContaining({
-          body: JSON.stringify({ ...params, source: config.appSource }),
-        }),
+      expect(httpMock.post).toHaveBeenCalledWith(
+        `${config.reporter!.url}/blind-signing-events`,
+        { ...params, source: config.appSource },
+        { responseType: "void" },
       );
     });
 
     it("should forward optional DTO fields when provided", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockResolvedValueOnce({ data: {} });
+      httpMock.post.mockResolvedValueOnce(undefined);
       const paramsWithOptionalFields: BlindSigningReportParams = {
         ...params,
         platform: BlindSigningPlatform.DESKTOP,
@@ -154,14 +107,13 @@ describe("HttpBlindSigningReporterDatasource", () => {
       };
 
       // WHEN
-      const dataSource = new HttpBlindSigningReporterDatasource(config);
       await dataSource.report(paramsWithOptionalFields);
 
       // THEN
-      expect(axios.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: { ...paramsWithOptionalFields, source: config.appSource },
-        }),
+      expect(httpMock.post).toHaveBeenCalledWith(
+        `${config.reporter!.url}/blind-signing-events`,
+        { ...paramsWithOptionalFields, source: config.appSource },
+        { responseType: "void" },
       );
     });
   });

--- a/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.test.ts
+++ b/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.test.ts
@@ -92,7 +92,9 @@ describe("HttpBlindSigningReporterDatasource", () => {
 
       // THEN
       expect(fetchSpy).toHaveBeenCalledWith(
-        `${config.reporter!.url}/blind-signing-events`,
+        expect.objectContaining({
+          href: `${config.reporter!.url}/blind-signing-events`,
+        }),
         expect.objectContaining({ method: "POST" }),
       );
     });
@@ -109,7 +111,7 @@ describe("HttpBlindSigningReporterDatasource", () => {
 
       // THEN
       expect(fetchSpy).toHaveBeenCalledWith(
-        expect.any(String),
+        expect.any(URL),
         expect.objectContaining({
           headers: expect.objectContaining({
             [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
@@ -131,7 +133,7 @@ describe("HttpBlindSigningReporterDatasource", () => {
 
       // THEN
       expect(fetchSpy).toHaveBeenCalledWith(
-        expect.any(String),
+        expect.any(URL),
         expect.objectContaining({
           body: JSON.stringify({ ...params, source: config.appSource }),
         }),

--- a/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.test.ts
+++ b/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.test.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { Left, Right } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
@@ -16,8 +15,6 @@ import {
   LEDGER_ORIGIN_TOKEN_HEADER,
 } from "@/shared/constant/HttpHeaders";
 import PACKAGE from "@root/package.json";
-
-vi.mock("axios");
 
 describe("HttpBlindSigningReporterDatasource", () => {
   const config = {
@@ -51,7 +48,9 @@ describe("HttpBlindSigningReporterDatasource", () => {
   describe("report", () => {
     it("should return Right(undefined) on success", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockResolvedValueOnce({ data: {} });
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(null, { status: 200 }),
+      );
 
       // WHEN
       const dataSource = new HttpBlindSigningReporterDatasource(config);
@@ -63,7 +62,7 @@ describe("HttpBlindSigningReporterDatasource", () => {
 
     it("should return Left(Error) when the request fails", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockRejectedValueOnce(
+      vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(
         new Error("network error"),
       );
 
@@ -81,54 +80,60 @@ describe("HttpBlindSigningReporterDatasource", () => {
       );
     });
 
-    it("should call axios with the correct URL and method", async () => {
+    it("should call fetch with the correct URL and method", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockResolvedValueOnce({ data: {} });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response(null, { status: 200 }));
 
       // WHEN
       const dataSource = new HttpBlindSigningReporterDatasource(config);
       await dataSource.report(params);
 
       // THEN
-      expect(axios.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          method: "POST",
-          url: `${config.reporter!.url}/blind-signing-events`,
-        }),
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${config.reporter!.url}/blind-signing-events`,
+        expect.objectContaining({ method: "POST" }),
       );
     });
 
-    it("should call axios with the correct headers", async () => {
+    it("should call fetch with the correct headers", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockResolvedValueOnce({ data: {} });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response(null, { status: 200 }));
 
       // WHEN
       const dataSource = new HttpBlindSigningReporterDatasource(config);
       await dataSource.report(params);
 
       // THEN
-      expect(axios.request).toHaveBeenCalledWith(
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(String),
         expect.objectContaining({
-          headers: {
+          headers: expect.objectContaining({
             [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
             [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
-          },
+          }),
         }),
       );
     });
 
-    it("should call axios with the event payload and injected source as data", async () => {
+    it("should call fetch with the event payload and injected source as body", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockResolvedValueOnce({ data: {} });
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response(null, { status: 200 }));
 
       // WHEN
       const dataSource = new HttpBlindSigningReporterDatasource(config);
       await dataSource.report(params);
 
       // THEN
-      expect(axios.request).toHaveBeenCalledWith(
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(String),
         expect.objectContaining({
-          data: { ...params, source: config.appSource },
+          body: JSON.stringify({ ...params, source: config.appSource }),
         }),
       );
     });

--- a/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
+++ b/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
@@ -28,7 +28,9 @@ export class HttpBlindSigningReporterDatasource
     this.http = new DmkNetworkClient({
       headers: {
         [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-        [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+        ...(this.config.originToken && {
+          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+        }),
       },
     });
   }

--- a/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
+++ b/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { type Either, Left, Right } from "purify-ts";
 
@@ -26,15 +25,21 @@ export class HttpBlindSigningReporterDatasource
 
   async report(params: BlindSigningReportParams): Promise<Either<Error, void>> {
     try {
-      await axios.request({
-        method: "POST",
-        url: `${this.config.reporter.url}/blind-signing-events`,
-        data: { ...params, source: this.config.appSource },
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+      const response = await fetch(
+        `${this.config.reporter.url}/blind-signing-events`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+            [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+          },
+          body: JSON.stringify({ ...params, source: this.config.appSource }),
         },
-      });
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
     } catch (_error) {
       return Left(
         new Error(

--- a/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
+++ b/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
@@ -4,11 +4,7 @@ import { type Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
+import { networkTypes } from "@/network/di/networkTypes";
 
 import {
   type BlindSigningReporterDatasource,
@@ -19,21 +15,12 @@ import {
 export class HttpBlindSigningReporterDatasource
   implements BlindSigningReporterDatasource
 {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-        ...(this.config.originToken && {
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-        }),
-      },
-    });
-  }
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
+  ) {}
 
   async report(params: BlindSigningReportParams): Promise<Either<Error, void>> {
     try {

--- a/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
+++ b/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
@@ -1,3 +1,4 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { type Either, Left, Right } from "purify-ts";
 
@@ -18,28 +19,27 @@ import {
 export class HttpBlindSigningReporterDatasource
   implements BlindSigningReporterDatasource
 {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {}
+  ) {
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+        [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+      },
+    });
+  }
 
   async report(params: BlindSigningReportParams): Promise<Either<Error, void>> {
     try {
-      const response = await fetch(
+      await this.http.post(
         `${this.config.reporter.url}/blind-signing-events`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-          },
-          body: JSON.stringify({ ...params, source: this.config.appSource }),
-        },
+        { ...params, source: this.config.appSource },
+        { responseType: "void" },
       );
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
     } catch (_error) {
       return Left(
         new Error(

--- a/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.test.ts
+++ b/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.test.ts
@@ -1,13 +1,11 @@
-import { type HexaString } from "@ledgerhq/device-management-kit";
+import {
+  type DmkNetworkClient,
+  type HexaString,
+} from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { HttpSafeAccountDataSource } from "@/safe/data/HttpSafeAccountDataSource";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
 
 describe("HttpSafeAccountDataSource", () => {
   const config: ContextModuleServiceConfig = {
@@ -33,8 +31,16 @@ describe("HttpSafeAccountDataSource", () => {
   const validsafeContractAddress: HexaString =
     "0x1234567890123456789012345678901234567890";
 
+  let httpMock: { get: ReturnType<typeof vi.fn> };
+  let datasource: HttpSafeAccountDataSource;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    httpMock = { get: vi.fn() };
+    datasource = new HttpSafeAccountDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
   });
 
   describe("getDescriptors", () => {
@@ -45,29 +51,15 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validSafeAccountDto)));
+      httpMock.get.mockResolvedValue(validSafeAccountDto);
 
       // WHEN
-      const result = await new HttpSafeAccountDataSource(config).getDescriptors(
-        params,
-      );
+      const result = await datasource.getDescriptors(params);
 
       // THEN
-      expect(fetchSpy).toHaveBeenCalled();
-      const calledUrl = fetchSpy.mock.calls[0]![0]!.toString();
-      expect(calledUrl).toBe(
-        "https://metadata.ledger.com/v2/ethereum/1/safe/account/0x1234567890123456789012345678901234567890?challenge=0xabcdef",
-      );
-      expect(fetchSpy.mock.calls[0]![1]).toEqual(
-        expect.objectContaining({
-          method: "GET",
-          headers: {
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            [LEDGER_ORIGIN_TOKEN_HEADER]: "test-origin-token",
-          },
-        }),
+      expect(httpMock.get).toHaveBeenCalledWith(
+        "https://metadata.ledger.com/v2/ethereum/1/safe/account/0x1234567890123456789012345678901234567890",
+        { params: { challenge: "0xabcdef" } },
       );
       expect(result).toEqual(
         Right({
@@ -92,17 +84,15 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 137, // Polygon
         challenge: "0xabcdef",
       };
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validSafeAccountDto)));
+      httpMock.get.mockResolvedValue(validSafeAccountDto);
 
       // WHEN
-      await new HttpSafeAccountDataSource(config).getDescriptors(params);
+      await datasource.getDescriptors(params);
 
       // THEN
-      const calledUrl = fetchSpy.mock.calls[0]![0]!.toString();
-      expect(calledUrl).toContain(
-        "/v2/ethereum/137/safe/account/0x1234567890123456789012345678901234567890",
+      expect(httpMock.get).toHaveBeenCalledWith(
+        "https://metadata.ledger.com/v2/ethereum/137/safe/account/0x1234567890123456789012345678901234567890",
+        { params: { challenge: "0xabcdef" } },
       );
     });
 
@@ -114,17 +104,15 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validSafeAccountDto)));
+      httpMock.get.mockResolvedValue(validSafeAccountDto);
 
       // WHEN
-      await new HttpSafeAccountDataSource(config).getDescriptors(params);
+      await datasource.getDescriptors(params);
 
       // THEN
-      const calledUrl = fetchSpy.mock.calls[0]![0]!.toString();
-      expect(calledUrl).toContain(
-        "/v2/ethereum/1/safe/account/0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+      expect(httpMock.get).toHaveBeenCalledWith(
+        "https://metadata.ledger.com/v2/ethereum/1/safe/account/0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+        { params: { challenge: "0xabcdef" } },
       );
     });
 
@@ -135,16 +123,15 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0x123456789",
       };
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validSafeAccountDto)));
+      httpMock.get.mockResolvedValue(validSafeAccountDto);
 
       // WHEN
-      await new HttpSafeAccountDataSource(config).getDescriptors(params);
+      await datasource.getDescriptors(params);
 
       // THEN
-      const calledUrl = new URL(fetchSpy.mock.calls[0]![0]!.toString());
-      expect(calledUrl.searchParams.get("challenge")).toBe("0x123456789");
+      expect(httpMock.get).toHaveBeenCalledWith(expect.any(String), {
+        params: { challenge: "0x123456789" },
+      });
     });
 
     it("should return error when response data is empty", async () => {
@@ -154,12 +141,10 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("null"));
+      httpMock.get.mockResolvedValue(null);
 
       // WHEN
-      const result = await new HttpSafeAccountDataSource(config).getDescriptors(
-        params,
-      );
+      const result = await datasource.getDescriptors(params);
 
       // THEN
       expect(result).toEqual(
@@ -178,12 +163,10 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(""));
+      httpMock.get.mockResolvedValue(undefined);
 
       // WHEN
-      const result = await new HttpSafeAccountDataSource(config).getDescriptors(
-        params,
-      );
+      const result = await datasource.getDescriptors(params);
 
       // THEN
       expect(result).toEqual(
@@ -202,18 +185,12 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            signersDescriptor: validSafeAccountDto.signersDescriptor,
-          }),
-        ),
-      );
+      httpMock.get.mockResolvedValue({
+        signersDescriptor: validSafeAccountDto.signersDescriptor,
+      });
 
       // WHEN
-      const result = await new HttpSafeAccountDataSource(config).getDescriptors(
-        params,
-      );
+      const result = await datasource.getDescriptors(params);
 
       // THEN
       expect(result).toEqual(
@@ -232,18 +209,12 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            accountDescriptor: validSafeAccountDto.accountDescriptor,
-          }),
-        ),
-      );
+      httpMock.get.mockResolvedValue({
+        accountDescriptor: validSafeAccountDto.accountDescriptor,
+      });
 
       // WHEN
-      const result = await new HttpSafeAccountDataSource(config).getDescriptors(
-        params,
-      );
+      const result = await datasource.getDescriptors(params);
 
       // THEN
       expect(result).toEqual(
@@ -262,22 +233,16 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            accountDescriptor: {
-              keyId: "account-key-id",
-              keyUsage: "account-key-usage",
-            },
-            signersDescriptor: validSafeAccountDto.signersDescriptor,
-          }),
-        ),
-      );
+      httpMock.get.mockResolvedValue({
+        accountDescriptor: {
+          keyId: "account-key-id",
+          keyUsage: "account-key-usage",
+        },
+        signersDescriptor: validSafeAccountDto.signersDescriptor,
+      });
 
       // WHEN
-      const result = await new HttpSafeAccountDataSource(config).getDescriptors(
-        params,
-      );
+      const result = await datasource.getDescriptors(params);
 
       // THEN
       expect(result).toEqual(
@@ -296,22 +261,16 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            accountDescriptor: {
-              signedDescriptor: "account-signed-descriptor-data",
-              keyUsage: "account-key-usage",
-            },
-            signersDescriptor: validSafeAccountDto.signersDescriptor,
-          }),
-        ),
-      );
+      httpMock.get.mockResolvedValue({
+        accountDescriptor: {
+          signedDescriptor: "account-signed-descriptor-data",
+          keyUsage: "account-key-usage",
+        },
+        signersDescriptor: validSafeAccountDto.signersDescriptor,
+      });
 
       // WHEN
-      const result = await new HttpSafeAccountDataSource(config).getDescriptors(
-        params,
-      );
+      const result = await datasource.getDescriptors(params);
 
       // THEN
       expect(result).toEqual(
@@ -330,22 +289,16 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            accountDescriptor: {
-              signedDescriptor: "account-signed-descriptor-data",
-              keyId: "account-key-id",
-            },
-            signersDescriptor: validSafeAccountDto.signersDescriptor,
-          }),
-        ),
-      );
+      httpMock.get.mockResolvedValue({
+        accountDescriptor: {
+          signedDescriptor: "account-signed-descriptor-data",
+          keyId: "account-key-id",
+        },
+        signersDescriptor: validSafeAccountDto.signersDescriptor,
+      });
 
       // WHEN
-      const result = await new HttpSafeAccountDataSource(config).getDescriptors(
-        params,
-      );
+      const result = await datasource.getDescriptors(params);
 
       // THEN
       expect(result).toEqual(
@@ -364,23 +317,17 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            accountDescriptor: validSafeAccountDto.accountDescriptor,
-            signersDescriptor: {
-              signedDescriptor: "signers-signed-descriptor-data",
-              keyId: 123, // wrong type
-              keyUsage: "signers-key-usage",
-            },
-          }),
-        ),
-      );
+      httpMock.get.mockResolvedValue({
+        accountDescriptor: validSafeAccountDto.accountDescriptor,
+        signersDescriptor: {
+          signedDescriptor: "signers-signed-descriptor-data",
+          keyId: 123, // wrong type
+          keyUsage: "signers-key-usage",
+        },
+      });
 
       // WHEN
-      const result = await new HttpSafeAccountDataSource(config).getDescriptors(
-        params,
-      );
+      const result = await datasource.getDescriptors(params);
 
       // THEN
       expect(result).toEqual(
@@ -399,19 +346,13 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            accountDescriptor: "invalid-string",
-            signersDescriptor: validSafeAccountDto.signersDescriptor,
-          }),
-        ),
-      );
+      httpMock.get.mockResolvedValue({
+        accountDescriptor: "invalid-string",
+        signersDescriptor: validSafeAccountDto.signersDescriptor,
+      });
 
       // WHEN
-      const result = await new HttpSafeAccountDataSource(config).getDescriptors(
-        params,
-      );
+      const result = await datasource.getDescriptors(params);
 
       // THEN
       expect(result).toEqual(
@@ -430,19 +371,13 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            accountDescriptor: validSafeAccountDto.accountDescriptor,
-            signersDescriptor: null,
-          }),
-        ),
-      );
+      httpMock.get.mockResolvedValue({
+        accountDescriptor: validSafeAccountDto.accountDescriptor,
+        signersDescriptor: null,
+      });
 
       // WHEN
-      const result = await new HttpSafeAccountDataSource(config).getDescriptors(
-        params,
-      );
+      const result = await datasource.getDescriptors(params);
 
       // THEN
       expect(result).toEqual(
@@ -454,21 +389,17 @@ describe("HttpSafeAccountDataSource", () => {
       );
     });
 
-    it("should return error when fetch request fails", async () => {
+    it("should return error when network client rejects", async () => {
       // GIVEN
       const params = {
         safeContractAddress: validsafeContractAddress,
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(globalThis, "fetch").mockRejectedValue(
-        new Error("Network error"),
-      );
+      httpMock.get.mockRejectedValue(new Error("Network error"));
 
       // WHEN
-      const result = await new HttpSafeAccountDataSource(config).getDescriptors(
-        params,
-      );
+      const result = await datasource.getDescriptors(params);
 
       // THEN
       expect(result).toEqual(
@@ -480,19 +411,17 @@ describe("HttpSafeAccountDataSource", () => {
       );
     });
 
-    it("should return error when fetch throws an exception", async () => {
+    it("should return error when network client throws an exception", async () => {
       // GIVEN
       const params = {
         safeContractAddress: validsafeContractAddress,
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("timeout"));
+      httpMock.get.mockRejectedValue(new Error("timeout"));
 
       // WHEN
-      const result = await new HttpSafeAccountDataSource(config).getDescriptors(
-        params,
-      );
+      const result = await datasource.getDescriptors(params);
 
       // THEN
       expect(result).toEqual(
@@ -511,27 +440,21 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            accountDescriptor: {
-              signedDescriptor: "",
-              keyId: "",
-              keyUsage: "",
-            },
-            signersDescriptor: {
-              signedDescriptor: "",
-              keyId: "",
-              keyUsage: "",
-            },
-          }),
-        ),
-      );
+      httpMock.get.mockResolvedValue({
+        accountDescriptor: {
+          signedDescriptor: "",
+          keyId: "",
+          keyUsage: "",
+        },
+        signersDescriptor: {
+          signedDescriptor: "",
+          keyId: "",
+          keyUsage: "",
+        },
+      });
 
       // WHEN
-      const result = await new HttpSafeAccountDataSource(config).getDescriptors(
-        params,
-      );
+      const result = await datasource.getDescriptors(params);
 
       // THEN
       expect(result).toEqual(
@@ -558,27 +481,21 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            accountDescriptor: {
-              signedDescriptor: longValue,
-              keyId: "account-key-id",
-              keyUsage: "account-key-usage",
-            },
-            signersDescriptor: {
-              signedDescriptor: longValue,
-              keyId: "signers-key-id",
-              keyUsage: "signers-key-usage",
-            },
-          }),
-        ),
-      );
+      httpMock.get.mockResolvedValue({
+        accountDescriptor: {
+          signedDescriptor: longValue,
+          keyId: "account-key-id",
+          keyUsage: "account-key-usage",
+        },
+        signersDescriptor: {
+          signedDescriptor: longValue,
+          keyId: "signers-key-id",
+          keyUsage: "signers-key-usage",
+        },
+      });
 
       // WHEN
-      const result = await new HttpSafeAccountDataSource(config).getDescriptors(
-        params,
-      );
+      const result = await datasource.getDescriptors(params);
 
       // THEN
       expect(result).toEqual(
@@ -597,37 +514,6 @@ describe("HttpSafeAccountDataSource", () => {
       );
     });
 
-    it("should use correct origin token from config", async () => {
-      // GIVEN
-      const customConfig: ContextModuleServiceConfig = {
-        metadataServiceDomain: {
-          url: "https://metadata.ledger.com",
-        },
-        originToken: "custom-origin-token",
-      } as ContextModuleServiceConfig;
-      const params = {
-        safeContractAddress: validsafeContractAddress,
-        chainId: 1,
-        challenge: "0xabcdef",
-      };
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validSafeAccountDto)));
-
-      // WHEN
-      await new HttpSafeAccountDataSource(customConfig).getDescriptors(params);
-
-      // THEN
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            [LEDGER_ORIGIN_TOKEN_HEADER]: "custom-origin-token",
-          }),
-        }),
-      );
-    });
-
     it("should use correct metadata service URL from config", async () => {
       // GIVEN
       const customConfig: ContextModuleServiceConfig = {
@@ -636,22 +522,24 @@ describe("HttpSafeAccountDataSource", () => {
         },
         originToken: "test-token",
       } as ContextModuleServiceConfig;
+      const customDatasource = new HttpSafeAccountDataSource(
+        customConfig,
+        httpMock as unknown as DmkNetworkClient,
+      );
       const params = {
         safeContractAddress: validsafeContractAddress,
         chainId: 1,
         challenge: "0xabcdef",
       };
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify(validSafeAccountDto)));
+      httpMock.get.mockResolvedValue(validSafeAccountDto);
 
       // WHEN
-      await new HttpSafeAccountDataSource(customConfig).getDescriptors(params);
+      await customDatasource.getDescriptors(params);
 
       // THEN
-      const calledUrl = fetchSpy.mock.calls[0]![0]!.toString();
-      expect(calledUrl).toContain(
+      expect(httpMock.get).toHaveBeenCalledWith(
         "https://custom-metadata.example.com/v2/ethereum/1/safe/account/0x1234567890123456789012345678901234567890",
+        { params: { challenge: "0xabcdef" } },
       );
     });
   });

--- a/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.test.ts
+++ b/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.test.ts
@@ -45,9 +45,9 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(validSafeAccountDto)),
-      );
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validSafeAccountDto)));
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(
@@ -89,9 +89,9 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 137, // Polygon
         challenge: "0xabcdef",
       };
-      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(validSafeAccountDto)),
-      );
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validSafeAccountDto)));
 
       // WHEN
       await new HttpSafeAccountDataSource(config).getDescriptors(params);
@@ -111,9 +111,9 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(validSafeAccountDto)),
-      );
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validSafeAccountDto)));
 
       // WHEN
       await new HttpSafeAccountDataSource(config).getDescriptors(params);
@@ -132,9 +132,9 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0x123456789",
       };
-      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(validSafeAccountDto)),
-      );
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validSafeAccountDto)));
 
       // WHEN
       await new HttpSafeAccountDataSource(config).getDescriptors(params);
@@ -151,9 +151,7 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response("null"),
-      );
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("null"));
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(
@@ -612,9 +610,9 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(validSafeAccountDto)),
-      );
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validSafeAccountDto)));
 
       // WHEN
       await new HttpSafeAccountDataSource(customConfig).getDescriptors(params);
@@ -643,9 +641,9 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(validSafeAccountDto)),
-      );
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(validSafeAccountDto)));
 
       // WHEN
       await new HttpSafeAccountDataSource(customConfig).getDescriptors(params);

--- a/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.test.ts
+++ b/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.test.ts
@@ -60,12 +60,15 @@ describe("HttpSafeAccountDataSource", () => {
       expect(calledUrl).toBe(
         "https://metadata.ledger.com/v2/ethereum/1/safe/account/0x1234567890123456789012345678901234567890?challenge=0xabcdef",
       );
-      expect(fetchSpy.mock.calls[0]![1]).toEqual({
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: "test-origin-token",
-        },
-      });
+      expect(fetchSpy.mock.calls[0]![1]).toEqual(
+        expect.objectContaining({
+          method: "GET",
+          headers: {
+            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+            [LEDGER_ORIGIN_TOKEN_HEADER]: "test-origin-token",
+          },
+        }),
+      );
       expect(result).toEqual(
         Right({
           account: {
@@ -175,10 +178,7 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(undefined),
-      } as Response);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(""));
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(

--- a/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.test.ts
+++ b/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.test.ts
@@ -1,5 +1,4 @@
 import { type HexaString } from "@ledgerhq/device-management-kit";
-import axios from "axios";
 import { Left, Right } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
@@ -9,8 +8,6 @@ import {
   LEDGER_ORIGIN_TOKEN_HEADER,
 } from "@/shared/constant/HttpHeaders";
 import PACKAGE from "@root/package.json";
-
-vi.mock("axios");
 
 describe("HttpSafeAccountDataSource", () => {
   const config: ContextModuleServiceConfig = {
@@ -48,10 +45,9 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: validSafeAccountDto,
-      });
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(validSafeAccountDto)),
+      );
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(
@@ -59,12 +55,12 @@ describe("HttpSafeAccountDataSource", () => {
       );
 
       // THEN
-      expect(axios.request).toHaveBeenCalledWith({
-        method: "GET",
-        url: "https://metadata.ledger.com/v2/ethereum/1/safe/account/0x1234567890123456789012345678901234567890",
-        params: {
-          challenge: "0xabcdef",
-        },
+      expect(fetchSpy).toHaveBeenCalled();
+      const calledUrl = fetchSpy.mock.calls[0]![0]!.toString();
+      expect(calledUrl).toBe(
+        "https://metadata.ledger.com/v2/ethereum/1/safe/account/0x1234567890123456789012345678901234567890?challenge=0xabcdef",
+      );
+      expect(fetchSpy.mock.calls[0]![1]).toEqual({
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
           [LEDGER_ORIGIN_TOKEN_HEADER]: "test-origin-token",
@@ -93,19 +89,17 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 137, // Polygon
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: validSafeAccountDto,
-      });
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(validSafeAccountDto)),
+      );
 
       // WHEN
       await new HttpSafeAccountDataSource(config).getDescriptors(params);
 
       // THEN
-      expect(axios.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: "https://metadata.ledger.com/v2/ethereum/137/safe/account/0x1234567890123456789012345678901234567890",
-        }),
+      const calledUrl = fetchSpy.mock.calls[0]![0]!.toString();
+      expect(calledUrl).toContain(
+        "/v2/ethereum/137/safe/account/0x1234567890123456789012345678901234567890",
       );
     });
 
@@ -117,19 +111,17 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: validSafeAccountDto,
-      });
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(validSafeAccountDto)),
+      );
 
       // WHEN
       await new HttpSafeAccountDataSource(config).getDescriptors(params);
 
       // THEN
-      expect(axios.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: "https://metadata.ledger.com/v2/ethereum/1/safe/account/0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
-        }),
+      const calledUrl = fetchSpy.mock.calls[0]![0]!.toString();
+      expect(calledUrl).toContain(
+        "/v2/ethereum/1/safe/account/0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
       );
     });
 
@@ -140,22 +132,16 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0x123456789",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: validSafeAccountDto,
-      });
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(validSafeAccountDto)),
+      );
 
       // WHEN
       await new HttpSafeAccountDataSource(config).getDescriptors(params);
 
       // THEN
-      expect(axios.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          params: {
-            challenge: "0x123456789",
-          },
-        }),
-      );
+      const calledUrl = new URL(fetchSpy.mock.calls[0]![0]!.toString());
+      expect(calledUrl.searchParams.get("challenge")).toBe("0x123456789");
     });
 
     it("should return error when response data is empty", async () => {
@@ -165,10 +151,9 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: null,
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response("null"),
+      );
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(
@@ -192,10 +177,10 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: undefined,
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(undefined),
+      } as Response);
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(
@@ -219,12 +204,13 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: {
-          signersDescriptor: validSafeAccountDto.signersDescriptor,
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            signersDescriptor: validSafeAccountDto.signersDescriptor,
+          }),
+        ),
+      );
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(
@@ -248,12 +234,13 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: {
-          accountDescriptor: validSafeAccountDto.accountDescriptor,
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            accountDescriptor: validSafeAccountDto.accountDescriptor,
+          }),
+        ),
+      );
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(
@@ -277,16 +264,17 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: {
-          accountDescriptor: {
-            keyId: "account-key-id",
-            keyUsage: "account-key-usage",
-          },
-          signersDescriptor: validSafeAccountDto.signersDescriptor,
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            accountDescriptor: {
+              keyId: "account-key-id",
+              keyUsage: "account-key-usage",
+            },
+            signersDescriptor: validSafeAccountDto.signersDescriptor,
+          }),
+        ),
+      );
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(
@@ -310,16 +298,17 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: {
-          accountDescriptor: {
-            signedDescriptor: "account-signed-descriptor-data",
-            keyUsage: "account-key-usage",
-          },
-          signersDescriptor: validSafeAccountDto.signersDescriptor,
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            accountDescriptor: {
+              signedDescriptor: "account-signed-descriptor-data",
+              keyUsage: "account-key-usage",
+            },
+            signersDescriptor: validSafeAccountDto.signersDescriptor,
+          }),
+        ),
+      );
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(
@@ -343,16 +332,17 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: {
-          accountDescriptor: {
-            signedDescriptor: "account-signed-descriptor-data",
-            keyId: "account-key-id",
-          },
-          signersDescriptor: validSafeAccountDto.signersDescriptor,
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            accountDescriptor: {
+              signedDescriptor: "account-signed-descriptor-data",
+              keyId: "account-key-id",
+            },
+            signersDescriptor: validSafeAccountDto.signersDescriptor,
+          }),
+        ),
+      );
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(
@@ -376,17 +366,18 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: {
-          accountDescriptor: validSafeAccountDto.accountDescriptor,
-          signersDescriptor: {
-            signedDescriptor: "signers-signed-descriptor-data",
-            keyId: 123, // wrong type
-            keyUsage: "signers-key-usage",
-          },
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            accountDescriptor: validSafeAccountDto.accountDescriptor,
+            signersDescriptor: {
+              signedDescriptor: "signers-signed-descriptor-data",
+              keyId: 123, // wrong type
+              keyUsage: "signers-key-usage",
+            },
+          }),
+        ),
+      );
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(
@@ -410,13 +401,14 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: {
-          accountDescriptor: "invalid-string",
-          signersDescriptor: validSafeAccountDto.signersDescriptor,
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            accountDescriptor: "invalid-string",
+            signersDescriptor: validSafeAccountDto.signersDescriptor,
+          }),
+        ),
+      );
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(
@@ -440,13 +432,14 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: {
-          accountDescriptor: validSafeAccountDto.accountDescriptor,
-          signersDescriptor: null,
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            accountDescriptor: validSafeAccountDto.accountDescriptor,
+            signersDescriptor: null,
+          }),
+        ),
+      );
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(
@@ -463,14 +456,16 @@ describe("HttpSafeAccountDataSource", () => {
       );
     });
 
-    it("should return error when axios request fails", async () => {
+    it("should return error when fetch request fails", async () => {
       // GIVEN
       const params = {
         safeContractAddress: validsafeContractAddress,
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockRejectedValue(new Error("Network error"));
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(
+        new Error("Network error"),
+      );
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(
@@ -487,14 +482,14 @@ describe("HttpSafeAccountDataSource", () => {
       );
     });
 
-    it("should return error when axios throws an exception", async () => {
+    it("should return error when fetch throws an exception", async () => {
       // GIVEN
       const params = {
         safeContractAddress: validsafeContractAddress,
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockRejectedValue(new Error("timeout"));
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("timeout"));
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(
@@ -518,21 +513,22 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: {
-          accountDescriptor: {
-            signedDescriptor: "",
-            keyId: "",
-            keyUsage: "",
-          },
-          signersDescriptor: {
-            signedDescriptor: "",
-            keyId: "",
-            keyUsage: "",
-          },
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            accountDescriptor: {
+              signedDescriptor: "",
+              keyId: "",
+              keyUsage: "",
+            },
+            signersDescriptor: {
+              signedDescriptor: "",
+              keyId: "",
+              keyUsage: "",
+            },
+          }),
+        ),
+      );
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(
@@ -564,21 +560,22 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: {
-          accountDescriptor: {
-            signedDescriptor: longValue,
-            keyId: "account-key-id",
-            keyUsage: "account-key-usage",
-          },
-          signersDescriptor: {
-            signedDescriptor: longValue,
-            keyId: "signers-key-id",
-            keyUsage: "signers-key-usage",
-          },
-        },
-      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            accountDescriptor: {
+              signedDescriptor: longValue,
+              keyId: "account-key-id",
+              keyUsage: "account-key-usage",
+            },
+            signersDescriptor: {
+              signedDescriptor: longValue,
+              keyId: "signers-key-id",
+              keyUsage: "signers-key-usage",
+            },
+          }),
+        ),
+      );
 
       // WHEN
       const result = await new HttpSafeAccountDataSource(config).getDescriptors(
@@ -615,16 +612,16 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: validSafeAccountDto,
-      });
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(validSafeAccountDto)),
+      );
 
       // WHEN
       await new HttpSafeAccountDataSource(customConfig).getDescriptors(params);
 
       // THEN
-      expect(axios.request).toHaveBeenCalledWith(
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.anything(),
         expect.objectContaining({
           headers: expect.objectContaining({
             [LEDGER_ORIGIN_TOKEN_HEADER]: "custom-origin-token",
@@ -646,19 +643,17 @@ describe("HttpSafeAccountDataSource", () => {
         chainId: 1,
         challenge: "0xabcdef",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: validSafeAccountDto,
-      });
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(validSafeAccountDto)),
+      );
 
       // WHEN
       await new HttpSafeAccountDataSource(customConfig).getDescriptors(params);
 
       // THEN
-      expect(axios.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: "https://custom-metadata.example.com/v2/ethereum/1/safe/account/0x1234567890123456789012345678901234567890",
-        }),
+      const calledUrl = fetchSpy.mock.calls[0]![0]!.toString();
+      expect(calledUrl).toContain(
+        "https://custom-metadata.example.com/v2/ethereum/1/safe/account/0x1234567890123456789012345678901234567890",
       );
     });
   });

--- a/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.ts
+++ b/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.ts
@@ -35,7 +35,9 @@ export class HttpSafeAccountDataSource implements SafeAccountDataSource {
       const response = await fetch(url, {
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
+          ...(this.config.originToken && {
+            [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+          }),
         },
       });
       if (!response.ok) {

--- a/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.ts
+++ b/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.ts
@@ -4,11 +4,7 @@ import { type Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
+import { networkTypes } from "@/network/di/networkTypes";
 
 import { SafeAccountDto, SafeDescriptorDto } from "./dto/SafeAccountDto";
 import {
@@ -18,21 +14,12 @@ import {
 } from "./SafeAccountDataSource";
 
 export class HttpSafeAccountDataSource implements SafeAccountDataSource {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-        ...(this.config.originToken && {
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-        }),
-      },
-    });
-  }
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
+  ) {}
 
   async getDescriptors({
     safeContractAddress,

--- a/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.ts
+++ b/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { inject } from "inversify";
 import { type Either, Left, Right } from "purify-ts";
 
@@ -29,19 +28,22 @@ export class HttpSafeAccountDataSource implements SafeAccountDataSource {
     challenge,
   }: GetSafeAccountParams): Promise<Either<Error, GetSafeAccountResponse>> {
     try {
-      const response = await axios.request<SafeAccountDto>({
-        method: "GET",
-        url: `${this.config.metadataServiceDomain.url}/v2/ethereum/${chainId}/safe/account/${safeContractAddress}`,
-        params: {
-          challenge,
-        },
+      const url = new URL(
+        `${this.config.metadataServiceDomain.url}/v2/ethereum/${chainId}/safe/account/${safeContractAddress}`,
+      );
+      url.searchParams.set("challenge", challenge);
+      const response = await fetch(url, {
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+          ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
         },
       });
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      const data = (await response.json()) as SafeAccountDto;
 
-      if (!response.data) {
+      if (!data) {
         return Left(
           new Error(
             "[ContextModule] HttpSafeAccountDataSource: unexpected empty response",
@@ -49,7 +51,7 @@ export class HttpSafeAccountDataSource implements SafeAccountDataSource {
         );
       }
 
-      if (!this.isSafeAccountDto(response.data)) {
+      if (!this.isSafeAccountDto(data)) {
         return Left(
           new Error(
             "[ContextModule] HttpSafeAccountDataSource: invalid safe account response format",
@@ -59,14 +61,14 @@ export class HttpSafeAccountDataSource implements SafeAccountDataSource {
 
       return Right({
         account: {
-          signedDescriptor: response.data.accountDescriptor.signedDescriptor,
-          keyId: response.data.accountDescriptor.keyId,
-          keyUsage: response.data.accountDescriptor.keyUsage,
+          signedDescriptor: data.accountDescriptor.signedDescriptor,
+          keyId: data.accountDescriptor.keyId,
+          keyUsage: data.accountDescriptor.keyUsage,
         },
         signers: {
-          signedDescriptor: response.data.signersDescriptor.signedDescriptor,
-          keyId: response.data.signersDescriptor.keyId,
-          keyUsage: response.data.signersDescriptor.keyUsage,
+          signedDescriptor: data.signersDescriptor.signedDescriptor,
+          keyId: data.signersDescriptor.keyId,
+          keyUsage: data.signersDescriptor.keyUsage,
         },
       });
     } catch (_error) {

--- a/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.ts
+++ b/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.ts
@@ -1,3 +1,4 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { inject } from "inversify";
 import { type Either, Left, Right } from "purify-ts";
 
@@ -17,10 +18,21 @@ import {
 } from "./SafeAccountDataSource";
 
 export class HttpSafeAccountDataSource implements SafeAccountDataSource {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {}
+  ) {
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+        ...(this.config.originToken && {
+          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+        }),
+      },
+    });
+  }
 
   async getDescriptors({
     safeContractAddress,
@@ -28,22 +40,10 @@ export class HttpSafeAccountDataSource implements SafeAccountDataSource {
     challenge,
   }: GetSafeAccountParams): Promise<Either<Error, GetSafeAccountResponse>> {
     try {
-      const url = new URL(
+      const data = (await this.http.get(
         `${this.config.metadataServiceDomain.url}/v2/ethereum/${chainId}/safe/account/${safeContractAddress}`,
-      );
-      url.searchParams.set("challenge", challenge);
-      const response = await fetch(url, {
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          ...(this.config.originToken && {
-            [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-          }),
-        },
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      const data = (await response.json()) as SafeAccountDto;
+        { params: { challenge } },
+      )) as SafeAccountDto;
 
       if (!data) {
         return Left(

--- a/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.test.ts
+++ b/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.test.ts
@@ -3,7 +3,6 @@ import {
   DeviceModelId,
   hexaStringToBuffer,
 } from "@ledgerhq/device-management-kit";
-import axios from "axios";
 import { Left } from "purify-ts";
 
 import type { ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
@@ -11,8 +10,6 @@ import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import { HttpSolanaOwnerInfoDataSource } from "@/solana/data/HttpSolanaOwnerInfoDataSource";
 import type { SolanaTransactionContext } from "@/solana/domain/solanaContextTypes";
 import PACKAGE from "@root/package.json";
-
-vi.mock("axios");
 
 function stringToHex(str: string): string {
   const encoder = new TextEncoder();
@@ -47,7 +44,9 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
       challenge: "random",
       createATA: undefined,
     };
-    vi.spyOn(axios, "request").mockResolvedValueOnce({ data: responseData });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify(responseData)),
+    );
 
     const dataSource = new HttpSolanaOwnerInfoDataSource(config);
     const result = await dataSource.getOwnerInfo(context);
@@ -99,9 +98,14 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
   });
 
   it("should return an error if the descriptor is not valid base64", async () => {
-    vi.spyOn(axios, "request").mockResolvedValueOnce({
-      data: { ...responseData, signedDescriptor: "!!!not-valid-base64!!!" },
-    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          ...responseData,
+          signedDescriptor: "!!!not-valid-base64!!!",
+        }),
+      ),
+    );
     const context: SolanaTransactionContext = {
       deviceModelId: DeviceModelId.FLEX,
       tokenAddress: "some-token",
@@ -122,7 +126,7 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
   });
 
   it("should return an error if the metadata request fails", async () => {
-    vi.spyOn(axios, "request").mockRejectedValueOnce(
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(
       new Error("Network error"),
     );
     const context: SolanaTransactionContext = {
@@ -144,10 +148,10 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
     );
   });
 
-  it("should return an error if axios request return wrong shape for fetchAddressMetadata", async () => {
-    vi.spyOn(axios, "request").mockResolvedValueOnce({
-      data: { wrong: "field" },
-    });
+  it("should return an error if fetch request return wrong shape for fetchAddressMetadata", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ wrong: "field" })),
+    );
 
     const context: SolanaTransactionContext = {
       deviceModelId: DeviceModelId.FLEX,
@@ -168,10 +172,10 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
     );
   });
 
-  it("should return an error if axios request return wrong shape for computeAddressMetadata", async () => {
-    vi.spyOn(axios, "request").mockResolvedValueOnce({
-      data: { wrong: "field" },
-    });
+  it("should return an error if fetch request return wrong shape for computeAddressMetadata", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ wrong: "field" })),
+    );
 
     const context: SolanaTransactionContext = {
       deviceModelId: DeviceModelId.FLEX,
@@ -206,21 +210,22 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
     );
   });
 
-  it("should call axios with correct headers", async () => {
+  it("should call fetch with correct headers", async () => {
     const context: SolanaTransactionContext = {
       deviceModelId: DeviceModelId.FLEX,
       tokenAddress: "some-token",
       challenge: "random",
       createATA: undefined,
     };
-    const spy = vi
-      .spyOn(axios, "request")
-      .mockResolvedValueOnce({ data: responseData });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify(responseData)));
 
     const dataSource = new HttpSolanaOwnerInfoDataSource(config);
     await dataSource.getOwnerInfo(context);
 
-    expect(spy).toHaveBeenCalledWith(
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.any(String),
       expect.objectContaining({
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,

--- a/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.test.ts
+++ b/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.test.ts
@@ -225,7 +225,7 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
     await dataSource.getOwnerInfo(context);
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      expect.any(String),
+      expect.any(URL),
       expect.objectContaining({
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,

--- a/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.test.ts
+++ b/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.test.ts
@@ -1,15 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   DeviceModelId,
+  type DmkNetworkClient,
   hexaStringToBuffer,
 } from "@ledgerhq/device-management-kit";
 import { Left } from "purify-ts";
 
 import type { ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import { HttpSolanaOwnerInfoDataSource } from "@/solana/data/HttpSolanaOwnerInfoDataSource";
 import type { SolanaTransactionContext } from "@/solana/domain/solanaContextTypes";
-import PACKAGE from "@root/package.json";
 
 function stringToHex(str: string): string {
   const encoder = new TextEncoder();
@@ -33,8 +32,11 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
     signedDescriptor: signedDescriptorHex,
   };
 
+  let httpMock: { get: ReturnType<typeof vi.fn> };
+
   beforeEach(() => {
     vi.resetAllMocks();
+    httpMock = { get: vi.fn() };
   });
 
   it("should fetch address metadata via tokenAddress", async () => {
@@ -44,13 +46,18 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
       challenge: "random",
       createATA: undefined,
     };
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify(responseData)),
-    );
+    httpMock.get.mockResolvedValueOnce(responseData);
 
-    const dataSource = new HttpSolanaOwnerInfoDataSource(config);
+    const dataSource = new HttpSolanaOwnerInfoDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
     const result = await dataSource.getOwnerInfo(context);
 
+    expect(httpMock.get).toHaveBeenCalledWith(
+      `${config.metadataServiceDomain.url}/v2/solana/owner/some-token`,
+      { params: { challenge: "random" } },
+    );
     expect(result.isRight()).toBe(true);
     expect(result.extract()).toEqual({
       tlvDescriptor: hexaStringToBuffer(signedDescriptorHex),
@@ -65,7 +72,10 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
       createATA: undefined,
     };
 
-    const dataSource = new HttpSolanaOwnerInfoDataSource(config);
+    const dataSource = new HttpSolanaOwnerInfoDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
     const result = await dataSource.getOwnerInfo(context);
 
     expect(result).toEqual(
@@ -85,7 +95,10 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
       createATA: undefined,
     };
 
-    const dataSource = new HttpSolanaOwnerInfoDataSource(config);
+    const dataSource = new HttpSolanaOwnerInfoDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
     const result = await dataSource.getOwnerInfo(context);
 
     expect(result).toEqual(
@@ -98,14 +111,10 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
   });
 
   it("should return an error if the descriptor is not valid base64", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          ...responseData,
-          signedDescriptor: "!!!not-valid-base64!!!",
-        }),
-      ),
-    );
+    httpMock.get.mockResolvedValueOnce({
+      ...responseData,
+      signedDescriptor: "!!!not-valid-base64!!!",
+    });
     const context: SolanaTransactionContext = {
       deviceModelId: DeviceModelId.FLEX,
       tokenAddress: "some-token",
@@ -113,7 +122,10 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
       createATA: undefined,
     };
 
-    const dataSource = new HttpSolanaOwnerInfoDataSource(config);
+    const dataSource = new HttpSolanaOwnerInfoDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
     const result = await dataSource.getOwnerInfo(context);
 
     expect(result).toEqual(
@@ -126,9 +138,7 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
   });
 
   it("should return an error if the metadata request fails", async () => {
-    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(
-      new Error("Network error"),
-    );
+    httpMock.get.mockRejectedValueOnce(new Error("Network error"));
     const context: SolanaTransactionContext = {
       deviceModelId: DeviceModelId.FLEX,
       tokenAddress: "some-token",
@@ -136,7 +146,10 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
       createATA: undefined,
     };
 
-    const dataSource = new HttpSolanaOwnerInfoDataSource(config);
+    const dataSource = new HttpSolanaOwnerInfoDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
     const result = await dataSource.getOwnerInfo(context);
 
     expect(result).toEqual(
@@ -149,9 +162,7 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
   });
 
   it("should return an error if fetch request return wrong shape for fetchAddressMetadata", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ wrong: "field" })),
-    );
+    httpMock.get.mockResolvedValueOnce({ wrong: "field" });
 
     const context: SolanaTransactionContext = {
       deviceModelId: DeviceModelId.FLEX,
@@ -160,7 +171,10 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
       createATA: undefined,
     };
 
-    const dataSource = new HttpSolanaOwnerInfoDataSource(config);
+    const dataSource = new HttpSolanaOwnerInfoDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
     const result = await dataSource.getOwnerInfo(context);
 
     expect(result).toEqual(
@@ -173,9 +187,7 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
   });
 
   it("should return an error if fetch request return wrong shape for computeAddressMetadata", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ wrong: "field" })),
-    );
+    httpMock.get.mockResolvedValueOnce({ wrong: "field" });
 
     const context: SolanaTransactionContext = {
       deviceModelId: DeviceModelId.FLEX,
@@ -187,9 +199,16 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
       },
     };
 
-    const dataSource = new HttpSolanaOwnerInfoDataSource(config);
+    const dataSource = new HttpSolanaOwnerInfoDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
     const result = await dataSource.getOwnerInfo(context);
 
+    expect(httpMock.get).toHaveBeenCalledWith(
+      `${config.metadataServiceDomain.url}/v2/solana/computed-token-account/some-address/some-mint`,
+      { params: { challenge: "random" } },
+    );
     expect(result).toEqual(
       Left(
         new Error(
@@ -201,37 +220,15 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
 
   it("should throw if originToken is missing", () => {
     expect(() => {
-      new HttpSolanaOwnerInfoDataSource({
-        ...config,
-        originToken: undefined,
-      } as any);
+      new HttpSolanaOwnerInfoDataSource(
+        {
+          ...config,
+          originToken: undefined,
+        } as any,
+        httpMock as unknown as DmkNetworkClient,
+      );
     }).toThrow(
       "[ContextModule] - HttpSolanaOwnerInfoDataSource: origin token is required",
-    );
-  });
-
-  it("should call fetch with correct headers", async () => {
-    const context: SolanaTransactionContext = {
-      deviceModelId: DeviceModelId.FLEX,
-      tokenAddress: "some-token",
-      challenge: "random",
-      createATA: undefined,
-    };
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(new Response(JSON.stringify(responseData)));
-
-    const dataSource = new HttpSolanaOwnerInfoDataSource(config);
-    await dataSource.getOwnerInfo(context);
-
-    expect(fetchSpy).toHaveBeenCalledWith(
-      expect.any(URL),
-      expect.objectContaining({
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          "X-Ledger-Client-Origin": config.originToken,
-        },
-      }),
     );
   });
 });

--- a/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.ts
+++ b/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.ts
@@ -7,15 +7,11 @@ import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
 import type { ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
+import { networkTypes } from "@/network/di/networkTypes";
 import {
   SolanaSPLOwnerInfo,
   type SolanaTransactionContext,
 } from "@/solana/domain/solanaContextTypes";
-import PACKAGE from "@root/package.json";
 
 import {
   HttpSolanaOwnerInfoDataSourceResult,
@@ -24,23 +20,17 @@ import {
 
 @injectable()
 export class HttpSolanaOwnerInfoDataSource implements SolanaDataSource {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
   ) {
     if (!this.config.originToken) {
       throw new Error(
         "[ContextModule] - HttpSolanaOwnerInfoDataSource: origin token is required",
       );
     }
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-        [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-      },
-    });
   }
 
   private isSolanaSPLOwnerInfo(data: {

--- a/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.ts
+++ b/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.ts
@@ -1,4 +1,7 @@
-import { hexaStringToBuffer } from "@ledgerhq/device-management-kit";
+import {
+  DmkNetworkClient,
+  hexaStringToBuffer,
+} from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -21,6 +24,8 @@ import {
 
 @injectable()
 export class HttpSolanaOwnerInfoDataSource implements SolanaDataSource {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
@@ -30,6 +35,12 @@ export class HttpSolanaOwnerInfoDataSource implements SolanaDataSource {
         "[ContextModule] - HttpSolanaOwnerInfoDataSource: origin token is required",
       );
     }
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+        [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+      },
+    });
   }
 
   private isSolanaSPLOwnerInfo(data: {
@@ -52,21 +63,10 @@ export class HttpSolanaOwnerInfoDataSource implements SolanaDataSource {
     challenge: string,
   ): Promise<Either<Error, SolanaSPLOwnerInfo>> {
     try {
-      const response = await fetch(
-        `${this.config.metadataServiceDomain.url}/v2/solana/owner/${tokenAddress}?challenge=${challenge}`,
-        {
-          headers: {
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            ...(this.config.originToken && {
-              [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-            }),
-          },
-        },
-      );
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      const data = (await response.json()) as SolanaSPLOwnerInfo;
+      const data = (await this.http.get(
+        `${this.config.metadataServiceDomain.url}/v2/solana/owner/${tokenAddress}`,
+        { params: { challenge } },
+      )) as SolanaSPLOwnerInfo;
       if (!this.isSolanaSPLOwnerInfo(data))
         return Left(
           new Error(
@@ -89,21 +89,10 @@ export class HttpSolanaOwnerInfoDataSource implements SolanaDataSource {
     challenge: string,
   ): Promise<Either<Error, SolanaSPLOwnerInfo>> {
     try {
-      const response = await fetch(
-        `${this.config.metadataServiceDomain.url}/v2/solana/computed-token-account/${address}/${mintAddress}?challenge=${challenge}`,
-        {
-          headers: {
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            ...(this.config.originToken && {
-              "X-Ledger-Client-Origin": this.config.originToken,
-            }),
-          },
-        },
-      );
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      const data = (await response.json()) as SolanaSPLOwnerInfo;
+      const data = (await this.http.get(
+        `${this.config.metadataServiceDomain.url}/v2/solana/computed-token-account/${address}/${mintAddress}`,
+        { params: { challenge } },
+      )) as SolanaSPLOwnerInfo;
       if (!this.isSolanaSPLOwnerInfo(data))
         return Left(
           new Error(

--- a/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.ts
+++ b/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.ts
@@ -1,5 +1,4 @@
 import { hexaStringToBuffer } from "@ledgerhq/device-management-kit";
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -52,31 +51,34 @@ export class HttpSolanaOwnerInfoDataSource implements SolanaDataSource {
     tokenAddress: string,
     challenge: string,
   ): Promise<Either<Error, SolanaSPLOwnerInfo>> {
-    return await axios
-      .request<SolanaSPLOwnerInfo>({
-        method: "GET",
-        url: `${this.config.metadataServiceDomain.url}/v2/solana/owner/${tokenAddress}?challenge=${challenge}`,
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+    try {
+      const response = await fetch(
+        `${this.config.metadataServiceDomain.url}/v2/solana/owner/${tokenAddress}?challenge=${challenge}`,
+        {
+          headers: {
+            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+            ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
+          },
         },
-      })
-      .then((res) => {
-        if (!this.isSolanaSPLOwnerInfo(res.data))
-          return Left(
-            new Error(
-              "[ContextModule] - HttpSolanaOwnerInfoDataSource: invalid fetchAddressMetadata response shape",
-            ),
-          );
-        return Right(res.data);
-      })
-      .catch(() =>
-        Left(
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      const data = (await response.json()) as SolanaSPLOwnerInfo;
+      if (!this.isSolanaSPLOwnerInfo(data))
+        return Left(
           new Error(
-            "[ContextModule] - HttpSolanaOwnerInfoDataSource: Failed to fetch address metadata",
+            "[ContextModule] - HttpSolanaOwnerInfoDataSource: invalid fetchAddressMetadata response shape",
           ),
+        );
+      return Right(data);
+    } catch {
+      return Left(
+        new Error(
+          "[ContextModule] - HttpSolanaOwnerInfoDataSource: Failed to fetch address metadata",
         ),
       );
+    }
   }
 
   async computeAddressMetadata(
@@ -84,31 +86,34 @@ export class HttpSolanaOwnerInfoDataSource implements SolanaDataSource {
     mintAddress: string,
     challenge: string,
   ): Promise<Either<Error, SolanaSPLOwnerInfo>> {
-    return await axios
-      .request<SolanaSPLOwnerInfo>({
-        method: "GET",
-        url: `${this.config.metadataServiceDomain.url}/v2/solana/computed-token-account/${address}/${mintAddress}?challenge=${challenge}`,
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          "X-Ledger-Client-Origin": this.config.originToken,
+    try {
+      const response = await fetch(
+        `${this.config.metadataServiceDomain.url}/v2/solana/computed-token-account/${address}/${mintAddress}?challenge=${challenge}`,
+        {
+          headers: {
+            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+            ...(this.config.originToken && { "X-Ledger-Client-Origin": this.config.originToken }),
+          },
         },
-      })
-      .then((res) => {
-        if (!this.isSolanaSPLOwnerInfo(res.data))
-          return Left(
-            new Error(
-              "[ContextModule] - HttpSolanaOwnerInfoDataSource: invalid computeAddressMetadata response shape",
-            ),
-          );
-        return Right(res.data);
-      })
-      .catch(() =>
-        Left(
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      const data = (await response.json()) as SolanaSPLOwnerInfo;
+      if (!this.isSolanaSPLOwnerInfo(data))
+        return Left(
           new Error(
-            "[ContextModule] - HttpSolanaOwnerInfoDataSource: Failed to compute address metadata",
+            "[ContextModule] - HttpSolanaOwnerInfoDataSource: invalid computeAddressMetadata response shape",
           ),
+        );
+      return Right(data);
+    } catch {
+      return Left(
+        new Error(
+          "[ContextModule] - HttpSolanaOwnerInfoDataSource: Failed to compute address metadata",
         ),
       );
+    }
   }
 
   async getOwnerInfo(

--- a/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.ts
+++ b/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.ts
@@ -57,7 +57,9 @@ export class HttpSolanaOwnerInfoDataSource implements SolanaDataSource {
         {
           headers: {
             [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
+            ...(this.config.originToken && {
+              [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+            }),
           },
         },
       );
@@ -92,7 +94,9 @@ export class HttpSolanaOwnerInfoDataSource implements SolanaDataSource {
         {
           headers: {
             [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            ...(this.config.originToken && { "X-Ledger-Client-Origin": this.config.originToken }),
+            ...(this.config.originToken && {
+              "X-Ledger-Client-Origin": this.config.originToken,
+            }),
           },
         },
       );

--- a/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.test.ts
+++ b/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import axios from "axios";
 import { Left, Right } from "purify-ts";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -13,8 +12,6 @@ import {
   type GetTransactionDescriptorsResponse,
   type SolanaLifiDataSource,
 } from "./SolanaLifiDataSource";
-
-vi.mock("axios");
 
 const mockLoggerFactory = () => ({
   debug: vi.fn(),
@@ -43,24 +40,20 @@ describe("HttpSolanaLifiDataSource", () => {
     vi.clearAllMocks();
   });
 
-  it("should call axios with the ledger client version header and correct params", async () => {
+  it("should call fetch with the ledger client version header and correct params", async () => {
     // given
-    const requestSpy = vi.fn(() => Promise.resolve({ data: [] }));
-    vi.spyOn(axios, "request").mockImplementation(requestSpy);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([])),
+    );
 
     // when
     await datasource.getTransactionDescriptorsPayload({ templateId });
 
     // then
-    expect(requestSpy).toHaveBeenCalledTimes(1);
-    expect(requestSpy).toHaveBeenCalledWith(
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.any(URL),
       expect.objectContaining({
-        method: "GET",
-        url: `${config.cal.url}/swap_templates`,
-        params: {
-          id: templateId,
-          output: "id,chain_id,instructions,descriptors",
-        },
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
         },
@@ -68,7 +61,7 @@ describe("HttpSolanaLifiDataSource", () => {
     );
   });
 
-  it("should return Right(data[0]) when axios responds with a non-empty array", async () => {
+  it("should return Right(data[0]) when fetch responds with a non-empty array", async () => {
     // given
     const response0: GetTransactionDescriptorsResponse = {
       descriptors: {
@@ -76,7 +69,9 @@ describe("HttpSolanaLifiDataSource", () => {
       },
     } as any;
 
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [response0] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([response0])),
+    );
 
     // when
     const result = await datasource.getTransactionDescriptorsPayload({
@@ -89,7 +84,7 @@ describe("HttpSolanaLifiDataSource", () => {
 
   it("should return an error when data is undefined", async () => {
     // given
-    vi.spyOn(axios, "request").mockResolvedValue({ data: undefined });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("null"));
 
     // when
     const result = await datasource.getTransactionDescriptorsPayload({
@@ -108,7 +103,9 @@ describe("HttpSolanaLifiDataSource", () => {
 
   it("should return an error when data array is empty", async () => {
     // given
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([])),
+    );
 
     // when
     const result = await datasource.getTransactionDescriptorsPayload({
@@ -127,7 +124,9 @@ describe("HttpSolanaLifiDataSource", () => {
 
   it("should return an error when first element is falsy", async () => {
     // given
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [undefined] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([null])),
+    );
 
     // when
     const result = await datasource.getTransactionDescriptorsPayload({
@@ -144,9 +143,9 @@ describe("HttpSolanaLifiDataSource", () => {
     );
   });
 
-  it("should return an error when axios throws", async () => {
+  it("should return an error when fetch throws", async () => {
     // given
-    vi.spyOn(axios, "request").mockRejectedValue(new Error("network"));
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
 
     // when
     const result = await datasource.getTransactionDescriptorsPayload({

--- a/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.test.ts
+++ b/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.test.ts
@@ -1,11 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
 
 import { HttpSolanaLifiDataSource } from "./HttpSolanaLifiDataSource";
 import {
@@ -23,6 +22,7 @@ const mockLoggerFactory = () => ({
 
 describe("HttpSolanaLifiDataSource", () => {
   let datasource: SolanaLifiDataSource;
+  let httpMock: { get: ReturnType<typeof vi.fn> };
   const templateId = "tpl-123";
   const config: ContextModuleServiceConfig = {
     cal: {
@@ -32,36 +32,38 @@ describe("HttpSolanaLifiDataSource", () => {
     },
   } as ContextModuleServiceConfig;
 
-  beforeAll(() => {
-    datasource = new HttpSolanaLifiDataSource(config, mockLoggerFactory);
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
+    httpMock = { get: vi.fn() };
+    datasource = new HttpSolanaLifiDataSource(
+      config,
+      mockLoggerFactory,
+      httpMock as unknown as DmkNetworkClient,
+    );
   });
 
-  it("should call fetch with the ledger client version header and correct params", async () => {
+  it("should call the network client with the expected URL and params", async () => {
     // given
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([])),
-    );
+    httpMock.get.mockResolvedValue([]);
 
     // when
     await datasource.getTransactionDescriptorsPayload({ templateId });
 
     // then
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.any(URL),
-      expect.objectContaining({
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+    expect(httpMock.get).toHaveBeenCalledTimes(1);
+    expect(httpMock.get).toHaveBeenCalledWith(
+      "https://crypto-assets-service.api.ledger.com/v1/swap_templates",
+      {
+        params: {
+          template_id: templateId,
+          output: "id,chain_id,instructions,descriptors",
+          ref: "ref=commit:866b6e7633a7a806fab7f9941bcc3df7ee640784",
         },
-      }),
+      },
     );
   });
 
-  it("should return Right(data[0]) when fetch responds with a non-empty array", async () => {
+  it("should return Right(data[0]) when the network client responds with a non-empty array", async () => {
     // given
     const response0: GetTransactionDescriptorsResponse = {
       descriptors: {
@@ -69,9 +71,7 @@ describe("HttpSolanaLifiDataSource", () => {
       },
     } as any;
 
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([response0])),
-    );
+    httpMock.get.mockResolvedValue([response0]);
 
     // when
     const result = await datasource.getTransactionDescriptorsPayload({
@@ -84,7 +84,7 @@ describe("HttpSolanaLifiDataSource", () => {
 
   it("should return an error when data is undefined", async () => {
     // given
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("null"));
+    httpMock.get.mockResolvedValue(null);
 
     // when
     const result = await datasource.getTransactionDescriptorsPayload({
@@ -103,9 +103,7 @@ describe("HttpSolanaLifiDataSource", () => {
 
   it("should return an error when data array is empty", async () => {
     // given
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([])),
-    );
+    httpMock.get.mockResolvedValue([]);
 
     // when
     const result = await datasource.getTransactionDescriptorsPayload({
@@ -124,9 +122,7 @@ describe("HttpSolanaLifiDataSource", () => {
 
   it("should return an error when first element is falsy", async () => {
     // given
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([null])),
-    );
+    httpMock.get.mockResolvedValue([null]);
 
     // when
     const result = await datasource.getTransactionDescriptorsPayload({
@@ -143,9 +139,9 @@ describe("HttpSolanaLifiDataSource", () => {
     );
   });
 
-  it("should return an error when fetch throws", async () => {
+  it("should return an error when the network client throws", async () => {
     // given
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
+    httpMock.get.mockRejectedValue(new Error("network"));
 
     // when
     const result = await datasource.getTransactionDescriptorsPayload({

--- a/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.ts
+++ b/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.ts
@@ -1,4 +1,7 @@
-import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
+import {
+  DmkNetworkClient,
+  LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -16,6 +19,7 @@ import {
 @injectable()
 export class HttpSolanaLifiDataSource implements SolanaLifiDataSource {
   private logger: LoggerPublisherService;
+  private readonly http: DmkNetworkClient;
 
   constructor(
     @inject(configTypes.Config)
@@ -24,6 +28,11 @@ export class HttpSolanaLifiDataSource implements SolanaLifiDataSource {
     loggerFactory: (tag: string) => LoggerPublisherService,
   ) {
     this.logger = loggerFactory("HttpSolanaLifiDataSource");
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+      },
+    });
   }
 
   public async getTransactionDescriptorsPayload({
@@ -39,25 +48,18 @@ export class HttpSolanaLifiDataSource implements SolanaLifiDataSource {
     );
 
     try {
-      const url = new URL(`${this.config.cal.url}/swap_templates`);
-      url.searchParams.set("template_id", templateId);
-      url.searchParams.set("output", "id,chain_id,instructions,descriptors");
-      // TODO LIFI
-      // REVERT WHEN CAL SUPPORTS IT
-      url.searchParams.set(
-        "ref",
-        "ref=commit:866b6e7633a7a806fab7f9941bcc3df7ee640784",
-      );
-      const response = await fetch(url, {
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+      const data = (await this.http.get(
+        `${this.config.cal.url}/swap_templates`,
+        {
+          params: {
+            template_id: templateId,
+            output: "id,chain_id,instructions,descriptors",
+            // TODO LIFI
+            // REVERT WHEN CAL SUPPORTS IT
+            ref: "ref=commit:866b6e7633a7a806fab7f9941bcc3df7ee640784",
+          },
         },
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      const data =
-        (await response.json()) as GetTransactionDescriptorsResponse[];
+      )) as GetTransactionDescriptorsResponse[];
 
       this.logger.debug(
         "[getTransactionDescriptorsPayload] Received response",

--- a/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.ts
+++ b/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.ts
@@ -7,8 +7,7 @@ import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
+import { networkTypes } from "@/network/di/networkTypes";
 
 import {
   GetTransactionDescriptorsParams,
@@ -19,20 +18,16 @@ import {
 @injectable()
 export class HttpSolanaLifiDataSource implements SolanaLifiDataSource {
   private logger: LoggerPublisherService;
-  private readonly http: DmkNetworkClient;
 
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
     @inject(configTypes.ContextModuleLoggerFactory)
     loggerFactory: (tag: string) => LoggerPublisherService,
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
   ) {
     this.logger = loggerFactory("HttpSolanaLifiDataSource");
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-      },
-    });
   }
 
   public async getTransactionDescriptorsPayload({

--- a/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.ts
+++ b/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.ts
@@ -1,5 +1,4 @@
 import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -32,30 +31,33 @@ export class HttpSolanaLifiDataSource implements SolanaLifiDataSource {
   }: GetTransactionDescriptorsParams): Promise<
     Either<Error, GetTransactionDescriptorsResponse>
   > {
-    const url = `${this.config.cal.url}/swap_templates`;
-    const params = {
-      id: templateId,
-      output: "id,chain_id,instructions,descriptors",
-    };
-
     this.logger.debug(
       "[getTransactionDescriptorsPayload] Fetching transaction descriptors",
       {
-        data: { templateId, url, params },
+        data: { templateId },
       },
     );
 
     try {
-      const { data } = await axios.request<GetTransactionDescriptorsResponse[]>(
-        {
-          method: "GET",
-          url,
-          params,
-          headers: {
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          },
-        },
+      const url = new URL(`${this.config.cal.url}/swap_templates`);
+      url.searchParams.set("template_id", templateId);
+      url.searchParams.set("output", "id,chain_id,instructions,descriptors");
+      // TODO LIFI
+      // REVERT WHEN CAL SUPPORTS IT
+      url.searchParams.set(
+        "ref",
+        "ref=commit:866b6e7633a7a806fab7f9941bcc3df7ee640784",
       );
+      const response = await fetch(url, {
+        headers: {
+          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+        },
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      const data =
+        (await response.json()) as GetTransactionDescriptorsResponse[];
 
       this.logger.debug(
         "[getTransactionDescriptorsPayload] Received response",
@@ -99,7 +101,6 @@ export class HttpSolanaLifiDataSource implements SolanaLifiDataSource {
         {
           data: {
             templateId,
-            url,
             error: error instanceof Error ? error.message : String(error),
           },
         },

--- a/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.test.ts
+++ b/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import axios from "axios";
 import { Left, Right } from "purify-ts";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -13,8 +12,6 @@ import {
   type SolanaTokenDataSource,
   type TokenDataResponse,
 } from "./SolanaTokenDataSource";
-
-vi.mock("axios");
 
 describe("HttpSolanaTokenDataSource", () => {
   let datasource: SolanaTokenDataSource;
@@ -38,24 +35,20 @@ describe("HttpSolanaTokenDataSource", () => {
     vi.clearAllMocks();
   });
 
-  it("should call axios with the ledger client version header and correct params", async () => {
+  it("should call fetch with the ledger client version header and correct params", async () => {
     // given
-    const requestSpy = vi.fn(() => Promise.resolve({ data: [] }));
-    vi.spyOn(axios, "request").mockImplementation(requestSpy);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([])),
+    );
 
     // when
     await datasource.getTokenInfosPayload({ tokenInternalId });
 
     // then
-    expect(requestSpy).toHaveBeenCalledTimes(1);
-    expect(requestSpy).toHaveBeenCalledWith(
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.any(URL),
       expect.objectContaining({
-        method: "GET",
-        url: `${config.cal.url}/tokens`,
-        params: expect.objectContaining({
-          id: tokenInternalId,
-          ref: `branch:${config.cal.branch}`,
-        }),
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
         },
@@ -63,7 +56,7 @@ describe("HttpSolanaTokenDataSource", () => {
     );
   });
 
-  it("should return Right(data[0]) when axios responds with a non-empty array", async () => {
+  it("should return Right(data[0]) when fetch responds with a non-empty array", async () => {
     // given
     const response0: TokenDataResponse = {
       descriptor: {
@@ -75,7 +68,9 @@ describe("HttpSolanaTokenDataSource", () => {
       },
     } as any;
 
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [response0] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([response0])),
+    );
 
     // when
     const result = await datasource.getTokenInfosPayload({ tokenInternalId });
@@ -85,14 +80,16 @@ describe("HttpSolanaTokenDataSource", () => {
   });
 
   describe.each`
-    caseName                    | apiResponse
-    ${"data is undefined"}      | ${{ data: undefined }}
-    ${"data array is empty"}    | ${{ data: [] }}
-    ${"first element is falsy"} | ${{ data: [undefined] }}
-  `("Error cases", ({ caseName, apiResponse }) => {
+    caseName                    | responseBody
+    ${"data is undefined"}      | ${"null"}
+    ${"data array is empty"}    | ${JSON.stringify([])}
+    ${"first element is falsy"} | ${JSON.stringify([null])}
+  `("Error cases", ({ caseName, responseBody }) => {
     it(`should return an error when ${caseName}`, async () => {
       // given
-      vi.spyOn(axios, "request").mockResolvedValue(apiResponse);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(responseBody as string),
+      );
 
       // when
       const result = await datasource.getTokenInfosPayload({ tokenInternalId });
@@ -102,9 +99,9 @@ describe("HttpSolanaTokenDataSource", () => {
     });
   });
 
-  it("should return an error when axios throws", async () => {
+  it("should return an error when fetch throws", async () => {
     // given
-    vi.spyOn(axios, "request").mockRejectedValue(new Error("network"));
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
 
     // when
     const result = await datasource.getTokenInfosPayload({ tokenInternalId });

--- a/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.test.ts
+++ b/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.test.ts
@@ -1,11 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
 
 import { HttpSolanaTokenDataSource } from "./HttpSolanaTokenDataSource";
 import {
@@ -15,6 +14,7 @@ import {
 
 describe("HttpSolanaTokenDataSource", () => {
   let datasource: SolanaTokenDataSource;
+  let httpMock: { get: ReturnType<typeof vi.fn> };
   const tokenInternalId = "sol:usdc";
   const config: ContextModuleServiceConfig = {
     cal: {
@@ -27,36 +27,35 @@ describe("HttpSolanaTokenDataSource", () => {
   const errorMessage = (id: string) =>
     `[ContextModule] HttpSolanaTokenDataSource: no token metadata for id ${id}`;
 
-  beforeAll(() => {
-    datasource = new HttpSolanaTokenDataSource(config);
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
+    httpMock = { get: vi.fn() };
+    datasource = new HttpSolanaTokenDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
   });
 
-  it("should call fetch with the ledger client version header and correct params", async () => {
+  it("should call http.get with the correct url and params", async () => {
     // given
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([])),
-    );
+    httpMock.get.mockResolvedValue([]);
 
     // when
     await datasource.getTokenInfosPayload({ tokenInternalId });
 
     // then
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.any(URL),
-      expect.objectContaining({
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-        },
-      }),
-    );
+    expect(httpMock.get).toHaveBeenCalledTimes(1);
+    expect(httpMock.get).toHaveBeenCalledWith(`${config.cal.url}/tokens`, {
+      params: {
+        id: tokenInternalId,
+        output:
+          "id,name,network,network_family,network_type,exchange_app_config_serialized,live_signature,ticker,decimals,blockchain_name,chain_id,contract_address,descriptor,descriptor_exchange_app,units,symbol",
+        ref: `branch:${config.cal.branch}`,
+      },
+    });
   });
 
-  it("should return Right(data[0]) when fetch responds with a non-empty array", async () => {
+  it("should return Right(data[0]) when http.get responds with a non-empty array", async () => {
     // given
     const response0: TokenDataResponse = {
       descriptor: {
@@ -68,9 +67,7 @@ describe("HttpSolanaTokenDataSource", () => {
       },
     } as any;
 
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([response0])),
-    );
+    httpMock.get.mockResolvedValue([response0]);
 
     // when
     const result = await datasource.getTokenInfosPayload({ tokenInternalId });
@@ -81,15 +78,13 @@ describe("HttpSolanaTokenDataSource", () => {
 
   describe.each`
     caseName                    | responseBody
-    ${"data is undefined"}      | ${"null"}
-    ${"data array is empty"}    | ${JSON.stringify([])}
-    ${"first element is falsy"} | ${JSON.stringify([null])}
+    ${"data is undefined"}      | ${null}
+    ${"data array is empty"}    | ${[]}
+    ${"first element is falsy"} | ${[null]}
   `("Error cases", ({ caseName, responseBody }) => {
     it(`should return an error when ${caseName}`, async () => {
       // given
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(responseBody as string),
-      );
+      httpMock.get.mockResolvedValue(responseBody);
 
       // when
       const result = await datasource.getTokenInfosPayload({ tokenInternalId });
@@ -99,9 +94,9 @@ describe("HttpSolanaTokenDataSource", () => {
     });
   });
 
-  it("should return an error when fetch throws", async () => {
+  it("should return an error when http.get throws", async () => {
     // given
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
+    httpMock.get.mockRejectedValue(new Error("network"));
 
     // when
     const result = await datasource.getTokenInfosPayload({ tokenInternalId });

--- a/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.ts
+++ b/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.ts
@@ -4,8 +4,7 @@ import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
+import { networkTypes } from "@/network/di/networkTypes";
 
 import {
   GetSolanaTokenInfosParams,
@@ -15,18 +14,12 @@ import {
 
 @injectable()
 export class HttpSolanaTokenDataSource implements SolanaTokenDataSource {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-      },
-    });
-  }
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
+  ) {}
 
   public async getTokenInfosPayload({
     tokenInternalId,

--- a/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.ts
+++ b/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -23,19 +22,22 @@ export class HttpSolanaTokenDataSource implements SolanaTokenDataSource {
     tokenInternalId,
   }: GetSolanaTokenInfosParams): Promise<Either<Error, TokenDataResponse>> {
     try {
-      const { data } = await axios.request<TokenDataResponse[]>({
-        method: "GET",
-        url: `${this.config.cal.url}/tokens`,
-        params: {
-          id: tokenInternalId,
-          output:
-            "id,name,network,network_family,network_type,exchange_app_config_serialized,live_signature,ticker,decimals,blockchain_name,chain_id,contract_address,descriptor,descriptor_exchange_app,units,symbol",
-          ref: `branch:${this.config.cal.branch}`,
-        },
+      const url = new URL(`${this.config.cal.url}/tokens`);
+      url.searchParams.set("id", tokenInternalId);
+      url.searchParams.set(
+        "output",
+        "id,name,network,network_family,network_type,exchange_app_config_serialized,live_signature,ticker,decimals,blockchain_name,chain_id,contract_address,descriptor,descriptor_exchange_app,units,symbol",
+      );
+      url.searchParams.set("ref", `branch:${this.config.cal.branch}`);
+      const response = await fetch(url, {
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
         },
       });
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      const data = (await response.json()) as TokenDataResponse[];
 
       if (!data || data.length === 0 || !data[0]) {
         return Left(

--- a/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.ts
+++ b/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.ts
@@ -1,3 +1,4 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -14,30 +15,31 @@ import {
 
 @injectable()
 export class HttpSolanaTokenDataSource implements SolanaTokenDataSource {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {}
+  ) {
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+      },
+    });
+  }
+
   public async getTokenInfosPayload({
     tokenInternalId,
   }: GetSolanaTokenInfosParams): Promise<Either<Error, TokenDataResponse>> {
     try {
-      const url = new URL(`${this.config.cal.url}/tokens`);
-      url.searchParams.set("id", tokenInternalId);
-      url.searchParams.set(
-        "output",
-        "id,name,network,network_family,network_type,exchange_app_config_serialized,live_signature,ticker,decimals,blockchain_name,chain_id,contract_address,descriptor,descriptor_exchange_app,units,symbol",
-      );
-      url.searchParams.set("ref", `branch:${this.config.cal.branch}`);
-      const response = await fetch(url, {
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+      const data = (await this.http.get(`${this.config.cal.url}/tokens`, {
+        params: {
+          id: tokenInternalId,
+          output:
+            "id,name,network,network_family,network_type,exchange_app_config_serialized,live_signature,ticker,decimals,blockchain_name,chain_id,contract_address,descriptor,descriptor_exchange_app,units,symbol",
+          ref: `branch:${this.config.cal.branch}`,
         },
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      const data = (await response.json()) as TokenDataResponse[];
+      })) as TokenDataResponse[];
 
       if (!data || data.length === 0 || !data[0]) {
         return Left(

--- a/packages/signer/context-module/src/token/data/HttpTokenDataSource.test.ts
+++ b/packages/signer/context-module/src/token/data/HttpTokenDataSource.test.ts
@@ -140,9 +140,7 @@ describe("HttpTokenDataSource", () => {
   it("should return undefined when no decimals", async () => {
     // GIVEN
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(
-        JSON.stringify([{ live_signature: "0x0", ticker: "USDC" }]),
-      ),
+      new Response(JSON.stringify([{ live_signature: "0x0", ticker: "USDC" }])),
     );
 
     // WHEN

--- a/packages/signer/context-module/src/token/data/HttpTokenDataSource.test.ts
+++ b/packages/signer/context-module/src/token/data/HttpTokenDataSource.test.ts
@@ -1,16 +1,17 @@
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { Left } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import { HttpTokenDataSource } from "@/token/data/HttpTokenDataSource";
 import { type TokenDataSource } from "@/token/data/TokenDataSource";
 import { type TokenDto } from "@/token/data/TokenDto";
-import PACKAGE from "@root/package.json";
 
 describe("HttpTokenDataSource", () => {
   let datasource: TokenDataSource;
+  let httpMock: { get: ReturnType<typeof vi.fn> };
 
-  beforeAll(() => {
+  beforeEach(() => {
+    vi.clearAllMocks();
     const config = {
       cal: {
         url: "https://crypto-assets-service.api.ledger.com/v1",
@@ -18,26 +19,31 @@ describe("HttpTokenDataSource", () => {
         branch: "main",
       },
     } as ContextModuleServiceConfig;
-    datasource = new HttpTokenDataSource(config);
-    vi.clearAllMocks();
+    httpMock = { get: vi.fn() };
+    datasource = new HttpTokenDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
   });
 
-  it("should call fetch with the ledger client version header", async () => {
+  it("should call the expected CAL tokens URL with params", async () => {
     // GIVEN
-    const version = `context-module/${PACKAGE.version}`;
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([])),
-    );
+    httpMock.get.mockResolvedValue([]);
 
     // WHEN
     await datasource.getTokenInfosPayload({ address: "0x00", chainId: 1 });
 
     // THEN
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.any(URL),
-      expect.objectContaining({
-        headers: { [LEDGER_CLIENT_VERSION_HEADER]: version },
-      }),
+    expect(httpMock.get).toHaveBeenCalledWith(
+      "https://crypto-assets-service.api.ledger.com/v1/tokens",
+      {
+        params: {
+          contract_address: "0x00",
+          chain_id: 1,
+          output: "descriptor",
+          ref: "branch:main",
+        },
+      },
     );
   });
 
@@ -52,9 +58,7 @@ describe("HttpTokenDataSource", () => {
         },
       },
     };
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([tokenDTO])),
-    );
+    httpMock.get.mockResolvedValue([tokenDTO]);
 
     // WHEN
     const result = await datasource.getTokenInfosPayload({
@@ -79,9 +83,7 @@ describe("HttpTokenDataSource", () => {
         },
       },
     };
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([tokenDTO])),
-    );
+    httpMock.get.mockResolvedValue([tokenDTO]);
 
     // WHEN
     const result = await datasource.getTokenInfosPayload({
@@ -97,7 +99,7 @@ describe("HttpTokenDataSource", () => {
 
   it("should return an error when data is empty", async () => {
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("null"));
+    httpMock.get.mockResolvedValue(null);
 
     // WHEN
     const result = await datasource.getTokenInfosPayload({
@@ -117,9 +119,7 @@ describe("HttpTokenDataSource", () => {
 
   it("should return undefined when no signature", async () => {
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([{}])),
-    );
+    httpMock.get.mockResolvedValue([{}]);
 
     // WHEN
     const result = await datasource.getTokenInfosPayload({
@@ -139,9 +139,7 @@ describe("HttpTokenDataSource", () => {
 
   it("should return undefined when no decimals", async () => {
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([{ live_signature: "0x0", ticker: "USDC" }])),
-    );
+    httpMock.get.mockResolvedValue([{ live_signature: "0x0", ticker: "USDC" }]);
 
     // WHEN
     const result = await datasource.getTokenInfosPayload({
@@ -159,9 +157,9 @@ describe("HttpTokenDataSource", () => {
     );
   });
 
-  it("should return an error when fetch throws an error", async () => {
+  it("should return an error when network client throws an error", async () => {
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error());
+    httpMock.get.mockRejectedValue(new Error());
 
     // WHEN
     const result = await datasource.getTokenInfosPayload({

--- a/packages/signer/context-module/src/token/data/HttpTokenDataSource.test.ts
+++ b/packages/signer/context-module/src/token/data/HttpTokenDataSource.test.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { Left } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
@@ -7,8 +6,6 @@ import { HttpTokenDataSource } from "@/token/data/HttpTokenDataSource";
 import { type TokenDataSource } from "@/token/data/TokenDataSource";
 import { type TokenDto } from "@/token/data/TokenDto";
 import PACKAGE from "@root/package.json";
-
-vi.mock("axios");
 
 describe("HttpTokenDataSource", () => {
   let datasource: TokenDataSource;
@@ -25,24 +22,26 @@ describe("HttpTokenDataSource", () => {
     vi.clearAllMocks();
   });
 
-  it("should call axios with the ledger client version header", async () => {
+  it("should call fetch with the ledger client version header", async () => {
     // GIVEN
     const version = `context-module/${PACKAGE.version}`;
-    const requestSpy = vi.fn(() => Promise.resolve({ data: [] }));
-    vi.spyOn(axios, "request").mockImplementation(requestSpy);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([])),
+    );
 
     // WHEN
     await datasource.getTokenInfosPayload({ address: "0x00", chainId: 1 });
 
     // THEN
-    expect(requestSpy).toHaveBeenCalledWith(
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.any(URL),
       expect.objectContaining({
         headers: { [LEDGER_CLIENT_VERSION_HEADER]: version },
       }),
     );
   });
 
-  it("should return a string when axios response is correct", async () => {
+  it("should return a string when response is correct", async () => {
     // GIVEN
     const tokenDTO: TokenDto = {
       ticker: "USDC",
@@ -53,7 +52,9 @@ describe("HttpTokenDataSource", () => {
         },
       },
     };
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [tokenDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([tokenDTO])),
+    );
 
     // WHEN
     const result = await datasource.getTokenInfosPayload({
@@ -67,7 +68,7 @@ describe("HttpTokenDataSource", () => {
     );
   });
 
-  it("should return a string when axios response is correct with a prefixed ticker", async () => {
+  it("should return a string when response is correct with a prefixed ticker", async () => {
     // GIVEN
     const tokenDTO: TokenDto = {
       ticker: "tUSDC",
@@ -78,7 +79,9 @@ describe("HttpTokenDataSource", () => {
         },
       },
     };
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [tokenDTO] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([tokenDTO])),
+    );
 
     // WHEN
     const result = await datasource.getTokenInfosPayload({
@@ -94,7 +97,7 @@ describe("HttpTokenDataSource", () => {
 
   it("should return an error when data is empty", async () => {
     // GIVEN
-    vi.spyOn(axios, "request").mockResolvedValue({ data: undefined });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("null"));
 
     // WHEN
     const result = await datasource.getTokenInfosPayload({
@@ -114,7 +117,9 @@ describe("HttpTokenDataSource", () => {
 
   it("should return undefined when no signature", async () => {
     // GIVEN
-    vi.spyOn(axios, "request").mockResolvedValue({ data: [{}] });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([{}])),
+    );
 
     // WHEN
     const result = await datasource.getTokenInfosPayload({
@@ -134,9 +139,11 @@ describe("HttpTokenDataSource", () => {
 
   it("should return undefined when no decimals", async () => {
     // GIVEN
-    vi.spyOn(axios, "request").mockResolvedValue({
-      data: [{ live_signature: "0x0", ticker: "USDC" }],
-    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify([{ live_signature: "0x0", ticker: "USDC" }]),
+      ),
+    );
 
     // WHEN
     const result = await datasource.getTokenInfosPayload({
@@ -154,9 +161,9 @@ describe("HttpTokenDataSource", () => {
     );
   });
 
-  it("should return an error when axios throws an error", async () => {
+  it("should return an error when fetch throws an error", async () => {
     // GIVEN
-    vi.spyOn(axios, "request").mockRejectedValue(new Error());
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error());
 
     // WHEN
     const result = await datasource.getTokenInfosPayload({

--- a/packages/signer/context-module/src/token/data/HttpTokenDataSource.ts
+++ b/packages/signer/context-module/src/token/data/HttpTokenDataSource.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -21,20 +20,21 @@ export class HttpTokenDataSource implements TokenDataSource {
     address,
   }: GetTokenInfosParams): Promise<Either<Error, string>> {
     try {
-      const response = await axios.request<TokenDto[]>({
-        method: "GET",
-        url: `${this.config.cal.url}/tokens`,
-        params: {
-          contract_address: address,
-          chain_id: chainId,
-          output: "descriptor",
-          ref: `branch:${this.config.cal.branch}`,
-        },
+      const url = new URL(`${this.config.cal.url}/tokens`);
+      url.searchParams.set("contract_address", address);
+      url.searchParams.set("chain_id", String(chainId));
+      url.searchParams.set("output", "descriptor");
+      url.searchParams.set("ref", `branch:${this.config.cal.branch}`);
+      const response = await fetch(url, {
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
         },
       });
-      const tokenInfos = response.data?.[0];
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      const data = (await response.json()) as TokenDto[];
+      const tokenInfos = data?.[0];
 
       if (
         !tokenInfos ||

--- a/packages/signer/context-module/src/token/data/HttpTokenDataSource.ts
+++ b/packages/signer/context-module/src/token/data/HttpTokenDataSource.ts
@@ -1,3 +1,4 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -11,29 +12,32 @@ import { TokenDto } from "./TokenDto";
 
 @injectable()
 export class HttpTokenDataSource implements TokenDataSource {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {}
+  ) {
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+      },
+    });
+  }
+
   public async getTokenInfosPayload({
     chainId,
     address,
   }: GetTokenInfosParams): Promise<Either<Error, string>> {
     try {
-      const url = new URL(`${this.config.cal.url}/tokens`);
-      url.searchParams.set("contract_address", address);
-      url.searchParams.set("chain_id", String(chainId));
-      url.searchParams.set("output", "descriptor");
-      url.searchParams.set("ref", `branch:${this.config.cal.branch}`);
-      const response = await fetch(url, {
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+      const data = (await this.http.get(`${this.config.cal.url}/tokens`, {
+        params: {
+          contract_address: address,
+          chain_id: chainId,
+          output: "descriptor",
+          ref: `branch:${this.config.cal.branch}`,
         },
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      const data = (await response.json()) as TokenDto[];
+      })) as TokenDto[];
       const tokenInfos = data?.[0];
 
       if (

--- a/packages/signer/context-module/src/token/data/HttpTokenDataSource.ts
+++ b/packages/signer/context-module/src/token/data/HttpTokenDataSource.ts
@@ -4,26 +4,19 @@ import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
 import type { ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
+import { networkTypes } from "@/network/di/networkTypes";
 
 import { GetTokenInfosParams, TokenDataSource } from "./TokenDataSource";
 import { TokenDto } from "./TokenDto";
 
 @injectable()
 export class HttpTokenDataSource implements TokenDataSource {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-      },
-    });
-  }
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
+  ) {}
 
   public async getTokenInfosPayload({
     chainId,

--- a/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.test.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.test.ts
@@ -1,14 +1,10 @@
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
 import { type TransactionCheckDto } from "@/transaction-check/data/dto/TransactionCheckDto";
 import { HttpTransactionCheckDataSource } from "@/transaction-check/data/HttpTransactionCheckDataSource";
 import { type GetTransactionCheckParams } from "@/transaction-check/data/TransactionCheckDataSource";
-import PACKAGE from "@root/package.json";
 
 describe("HttpTransactionCheckDataSource", () => {
   const config = {
@@ -18,8 +14,16 @@ describe("HttpTransactionCheckDataSource", () => {
     originToken: "originToken",
   } as ContextModuleServiceConfig;
 
+  let httpMock: { post: ReturnType<typeof vi.fn> };
+  let dataSource: HttpTransactionCheckDataSource;
+
   beforeEach(() => {
     vi.resetAllMocks();
+    httpMock = { post: vi.fn() };
+    dataSource = new HttpTransactionCheckDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
   });
 
   describe("getTransactionCheck", () => {
@@ -34,12 +38,9 @@ describe("HttpTransactionCheckDataSource", () => {
         public_key_id: "test-key-id",
         descriptor: "test-descriptor",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-        new Response(JSON.stringify(dto)),
-      );
+      httpMock.post.mockResolvedValueOnce(dto);
 
       // WHEN
-      const dataSource = new HttpTransactionCheckDataSource(config);
       const result = await dataSource.getTransactionCheck(params);
 
       // THEN
@@ -58,10 +59,9 @@ describe("HttpTransactionCheckDataSource", () => {
         rawTx: "0xabcdef",
         chainId: 1,
       };
-      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("error"));
+      httpMock.post.mockRejectedValue(new Error("error"));
 
       // WHEN
-      const dataSource = new HttpTransactionCheckDataSource(config);
       const result = await dataSource.getTransactionCheck(params);
 
       // THEN
@@ -81,13 +81,9 @@ describe("HttpTransactionCheckDataSource", () => {
         rawTx: "0xabcdef",
         chainId: 1,
       };
-      const dto = {};
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(dto)),
-      );
+      httpMock.post.mockResolvedValue({});
 
       // WHEN
-      const dataSource = new HttpTransactionCheckDataSource(config);
       const result = await dataSource.getTransactionCheck(params);
 
       // THEN
@@ -107,15 +103,11 @@ describe("HttpTransactionCheckDataSource", () => {
         rawTx: "0xabcdef",
         chainId: 1,
       };
-      const dto = {
+      httpMock.post.mockResolvedValue({
         descriptor: "test-descriptor",
-      };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(dto)),
-      );
+      });
 
       // WHEN
-      const dataSource = new HttpTransactionCheckDataSource(config);
       const result = await dataSource.getTransactionCheck(params);
 
       // THEN
@@ -135,15 +127,11 @@ describe("HttpTransactionCheckDataSource", () => {
         rawTx: "0xabcdef",
         chainId: 1,
       };
-      const dto = {
+      httpMock.post.mockResolvedValue({
         public_key_id: "test-key-id",
-      };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(dto)),
-      );
+      });
 
       // WHEN
-      const dataSource = new HttpTransactionCheckDataSource(config);
       const result = await dataSource.getTransactionCheck(params);
 
       // THEN
@@ -156,86 +144,28 @@ describe("HttpTransactionCheckDataSource", () => {
       );
     });
 
-    it("should call fetch with the correct headers", async () => {
+    it("should call http.post with the correct URL and body", async () => {
       // GIVEN
       const params: GetTransactionCheckParams = {
         from: "0x1234567890123456789012345678901234567890",
         rawTx: "0xabcdef",
         chainId: 1,
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-        new Response(JSON.stringify({})),
-      );
+      httpMock.post.mockResolvedValueOnce({});
 
       // WHEN
-      const dataSource = new HttpTransactionCheckDataSource(config);
       await dataSource.getTransactionCheck(params);
 
       // THEN
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.any(URL),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
-          }),
-        }),
-      );
-    });
-
-    it("should call fetch with the correct URL and method", async () => {
-      // GIVEN
-      const params: GetTransactionCheckParams = {
-        from: "0x1234567890123456789012345678901234567890",
-        rawTx: "0xabcdef",
-        chainId: 1,
-      };
-      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-        new Response(JSON.stringify({})),
-      );
-
-      // WHEN
-      const dataSource = new HttpTransactionCheckDataSource(config);
-      await dataSource.getTransactionCheck(params);
-
-      // THEN
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.objectContaining({
-          href: `${config.web3checks.url}/ethereum/scan/tx`,
-        }),
-        expect.objectContaining({
-          method: "POST",
-        }),
-      );
-    });
-
-    it("should call fetch with the correct request body", async () => {
-      // GIVEN
-      const params: GetTransactionCheckParams = {
-        from: "0x1234567890123456789012345678901234567890",
-        rawTx: "0xabcdef",
-        chainId: 1,
-      };
-      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-        new Response(JSON.stringify({})),
-      );
-
-      // WHEN
-      const dataSource = new HttpTransactionCheckDataSource(config);
-      await dataSource.getTransactionCheck(params);
-
-      // THEN
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.any(URL),
-        expect.objectContaining({
-          body: JSON.stringify({
-            tx: {
-              from: "0x1234567890123456789012345678901234567890",
-              raw: "0xabcdef",
-            },
-            chain: 1,
-          }),
-        }),
+      expect(httpMock.post).toHaveBeenCalledWith(
+        `${config.web3checks.url}/ethereum/scan/tx`,
+        {
+          tx: {
+            from: "0x1234567890123456789012345678901234567890",
+            raw: "0xabcdef",
+          },
+          chain: 1,
+        },
       );
     });
   });

--- a/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.test.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.test.ts
@@ -13,7 +13,7 @@ import PACKAGE from "@root/package.json";
 describe("HttpTransactionCheckDataSource", () => {
   const config = {
     web3checks: {
-      url: "web3checksUrl",
+      url: "https://web3checks.test",
     },
     originToken: "originToken",
   } as ContextModuleServiceConfig;
@@ -173,7 +173,7 @@ describe("HttpTransactionCheckDataSource", () => {
 
       // THEN
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.any(String),
+        expect.any(URL),
         expect.objectContaining({
           headers: expect.objectContaining({
             [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
@@ -200,7 +200,9 @@ describe("HttpTransactionCheckDataSource", () => {
 
       // THEN
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        `${config.web3checks.url}/ethereum/scan/tx`,
+        expect.objectContaining({
+          href: `${config.web3checks.url}/ethereum/scan/tx`,
+        }),
         expect.objectContaining({
           method: "POST",
         }),
@@ -224,7 +226,7 @@ describe("HttpTransactionCheckDataSource", () => {
 
       // THEN
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.any(String),
+        expect.any(URL),
         expect.objectContaining({
           body: JSON.stringify({
             tx: {

--- a/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.test.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.test.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { Left, Right } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
@@ -10,8 +9,6 @@ import { type TransactionCheckDto } from "@/transaction-check/data/dto/Transacti
 import { HttpTransactionCheckDataSource } from "@/transaction-check/data/HttpTransactionCheckDataSource";
 import { type GetTransactionCheckParams } from "@/transaction-check/data/TransactionCheckDataSource";
 import PACKAGE from "@root/package.json";
-
-vi.mock("axios");
 
 describe("HttpTransactionCheckDataSource", () => {
   const config = {
@@ -37,7 +34,9 @@ describe("HttpTransactionCheckDataSource", () => {
         public_key_id: "test-key-id",
         descriptor: "test-descriptor",
       };
-      vi.spyOn(axios, "request").mockResolvedValueOnce({ data: dto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(JSON.stringify(dto)),
+      );
 
       // WHEN
       const dataSource = new HttpTransactionCheckDataSource(config);
@@ -59,7 +58,7 @@ describe("HttpTransactionCheckDataSource", () => {
         rawTx: "0xabcdef",
         chainId: 1,
       };
-      vi.spyOn(axios, "request").mockRejectedValue(new Error("error"));
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("error"));
 
       // WHEN
       const dataSource = new HttpTransactionCheckDataSource(config);
@@ -83,7 +82,9 @@ describe("HttpTransactionCheckDataSource", () => {
         chainId: 1,
       };
       const dto = {};
-      vi.spyOn(axios, "request").mockResolvedValue({ data: dto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(dto)),
+      );
 
       // WHEN
       const dataSource = new HttpTransactionCheckDataSource(config);
@@ -109,7 +110,9 @@ describe("HttpTransactionCheckDataSource", () => {
       const dto = {
         descriptor: "test-descriptor",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: dto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(dto)),
+      );
 
       // WHEN
       const dataSource = new HttpTransactionCheckDataSource(config);
@@ -135,7 +138,9 @@ describe("HttpTransactionCheckDataSource", () => {
       const dto = {
         public_key_id: "test-key-id",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: dto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(dto)),
+      );
 
       // WHEN
       const dataSource = new HttpTransactionCheckDataSource(config);
@@ -151,75 +156,83 @@ describe("HttpTransactionCheckDataSource", () => {
       );
     });
 
-    it("should call axios with the correct headers", async () => {
+    it("should call fetch with the correct headers", async () => {
       // GIVEN
       const params: GetTransactionCheckParams = {
         from: "0x1234567890123456789012345678901234567890",
         rawTx: "0xabcdef",
         chainId: 1,
       };
-      vi.spyOn(axios, "request").mockResolvedValueOnce({ data: {} });
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(JSON.stringify({})),
+      );
 
       // WHEN
       const dataSource = new HttpTransactionCheckDataSource(config);
       await dataSource.getTransactionCheck(params);
 
       // THEN
-      expect(axios.request).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.any(String),
         expect.objectContaining({
-          headers: {
+          headers: expect.objectContaining({
             [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
             [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
-          },
+          }),
         }),
       );
     });
 
-    it("should call axios with the correct URL and method", async () => {
+    it("should call fetch with the correct URL and method", async () => {
       // GIVEN
       const params: GetTransactionCheckParams = {
         from: "0x1234567890123456789012345678901234567890",
         rawTx: "0xabcdef",
         chainId: 1,
       };
-      vi.spyOn(axios, "request").mockResolvedValueOnce({ data: {} });
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(JSON.stringify({})),
+      );
 
       // WHEN
       const dataSource = new HttpTransactionCheckDataSource(config);
       await dataSource.getTransactionCheck(params);
 
       // THEN
-      expect(axios.request).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        `${config.web3checks.url}/ethereum/scan/tx`,
         expect.objectContaining({
           method: "POST",
-          url: `${config.web3checks.url}/ethereum/scan/tx`,
         }),
       );
     });
 
-    it("should call axios with the correct request data", async () => {
+    it("should call fetch with the correct request body", async () => {
       // GIVEN
       const params: GetTransactionCheckParams = {
         from: "0x1234567890123456789012345678901234567890",
         rawTx: "0xabcdef",
         chainId: 1,
       };
-      vi.spyOn(axios, "request").mockResolvedValueOnce({ data: {} });
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(JSON.stringify({})),
+      );
 
       // WHEN
       const dataSource = new HttpTransactionCheckDataSource(config);
       await dataSource.getTransactionCheck(params);
 
       // THEN
-      expect(axios.request).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.any(String),
         expect.objectContaining({
-          data: {
+          body: JSON.stringify({
             tx: {
               from: "0x1234567890123456789012345678901234567890",
               raw: "0xabcdef",
             },
             chain: 1,
-          },
+          }),
         }),
       );
     });

--- a/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.ts
@@ -1,3 +1,4 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -17,10 +18,21 @@ import {
 
 @injectable()
 export class HttpTransactionCheckDataSource {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {}
+  ) {
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+        ...(this.config.originToken && {
+          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+        }),
+      },
+    });
+  }
 
   public async getTransactionCheck({
     chainId,
@@ -37,24 +49,10 @@ export class HttpTransactionCheckDataSource {
     };
 
     try {
-      const response = await fetch(
+      transactionCheckDto = (await this.http.post(
         `${this.config.web3checks.url}/ethereum/scan/tx`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            ...(this.config.originToken && {
-              [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-            }),
-          },
-          body: JSON.stringify(requestDto),
-        },
-      );
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      transactionCheckDto = (await response.json()) as TransactionCheckDto;
+        requestDto,
+      )) as TransactionCheckDto;
     } catch (_error) {
       return Left(
         new Error(

--- a/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -38,16 +37,24 @@ export class HttpTransactionCheckDataSource {
     };
 
     try {
-      const response = await axios.request<TransactionCheckDto>({
-        method: "POST",
-        url: `${this.config.web3checks.url}/ethereum/scan/tx`,
-        data: requestDto,
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+      const response = await fetch(
+        `${this.config.web3checks.url}/ethereum/scan/tx`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+            ...(this.config.originToken && {
+              [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+            }),
+          },
+          body: JSON.stringify(requestDto),
         },
-      });
-      transactionCheckDto = response.data;
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      transactionCheckDto = (await response.json()) as TransactionCheckDto;
     } catch (_error) {
       return Left(
         new Error(

--- a/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.ts
@@ -4,11 +4,7 @@ import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
+import { networkTypes } from "@/network/di/networkTypes";
 
 import { TransactionCheckDto } from "./dto/TransactionCheckDto";
 import {
@@ -18,21 +14,12 @@ import {
 
 @injectable()
 export class HttpTransactionCheckDataSource {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-        ...(this.config.originToken && {
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-        }),
-      },
-    });
-  }
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
+  ) {}
 
   public async getTransactionCheck({
     chainId,

--- a/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.test.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.test.ts
@@ -1,17 +1,13 @@
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
 import { type TypedDataCheckDto } from "@/transaction-check/data/dto/TypedDataCheckDto";
 import { HttpTypedDataCheckDataSource } from "@/transaction-check/data/HttpTypedDataCheckDataSource";
 import {
   type GetTypedDataCheckParams,
   type TypedData,
 } from "@/transaction-check/data/TypedDataCheckDataSource";
-import PACKAGE from "@root/package.json";
 
 describe("HttpTypedDataCheckDataSource", () => {
   const config = {
@@ -21,8 +17,16 @@ describe("HttpTypedDataCheckDataSource", () => {
     originToken: "originToken",
   } as ContextModuleServiceConfig;
 
+  let httpMock: { post: ReturnType<typeof vi.fn> };
+  let dataSource: HttpTypedDataCheckDataSource;
+
   beforeEach(() => {
     vi.resetAllMocks();
+    httpMock = { post: vi.fn() };
+    dataSource = new HttpTypedDataCheckDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
   });
 
   describe("getTypedDataCheck", () => {
@@ -63,12 +67,9 @@ describe("HttpTypedDataCheckDataSource", () => {
         public_key_id: "test-key-id",
         descriptor: "test-descriptor",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-        new Response(JSON.stringify(dto)),
-      );
+      httpMock.post.mockResolvedValueOnce(dto);
 
       // WHEN
-      const dataSource = new HttpTypedDataCheckDataSource(config);
       const result = await dataSource.getTypedDataCheck(params);
 
       // THEN
@@ -82,10 +83,9 @@ describe("HttpTypedDataCheckDataSource", () => {
 
     it("should return an error if the request fails", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("error"));
+      httpMock.post.mockRejectedValue(new Error("error"));
 
       // WHEN
-      const dataSource = new HttpTypedDataCheckDataSource(config);
       const result = await dataSource.getTypedDataCheck(params);
 
       // THEN
@@ -100,13 +100,9 @@ describe("HttpTypedDataCheckDataSource", () => {
 
     it("should return an error if the response is invalid", async () => {
       // GIVEN
-      const dto = {};
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(dto)),
-      );
+      httpMock.post.mockResolvedValue({});
 
       // WHEN
-      const dataSource = new HttpTypedDataCheckDataSource(config);
       const result = await dataSource.getTypedDataCheck(params);
 
       // THEN
@@ -121,15 +117,11 @@ describe("HttpTypedDataCheckDataSource", () => {
 
     it("should return an error if public_key_id is missing", async () => {
       // GIVEN
-      const dto = {
+      httpMock.post.mockResolvedValue({
         descriptor: "test-descriptor",
-      };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(dto)),
-      );
+      });
 
       // WHEN
-      const dataSource = new HttpTypedDataCheckDataSource(config);
       const result = await dataSource.getTypedDataCheck(params);
 
       // THEN
@@ -144,15 +136,11 @@ describe("HttpTypedDataCheckDataSource", () => {
 
     it("should return an error if descriptor is missing", async () => {
       // GIVEN
-      const dto = {
+      httpMock.post.mockResolvedValue({
         public_key_id: "test-key-id",
-      };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(dto)),
-      );
+      });
 
       // WHEN
-      const dataSource = new HttpTypedDataCheckDataSource(config);
       const result = await dataSource.getTypedDataCheck(params);
 
       // THEN
@@ -167,16 +155,12 @@ describe("HttpTypedDataCheckDataSource", () => {
 
     it("should return an error if public_key_id is null", async () => {
       // GIVEN
-      const dto = {
+      httpMock.post.mockResolvedValue({
         public_key_id: null,
         descriptor: "test-descriptor",
-      };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(dto)),
-      );
+      });
 
       // WHEN
-      const dataSource = new HttpTypedDataCheckDataSource(config);
       const result = await dataSource.getTypedDataCheck(params);
 
       // THEN
@@ -191,16 +175,12 @@ describe("HttpTypedDataCheckDataSource", () => {
 
     it("should return an error if descriptor is null", async () => {
       // GIVEN
-      const dto = {
+      httpMock.post.mockResolvedValue({
         public_key_id: "test-key-id",
         descriptor: null,
-      };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(dto)),
-      );
+      });
 
       // WHEN
-      const dataSource = new HttpTypedDataCheckDataSource(config);
       const result = await dataSource.getTypedDataCheck(params);
 
       // THEN
@@ -213,82 +193,26 @@ describe("HttpTypedDataCheckDataSource", () => {
       );
     });
 
-    it("should call fetch with the correct headers", async () => {
+    it("should call http.post with the correct URL and body", async () => {
       // GIVEN
       const dto: TypedDataCheckDto = {
         public_key_id: "test-key-id",
         descriptor: "test-descriptor",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-        new Response(JSON.stringify(dto)),
-      );
+      httpMock.post.mockResolvedValueOnce(dto);
 
       // WHEN
-      const dataSource = new HttpTypedDataCheckDataSource(config);
       await dataSource.getTypedDataCheck(params);
 
       // THEN
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.any(URL),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
-          }),
-        }),
-      );
-    });
-
-    it("should call fetch with the correct URL and method", async () => {
-      // GIVEN
-      const dto: TypedDataCheckDto = {
-        public_key_id: "test-key-id",
-        descriptor: "test-descriptor",
-      };
-      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-        new Response(JSON.stringify(dto)),
-      );
-
-      // WHEN
-      const dataSource = new HttpTypedDataCheckDataSource(config);
-      await dataSource.getTypedDataCheck(params);
-
-      // THEN
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.objectContaining({
-          href: `${config.web3checks.url}/ethereum/scan/eip-712`,
-        }),
-        expect.objectContaining({
-          method: "POST",
-        }),
-      );
-    });
-
-    it("should call fetch with the correct request body", async () => {
-      // GIVEN
-      const dto: TypedDataCheckDto = {
-        public_key_id: "test-key-id",
-        descriptor: "test-descriptor",
-      };
-      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-        new Response(JSON.stringify(dto)),
-      );
-
-      // WHEN
-      const dataSource = new HttpTypedDataCheckDataSource(config);
-      await dataSource.getTypedDataCheck(params);
-
-      // THEN
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.any(URL),
-        expect.objectContaining({
-          body: JSON.stringify({
-            msg: {
-              from: params.from,
-              data: params.data,
-            },
-          }),
-        }),
+      expect(httpMock.post).toHaveBeenCalledWith(
+        `${config.web3checks.url}/ethereum/scan/eip-712`,
+        {
+          msg: {
+            from: params.from,
+            data: params.data,
+          },
+        },
       );
     });
 
@@ -308,12 +232,9 @@ describe("HttpTypedDataCheckDataSource", () => {
         public_key_id: "test-key-id",
         descriptor: "test-descriptor",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-        new Response(JSON.stringify(dto)),
-      );
+      httpMock.post.mockResolvedValueOnce(dto);
 
       // WHEN
-      const dataSource = new HttpTypedDataCheckDataSource(config);
       const result = await dataSource.getTypedDataCheck(paramsWithEmptyData);
 
       // THEN

--- a/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.test.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.test.ts
@@ -16,7 +16,7 @@ import PACKAGE from "@root/package.json";
 describe("HttpTypedDataCheckDataSource", () => {
   const config = {
     web3checks: {
-      url: "web3checksUrl",
+      url: "https://web3checks.test",
     },
     originToken: "originToken",
   } as ContextModuleServiceConfig;
@@ -229,7 +229,7 @@ describe("HttpTypedDataCheckDataSource", () => {
 
       // THEN
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.any(String),
+        expect.any(URL),
         expect.objectContaining({
           headers: expect.objectContaining({
             [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
@@ -255,7 +255,9 @@ describe("HttpTypedDataCheckDataSource", () => {
 
       // THEN
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        `${config.web3checks.url}/ethereum/scan/eip-712`,
+        expect.objectContaining({
+          href: `${config.web3checks.url}/ethereum/scan/eip-712`,
+        }),
         expect.objectContaining({
           method: "POST",
         }),
@@ -278,7 +280,7 @@ describe("HttpTypedDataCheckDataSource", () => {
 
       // THEN
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.any(String),
+        expect.any(URL),
         expect.objectContaining({
           body: JSON.stringify({
             msg: {

--- a/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.test.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.test.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { Left, Right } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
@@ -13,8 +12,6 @@ import {
   type TypedData,
 } from "@/transaction-check/data/TypedDataCheckDataSource";
 import PACKAGE from "@root/package.json";
-
-vi.mock("axios");
 
 describe("HttpTypedDataCheckDataSource", () => {
   const config = {
@@ -66,7 +63,9 @@ describe("HttpTypedDataCheckDataSource", () => {
         public_key_id: "test-key-id",
         descriptor: "test-descriptor",
       };
-      vi.spyOn(axios, "request").mockResolvedValueOnce({ data: dto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(JSON.stringify(dto)),
+      );
 
       // WHEN
       const dataSource = new HttpTypedDataCheckDataSource(config);
@@ -83,7 +82,7 @@ describe("HttpTypedDataCheckDataSource", () => {
 
     it("should return an error if the request fails", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockRejectedValue(new Error("error"));
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("error"));
 
       // WHEN
       const dataSource = new HttpTypedDataCheckDataSource(config);
@@ -102,7 +101,9 @@ describe("HttpTypedDataCheckDataSource", () => {
     it("should return an error if the response is invalid", async () => {
       // GIVEN
       const dto = {};
-      vi.spyOn(axios, "request").mockResolvedValue({ data: dto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(dto)),
+      );
 
       // WHEN
       const dataSource = new HttpTypedDataCheckDataSource(config);
@@ -123,7 +124,9 @@ describe("HttpTypedDataCheckDataSource", () => {
       const dto = {
         descriptor: "test-descriptor",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: dto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(dto)),
+      );
 
       // WHEN
       const dataSource = new HttpTypedDataCheckDataSource(config);
@@ -144,7 +147,9 @@ describe("HttpTypedDataCheckDataSource", () => {
       const dto = {
         public_key_id: "test-key-id",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: dto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(dto)),
+      );
 
       // WHEN
       const dataSource = new HttpTypedDataCheckDataSource(config);
@@ -166,7 +171,9 @@ describe("HttpTypedDataCheckDataSource", () => {
         public_key_id: null,
         descriptor: "test-descriptor",
       };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: dto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(dto)),
+      );
 
       // WHEN
       const dataSource = new HttpTypedDataCheckDataSource(config);
@@ -188,7 +195,9 @@ describe("HttpTypedDataCheckDataSource", () => {
         public_key_id: "test-key-id",
         descriptor: null,
       };
-      vi.spyOn(axios, "request").mockResolvedValue({ data: dto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(dto)),
+      );
 
       // WHEN
       const dataSource = new HttpTypedDataCheckDataSource(config);
@@ -204,71 +213,79 @@ describe("HttpTypedDataCheckDataSource", () => {
       );
     });
 
-    it("should call axios with the correct headers", async () => {
+    it("should call fetch with the correct headers", async () => {
       // GIVEN
       const dto: TypedDataCheckDto = {
         public_key_id: "test-key-id",
         descriptor: "test-descriptor",
       };
-      vi.spyOn(axios, "request").mockResolvedValueOnce({ data: dto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(JSON.stringify(dto)),
+      );
 
       // WHEN
       const dataSource = new HttpTypedDataCheckDataSource(config);
       await dataSource.getTypedDataCheck(params);
 
       // THEN
-      expect(axios.request).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.any(String),
         expect.objectContaining({
-          headers: {
+          headers: expect.objectContaining({
             [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
             [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
-          },
+          }),
         }),
       );
     });
 
-    it("should call axios with the correct URL and method", async () => {
+    it("should call fetch with the correct URL and method", async () => {
       // GIVEN
       const dto: TypedDataCheckDto = {
         public_key_id: "test-key-id",
         descriptor: "test-descriptor",
       };
-      vi.spyOn(axios, "request").mockResolvedValueOnce({ data: dto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(JSON.stringify(dto)),
+      );
 
       // WHEN
       const dataSource = new HttpTypedDataCheckDataSource(config);
       await dataSource.getTypedDataCheck(params);
 
       // THEN
-      expect(axios.request).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        `${config.web3checks.url}/ethereum/scan/eip-712`,
         expect.objectContaining({
           method: "POST",
-          url: `${config.web3checks.url}/ethereum/scan/eip-712`,
         }),
       );
     });
 
-    it("should call axios with the correct request data", async () => {
+    it("should call fetch with the correct request body", async () => {
       // GIVEN
       const dto: TypedDataCheckDto = {
         public_key_id: "test-key-id",
         descriptor: "test-descriptor",
       };
-      vi.spyOn(axios, "request").mockResolvedValueOnce({ data: dto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(JSON.stringify(dto)),
+      );
 
       // WHEN
       const dataSource = new HttpTypedDataCheckDataSource(config);
       await dataSource.getTypedDataCheck(params);
 
       // THEN
-      expect(axios.request).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.any(String),
         expect.objectContaining({
-          data: {
+          body: JSON.stringify({
             msg: {
               from: params.from,
               data: params.data,
             },
-          },
+          }),
         }),
       );
     });
@@ -289,7 +306,9 @@ describe("HttpTypedDataCheckDataSource", () => {
         public_key_id: "test-key-id",
         descriptor: "test-descriptor",
       };
-      vi.spyOn(axios, "request").mockResolvedValueOnce({ data: dto });
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response(JSON.stringify(dto)),
+      );
 
       // WHEN
       const dataSource = new HttpTypedDataCheckDataSource(config);

--- a/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.ts
@@ -43,7 +43,9 @@ export class HttpTypedDataCheckDataSource implements TypedDataCheckDataSource {
           headers: {
             "Content-Type": "application/json",
             [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
+            ...(this.config.originToken && {
+              [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+            }),
           },
           body: JSON.stringify(requestDto),
         },

--- a/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.ts
@@ -4,11 +4,7 @@ import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
+import { networkTypes } from "@/network/di/networkTypes";
 
 import { TypedDataCheckDto } from "./dto/TypedDataCheckDto";
 import {
@@ -19,21 +15,12 @@ import {
 
 @injectable()
 export class HttpTypedDataCheckDataSource implements TypedDataCheckDataSource {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-        ...(this.config.originToken && {
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-        }),
-      },
-    });
-  }
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
+  ) {}
 
   public async getTypedDataCheck({
     from,

--- a/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.ts
@@ -1,3 +1,4 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -18,10 +19,21 @@ import {
 
 @injectable()
 export class HttpTypedDataCheckDataSource implements TypedDataCheckDataSource {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {}
+  ) {
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+        ...(this.config.originToken && {
+          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+        }),
+      },
+    });
+  }
 
   public async getTypedDataCheck({
     from,
@@ -36,24 +48,10 @@ export class HttpTypedDataCheckDataSource implements TypedDataCheckDataSource {
     };
 
     try {
-      const response = await fetch(
+      typedDataCheckDto = (await this.http.post(
         `${this.config.web3checks.url}/ethereum/scan/eip-712`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            ...(this.config.originToken && {
-              [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-            }),
-          },
-          body: JSON.stringify(requestDto),
-        },
-      );
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      typedDataCheckDto = (await response.json()) as TypedDataCheckDto;
+        requestDto,
+      )) as TypedDataCheckDto;
     } catch (_error) {
       return Left(
         new Error(

--- a/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -37,16 +36,22 @@ export class HttpTypedDataCheckDataSource implements TypedDataCheckDataSource {
     };
 
     try {
-      const response = await axios.request<TypedDataCheckDto>({
-        method: "POST",
-        url: `${this.config.web3checks.url}/ethereum/scan/eip-712`,
-        data: requestDto,
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+      const response = await fetch(
+        `${this.config.web3checks.url}/ethereum/scan/eip-712`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+            ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
+          },
+          body: JSON.stringify(requestDto),
         },
-      });
-      typedDataCheckDto = response.data;
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      typedDataCheckDto = (await response.json()) as TypedDataCheckDto;
     } catch (_error) {
       return Left(
         new Error(

--- a/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.test.ts
+++ b/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.test.ts
@@ -1,13 +1,9 @@
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
 import { HttpTrustedNameDataSource } from "@/trusted-name/data/HttpTrustedNameDataSource";
 import { type TrustedNameDataSource } from "@/trusted-name/data/TrustedNameDataSource";
-import PACKAGE from "@root/package.json";
 
 const config = {
   cal: {
@@ -20,21 +16,24 @@ const config = {
   },
   originToken: "originToken",
 } as ContextModuleServiceConfig;
+
 describe("HttpTrustedNameDataSource", () => {
   let datasource: TrustedNameDataSource;
+  let httpMock: { get: ReturnType<typeof vi.fn> };
 
-  beforeAll(() => {
-    datasource = new HttpTrustedNameDataSource(config);
+  beforeEach(() => {
     vi.clearAllMocks();
+    httpMock = { get: vi.fn() };
+    datasource = new HttpTrustedNameDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
   });
 
   describe("getDomainNamePayload", () => {
-    it("should call fetch with the correct url and ledger client version header", async () => {
+    it("should call http.get with the correct url and params", async () => {
       // GIVEN
-      const version = `context-module/${PACKAGE.version}`;
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify([])));
+      httpMock.get.mockResolvedValue([]);
 
       // WHEN
       await datasource.getDomainNamePayload({
@@ -44,22 +43,17 @@ describe("HttpTrustedNameDataSource", () => {
       });
 
       // THEN
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          href: `https://nft.api.live.ledger.com/v2/names/ethereum/137/forward/hello.eth?types=eoa&sources=ens&challenge=9876`,
-        }),
-        expect.objectContaining({
-          headers: {
-            [LEDGER_CLIENT_VERSION_HEADER]: version,
-            [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
-          },
-        }),
+      expect(httpMock.get).toHaveBeenCalledWith(
+        `${config.metadataServiceDomain.url}/v2/names/ethereum/137/forward/hello.eth`,
+        {
+          params: { types: "eoa", sources: "ens", challenge: "9876" },
+        },
       );
     });
 
-    it("should throw an error when fetch throws an error", async () => {
+    it("should throw an error when http.get throws an error", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error());
+      httpMock.get.mockRejectedValue(new Error());
 
       // WHEN
       const result = await datasource.getDomainNamePayload({
@@ -80,9 +74,7 @@ describe("HttpTrustedNameDataSource", () => {
 
     it("should return an error when no payload is returned", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify({ test: "" })),
-      );
+      httpMock.get.mockResolvedValue({ test: "" });
 
       // WHEN
       const result = await datasource.getDomainNamePayload({
@@ -108,9 +100,7 @@ describe("HttpTrustedNameDataSource", () => {
         keyId: "testKeyId",
         keyUsage: "testKeyUsage",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(responseData)),
-      );
+      httpMock.get.mockResolvedValue(responseData);
 
       // WHEN
       const result = await datasource.getDomainNamePayload({
@@ -131,12 +121,9 @@ describe("HttpTrustedNameDataSource", () => {
   });
 
   describe("getTrustedNamePayload", () => {
-    it("should call fetch with the correct url and ledger client version header", async () => {
+    it("should call http.get with the correct url and params", async () => {
       // GIVEN
-      const version = `context-module/${PACKAGE.version}`;
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(new Response(JSON.stringify([])));
+      httpMock.get.mockResolvedValue([]);
 
       // WHEN
       await datasource.getTrustedNamePayload({
@@ -148,22 +135,21 @@ describe("HttpTrustedNameDataSource", () => {
       });
 
       // THEN
-      expect(fetchSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          href: `https://nft.api.live.ledger.com/v2/names/ethereum/137/reverse/0x1234?types=eoa&sources=ens%2Ccrypto_asset_list&challenge=5678`,
-        }),
-        expect.objectContaining({
-          headers: {
-            [LEDGER_CLIENT_VERSION_HEADER]: version,
-            [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
+      expect(httpMock.get).toHaveBeenCalledWith(
+        `${config.metadataServiceDomain.url}/v2/names/ethereum/137/reverse/0x1234`,
+        {
+          params: {
+            types: "eoa",
+            sources: "ens,crypto_asset_list",
+            challenge: "5678",
           },
-        }),
+        },
       );
     });
 
-    it("should throw an error when fetch throws an error", async () => {
+    it("should throw an error when http.get throws an error", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error());
+      httpMock.get.mockRejectedValue(new Error());
 
       // WHEN
       const result = await datasource.getTrustedNamePayload({
@@ -186,9 +172,7 @@ describe("HttpTrustedNameDataSource", () => {
 
     it("should return an error when no payload is returned", async () => {
       // GIVEN
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify({ test: "" })),
-      );
+      httpMock.get.mockResolvedValue({ test: "" });
 
       // WHEN
       const result = await datasource.getTrustedNamePayload({
@@ -214,9 +198,7 @@ describe("HttpTrustedNameDataSource", () => {
       const responseData = {
         signedDescriptor: { data: "payload", signatures: { prod: "12345" } },
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(responseData)),
-      );
+      httpMock.get.mockResolvedValue(responseData);
 
       // WHEN
       const result = await datasource.getTrustedNamePayload({
@@ -244,9 +226,7 @@ describe("HttpTrustedNameDataSource", () => {
         keyId: "testKeyId",
         keyUsage: "testKeyUsage",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(responseData)),
-      );
+      httpMock.get.mockResolvedValue(responseData);
 
       // WHEN
       const result = await datasource.getTrustedNamePayload({
@@ -274,9 +254,7 @@ describe("HttpTrustedNameDataSource", () => {
         keyId: "testKeyId",
         keyUsage: "testKeyUsage",
       };
-      vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(responseData)),
-      );
+      httpMock.get.mockResolvedValue(responseData);
 
       // WHEN
       const result = await datasource.getTrustedNamePayload({

--- a/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.test.ts
+++ b/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.test.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { Left, Right } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
@@ -9,8 +8,6 @@ import {
 import { HttpTrustedNameDataSource } from "@/trusted-name/data/HttpTrustedNameDataSource";
 import { type TrustedNameDataSource } from "@/trusted-name/data/TrustedNameDataSource";
 import PACKAGE from "@root/package.json";
-
-vi.mock("axios");
 
 const config = {
   cal: {
@@ -32,11 +29,12 @@ describe("HttpTrustedNameDataSource", () => {
   });
 
   describe("getDomainNamePayload", () => {
-    it("should call axios with the correct url and ledger client version header", async () => {
+    it("should call fetch with the correct url and ledger client version header", async () => {
       // GIVEN
       const version = `context-module/${PACKAGE.version}`;
-      const requestSpy = vi.fn(() => Promise.resolve({ data: [] }));
-      vi.spyOn(axios, "request").mockImplementation(requestSpy);
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify([])),
+      );
 
       // WHEN
       await datasource.getDomainNamePayload({
@@ -46,9 +44,9 @@ describe("HttpTrustedNameDataSource", () => {
       });
 
       // THEN
-      expect(requestSpy).toHaveBeenCalledWith(
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `https://nft.api.live.ledger.com/v2/names/ethereum/137/forward/hello.eth?types=eoa&sources=ens&challenge=9876`,
         expect.objectContaining({
-          url: `https://nft.api.live.ledger.com/v2/names/ethereum/137/forward/hello.eth?types=eoa&sources=ens&challenge=9876`,
           headers: {
             [LEDGER_CLIENT_VERSION_HEADER]: version,
             [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
@@ -57,9 +55,9 @@ describe("HttpTrustedNameDataSource", () => {
       );
     });
 
-    it("should throw an error when axios throws an error", async () => {
+    it("should throw an error when fetch throws an error", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockRejectedValue(new Error());
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error());
 
       // WHEN
       const result = await datasource.getDomainNamePayload({
@@ -80,8 +78,9 @@ describe("HttpTrustedNameDataSource", () => {
 
     it("should return an error when no payload is returned", async () => {
       // GIVEN
-      const response = { data: { test: "" } };
-      vi.spyOn(axios, "request").mockResolvedValue(response);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ test: "" })),
+      );
 
       // WHEN
       const result = await datasource.getDomainNamePayload({
@@ -102,14 +101,14 @@ describe("HttpTrustedNameDataSource", () => {
 
     it("should return a payload", async () => {
       // GIVEN
-      const response = {
-        data: {
-          signedDescriptor: { data: "payload", signatures: {} },
-          keyId: "testKeyId",
-          keyUsage: "testKeyUsage",
-        },
+      const responseData = {
+        signedDescriptor: { data: "payload", signatures: {} },
+        keyId: "testKeyId",
+        keyUsage: "testKeyUsage",
       };
-      vi.spyOn(axios, "request").mockResolvedValue(response);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(responseData)),
+      );
 
       // WHEN
       const result = await datasource.getDomainNamePayload({
@@ -130,11 +129,12 @@ describe("HttpTrustedNameDataSource", () => {
   });
 
   describe("getTrustedNamePayload", () => {
-    it("should call axios with the correct url and ledger client version header", async () => {
+    it("should call fetch with the correct url and ledger client version header", async () => {
       // GIVEN
       const version = `context-module/${PACKAGE.version}`;
-      const requestSpy = vi.fn(() => Promise.resolve({ data: [] }));
-      vi.spyOn(axios, "request").mockImplementation(requestSpy);
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify([])),
+      );
 
       // WHEN
       await datasource.getTrustedNamePayload({
@@ -146,9 +146,9 @@ describe("HttpTrustedNameDataSource", () => {
       });
 
       // THEN
-      expect(requestSpy).toHaveBeenCalledWith(
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `https://nft.api.live.ledger.com/v2/names/ethereum/137/reverse/0x1234?types=eoa&sources=ens,crypto_asset_list&challenge=5678`,
         expect.objectContaining({
-          url: `https://nft.api.live.ledger.com/v2/names/ethereum/137/reverse/0x1234?types=eoa&sources=ens,crypto_asset_list&challenge=5678`,
           headers: {
             [LEDGER_CLIENT_VERSION_HEADER]: version,
             [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
@@ -157,9 +157,9 @@ describe("HttpTrustedNameDataSource", () => {
       );
     });
 
-    it("should throw an error when axios throws an error", async () => {
+    it("should throw an error when fetch throws an error", async () => {
       // GIVEN
-      vi.spyOn(axios, "request").mockRejectedValue(new Error());
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error());
 
       // WHEN
       const result = await datasource.getTrustedNamePayload({
@@ -182,8 +182,9 @@ describe("HttpTrustedNameDataSource", () => {
 
     it("should return an error when no payload is returned", async () => {
       // GIVEN
-      const response = { data: { test: "" } };
-      vi.spyOn(axios, "request").mockResolvedValue(response);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ test: "" })),
+      );
 
       // WHEN
       const result = await datasource.getTrustedNamePayload({
@@ -206,12 +207,12 @@ describe("HttpTrustedNameDataSource", () => {
 
     it("should return an error when no keys are returned", async () => {
       // GIVEN
-      const response = {
-        data: {
-          signedDescriptor: { data: "payload", signatures: { prod: "12345" } },
-        },
+      const responseData = {
+        signedDescriptor: { data: "payload", signatures: { prod: "12345" } },
       };
-      vi.spyOn(axios, "request").mockResolvedValue(response);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(responseData)),
+      );
 
       // WHEN
       const result = await datasource.getTrustedNamePayload({
@@ -234,14 +235,14 @@ describe("HttpTrustedNameDataSource", () => {
 
     it("should return a payload", async () => {
       // GIVEN
-      const response = {
-        data: {
-          signedDescriptor: { data: "payload", signatures: {} },
-          keyId: "testKeyId",
-          keyUsage: "testKeyUsage",
-        },
+      const responseData = {
+        signedDescriptor: { data: "payload", signatures: {} },
+        keyId: "testKeyId",
+        keyUsage: "testKeyUsage",
       };
-      vi.spyOn(axios, "request").mockResolvedValue(response);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(responseData)),
+      );
 
       // WHEN
       const result = await datasource.getTrustedNamePayload({
@@ -264,14 +265,14 @@ describe("HttpTrustedNameDataSource", () => {
 
     it("should return a payload with a signature", async () => {
       // GIVEN
-      const response = {
-        data: {
-          signedDescriptor: { data: "payload", signatures: { prod: "12345" } },
-          keyId: "testKeyId",
-          keyUsage: "testKeyUsage",
-        },
+      const responseData = {
+        signedDescriptor: { data: "payload", signatures: { prod: "12345" } },
+        keyId: "testKeyId",
+        keyUsage: "testKeyUsage",
       };
-      vi.spyOn(axios, "request").mockResolvedValue(response);
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(responseData)),
+      );
 
       // WHEN
       const result = await datasource.getTrustedNamePayload({

--- a/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.test.ts
+++ b/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.test.ts
@@ -45,7 +45,9 @@ describe("HttpTrustedNameDataSource", () => {
 
       // THEN
       expect(fetchSpy).toHaveBeenCalledWith(
-        `https://nft.api.live.ledger.com/v2/names/ethereum/137/forward/hello.eth?types=eoa&sources=ens&challenge=9876`,
+        expect.objectContaining({
+          href: `https://nft.api.live.ledger.com/v2/names/ethereum/137/forward/hello.eth?types=eoa&sources=ens&challenge=9876`,
+        }),
         expect.objectContaining({
           headers: {
             [LEDGER_CLIENT_VERSION_HEADER]: version,
@@ -147,7 +149,9 @@ describe("HttpTrustedNameDataSource", () => {
 
       // THEN
       expect(fetchSpy).toHaveBeenCalledWith(
-        `https://nft.api.live.ledger.com/v2/names/ethereum/137/reverse/0x1234?types=eoa&sources=ens,crypto_asset_list&challenge=5678`,
+        expect.objectContaining({
+          href: `https://nft.api.live.ledger.com/v2/names/ethereum/137/reverse/0x1234?types=eoa&sources=ens%2Ccrypto_asset_list&challenge=5678`,
+        }),
         expect.objectContaining({
           headers: {
             [LEDGER_CLIENT_VERSION_HEADER]: version,

--- a/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.test.ts
+++ b/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.test.ts
@@ -32,9 +32,9 @@ describe("HttpTrustedNameDataSource", () => {
     it("should call fetch with the correct url and ledger client version header", async () => {
       // GIVEN
       const version = `context-module/${PACKAGE.version}`;
-      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify([])),
-      );
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify([])));
 
       // WHEN
       await datasource.getDomainNamePayload({
@@ -132,9 +132,9 @@ describe("HttpTrustedNameDataSource", () => {
     it("should call fetch with the correct url and ledger client version header", async () => {
       // GIVEN
       const version = `context-module/${PACKAGE.version}`;
-      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify([])),
-      );
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify([])));
 
       // WHEN
       await datasource.getTrustedNamePayload({

--- a/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.ts
+++ b/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.ts
@@ -38,7 +38,9 @@ export class HttpTrustedNameDataSource implements TrustedNameDataSource {
         {
           headers: {
             [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
+            ...(this.config.originToken && {
+              [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+            }),
           },
         },
       );
@@ -97,7 +99,9 @@ export class HttpTrustedNameDataSource implements TrustedNameDataSource {
         {
           headers: {
             [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
+            ...(this.config.originToken && {
+              [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+            }),
           },
         },
       );

--- a/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.ts
+++ b/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -34,15 +33,19 @@ export class HttpTrustedNameDataSource implements TrustedNameDataSource {
     try {
       const type = "eoa"; // Externally owned account
       const source = "ens"; // Ethereum name service
-      const response = await axios.request<TrustedNameDto>({
-        method: "GET",
-        url: `${this.config.metadataServiceDomain.url}/v2/names/ethereum/${chainId}/forward/${domain}?types=${type}&sources=${source}&challenge=${challenge}`,
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+      const response = await fetch(
+        `${this.config.metadataServiceDomain.url}/v2/names/ethereum/${chainId}/forward/${domain}?types=${type}&sources=${source}&challenge=${challenge}`,
+        {
+          headers: {
+            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+            ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
+          },
         },
-      });
-      dto = response.data;
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      dto = (await response.json()) as TrustedNameDto;
     } catch (_error) {
       return Left(
         new Error(
@@ -89,15 +92,19 @@ export class HttpTrustedNameDataSource implements TrustedNameDataSource {
       sources = sources.filter(
         (source) => source === "ens" || source === "crypto_asset_list",
       );
-      const response = await axios.request<TrustedNameDto>({
-        method: "GET",
-        url: `${this.config.metadataServiceDomain.url}/v2/names/ethereum/${chainId}/reverse/${address}?types=${types.join(",")}&sources=${sources.join(",")}&challenge=${challenge}`,
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+      const response = await fetch(
+        `${this.config.metadataServiceDomain.url}/v2/names/ethereum/${chainId}/reverse/${address}?types=${types.join(",")}&sources=${sources.join(",")}&challenge=${challenge}`,
+        {
+          headers: {
+            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+            ...(this.config.originToken && { [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken }),
+          },
         },
-      });
-      dto = response.data;
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      dto = (await response.json()) as TrustedNameDto;
     } catch (_error) {
       return Left(
         new Error(

--- a/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.ts
+++ b/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.ts
@@ -4,37 +4,24 @@ import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
 import type { ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
+import { networkTypes } from "@/network/di/networkTypes";
 import {
   GetDomainNameInfosParams,
   GetTrustedNameInfosParams,
   TrustedNameDataSource,
   TrustedNamePayload,
 } from "@/trusted-name/data/TrustedNameDataSource";
-import PACKAGE from "@root/package.json";
 
 import { TrustedNameDto } from "./TrustedNameDto";
 
 @injectable()
 export class HttpTrustedNameDataSource implements TrustedNameDataSource {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-        ...(this.config.originToken && {
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-        }),
-      },
-    });
-  }
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
+  ) {}
 
   public async getDomainNamePayload({
     chainId,

--- a/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.ts
+++ b/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.ts
@@ -1,3 +1,4 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -19,10 +20,21 @@ import { TrustedNameDto } from "./TrustedNameDto";
 
 @injectable()
 export class HttpTrustedNameDataSource implements TrustedNameDataSource {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {}
+  ) {
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+        ...(this.config.originToken && {
+          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+        }),
+      },
+    });
+  }
 
   public async getDomainNamePayload({
     chainId,
@@ -33,21 +45,12 @@ export class HttpTrustedNameDataSource implements TrustedNameDataSource {
     try {
       const type = "eoa"; // Externally owned account
       const source = "ens"; // Ethereum name service
-      const response = await fetch(
-        `${this.config.metadataServiceDomain.url}/v2/names/ethereum/${chainId}/forward/${domain}?types=${type}&sources=${source}&challenge=${challenge}`,
+      dto = (await this.http.get(
+        `${this.config.metadataServiceDomain.url}/v2/names/ethereum/${chainId}/forward/${domain}`,
         {
-          headers: {
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            ...(this.config.originToken && {
-              [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-            }),
-          },
+          params: { types: type, sources: source, challenge },
         },
-      );
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      dto = (await response.json()) as TrustedNameDto;
+      )) as TrustedNameDto;
     } catch (_error) {
       return Left(
         new Error(
@@ -94,21 +97,16 @@ export class HttpTrustedNameDataSource implements TrustedNameDataSource {
       sources = sources.filter(
         (source) => source === "ens" || source === "crypto_asset_list",
       );
-      const response = await fetch(
-        `${this.config.metadataServiceDomain.url}/v2/names/ethereum/${chainId}/reverse/${address}?types=${types.join(",")}&sources=${sources.join(",")}&challenge=${challenge}`,
+      dto = (await this.http.get(
+        `${this.config.metadataServiceDomain.url}/v2/names/ethereum/${chainId}/reverse/${address}`,
         {
-          headers: {
-            [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-            ...(this.config.originToken && {
-              [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-            }),
+          params: {
+            types: types.join(","),
+            sources: sources.join(","),
+            challenge,
           },
         },
-      );
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      dto = (await response.json()) as TrustedNameDto;
+      )) as TrustedNameDto;
     } catch (_error) {
       return Left(
         new Error(

--- a/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.test.ts
+++ b/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.test.ts
@@ -1,14 +1,10 @@
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { Right } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
 import { TypedDataCalldataParamPresence } from "@/shared/model/TypedDataClearSignContext";
 import { HttpTypedDataDataSource } from "@/typed-data/data/HttpTypedDataDataSource";
 import { type TypedDataDataSource } from "@/typed-data/data/TypedDataDataSource";
-import PACKAGE from "@root/package.json";
 
 import { type FiltersDto, type InstructionField } from "./FiltersDto";
 
@@ -52,6 +48,7 @@ const config = {
 } as ContextModuleServiceConfig;
 describe("HttpTypedDataDataSource", () => {
   let datasource: TypedDataDataSource;
+  let httpMock: { get: ReturnType<typeof vi.fn> };
 
   const TEST_TYPES = {
     PermitSingle: [
@@ -102,17 +99,18 @@ describe("HttpTypedDataDataSource", () => {
     ],
   };
 
-  beforeAll(() => {
-    datasource = new HttpTypedDataDataSource(config);
+  beforeEach(() => {
     vi.clearAllMocks();
+    httpMock = { get: vi.fn() };
+    datasource = new HttpTypedDataDataSource(
+      config,
+      httpMock as unknown as DmkNetworkClient,
+    );
   });
 
-  it("should call fetch with the ledger client version header", async () => {
+  it("should call the network client with the expected URL and params", async () => {
     // GIVEN
-    const version = `context-module/${PACKAGE.version}`;
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response(JSON.stringify([])));
+    httpMock.get.mockResolvedValue([]);
 
     // WHEN
     await datasource.getTypedDataFilters({
@@ -123,13 +121,16 @@ describe("HttpTypedDataDataSource", () => {
     });
 
     // THEN
-    expect(fetchSpy).toHaveBeenCalledWith(
-      expect.any(URL),
+    expect(httpMock.get).toHaveBeenCalledWith(
+      "https://crypto-assets-service.api.ledger.com/v1/dapps",
       expect.objectContaining({
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: version,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
-        },
+        params: expect.objectContaining({
+          contracts: "0x00",
+          chain_id: 1,
+          output: "descriptors_eip712",
+          descriptors_eip712_version: "v2",
+          descriptors_eip712: "<set>",
+        }),
       }),
     );
   });
@@ -207,9 +208,7 @@ describe("HttpTypedDataDataSource", () => {
         type: "field",
       },
     ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(filtersDTO)),
-    );
+    httpMock.get.mockResolvedValue(filtersDTO);
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -352,9 +351,7 @@ describe("HttpTypedDataDataSource", () => {
         type: "field",
       },
     ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(filtersDTO)),
-    );
+    httpMock.get.mockResolvedValue(filtersDTO);
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -484,9 +481,7 @@ describe("HttpTypedDataDataSource", () => {
         type: "field",
       },
     ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(filtersDTO)),
-    );
+    httpMock.get.mockResolvedValue(filtersDTO);
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -550,9 +545,7 @@ describe("HttpTypedDataDataSource", () => {
         type: "message",
       },
     ]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([{ descriptors_eip712: {} }, ...match])),
-    );
+    httpMock.get.mockResolvedValue([{ descriptors_eip712: {} }, ...match]);
 
     const result = await datasource.getTypedDataFilters({
       chainId: 1,
@@ -576,7 +569,7 @@ describe("HttpTypedDataDataSource", () => {
 
   it("should return an error when data is empty", async () => {
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("null"));
+    httpMock.get.mockResolvedValue(null);
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -598,9 +591,7 @@ describe("HttpTypedDataDataSource", () => {
   it("should return an error when schema is not found", async () => {
     const filtersDTO = buildDescriptor([]);
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(filtersDTO)),
-    );
+    httpMock.get.mockResolvedValue(filtersDTO);
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -624,9 +615,7 @@ describe("HttpTypedDataDataSource", () => {
       undefined as unknown as InstructionField[],
     );
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(filtersDTO)),
-    );
+    httpMock.get.mockResolvedValue(filtersDTO);
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -661,9 +650,7 @@ describe("HttpTypedDataDataSource", () => {
       },
     ]);
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(filtersDTO)),
-    );
+    httpMock.get.mockResolvedValue(filtersDTO);
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -696,9 +683,7 @@ describe("HttpTypedDataDataSource", () => {
       } as InstructionField,
     ]);
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(filtersDTO)),
-    );
+    httpMock.get.mockResolvedValue(filtersDTO);
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -733,9 +718,7 @@ describe("HttpTypedDataDataSource", () => {
       } as InstructionField,
     ]);
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(filtersDTO)),
-    );
+    httpMock.get.mockResolvedValue(filtersDTO);
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -770,9 +753,7 @@ describe("HttpTypedDataDataSource", () => {
       } as InstructionField,
     ]);
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(filtersDTO)),
-    );
+    httpMock.get.mockResolvedValue(filtersDTO);
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -807,9 +788,7 @@ describe("HttpTypedDataDataSource", () => {
       } as InstructionField,
     ]);
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(filtersDTO)),
-    );
+    httpMock.get.mockResolvedValue(filtersDTO);
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -844,9 +823,7 @@ describe("HttpTypedDataDataSource", () => {
       } as unknown as InstructionField,
     ]);
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(filtersDTO)),
-    );
+    httpMock.get.mockResolvedValue(filtersDTO);
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -880,9 +857,7 @@ describe("HttpTypedDataDataSource", () => {
       } as unknown as InstructionField,
     ]);
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(filtersDTO)),
-    );
+    httpMock.get.mockResolvedValue(filtersDTO);
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -919,9 +894,7 @@ describe("HttpTypedDataDataSource", () => {
       } as unknown as InstructionField,
     ]);
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(filtersDTO)),
-    );
+    httpMock.get.mockResolvedValue(filtersDTO);
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -955,9 +928,7 @@ describe("HttpTypedDataDataSource", () => {
       } as unknown as InstructionField,
     ]);
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(filtersDTO)),
-    );
+    httpMock.get.mockResolvedValue(filtersDTO);
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -976,9 +947,9 @@ describe("HttpTypedDataDataSource", () => {
     );
   });
 
-  it("should return an error when fetch throws an error", async () => {
+  it("should return an error when network client throws", async () => {
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("error"));
+    httpMock.get.mockRejectedValue(new Error("error"));
 
     // WHEN
     const result = await datasource.getTypedDataFilters({

--- a/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.test.ts
+++ b/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.test.ts
@@ -110,9 +110,9 @@ describe("HttpTypedDataDataSource", () => {
   it("should call fetch with the ledger client version header", async () => {
     // GIVEN
     const version = `context-module/${PACKAGE.version}`;
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify([])),
-    );
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify([])));
 
     // WHEN
     await datasource.getTypedDataFilters({
@@ -551,9 +551,7 @@ describe("HttpTypedDataDataSource", () => {
       },
     ]);
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(
-        JSON.stringify([{ descriptors_eip712: {} }, ...match]),
-      ),
+      new Response(JSON.stringify([{ descriptors_eip712: {} }, ...match])),
     );
 
     const result = await datasource.getTypedDataFilters({
@@ -578,9 +576,7 @@ describe("HttpTypedDataDataSource", () => {
 
   it("should return an error when data is empty", async () => {
     // GIVEN
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response("null"),
-    );
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("null"));
 
     // WHEN
     const result = await datasource.getTypedDataFilters({

--- a/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.test.ts
+++ b/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.test.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { Right } from "purify-ts";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
@@ -12,8 +11,6 @@ import { type TypedDataDataSource } from "@/typed-data/data/TypedDataDataSource"
 import PACKAGE from "@root/package.json";
 
 import { type FiltersDto, type InstructionField } from "./FiltersDto";
-
-vi.mock("axios");
 
 export const buildDescriptor = (
   instructions: InstructionField[],
@@ -110,11 +107,12 @@ describe("HttpTypedDataDataSource", () => {
     vi.clearAllMocks();
   });
 
-  it("should call axios with the ledger client version header", async () => {
+  it("should call fetch with the ledger client version header", async () => {
     // GIVEN
     const version = `context-module/${PACKAGE.version}`;
-    const requestSpy = vi.fn(() => Promise.resolve({ data: [] }));
-    vi.spyOn(axios, "request").mockImplementation(requestSpy);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([])),
+    );
 
     // WHEN
     await datasource.getTypedDataFilters({
@@ -125,7 +123,8 @@ describe("HttpTypedDataDataSource", () => {
     });
 
     // THEN
-    expect(requestSpy).toHaveBeenCalledWith(
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.any(URL),
       expect.objectContaining({
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: version,
@@ -135,7 +134,7 @@ describe("HttpTypedDataDataSource", () => {
     );
   });
 
-  it("should return V2 filters when axios response is correct", async () => {
+  it("should return V2 filters when fetch response is correct", async () => {
     // GIVEN
     const filtersDTO = buildDescriptor([
       {
@@ -208,7 +207,9 @@ describe("HttpTypedDataDataSource", () => {
         type: "field",
       },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue({ data: filtersDTO });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(filtersDTO)),
+    );
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -274,7 +275,7 @@ describe("HttpTypedDataDataSource", () => {
     );
   });
 
-  it("should return V2 filters with calldatas when axios response is correct", async () => {
+  it("should return V2 filters with calldatas when fetch response is correct", async () => {
     // GIVEN
     const filtersDTO = buildDescriptorCalldata([
       {
@@ -351,7 +352,9 @@ describe("HttpTypedDataDataSource", () => {
         type: "field",
       },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue({ data: filtersDTO });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(filtersDTO)),
+    );
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -421,7 +424,7 @@ describe("HttpTypedDataDataSource", () => {
     );
   });
 
-  it("should return V1 filters when axios response is correct", async () => {
+  it("should return V1 filters when fetch response is correct", async () => {
     // GIVEN
     const filtersDTO = buildDescriptor([
       {
@@ -481,7 +484,9 @@ describe("HttpTypedDataDataSource", () => {
         type: "field",
       },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue({ data: filtersDTO });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(filtersDTO)),
+    );
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -545,9 +550,11 @@ describe("HttpTypedDataDataSource", () => {
         type: "message",
       },
     ]);
-    vi.spyOn(axios, "request").mockResolvedValue({
-      data: [{ descriptors_eip712: {} }, ...match],
-    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify([{ descriptors_eip712: {} }, ...match]),
+      ),
+    );
 
     const result = await datasource.getTypedDataFilters({
       chainId: 1,
@@ -571,7 +578,9 @@ describe("HttpTypedDataDataSource", () => {
 
   it("should return an error when data is empty", async () => {
     // GIVEN
-    vi.spyOn(axios, "request").mockResolvedValue({ data: undefined });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("null"),
+    );
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -593,7 +602,9 @@ describe("HttpTypedDataDataSource", () => {
   it("should return an error when schema is not found", async () => {
     const filtersDTO = buildDescriptor([]);
     // GIVEN
-    vi.spyOn(axios, "request").mockResolvedValue({ data: filtersDTO });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(filtersDTO)),
+    );
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -617,7 +628,9 @@ describe("HttpTypedDataDataSource", () => {
       undefined as unknown as InstructionField[],
     );
     // GIVEN
-    vi.spyOn(axios, "request").mockResolvedValue({ data: filtersDTO });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(filtersDTO)),
+    );
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -652,7 +665,9 @@ describe("HttpTypedDataDataSource", () => {
       },
     ]);
     // GIVEN
-    vi.spyOn(axios, "request").mockResolvedValue({ data: filtersDTO });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(filtersDTO)),
+    );
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -685,7 +700,9 @@ describe("HttpTypedDataDataSource", () => {
       } as InstructionField,
     ]);
     // GIVEN
-    vi.spyOn(axios, "request").mockResolvedValue({ data: filtersDTO });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(filtersDTO)),
+    );
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -720,7 +737,9 @@ describe("HttpTypedDataDataSource", () => {
       } as InstructionField,
     ]);
     // GIVEN
-    vi.spyOn(axios, "request").mockResolvedValue({ data: filtersDTO });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(filtersDTO)),
+    );
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -755,7 +774,9 @@ describe("HttpTypedDataDataSource", () => {
       } as InstructionField,
     ]);
     // GIVEN
-    vi.spyOn(axios, "request").mockResolvedValue({ data: filtersDTO });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(filtersDTO)),
+    );
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -790,7 +811,9 @@ describe("HttpTypedDataDataSource", () => {
       } as InstructionField,
     ]);
     // GIVEN
-    vi.spyOn(axios, "request").mockResolvedValue({ data: filtersDTO });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(filtersDTO)),
+    );
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -825,7 +848,9 @@ describe("HttpTypedDataDataSource", () => {
       } as unknown as InstructionField,
     ]);
     // GIVEN
-    vi.spyOn(axios, "request").mockResolvedValue({ data: filtersDTO });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(filtersDTO)),
+    );
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -859,7 +884,9 @@ describe("HttpTypedDataDataSource", () => {
       } as unknown as InstructionField,
     ]);
     // GIVEN
-    vi.spyOn(axios, "request").mockResolvedValue({ data: filtersDTO });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(filtersDTO)),
+    );
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -896,7 +923,9 @@ describe("HttpTypedDataDataSource", () => {
       } as unknown as InstructionField,
     ]);
     // GIVEN
-    vi.spyOn(axios, "request").mockResolvedValue({ data: filtersDTO });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(filtersDTO)),
+    );
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -930,7 +959,9 @@ describe("HttpTypedDataDataSource", () => {
       } as unknown as InstructionField,
     ]);
     // GIVEN
-    vi.spyOn(axios, "request").mockResolvedValue({ data: filtersDTO });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(filtersDTO)),
+    );
 
     // WHEN
     const result = await datasource.getTypedDataFilters({
@@ -949,9 +980,9 @@ describe("HttpTypedDataDataSource", () => {
     );
   });
 
-  it("should return an error when axios throws an error", async () => {
+  it("should return an error when fetch throws an error", async () => {
     // GIVEN
-    vi.spyOn(axios, "request").mockRejectedValue(new Error("error"));
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("error"));
 
     // WHEN
     const result = await datasource.getTypedDataFilters({

--- a/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.ts
+++ b/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.ts
@@ -7,10 +7,7 @@ import type {
   ContextModuleCalMode,
   ContextModuleServiceConfig,
 } from "@/config/model/ContextModuleConfig";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
+import { networkTypes } from "@/network/di/networkTypes";
 import type {
   TypedDataCalldataIndex,
   TypedDataFilter,
@@ -19,7 +16,6 @@ import type {
 } from "@/shared/model/TypedDataClearSignContext";
 import { TypedDataCalldataParamPresence } from "@/shared/model/TypedDataClearSignContext";
 import { getSchemaHash } from "@/typed-data/utils/getSchemaHash";
-import PACKAGE from "@root/package.json";
 
 import type {
   FiltersDto,
@@ -41,21 +37,12 @@ import {
 
 @injectable()
 export class HttpTypedDataDataSource implements TypedDataDataSource {
-  private readonly http: DmkNetworkClient;
-
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {
-    this.http = new DmkNetworkClient({
-      headers: {
-        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-        ...(this.config.originToken && {
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-        }),
-      },
-    });
-  }
+    @inject(networkTypes.NetworkClient)
+    private readonly http: DmkNetworkClient,
+  ) {}
 
   public async getTypedDataFilters({
     chainId,

--- a/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.ts
+++ b/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -57,27 +56,29 @@ export class HttpTypedDataDataSource implements TypedDataDataSource {
     let messageInfo: TypedDataMessageInfo | undefined = undefined;
 
     try {
-      const response = await axios.request<FiltersDto[]>({
-        method: "GET",
-        url: `${this.config.cal.url}/dapps`,
-        params: {
-          contracts: address,
-          chain_id: chainId,
-          output: "descriptors_eip712",
-          descriptors_eip712_version: version,
-          descriptors_eip712: "<set>",
-          ref: `branch:${this.config.cal.branch}`,
-        },
+      const url = new URL(`${this.config.cal.url}/dapps`);
+      url.searchParams.set("contracts", address);
+      url.searchParams.set("chain_id", String(chainId));
+      url.searchParams.set("output", "descriptors_eip712");
+      url.searchParams.set("descriptors_eip712_version", version);
+      url.searchParams.set("descriptors_eip712", "<set>");
+      url.searchParams.set("ref", `branch:${this.config.cal.branch}`);
+      const response = await fetch(url, {
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+          ...(this.config.originToken && {
+            [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+          }),
         },
       });
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      const data = (await response.json()) as FiltersDto[];
 
-      // Try to get the filters JSON descriptor, from address and schema hash
       const schemaHash = getSchemaHash(schema);
       address = address.toLowerCase();
-      const dataArray = response.data ?? [];
+      const dataArray = data ?? [];
       const filtersJson = dataArray
         .map((item) => item?.descriptors_eip712?.[address]?.[schemaHash])
         .find(Boolean);

--- a/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.ts
+++ b/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.ts
@@ -1,3 +1,4 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
@@ -40,10 +41,21 @@ import {
 
 @injectable()
 export class HttpTypedDataDataSource implements TypedDataDataSource {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
-  ) {}
+  ) {
+    this.http = new DmkNetworkClient({
+      headers: {
+        [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+        ...(this.config.originToken && {
+          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+        }),
+      },
+    });
+  }
 
   public async getTypedDataFilters({
     chainId,
@@ -56,25 +68,16 @@ export class HttpTypedDataDataSource implements TypedDataDataSource {
     let messageInfo: TypedDataMessageInfo | undefined = undefined;
 
     try {
-      const url = new URL(`${this.config.cal.url}/dapps`);
-      url.searchParams.set("contracts", address);
-      url.searchParams.set("chain_id", String(chainId));
-      url.searchParams.set("output", "descriptors_eip712");
-      url.searchParams.set("descriptors_eip712_version", version);
-      url.searchParams.set("descriptors_eip712", "<set>");
-      url.searchParams.set("ref", `branch:${this.config.cal.branch}`);
-      const response = await fetch(url, {
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          ...(this.config.originToken && {
-            [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
-          }),
+      const data = (await this.http.get(`${this.config.cal.url}/dapps`, {
+        params: {
+          contracts: address,
+          chain_id: chainId,
+          output: "descriptors_eip712",
+          descriptors_eip712_version: version,
+          descriptors_eip712: "<set>",
+          ref: `branch:${this.config.cal.branch}`,
         },
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP error ${response.status}`);
-      }
-      const data = (await response.json()) as FiltersDto[];
+      })) as FiltersDto[];
 
       const schemaHash = getSchemaHash(schema);
       address = address.toLowerCase();

--- a/packages/speculos-device-controller/README.md
+++ b/packages/speculos-device-controller/README.md
@@ -40,7 +40,7 @@ Under the hood, percentages are clamped to [0, 100] and converted to pixels usin
 
 ```ts
 const deviceClient = deviceControllerClientFactory("http://localhost:4000", {
-  timeoutMs: 2000, // optional axios timeout
+  timeoutMs: 2000, // optional fetch timeout
   clientHeader: "ldmk-transport-speculos", // optional header
   screens: {
     // override by default keys
@@ -91,7 +91,7 @@ type DeviceControllerClient = {
 type DeviceControllerClientFactory = (
   baseURL: string,
   opts?: {
-    timeoutMs?: number; // axios timeout (ms)
+    timeoutMs?: number; // fetch timeout (ms)
     clientHeader?: string; // "X-Ledger-Client-Version" header
     screens?: DeviceScreens<string>;
   },

--- a/packages/speculos-device-controller/package.json
+++ b/packages/speculos-device-controller/package.json
@@ -40,8 +40,7 @@
   },
   "dependencies": {
     "@ledgerhq/device-management-kit": "workspace:^",
-    "@sentry/minimal": "catalog:",
-    "axios": "catalog:"
+    "@sentry/minimal": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/eslint-config-dsdk": "workspace:^",

--- a/packages/speculos-device-controller/src/internal/adapters/DefaultButtonController.test.ts
+++ b/packages/speculos-device-controller/src/internal/adapters/DefaultButtonController.test.ts
@@ -1,18 +1,16 @@
-import type { AxiosInstance } from "axios";
-
-import type { ButtonKey } from "@internal/core/types";
+import type { ButtonKey, HttpClient } from "@internal/core/types";
 
 import { DefaultButtonController } from "./DefaultButtonController";
 
 describe("DefaultButtonController", () => {
   let postMock: ReturnType<typeof vi.fn>;
-  let axiosFake: AxiosInstance;
+  let httpClient: HttpClient;
   let controller: DefaultButtonController;
 
   beforeEach(() => {
-    postMock = vi.fn().mockResolvedValue({ status: 200, data: {} });
-    axiosFake = { post: postMock } as unknown as AxiosInstance;
-    controller = new DefaultButtonController(axiosFake);
+    postMock = vi.fn().mockResolvedValue(undefined);
+    httpClient = { post: postMock };
+    controller = new DefaultButtonController(httpClient);
   });
 
   const keys: ButtonKey[] = ["left", "right", "both"];

--- a/packages/speculos-device-controller/src/internal/adapters/DefaultButtonController.ts
+++ b/packages/speculos-device-controller/src/internal/adapters/DefaultButtonController.ts
@@ -1,10 +1,8 @@
-import type { AxiosInstance } from "axios";
-
 import type { ButtonController } from "@internal/core/ButtonController";
-import { type ButtonKey, SpeculosActions } from "@internal/core/types";
+import { type ButtonKey, type HttpClient, SpeculosActions } from "@internal/core/types";
 
 export class DefaultButtonController implements ButtonController {
-  constructor(private readonly client: AxiosInstance) {}
+  constructor(private readonly client: HttpClient) {}
 
   async press(key: ButtonKey): Promise<void> {
     await this.client.post(`/button/${key}`, {

--- a/packages/speculos-device-controller/src/internal/adapters/DefaultButtonController.ts
+++ b/packages/speculos-device-controller/src/internal/adapters/DefaultButtonController.ts
@@ -1,5 +1,9 @@
 import type { ButtonController } from "@internal/core/ButtonController";
-import { type ButtonKey, type HttpClient, SpeculosActions } from "@internal/core/types";
+import {
+  type ButtonKey,
+  type HttpClient,
+  SpeculosActions,
+} from "@internal/core/types";
 
 export class DefaultButtonController implements ButtonController {
   constructor(private readonly client: HttpClient) {}

--- a/packages/speculos-device-controller/src/internal/adapters/DefaultTouchController.test.ts
+++ b/packages/speculos-device-controller/src/internal/adapters/DefaultTouchController.test.ts
@@ -2,14 +2,12 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import type { AxiosInstance } from "axios";
-
-import type { PercentCoordinates } from "../core/types";
+import type { HttpClient, PercentCoordinates } from "../core/types";
 import { DefaultTouchController } from "./DefaultTouchController";
 
 describe("DefaultTouchController", () => {
   let postMock: ReturnType<typeof vi.fn>;
-  let axiosFake: AxiosInstance;
+  let httpClient: HttpClient;
 
   const axisA = {
     xy: vi.fn((xPct: number, yPct: number) => ({
@@ -31,14 +29,14 @@ describe("DefaultTouchController", () => {
   let controller: DefaultTouchController<string>;
 
   beforeEach(() => {
-    postMock = vi.fn().mockResolvedValue({ status: 200, data: {} });
-    axiosFake = { post: postMock } as unknown as AxiosInstance;
+    postMock = vi.fn().mockResolvedValue(undefined);
+    httpClient = { post: postMock };
 
     axisA.xy.mockClear();
     axisB.xy.mockClear();
 
     axesFake = { devA: axisA, devB: axisB };
-    controller = new DefaultTouchController(axiosFake, axesFake as any);
+    controller = new DefaultTouchController(httpClient, axesFake as any);
   });
 
   const point: PercentCoordinates = { x: 12, y: 45 };
@@ -86,7 +84,7 @@ describe("DefaultTouchController", () => {
     expect(postMock).not.toHaveBeenCalled();
   });
 
-  it("propagates HTTP errors from axios client", async () => {
+  it("propagates HTTP errors", async () => {
     const boom = new Error("backend down");
     postMock.mockRejectedValueOnce(boom);
 
@@ -97,7 +95,7 @@ describe("DefaultTouchController", () => {
 describe("percent validation", () => {
   let controller: DefaultTouchController<string>;
   let postMock: ReturnType<typeof vi.fn>;
-  let axiosFake: AxiosInstance;
+  let httpClient: HttpClient;
 
   const axis = {
     xy: vi.fn((xPct: number, yPct: number) => ({ x: xPct, y: yPct })),
@@ -105,10 +103,10 @@ describe("percent validation", () => {
   const axesFake = { devA: axis };
 
   beforeEach(() => {
-    postMock = vi.fn().mockResolvedValue({ status: 200, data: {} });
-    axiosFake = { post: postMock } as unknown as AxiosInstance;
+    postMock = vi.fn().mockResolvedValue(undefined);
+    httpClient = { post: postMock };
     axis.xy.mockClear();
-    controller = new DefaultTouchController(axiosFake, axesFake as any);
+    controller = new DefaultTouchController(httpClient, axesFake as any);
   });
 
   it("accepts boundary values 0 and 100", async () => {

--- a/packages/speculos-device-controller/src/internal/adapters/DefaultTouchController.ts
+++ b/packages/speculos-device-controller/src/internal/adapters/DefaultTouchController.ts
@@ -1,6 +1,4 @@
-import type { AxiosInstance } from "axios";
-
-import { type PercentCoordinates, SpeculosActions } from "@internal/core/types";
+import { type HttpClient, type PercentCoordinates, SpeculosActions } from "@internal/core/types";
 import type { AxisMap } from "@internal/utils/axisClamp";
 import type { TouchController } from "@root/src/internal/core/TouchController";
 
@@ -8,7 +6,7 @@ export class DefaultTouchController<K extends string>
   implements TouchController<K>
 {
   constructor(
-    private readonly client: AxiosInstance,
+    private readonly client: HttpClient,
     private readonly axes: AxisMap<K>,
   ) {}
 

--- a/packages/speculos-device-controller/src/internal/adapters/DefaultTouchController.ts
+++ b/packages/speculos-device-controller/src/internal/adapters/DefaultTouchController.ts
@@ -1,4 +1,8 @@
-import { type HttpClient, type PercentCoordinates, SpeculosActions } from "@internal/core/types";
+import {
+  type HttpClient,
+  type PercentCoordinates,
+  SpeculosActions,
+} from "@internal/core/types";
 import type { AxisMap } from "@internal/utils/axisClamp";
 import type { TouchController } from "@root/src/internal/core/TouchController";
 

--- a/packages/speculos-device-controller/src/internal/core/types.ts
+++ b/packages/speculos-device-controller/src/internal/core/types.ts
@@ -20,6 +20,10 @@ export type DeviceControllerOptions<K extends string = string> = {
   clientHeader?: string;
 };
 
+export interface HttpClient {
+  post(url: string, data?: unknown): Promise<unknown>;
+}
+
 export enum SpeculosActions {
   PRESS = "press",
   RELEASE = "release",

--- a/packages/speculos-device-controller/src/internal/di.test.ts
+++ b/packages/speculos-device-controller/src/internal/di.test.ts
@@ -1,10 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-
-import axios from "axios";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DefaultButtonController } from "@internal/adapters/DefaultButtonController";
@@ -21,65 +15,67 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("createDefaultControllers - axios configuration", () => {
-  it("configures axios with normalised baseURL, custom timeout and header", () => {
-    const createSpy = vi
-      .spyOn(axios, "create")
-      .mockImplementation((cfg: any) => {
-        return { post: vi.fn(), defaults: { ...cfg } } as any;
-      });
+describe("createDefaultControllers - fetch configuration", () => {
+  it("configures with custom timeout and header", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}"));
 
-    createDefaultControllers("http://example.com/api", {
+    const { buttons } = createDefaultControllers("http://example.com/api", {
       screens: SCREENS,
       timeoutMs: 2345,
       clientHeader: "test-client",
     });
 
-    expect(createSpy).toHaveBeenCalledTimes(1);
-    const cfg = createSpy.mock.calls[0]![0] as any;
-    expect(cfg.baseURL).toBe("http://example.com/api");
-    expect(cfg.timeout).toBe(2345);
-    expect(cfg.headers?.["X-Ledger-Client-Version"]).toBe("test-client");
-    expect(cfg.transitional?.clarifyTimeoutError).toBe(true);
+    await buttons.press("left");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://example.com/api/button/left",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "X-Ledger-Client-Version": "test-client",
+        }),
+      }),
+    );
   });
 
-  it("applies default timeout and client header when not provided", () => {
-    const createSpy = vi
-      .spyOn(axios, "create")
-      .mockImplementation((cfg: any) => {
-        return { post: vi.fn(), defaults: { ...cfg } } as any;
-      });
+  it("applies default timeout and client header when not provided", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}"));
 
-    createDefaultControllers("http://localhost:1234", { screens: SCREENS });
+    const { buttons } = createDefaultControllers("http://localhost:1234", {
+      screens: SCREENS,
+    });
 
-    const cfg = createSpy.mock.calls[0]![0] as any;
-    expect(cfg.baseURL).toBe("http://localhost:1234");
-    expect(cfg.timeout).toBe(1500);
-    expect(cfg.headers?.["X-Ledger-Client-Version"]).toBe(
-      "ldmk-transport-speculos",
+    await buttons.press("left");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://localhost:1234/button/left",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "X-Ledger-Client-Version": "ldmk-transport-speculos",
+        }),
+      }),
     );
   });
 });
 
 describe("createDefaultControllers - wiring", () => {
-  it("returns axios implementations wired by the factory", () => {
-    const http = { post: vi.fn() } as any;
-    vi.spyOn(axios, "create").mockReturnValue(http);
-
+  it("returns correct controller implementations", () => {
     const { buttons, touch } = createDefaultControllers("http://x", {
       screens: SCREENS,
     });
 
     expect(buttons).toBeInstanceOf(DefaultButtonController);
     expect(touch).toBeInstanceOf(DefaultTouchController);
-    expect(typeof (buttons as any).press).toBe("function");
+    expect(typeof buttons.press).toBe("function");
   });
 
   it("creates fresh instances per invocation", () => {
-    vi.spyOn(axios, "create")
-      .mockReturnValueOnce({ post: vi.fn() } as any)
-      .mockReturnValueOnce({ post: vi.fn() } as any);
-
     const a = createDefaultControllers("http://x", { screens: SCREENS });
     const b = createDefaultControllers("http://x", { screens: SCREENS });
 
@@ -88,22 +84,29 @@ describe("createDefaultControllers - wiring", () => {
   });
 
   it("button.press posts the correct payload", async () => {
-    const post = vi.fn().mockResolvedValue(undefined);
-    vi.spyOn(axios, "create").mockReturnValue({ post } as any);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}"));
 
     const { buttons } = createDefaultControllers("http://x", {
       screens: SCREENS,
     });
 
     await buttons.press("left");
-    expect(post).toHaveBeenCalledWith("/button/left", {
-      action: "press-and-release",
-    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://x/button/left",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ action: "press-and-release" }),
+      }),
+    );
   });
 
   it("touch.tapAndRelease maps percent to absolute coords", async () => {
-    const post = vi.fn().mockResolvedValue(undefined);
-    vi.spyOn(axios, "create").mockReturnValue({ post } as any);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}"));
 
     const { touch } = createDefaultControllers("http://x", {
       screens: SCREENS,
@@ -112,10 +115,16 @@ describe("createDefaultControllers - wiring", () => {
     // 50% of 128x64 → (64, 32)
     await touch.tapAndRelease("flex", { x: 50 as any, y: 50 as any });
 
-    expect(post).toHaveBeenCalledWith("/finger", {
-      action: "press-and-release",
-      x: 64,
-      y: 32,
-    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://x/finger",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          action: "press-and-release",
+          x: 64,
+          y: 32,
+        }),
+      }),
+    );
   });
 });

--- a/packages/speculos-device-controller/src/internal/di.test.ts
+++ b/packages/speculos-device-controller/src/internal/di.test.ts
@@ -21,7 +21,7 @@ describe("createDefaultControllers - fetch configuration", () => {
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response("{}"));
 
-    const { buttons } = createDefaultControllers("http://example.com/api", {
+    const { buttons } = createDefaultControllers("https://example.com/api", {
       screens: SCREENS,
       timeoutMs: 2345,
       clientHeader: "test-client",
@@ -31,7 +31,7 @@ describe("createDefaultControllers - fetch configuration", () => {
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy).toHaveBeenCalledWith(
-      "http://example.com/api/button/left",
+      "https://example.com/api/button/left",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
@@ -46,14 +46,14 @@ describe("createDefaultControllers - fetch configuration", () => {
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response("{}"));
 
-    const { buttons } = createDefaultControllers("http://localhost:1234", {
+    const { buttons } = createDefaultControllers("https://localhost:1234", {
       screens: SCREENS,
     });
 
     await buttons.press("left");
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      "http://localhost:1234/button/left",
+      "https://localhost:1234/button/left",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
@@ -66,7 +66,7 @@ describe("createDefaultControllers - fetch configuration", () => {
 
 describe("createDefaultControllers - wiring", () => {
   it("returns correct controller implementations", () => {
-    const { buttons, touch } = createDefaultControllers("http://x", {
+    const { buttons, touch } = createDefaultControllers("https://x", {
       screens: SCREENS,
     });
 
@@ -76,8 +76,8 @@ describe("createDefaultControllers - wiring", () => {
   });
 
   it("creates fresh instances per invocation", () => {
-    const a = createDefaultControllers("http://x", { screens: SCREENS });
-    const b = createDefaultControllers("http://x", { screens: SCREENS });
+    const a = createDefaultControllers("https://x", { screens: SCREENS });
+    const b = createDefaultControllers("https://x", { screens: SCREENS });
 
     expect(a.buttons).not.toBe(b.buttons);
     expect(a.touch).not.toBe(b.touch);
@@ -88,14 +88,14 @@ describe("createDefaultControllers - wiring", () => {
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response("{}"));
 
-    const { buttons } = createDefaultControllers("http://x", {
+    const { buttons } = createDefaultControllers("https://x", {
       screens: SCREENS,
     });
 
     await buttons.press("left");
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      "http://x/button/left",
+      "https://x/button/left",
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({ action: "press-and-release" }),
@@ -108,7 +108,7 @@ describe("createDefaultControllers - wiring", () => {
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response("{}"));
 
-    const { touch } = createDefaultControllers("http://x", {
+    const { touch } = createDefaultControllers("https://x", {
       screens: SCREENS,
     });
 
@@ -116,7 +116,7 @@ describe("createDefaultControllers - wiring", () => {
     await touch.tapAndRelease("flex", { x: 50 as any, y: 50 as any });
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      "http://x/finger",
+      "https://x/finger",
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({

--- a/packages/speculos-device-controller/src/internal/di.test.ts
+++ b/packages/speculos-device-controller/src/internal/di.test.ts
@@ -31,7 +31,9 @@ describe("createDefaultControllers - fetch configuration", () => {
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy).toHaveBeenCalledWith(
-      "https://example.com/api/button/left",
+      expect.objectContaining({
+        href: "https://example.com/api/button/left",
+      }),
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
@@ -53,7 +55,9 @@ describe("createDefaultControllers - fetch configuration", () => {
     await buttons.press("left");
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      "https://localhost:1234/button/left",
+      expect.objectContaining({
+        href: "https://localhost:1234/button/left",
+      }),
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
@@ -95,7 +99,7 @@ describe("createDefaultControllers - wiring", () => {
     await buttons.press("left");
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      "https://x/button/left",
+      expect.objectContaining({ href: "https://x/button/left" }),
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({ action: "press-and-release" }),
@@ -116,7 +120,7 @@ describe("createDefaultControllers - wiring", () => {
     await touch.tapAndRelease("flex", { x: 50 as any, y: 50 as any });
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      "https://x/finger",
+      expect.objectContaining({ href: "https://x/finger" }),
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({

--- a/packages/speculos-device-controller/src/internal/di.ts
+++ b/packages/speculos-device-controller/src/internal/di.ts
@@ -1,9 +1,7 @@
-import axios, { type AxiosInstance } from "axios";
-
 import { DefaultButtonController } from "@internal/adapters/DefaultButtonController";
 import { DefaultTouchController } from "@internal/adapters/DefaultTouchController";
 import type { ButtonController } from "@internal/core/ButtonController";
-import type { DeviceControllerOptions } from "@internal/core/types";
+import type { DeviceControllerOptions, HttpClient } from "@internal/core/types";
 import { type AxisMap, createAxes } from "@internal/utils/axisClamp";
 import type { TouchController } from "@root/src/internal/core/TouchController";
 
@@ -16,14 +14,31 @@ export function createDefaultControllers(
   baseURL: string,
   opts: DeviceControllerOptions,
 ): ControllersContainer {
-  const http: AxiosInstance = axios.create({
-    baseURL: baseURL,
-    timeout: opts.timeoutMs ?? 1500,
-    headers: {
-      "X-Ledger-Client-Version": opts.clientHeader ?? "ldmk-transport-speculos",
+  const timeoutMs = opts.timeoutMs ?? 1500;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-Ledger-Client-Version":
+      opts.clientHeader ?? "ldmk-transport-speculos",
+  };
+
+  const http: HttpClient = {
+    async post(url: string, data?: unknown): Promise<unknown> {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const response = await fetch(`${baseURL}${url}`, {
+          method: "POST",
+          headers,
+          body: data !== undefined ? JSON.stringify(data) : undefined,
+          signal: controller.signal,
+        });
+        if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+        return response.json();
+      } finally {
+        clearTimeout(timeoutId);
+      }
     },
-    transitional: { clarifyTimeoutError: true },
-  });
+  };
 
   const axes: AxisMap = createAxes(opts.screens);
 

--- a/packages/speculos-device-controller/src/internal/di.ts
+++ b/packages/speculos-device-controller/src/internal/di.ts
@@ -17,8 +17,7 @@ export function createDefaultControllers(
   const timeoutMs = opts.timeoutMs ?? 1500;
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    "X-Ledger-Client-Version":
-      opts.clientHeader ?? "ldmk-transport-speculos",
+    "X-Ledger-Client-Version": opts.clientHeader ?? "ldmk-transport-speculos",
   };
 
   const http: HttpClient = {

--- a/packages/speculos-device-controller/src/internal/di.ts
+++ b/packages/speculos-device-controller/src/internal/di.ts
@@ -1,3 +1,5 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
+
 import { DefaultButtonController } from "@internal/adapters/DefaultButtonController";
 import { DefaultTouchController } from "@internal/adapters/DefaultTouchController";
 import type { ButtonController } from "@internal/core/ButtonController";
@@ -15,27 +17,17 @@ export function createDefaultControllers(
   opts: DeviceControllerOptions,
 ): ControllersContainer {
   const timeoutMs = opts.timeoutMs ?? 1500;
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    "X-Ledger-Client-Version": opts.clientHeader ?? "ldmk-transport-speculos",
-  };
+  const client = new DmkNetworkClient({
+    baseUrl: baseURL,
+    timeoutMs,
+    headers: {
+      "X-Ledger-Client-Version": opts.clientHeader ?? "ldmk-transport-speculos",
+    },
+  });
 
   const http: HttpClient = {
     async post(url: string, data?: unknown): Promise<unknown> {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-      try {
-        const response = await fetch(`${baseURL}${url}`, {
-          method: "POST",
-          headers,
-          body: data !== undefined ? JSON.stringify(data) : undefined,
-          signal: controller.signal,
-        });
-        if (!response.ok) throw new Error(`HTTP error ${response.status}`);
-        return response.json();
-      } finally {
-        clearTimeout(timeoutId);
-      }
+      return client.post(url, data);
     },
   };
 

--- a/packages/speculos-device-controller/src/internal/di.ts
+++ b/packages/speculos-device-controller/src/internal/di.ts
@@ -19,7 +19,6 @@ export function createDefaultControllers(
   const timeoutMs = opts.timeoutMs ?? 1500;
   const client = new DmkNetworkClient({
     baseUrl: baseURL,
-    timeoutMs,
     headers: {
       "X-Ledger-Client-Version": opts.clientHeader ?? "ldmk-transport-speculos",
     },
@@ -27,7 +26,7 @@ export function createDefaultControllers(
 
   const http: HttpClient = {
     async post(url: string, data?: unknown): Promise<unknown> {
-      return client.post(url, data);
+      return client.post(url, data, { timeoutMs });
     },
   };
 

--- a/packages/tools/cal-interceptor/package.json
+++ b/packages/tools/cal-interceptor/package.json
@@ -34,9 +34,7 @@
     "prettier:fix": "prettier . --write",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "axios": "catalog:"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@ledgerhq/eslint-config-dsdk": "workspace:*",
     "@ledgerhq/ldmk-tool": "workspace:*",

--- a/packages/tools/cal-interceptor/src/AxiosInterceptor.ts
+++ b/packages/tools/cal-interceptor/src/AxiosInterceptor.ts
@@ -1,174 +1,61 @@
-import axios, {
-  type AxiosInstance,
-  type AxiosResponse,
-  type InternalAxiosRequestConfig,
-} from "axios";
-
-/**
- * Axios Interceptor - intercepts axios requests and modifies their responses
- * Works in both browser and Node.js environments
- */
-
 type GetJsonResponse = (url: string) => string | null;
 
-export class AxiosInterceptor {
+export class FetchInterceptor {
   private getJsonResponse: GetJsonResponse;
   private isActive = false;
-  private requestInterceptorId: number | null = null;
-  private responseInterceptorId: number | null = null;
-  private axiosInstance: AxiosInstance;
+  private originalFetch: typeof fetch | null = null;
 
-  constructor(
-    getJsonResponse: GetJsonResponse,
-    axiosInstance: AxiosInstance = axios,
-  ) {
+  constructor(getJsonResponse: GetJsonResponse) {
     this.getJsonResponse = getJsonResponse;
-    this.axiosInstance = axiosInstance;
   }
 
-  /**
-   * Start intercepting axios requests
-   */
   start(): void {
     if (this.isActive) {
-      console.warn("Axios Interceptor is already active");
+      console.warn("Fetch Interceptor is already active");
       return;
     }
 
-    // Add request interceptor
-    this.requestInterceptorId = this.axiosInstance.interceptors.request.use(
-      (config: InternalAxiosRequestConfig) => {
-        const url = config.url;
-        if (!url) {
-          return config;
-        }
+    this.originalFetch = globalThis.fetch;
+    globalThis.fetch = async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const url =
+        input instanceof Request
+          ? input.url
+          : input instanceof URL
+            ? input.toString()
+            : input;
 
-        // Build full URL with query parameters
-        let fullUrl = this.buildFullUrl(config.baseURL, url);
+      const jsonResponse = this.getJsonResponse(url);
+      if (jsonResponse) {
+        return new Response(jsonResponse, {
+          status: 200,
+          statusText: "OK",
+          headers: { "Content-Type": "application/json" },
+        });
+      }
 
-        // Add query parameters if present
-        if (config.params) {
-          fullUrl = this.addQueryParams(fullUrl, config.params);
-        }
-
-        // Try to get modified response
-        const response = this.getJsonResponse(fullUrl);
-        if (response) {
-          // Cancel the original request and inject our response
-          const cancelToken = axios.CancelToken.source();
-          config.cancelToken = cancelToken.token;
-
-          // Immediately cancel the request and provide our response
-          setTimeout(() => {
-            cancelToken.cancel(response);
-          }, 0);
-        }
-
-        return config;
-      },
-    );
-
-    // Add response interceptor to handle our canceled requests
-    this.responseInterceptorId = this.axiosInstance.interceptors.response.use(
-      (response: AxiosResponse) => response,
-      (error: unknown) => this.handleResponseError(error),
-    );
+      return this.originalFetch!(input, init);
+    };
 
     this.isActive = true;
   }
 
-  /**
-   * Stop intercepting axios requests
-   */
   stop(): void {
     if (!this.isActive) {
       return;
     }
 
-    if (this.requestInterceptorId !== null) {
-      this.axiosInstance.interceptors.request.eject(this.requestInterceptorId);
-      this.requestInterceptorId = null;
-    }
-
-    if (this.responseInterceptorId !== null) {
-      this.axiosInstance.interceptors.response.eject(
-        this.responseInterceptorId,
-      );
-      this.responseInterceptorId = null;
+    if (this.originalFetch) {
+      globalThis.fetch = this.originalFetch;
+      this.originalFetch = null;
     }
 
     this.isActive = false;
   }
 
-  /**
-   * Check if interceptor is currently active
-   */
   isIntercepting(): boolean {
     return this.isActive;
-  }
-
-  /**
-   * Build full URL from base URL and path
-   */
-  private buildFullUrl(baseURL: string | undefined, url: string): string {
-    if (!baseURL) {
-      return url;
-    }
-    return `${baseURL}${url.startsWith("/") ? url : `/${url}`}`;
-  }
-
-  /**
-   * Add query parameters to URL
-   */
-  private addQueryParams(url: string, params: Record<string, unknown>): string {
-    const searchParams = new URLSearchParams();
-    Object.entries(params).forEach(([key, value]) => {
-      if (value !== null && value !== undefined) {
-        searchParams.append(key, String(value));
-      }
-    });
-
-    const queryString = searchParams.toString();
-    return queryString ? `${url}?${queryString}` : url;
-  }
-
-  /**
-   * Handle axios response errors
-   */
-  private handleResponseError(error: unknown): Promise<AxiosResponse | never> {
-    // Check if this is our intentional cancellation with a JSON response
-    if (axios.isCancel(error) && this.isCustomCancellation(error)) {
-      try {
-        const message = (error as { message: string }).message;
-        const data: unknown = JSON.parse(message);
-        const config = (error as { config?: InternalAxiosRequestConfig })
-          .config;
-
-        // Return a successful response with our data
-        return Promise.resolve({
-          data,
-          status: 200,
-          statusText: "OK",
-          headers: {},
-          config: config!,
-        } as AxiosResponse);
-      } catch {
-        // Not a valid JSON cancellation, pass through
-      }
-    }
-
-    return Promise.reject(error);
-  }
-
-  /**
-   * Check if the cancellation is one of ours (contains JSON message)
-   */
-  private isCustomCancellation(error: unknown): boolean {
-    return (
-      typeof error === "object" &&
-      error !== null &&
-      "message" in error &&
-      typeof (error as { message: unknown }).message === "string"
-    );
   }
 }

--- a/packages/tools/cal-interceptor/src/CalInterceptor.ts
+++ b/packages/tools/cal-interceptor/src/CalInterceptor.ts
@@ -1,19 +1,21 @@
 import { MemoryStorage } from "./storage/MemoryStorage";
 import type { StorageInterface } from "./storage/StorageInterface";
-import { AxiosInterceptor } from "./AxiosInterceptor";
+import { FetchInterceptor } from "./AxiosInterceptor";
 
 /**
  * CAL Interceptor - intercepts CAL (Crypto Assets List) API calls
  * and returns locally stored descriptors when available
  */
 export class CalInterceptor {
-  private readonly interceptor: AxiosInterceptor;
+  private readonly interceptor: FetchInterceptor;
   private readonly storage: StorageInterface;
 
   constructor(storage?: StorageInterface) {
     // Default to in-memory storage for environment-agnostic behavior
     this.storage = storage ?? new MemoryStorage();
-    this.interceptor = new AxiosInterceptor(this.modifyCalResponse.bind(this));
+    this.interceptor = new FetchInterceptor(
+      this.modifyCalResponse.bind(this),
+    );
   }
 
   /**

--- a/packages/tools/cal-interceptor/src/CalInterceptor.ts
+++ b/packages/tools/cal-interceptor/src/CalInterceptor.ts
@@ -13,9 +13,7 @@ export class CalInterceptor {
   constructor(storage?: StorageInterface) {
     // Default to in-memory storage for environment-agnostic behavior
     this.storage = storage ?? new MemoryStorage();
-    this.interceptor = new FetchInterceptor(
-      this.modifyCalResponse.bind(this),
-    );
+    this.interceptor = new FetchInterceptor(this.modifyCalResponse.bind(this));
   }
 
   /**

--- a/packages/tools/cal-interceptor/src/index.ts
+++ b/packages/tools/cal-interceptor/src/index.ts
@@ -1,4 +1,7 @@
-export { AxiosInterceptor } from "./AxiosInterceptor";
+export {
+  FetchInterceptor,
+  FetchInterceptor as AxiosInterceptor,
+} from "./AxiosInterceptor";
 export { CalInterceptor } from "./CalInterceptor";
 export type {
   ERC7730ClientConfig,

--- a/packages/tools/cal-interceptor/src/index.ts
+++ b/packages/tools/cal-interceptor/src/index.ts
@@ -1,6 +1,6 @@
 export {
-  FetchInterceptor,
   FetchInterceptor as AxiosInterceptor,
+  FetchInterceptor,
 } from "./AxiosInterceptor";
 export { CalInterceptor } from "./CalInterceptor";
 export type {

--- a/packages/transport/speculos/package.json
+++ b/packages/transport/speculos/package.json
@@ -40,8 +40,7 @@
   },
   "dependencies": {
     "@sentry/minimal": "catalog:",
-    "purify-ts": "catalog:",
-    "axios": "catalog:"
+    "purify-ts": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/device-management-kit": "workspace:^",

--- a/packages/transport/speculos/src/internal/datasource/HttpSpeculosDatasource.ts
+++ b/packages/transport/speculos/src/internal/datasource/HttpSpeculosDatasource.ts
@@ -1,5 +1,3 @@
-import axios, { type AxiosInstance } from "axios";
-
 import PACKAGE from "@root/package.json";
 
 import { type SpeculosDatasource } from "./SpeculosDatasource";
@@ -8,48 +6,45 @@ const TIMEOUT = 2000; // 2 second timeout for availability check
 
 const removeTrailingSlashes = (url: string) => url.replace(/\/+$/, "");
 
-export function axiosClientFactory(
-  baseUrl: string,
-  clientHeader: string,
-): AxiosInstance {
-  return axios.create({
-    baseURL: removeTrailingSlashes(baseUrl),
-    timeout: 0,
-    headers: {
-      "X-Ledger-Client-Version": clientHeader,
-    },
-    transitional: { clarifyTimeoutError: true },
-  });
-}
-
 export class HttpSpeculosDatasource implements SpeculosDatasource {
-  private readonly speculosAxiosClient: AxiosInstance;
+  private readonly baseUrl: string;
+  private readonly clientHeader: string;
 
   constructor(
-    private readonly baseUrl: string,
+    baseUrl: string,
     clientHeader: string = `ldmk-transport-speculos/${PACKAGE.version}`,
   ) {
-    this.speculosAxiosClient = axiosClientFactory(baseUrl, clientHeader);
+    this.baseUrl = removeTrailingSlashes(baseUrl);
+    this.clientHeader = clientHeader;
   }
 
   async postApdu(apdu: string): Promise<string> {
-    const { data } = await this.speculosAxiosClient.post<SpeculosApduDTO>(
-      "/apdu",
-      {
-        data: apdu,
+    const response = await fetch(`${this.baseUrl}/apdu`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Ledger-Client-Version": this.clientHeader,
       },
-    );
+      body: JSON.stringify({ data: apdu }),
+    });
+    if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+    const data = (await response.json()) as SpeculosApduDTO;
     return data.data;
   }
 
   async isServerAvailable(): Promise<boolean> {
     try {
-      await this.speculosAxiosClient.request<SpeculosEventsDTO>({
-        method: "GET",
-        url: "/events",
-        timeout: TIMEOUT,
-      });
-      return true;
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), TIMEOUT);
+      try {
+        await fetch(`${this.baseUrl}/events`, {
+          headers: { "X-Ledger-Client-Version": this.clientHeader },
+          signal: controller.signal,
+        });
+        return true;
+      } finally {
+        clearTimeout(timeoutId);
+      }
     } catch {
       return false;
     }
@@ -69,18 +64,14 @@ export class HttpSpeculosDatasource implements SpeculosDatasource {
       throw new Error("global fetch is not available in Node < 18");
     }
 
-    const urlBase = this.speculosAxiosClient.defaults.baseURL ?? this.baseUrl;
-    const url = `${removeTrailingSlashes(urlBase)}/events?stream=true`;
+    const url = `${this.baseUrl}/events?stream=true`;
 
     const controller = new AbortController();
 
     const headers: HeadersInit = {
       Accept: "text/event-stream",
       "Cache-Control": "no-cache",
-      "X-Ledger-Client-Version":
-        (this.speculosAxiosClient.defaults.headers?.common?.[
-          "X-Ledger-Client-Version"
-        ] as string) ?? "ldmk-transport-speculos",
+      "X-Ledger-Client-Version": this.clientHeader,
     };
 
     const response = await fetch(url, {
@@ -166,10 +157,3 @@ type SpeculosApduDTO = {
   data: string;
 };
 
-type SpeculosEventsDTO = {
-  events: Array<{
-    text?: string;
-    x?: number;
-    y?: number;
-  }>;
-};

--- a/packages/transport/speculos/src/internal/datasource/HttpSpeculosDatasource.ts
+++ b/packages/transport/speculos/src/internal/datasource/HttpSpeculosDatasource.ts
@@ -1,3 +1,5 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
+
 import PACKAGE from "@root/package.json";
 
 import { type SpeculosDatasource } from "./SpeculosDatasource";
@@ -9,6 +11,7 @@ const removeTrailingSlashes = (url: string) => url.replace(/\/+$/, "");
 export class HttpSpeculosDatasource implements SpeculosDatasource {
   private readonly baseUrl: string;
   private readonly clientHeader: string;
+  private readonly http: DmkNetworkClient;
 
   constructor(
     baseUrl: string,
@@ -16,35 +19,27 @@ export class HttpSpeculosDatasource implements SpeculosDatasource {
   ) {
     this.baseUrl = removeTrailingSlashes(baseUrl);
     this.clientHeader = clientHeader;
+    this.http = new DmkNetworkClient({
+      headers: {
+        "X-Ledger-Client-Version": this.clientHeader,
+      },
+    });
   }
 
   async postApdu(apdu: string): Promise<string> {
-    const response = await fetch(`${this.baseUrl}/apdu`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Ledger-Client-Version": this.clientHeader,
-      },
-      body: JSON.stringify({ data: apdu }),
-    });
-    if (!response.ok) throw new Error(`HTTP error ${response.status}`);
-    const data = (await response.json()) as SpeculosApduDTO;
+    const data = (await this.http.post(`${this.baseUrl}/apdu`, {
+      data: apdu,
+    })) as SpeculosApduDTO;
     return data.data;
   }
 
   async isServerAvailable(): Promise<boolean> {
     try {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), TIMEOUT);
-      try {
-        await fetch(`${this.baseUrl}/events`, {
-          headers: { "X-Ledger-Client-Version": this.clientHeader },
-          signal: controller.signal,
-        });
-        return true;
-      } finally {
-        clearTimeout(timeoutId);
-      }
+      await this.http.get(`${this.baseUrl}/events`, {
+        timeoutMs: TIMEOUT,
+        responseType: "void",
+      });
+      return true;
     } catch {
       return false;
     }

--- a/packages/transport/speculos/src/internal/datasource/HttpSpeculosDatasource.ts
+++ b/packages/transport/speculos/src/internal/datasource/HttpSpeculosDatasource.ts
@@ -156,4 +156,3 @@ export class HttpSpeculosDatasource implements SpeculosDatasource {
 type SpeculosApduDTO = {
   data: string;
 };
-

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,9 +162,6 @@ catalogs:
     autoprefixer:
       specifier: ^10.4.17
       version: 10.4.20
-    axios:
-      specifier: 1.13.5
-      version: 1.13.5
     babel-plugin-module-resolver:
       specifier: ^5.0.2
       version: 5.0.2
@@ -485,9 +482,6 @@ importers:
       '@ledgerhq/speculos-device-controller':
         specifier: workspace:^
         version: link:../../packages/speculos-device-controller
-      axios:
-        specifier: 'catalog:'
-        version: 1.13.5
       commander:
         specifier: 'catalog:'
         version: 14.0.1
@@ -1069,9 +1063,6 @@ importers:
       '@sentry/minimal':
         specifier: 'catalog:'
         version: 6.19.7
-      axios:
-        specifier: 'catalog:'
-        version: 1.13.5
       inversify:
         specifier: 'catalog:'
         version: 7.5.1(reflect-metadata@0.2.2)
@@ -1417,9 +1408,6 @@ importers:
 
   packages/signer/context-module:
     dependencies:
-      axios:
-        specifier: 'catalog:'
-        version: 1.13.5
       crypto-js:
         specifier: 'catalog:'
         version: 4.2.0
@@ -1895,9 +1883,6 @@ importers:
       '@sentry/minimal':
         specifier: 'catalog:'
         version: 6.19.7
-      axios:
-        specifier: 'catalog:'
-        version: 1.13.5
     devDependencies:
       '@ledgerhq/eslint-config-dsdk':
         specifier: workspace:^
@@ -1919,10 +1904,6 @@ importers:
         version: 10.9.2(@types/node@24.3.0)(typescript@5.9.2)
 
   packages/tools/cal-interceptor:
-    dependencies:
-      axios:
-        specifier: 'catalog:'
-        version: 1.13.5
     devDependencies:
       '@ledgerhq/eslint-config-dsdk':
         specifier: workspace:*
@@ -2191,9 +2172,6 @@ importers:
       '@sentry/minimal':
         specifier: 'catalog:'
         version: 6.19.7
-      axios:
-        specifier: 'catalog:'
-        version: 1.13.5
       purify-ts:
         specifier: 'catalog:'
         version: 2.1.0
@@ -6720,9 +6698,6 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.13.5:
-    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
-
   babel-core@7.0.0-bridge.0:
     resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
     peerDependencies:
@@ -8423,15 +8398,6 @@ packages:
     resolution: {integrity: sha512-+aMGE8hxvz0d8jeju8V7+JGlDDrtaJHbVqOQQLBwXykZx9Gs15QOoXoAO+HeVEjfXtZci2VmdbKPIRWeSZTyMg==}
     engines: {node: '>=4'}
     hasBin: true
-
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
 
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -18431,14 +18397,6 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   babel-core@7.0.0-bridge.0(@babel/core@7.28.3):
     dependencies:
       '@babel/core': 7.28.3
@@ -20633,8 +20591,6 @@ snapshots:
       hermes-parser: 0.32.0
       pirates: 3.0.2
       vlq: 0.2.3
-
-  follow-redirects@1.15.11: {}
 
   for-each@0.3.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,7 +62,7 @@ catalog:
   '@vitejs/plugin-react': ^5.0.0
   '@vitest/coverage-istanbul': ^3.2.4
   autoprefixer: ^10.4.17
-  axios: 1.13.5
+
   babel-plugin-module-resolver: ^5.0.2
   bitcoinjs-lib: ^6.1.6
   bs58: ^6.0.0


### PR DESCRIPTION
### 📝 Description

Remove the `axios` dependency from all packages and replace all HTTP calls with the native `fetch` API.

**Changes per package:**
- **context-module**: Migrated 16 data sources from `axios.request()`/`axios.get()` to `fetch()` with `URL`/`URLSearchParams` for query params
- **device-management-kit**: Migrated `AxiosManagerApiDataSource` (9 API methods) from `axios.get()`/`axios.post()` to `fetch()` within `EitherAsync` blocks
- **speculos-transport**: Replaced `axiosClientFactory` and axios instance with direct `fetch()` calls and `AbortController` for timeouts
- **speculos-device-controller**: Introduced `HttpClient` interface replacing `AxiosInstance`, implemented with `fetch()` and `AbortController`-based timeouts
- **cal-interceptor**: Rewrote `AxiosInterceptor` as `FetchInterceptor` using `globalThis.fetch` monkey-patching instead of axios interceptors/cancel tokens. Exported backwards-compatible `AxiosInterceptor` alias.
- **clear-signing-tester**: Migrated 4 HTTP adapters (Etherscan, CAL, screenshot, screen reader)
- Removed `axios` from all 6 `package.json` files and the `pnpm-workspace.yaml` catalog

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Remove third-party HTTP client dependency in favor of the native fetch API, reducing bundle size and external dependencies.

### ✅ Checklist

- [x] **Covered by automatic tests** — All existing tests migrated from mocking axios to mocking `globalThis.fetch`. 1,592 tests pass across affected packages.
- [x] **Changeset is provided**
- [ ] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - All HTTP calls now use native `fetch` instead of `axios`
  - `FetchInterceptor` replaces `AxiosInterceptor` in cal-interceptor (backwards-compatible alias provided)
  - `HttpClient` interface replaces `AxiosInstance` in speculos-device-controller
  - No public API changes for consumers of the packages

Made with [Cursor](https://cursor.com)