### PR TITLE
✨ (signer-eth) [NO-ISSUE]: Add device action factories for GetAddress and SignPersonalMessage

### DIFF
--- a/.changeset/common-bats-fail.md
+++ b/.changeset/common-bats-fail.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": minor
+---
+
+Add device action factories for GetAddress and SignPersonalMessage

--- a/.changeset/heavy-mangos-write.md
+++ b/.changeset/heavy-mangos-write.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": patch
+---
+
+Extract hardcoded appName string literals into shared APP_NAME constants

--- a/.changeset/heavy-pied-write.md
+++ b/.changeset/heavy-pied-write.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-hyperliquid": patch
+---
+
+Extract hardcoded appName string literals into shared APP_NAME constants

--- a/packages/signer/signer-eth/src/api/app-binder/GetAddressDeviceActionFactory.test.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/GetAddressDeviceActionFactory.test.ts
@@ -1,0 +1,86 @@
+import { type ContextModule } from "@ledgerhq/context-module";
+import {
+  CallTaskInAppDeviceAction,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import { APP_NAME } from "@internal/app-binder/constants";
+
+import { GetAddressDeviceActionFactory } from "./GetAddressDeviceActionFactory";
+
+vi.mock("@ledgerhq/device-management-kit", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@ledgerhq/device-management-kit")>();
+  return {
+    ...original,
+    CallTaskInAppDeviceAction: vi.fn(),
+  };
+});
+
+const mockLoggerFactory = () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  subscribers: [],
+});
+
+describe("GetAddressDeviceActionFactory", () => {
+  const defaultArgs = {
+    derivationPath: "44'/60'/0'/0/0",
+    checkOnDevice: false,
+    returnChainCode: false,
+    skipOpenApp: false,
+    contextModule: {} as ContextModule,
+    loggerFactory: mockLoggerFactory,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    {
+      desc: "checkOnDevice is false",
+      overrides: { checkOnDevice: false },
+      expectedInteraction: UserInteractionRequired.None,
+    },
+    {
+      desc: "checkOnDevice is true",
+      overrides: { checkOnDevice: true },
+      expectedInteraction: UserInteractionRequired.VerifyAddress,
+    },
+  ])(
+    "should use $expectedInteraction interaction when $desc",
+    ({ overrides, expectedInteraction }) => {
+      GetAddressDeviceActionFactory({ ...defaultArgs, ...overrides });
+
+      expect(CallTaskInAppDeviceAction).toHaveBeenCalledWith({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        input: expect.objectContaining({
+          appName: APP_NAME,
+          requiredUserInteraction: expectedInteraction,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          task: expect.any(Function),
+        }),
+      });
+    },
+  );
+
+  it("should forward skipOpenApp to the device action", () => {
+    GetAddressDeviceActionFactory({ ...defaultArgs, skipOpenApp: true });
+
+    expect(CallTaskInAppDeviceAction).toHaveBeenCalledWith({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      input: expect.objectContaining({
+        skipOpenApp: true,
+      }),
+    });
+  });
+
+  it("should accept an optional chainId", () => {
+    GetAddressDeviceActionFactory({ ...defaultArgs, chainId: 1 });
+
+    expect(CallTaskInAppDeviceAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/signer/signer-eth/src/api/app-binder/GetAddressDeviceActionFactory.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/GetAddressDeviceActionFactory.ts
@@ -1,0 +1,48 @@
+import { type ContextModule } from "@ledgerhq/context-module";
+import {
+  CallTaskInAppDeviceAction,
+  type LoggerPublisherService,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import { type GetAddressCommandResponse } from "@api/app-binder/GetAddressCommandTypes";
+import { type EthErrorCodes } from "@internal/app-binder/command/utils/ethAppErrors";
+import { APP_NAME } from "@internal/app-binder/constants";
+import { SendGetAddressTask } from "@internal/app-binder/task/SendGetAddressTask";
+
+export const GetAddressDeviceActionFactory = (args: {
+  derivationPath: string;
+  checkOnDevice: boolean;
+  returnChainCode: boolean;
+  skipOpenApp: boolean;
+  chainId?: number;
+  contextModule: ContextModule;
+  loggerFactory: (tag: string) => LoggerPublisherService;
+}): CallTaskInAppDeviceAction<
+  GetAddressCommandResponse,
+  EthErrorCodes,
+  UserInteractionRequired.VerifyAddress | UserInteractionRequired.None
+> => {
+  return new CallTaskInAppDeviceAction<
+    GetAddressCommandResponse,
+    EthErrorCodes,
+    UserInteractionRequired.VerifyAddress | UserInteractionRequired.None
+  >({
+    input: {
+      task: async (internalApi) =>
+        new SendGetAddressTask(internalApi, {
+          contextModule: args.contextModule,
+          derivationPath: args.derivationPath,
+          checkOnDevice: args.checkOnDevice,
+          returnChainCode: args.returnChainCode,
+          chainId: args.chainId,
+          loggerFactory: args.loggerFactory,
+        }).run(),
+      appName: APP_NAME,
+      requiredUserInteraction: args.checkOnDevice
+        ? UserInteractionRequired.VerifyAddress
+        : UserInteractionRequired.None,
+      skipOpenApp: args.skipOpenApp,
+    },
+  });
+};

--- a/packages/signer/signer-eth/src/api/app-binder/SignPersonalMessageDeviceActionFactory.test.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignPersonalMessageDeviceActionFactory.test.ts
@@ -1,0 +1,72 @@
+import {
+  CallTaskInAppDeviceAction,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import { APP_NAME } from "@internal/app-binder/constants";
+
+import { SignPersonalMessageDeviceActionFactory } from "./SignPersonalMessageDeviceActionFactory";
+
+vi.mock("@ledgerhq/device-management-kit", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@ledgerhq/device-management-kit")>();
+  return {
+    ...original,
+    CallTaskInAppDeviceAction: vi.fn(),
+  };
+});
+
+const mockLoggerFactory = () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  subscribers: [],
+});
+
+describe("SignPersonalMessageDeviceActionFactory", () => {
+  const defaultArgs = {
+    derivationPath: "44'/60'/0'/0/0",
+    message: "Hello, world!" as string | Uint8Array,
+    skipOpenApp: false,
+    loggerFactory: mockLoggerFactory,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    { desc: "a string message", message: "Hello, world!" },
+    {
+      desc: "a Uint8Array message",
+      message: new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f]),
+    },
+  ])("should create a CallTaskInAppDeviceAction for $desc", ({ message }) => {
+    SignPersonalMessageDeviceActionFactory({ ...defaultArgs, message });
+
+    expect(CallTaskInAppDeviceAction).toHaveBeenCalledWith({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      input: expect.objectContaining({
+        appName: APP_NAME,
+        requiredUserInteraction: UserInteractionRequired.SignPersonalMessage,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        task: expect.any(Function),
+      }),
+    });
+  });
+
+  it("should forward skipOpenApp to the device action", () => {
+    SignPersonalMessageDeviceActionFactory({
+      ...defaultArgs,
+      skipOpenApp: true,
+    });
+
+    expect(CallTaskInAppDeviceAction).toHaveBeenCalledWith({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      input: expect.objectContaining({
+        skipOpenApp: true,
+      }),
+    });
+  });
+});

--- a/packages/signer/signer-eth/src/api/app-binder/SignPersonalMessageDeviceActionFactory.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignPersonalMessageDeviceActionFactory.ts
@@ -1,0 +1,40 @@
+import {
+  CallTaskInAppDeviceAction,
+  type LoggerPublisherService,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import { type Signature } from "@api/model/Signature";
+import { type EthErrorCodes } from "@internal/app-binder/command/utils/ethAppErrors";
+import { APP_NAME } from "@internal/app-binder/constants";
+import { SendSignPersonalMessageTask } from "@internal/app-binder/task/SendSignPersonalMessageTask";
+
+export const SignPersonalMessageDeviceActionFactory = (args: {
+  derivationPath: string;
+  message: string | Uint8Array;
+  skipOpenApp: boolean;
+  loggerFactory: (tag: string) => LoggerPublisherService;
+}): CallTaskInAppDeviceAction<
+  Signature,
+  EthErrorCodes,
+  UserInteractionRequired.SignPersonalMessage
+> => {
+  const taskLogger = args.loggerFactory("SendSignPersonalMessageTask");
+  return new CallTaskInAppDeviceAction<
+    Signature,
+    EthErrorCodes,
+    UserInteractionRequired.SignPersonalMessage
+  >({
+    input: {
+      task: async (internalApi) =>
+        new SendSignPersonalMessageTask(internalApi, {
+          derivationPath: args.derivationPath,
+          message: args.message,
+          logger: taskLogger,
+        }).run(),
+      appName: APP_NAME,
+      requiredUserInteraction: UserInteractionRequired.SignPersonalMessage,
+      skipOpenApp: args.skipOpenApp,
+    },
+  });
+};

--- a/packages/signer/signer-eth/src/api/app-binder/SignPersonalMessageDeviceActionTypes.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignPersonalMessageDeviceActionTypes.ts
@@ -15,7 +15,7 @@ export type SignPersonalMessageDAError =
   | OpenAppDAError
   | CommandErrorResult<EthErrorCodes>["error"];
 
-type SignPersonalMessageDARequiredInteraction =
+export type SignPersonalMessageDARequiredInteraction =
   | OpenAppDARequiredInteraction
   | UserInteractionRequired.SignPersonalMessage;
 

--- a/packages/signer/signer-eth/src/api/index.ts
+++ b/packages/signer/signer-eth/src/api/index.ts
@@ -1,3 +1,4 @@
+export { GetAddressDeviceActionFactory } from "@api/app-binder/GetAddressDeviceActionFactory";
 export {
   type GetAddressDAError,
   type GetAddressDAIntermediateValue,
@@ -12,6 +13,7 @@ export {
   type SignDelegationAuthorizationDAReturnType,
   type SignDelegationAuthorizationDAState,
 } from "@api/app-binder/SignDelegationAuthorizationTypes";
+export { SignPersonalMessageDeviceActionFactory } from "@api/app-binder/SignPersonalMessageDeviceActionFactory";
 export {
   type SignPersonalMessageDAError,
   type SignPersonalMessageDAIntermediateValue,


### PR DESCRIPTION
### 📝 Description

Add standalone factory functions for `GetAddress` and `SignPersonalMessage` device actions in the Ethereum signer package. These factories create `CallTaskInAppDeviceAction` instances, making it easier to instantiate device actions without going through the `EthAppBinder`.

Changes:
- New `GetAddressDeviceActionFactory` with support for `checkOnDevice`, `returnChainCode`, `skipOpenApp`, and optional `chainId`
- New `SignPersonalMessageDeviceActionFactory` with support for string and `Uint8Array` messages
- Unit tests for both factories
- Export `SignPersonalMessageDARequiredInteraction` type (previously unexported)
- Export both factories from the public API index

### ❓ Context

- **JIRA or GitHub link**: NO-ISSUE

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [ ] **Documentation is up-to-date**
- [ ] **Impact of the changes:**
  - New public API exports: `GetAddressDeviceActionFactory`, `SignPersonalMessageDeviceActionFactory`
  - Exported `SignPersonalMessageDARequiredInteraction` type

Made with [Cursor](https://cursor.com)