### PR TITLE
✨ (sample) [NO-ISSUE]: Add Celo signer to sample app

### DIFF
--- a/apps/sample/src/app/signers/celo/page.tsx
+++ b/apps/sample/src/app/signers/celo/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+import React from "react";
+
+import { SessionIdWrapper } from "@/components/SessionIdWrapper";
+import { SignerCelo } from "@/components/SignerCelo";
+
+const Signer: React.FC = () => {
+  return <SessionIdWrapper ChildComponent={SignerCelo} />;
+};
+
+export default Signer;

--- a/apps/sample/src/components/SignerCelo/index.tsx
+++ b/apps/sample/src/components/SignerCelo/index.tsx
@@ -1,0 +1,199 @@
+import React, { useMemo } from "react";
+import { hexaStringToBuffer } from "@ledgerhq/device-management-kit";
+import {
+  type GetAddressDAError,
+  type GetAddressDAIntermediateValue,
+  type GetAddressDAOutput,
+  type SignPersonalMessageDAError,
+  type SignPersonalMessageDAIntermediateValue,
+  type SignPersonalMessageDAOutput,
+  type SignTransactionDAError,
+  type SignTransactionDAIntermediateValue,
+  type SignTransactionDAOutput,
+  type SignTypedDataDAError,
+  type SignTypedDataDAIntermediateValue,
+  type SignTypedDataDAOutput,
+  type TypedData,
+} from "@ledgerhq/device-signer-kit-ethereum";
+
+import { DeviceActionsList } from "@/components/DeviceActionsView/DeviceActionsList";
+import { type DeviceActionProps } from "@/components/DeviceActionsView/DeviceActionTester";
+import { useDmk } from "@/providers/DeviceManagementKitProvider";
+import { useSignerEth } from "@/providers/SignerEthProvider";
+
+export const SignerCelo: React.FC<{ sessionId: string }> = ({
+  sessionId,
+}) => {
+  const dmk = useDmk();
+  const signer = useSignerEth();
+
+  const deviceModelId = dmk.getConnectedDevice({
+    sessionId,
+  }).modelId;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const deviceActions: DeviceActionProps<any, any, any, any>[] = useMemo(
+    () => [
+      {
+        title: "Get address",
+        description:
+          "Perform all the actions necessary to get an ethereum address from the device",
+        executeDeviceAction: ({
+          derivationPath,
+          chainId,
+          checkOnDevice,
+          returnChainCode,
+          skipOpenApp,
+        }) => {
+          if (!signer) {
+            throw new Error("Signer not initialized");
+          }
+          return signer.getAddress(derivationPath, {
+            ...(checkOnDevice &&
+              chainId !== undefined &&
+              chainId !== "" &&
+              !Number.isNaN(Number(chainId)) && { chainId: Number(chainId) }),
+            checkOnDevice,
+            returnChainCode,
+            skipOpenApp,
+          });
+        },
+        initialValues: {
+          derivationPath: "44'/52752'/0'/0",
+          chainId: "",
+          checkOnDevice: false,
+          returnChainCode: false,
+          skipOpenApp: false,
+        },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        GetAddressDAOutput,
+        {
+          derivationPath: string;
+          chainId?: number | string;
+          checkOnDevice?: boolean;
+          returnChainCode?: boolean;
+          skipOpenApp?: boolean;
+        },
+        GetAddressDAError,
+        GetAddressDAIntermediateValue
+      >,
+      {
+        title: "Sign message",
+        description:
+          "Perform all the actions necessary to sign a message with the device",
+        executeDeviceAction: ({ derivationPath, message, skipOpenApp }) => {
+          if (!signer) {
+            throw new Error("Signer not initialized");
+          }
+          return signer.signMessage(derivationPath, message, { skipOpenApp });
+        },
+        initialValues: {
+          derivationPath: "44'/52752'/0'/0",
+          message: "Hello World",
+          skipOpenApp: false,
+        },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        SignPersonalMessageDAOutput,
+        {
+          derivationPath: string;
+          message: string;
+          skipOpenApp?: boolean;
+        },
+        SignPersonalMessageDAError,
+        SignPersonalMessageDAIntermediateValue
+      >,
+      {
+        title: "Sign transaction",
+        description:
+          "Perform all the actions necessary to sign a transaction with the device (JSON or serialized raw TX)",
+        executeDeviceAction: ({ derivationPath, transaction, skipOpenApp }) => {
+          if (!signer) {
+            throw new Error("Signer not initialized");
+          }
+
+          const tx = hexaStringToBuffer(transaction);
+          if (!tx) {
+            throw new Error("Invalid transaction format");
+          }
+
+          return signer.signTransaction(derivationPath, tx, {
+            skipOpenApp,
+          });
+        },
+        initialValues: {
+          derivationPath: "44'/52752'/0'/0",
+          transaction: "",
+          skipOpenApp: true,
+        },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        SignTransactionDAOutput,
+        {
+          derivationPath: string;
+          transaction: string;
+          skipOpenApp?: boolean;
+        },
+        SignTransactionDAError,
+        SignTransactionDAIntermediateValue
+      >,
+      {
+        title: "Sign typed message",
+        description:
+          "Perform all the actions necessary to sign a typed message on the device",
+        executeDeviceAction: ({ derivationPath, message, skipOpenApp }) => {
+          const typedData = JSON.parse(message) as TypedData;
+
+          if (!signer) {
+            throw new Error("Signer not initialized");
+          }
+          return signer.signTypedData(derivationPath, typedData, {
+            skipOpenApp,
+          });
+        },
+        initialValues: {
+          derivationPath: "44'/60'/0'/0/0",
+          message: `{"domain":{"name":"USD Coin","verifyingContract":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","chainId":1,"version":"2"},"primaryType":"Permit","message":{"deadline":1718992051,"nonce":0,"spender":"0x111111125421ca6dc452d289314280a0f8842a65","owner":"0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d","value":"115792089237316195423570985008687907853269984665640564039457584007913129639935"},"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Permit":[{"name":"owner","type":"address"},{"name":"spender","type":"address"},{"name":"value","type":"uint256"},{"name":"nonce","type":"uint256"},{"name":"deadline","type":"uint256"}]}}`,
+          skipOpenApp: false,
+        },
+        validateValues: ({ message }) => {
+          try {
+            const parsedData = JSON.parse(message);
+            if (
+              typeof parsedData !== "object" ||
+              typeof parsedData.domain !== "object" ||
+              typeof parsedData.types !== "object" ||
+              typeof parsedData.primaryType !== "string" ||
+              typeof parsedData.message !== "object"
+            ) {
+              console.log(
+                `Invalid typed message format: should conform to EIP712 specification`,
+              );
+              return false;
+            }
+          } catch (error) {
+            console.log(`Invalid typed message format (${error})`);
+            return false;
+          }
+          return true;
+        },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        SignTypedDataDAOutput,
+        {
+          derivationPath: string;
+          message: string;
+          skipOpenApp?: boolean;
+        },
+        SignTypedDataDAError,
+        SignTypedDataDAIntermediateValue
+      >,
+    ],
+    [deviceModelId, signer],
+  );
+
+  return (
+    <DeviceActionsList title="Signer Celo" deviceActions={deviceActions} />
+  );
+};

--- a/apps/sample/src/components/SignerView/index.tsx
+++ b/apps/sample/src/components/SignerView/index.tsx
@@ -41,6 +41,11 @@ const SUPPORTED_SIGNERS = [
     description: "Access Aleo signer functionality",
     icon: <CryptoIcon ledgerId="aleo" ticker="ALEO" size="56px" />,
   },
+  {
+    title: "Celo",
+    description: "Access Celo signer functionality",
+    icon: <CryptoIcon ledgerId="celo" ticker="CELO" size="56px" />,
+  },
 ];
 
 export const SignerView = () => {


### PR DESCRIPTION
### 📝 Description

Add a Celo signer page to the sample application. This reuses the Ethereum signer kit with a Celo-specific derivation path (`44'/52752'/0'/0`) and adds a new entry in the signers list view.

**Changes:**
- New `SignerCelo` component with Get Address, Sign Message, Sign Transaction, and Sign Typed Data device actions
- New `/signers/celo` page route
- Added Celo entry to the `SignerView` supported signers list

### ❓ Context

- **JIRA or GitHub link**: NO-ISSUE

### ✅ Checklist

- [ ] **Covered by automatic tests**
- [x] **Changeset is provided** — No changeset needed: changes only affect the sample app (not a published package)
- [ ] **Documentation is up-to-date**
- [ ] **Impact of the changes:**
  - Adds Celo signer support to the sample application
  - No impact on published packages

Made with [Cursor](https://cursor.com)