### PR TITLE
✨ (solana-signer) [DSDK-1054]: Add delayed signing feature

### DIFF
--- a/.changeset/itchy-teams-join.md
+++ b/.changeset/itchy-teams-join.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": minor
+---
+
+Add delayed transaction signing feature

--- a/.changeset/little-beans-spend.md
+++ b/.changeset/little-beans-spend.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+deduplicate repeated state logs, log terminal states, include intermediateValue in debug output

--- a/apps/docs/pages/docs/references/signers/solana.mdx
+++ b/apps/docs/pages/docs/references/signers/solana.mdx
@@ -39,8 +39,14 @@ npm install @ledgerhq/device-signer-kit-solana
 To initialise a Solana signer instance, you need a Ledger Device Management Kit instance and the ID of the session of the connected device. Use the `SignerSolanaBuilder` along with the [Context Module](https://github.com/LedgerHQ/device-sdk-ts/tree/develop/packages/signer/context-module) by default developed by Ledger:
 
 ```typescript
-const signerSolana = new SignerSolanaBuilder({ dmk, sessionId }).build();
+const signerSolana = new SignerSolanaBuilder({
+  dmk,
+  sessionId,
+  solanaRPCURL: "https://api.mainnet-beta.solana.com/",
+}).build();
 ```
+
+- **solanaRPCURL** _(optional)_ — Default Solana RPC endpoint for transaction inspection (SPL token resolution) and fetching a fresh `recentBlockhash` during delayed signing. Override per call with `SolanaTransactionOptionalConfig.solanaRPCURL`. In browser environments, use a CORS-enabled RPC URL.
 
 ## 🔹 Use Cases
 
@@ -119,6 +125,9 @@ const { observable, cancel } = signerSolana.signTransaction(
 - **transactionOptions** `SolanaTransactionOptionalConfig`  
   Provides additional context for transaction signing.
 
+  - **solanaRPCURL** `string` _(optional)_  
+    Overrides the RPC URL from `SignerSolanaBuilder` for this call (inspection and delayed signing).
+
   - **transactionResolutionContext** `object`  
     Lets you explicitly pass `tokenAddress` and ATA details, bypassing extraction from the transaction itself.
 
@@ -134,13 +143,8 @@ const { observable, cancel } = signerSolana.signTransaction(
     - **tokenInternalId** `string`
       Ledger internal token ID
 
-  - **solanaRPCURL** `string`  
-    RPC endpoint used for address-lookup table resolution in versioned (v0) transactions.
-    Defaults to `https://api.mainnet-beta.solana.com/`. Override this to use a private RPC
-    or to avoid CORS issues in browser environments.
-
-  - **skipOpenApp** `boolean`  
-    If `true`, skips opening the Solana app on the device.
+- **skipOpenApp** `boolean`  
+  If `true`, skips opening the Solana app on the device.
 
 ---
 

--- a/apps/sample/src/components/SignerSolanaView/index.tsx
+++ b/apps/sample/src/components/SignerSolanaView/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import {
   base64StringToBuffer,
   isBase64String,
@@ -42,6 +42,7 @@ type SignTransactionInput = {
   derivationPath: string;
   transaction: string;
   skipOpenApp: boolean;
+  delayed: boolean;
   templateId: string;
   tokenAddress: string;
   tokenInternalId: string;
@@ -53,6 +54,7 @@ const MAIN_KEYS: (keyof SignTransactionInput)[] = [
   "derivationPath",
   "transaction",
   "skipOpenApp",
+  "delayed",
 ];
 
 const CONTEXT_KEYS: (keyof SignTransactionInput)[] = [
@@ -70,6 +72,9 @@ const SignTransactionForm: React.FC<{
 }> = ({ initialValues, onChange, disabled }) => {
   const [expanded, setExpanded] = useState(false);
 
+  const initialValuesRef = useRef(initialValues);
+  initialValuesRef.current = initialValues;
+
   const mainValues = Object.fromEntries(
     MAIN_KEYS.map((k) => [k, initialValues[k]]),
   ) as Pick<SignTransactionInput, (typeof MAIN_KEYS)[number]>;
@@ -79,13 +84,15 @@ const SignTransactionForm: React.FC<{
   ) as Pick<SignTransactionInput, (typeof CONTEXT_KEYS)[number]>;
 
   const handleMainChange = useCallback(
-    (vals: typeof mainValues) => onChange({ ...initialValues, ...vals }),
-    [initialValues, onChange],
+    (vals: typeof mainValues) =>
+      onChange({ ...initialValuesRef.current, ...vals }),
+    [onChange],
   );
 
   const handleContextChange = useCallback(
-    (vals: typeof contextValues) => onChange({ ...initialValues, ...vals }),
-    [initialValues, onChange],
+    (vals: typeof contextValues) =>
+      onChange({ ...initialValuesRef.current, ...vals }),
+    [onChange],
   );
 
   return (
@@ -137,6 +144,7 @@ export const SignerSolanaView: React.FC<{ sessionId: string }> = ({
     dmk,
     sessionId,
     originToken: "Solana",
+    solanaRPCURL: "https://solana.coin.ledger.com",
   }).build();
   const solanaTools = new SolanaToolsBuilder({
     dmk,
@@ -186,6 +194,7 @@ export const SignerSolanaView: React.FC<{ sessionId: string }> = ({
         executeDeviceAction: ({
           derivationPath,
           transaction,
+          delayed,
           templateId,
           tokenAddress,
           tokenInternalId,
@@ -203,25 +212,23 @@ export const SignerSolanaView: React.FC<{ sessionId: string }> = ({
           const hasResolutionContext =
             templateId || tokenAddress || tokenInternalId || createATA;
 
-          return signer.signTransaction(
-            derivationPath,
-            serializedTransaction,
-            hasResolutionContext
-              ? {
-                  transactionResolutionContext: {
-                    templateId: templateId || undefined,
-                    tokenAddress: tokenAddress || undefined,
-                    tokenInternalId: tokenInternalId || undefined,
-                    createATA,
-                  },
-                }
-              : undefined,
-          );
+          return signer.signTransaction(derivationPath, serializedTransaction, {
+            ...(hasResolutionContext && {
+              transactionResolutionContext: {
+                templateId: templateId || undefined,
+                tokenAddress: tokenAddress || undefined,
+                tokenInternalId: tokenInternalId || undefined,
+                createATA,
+              },
+            }),
+            delayed,
+          });
         },
         initialValues: {
           derivationPath: DEFAULT_DERIVATION_PATH,
           transaction: "",
           skipOpenApp: false,
+          delayed: false,
           templateId: "",
           tokenAddress: "",
           tokenInternalId: "",

--- a/packages/device-management-kit/src/api/device-action/xstate-utils/XStateDeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/xstate-utils/XStateDeviceAction.ts
@@ -185,13 +185,16 @@ export abstract class XStateDeviceAction<
       }
 
       // Log internal state on each state transition
-      if (this.logger && status === "active") {
+      if (this.logger && (status === "active" || status === "done")) {
         const stateValue =
           typeof snapshot.value === "string"
             ? snapshot.value
             : JSON.stringify(snapshot.value);
         this.logger.debug(`[XStateDeviceAction] State: ${stateValue}`, {
-          data: { internalState: context._internalState },
+          data: {
+            internalState: context._internalState,
+            intermediateValue: context.intermediateValue,
+          },
         });
       }
 

--- a/packages/signer/signer-solana/README.md
+++ b/packages/signer/signer-solana/README.md
@@ -39,8 +39,14 @@ npm install @ledgerhq/device-signer-kit-solana
 To initialise a Solana signer instance, you need a Ledger Device Management Kit instance and the ID of the session of the connected device. Use the `SignerSolanaBuilder` along with the [Context Module](https://github.com/LedgerHQ/device-sdk-ts/tree/develop/packages/signer/context-module) by default developed by Ledger:
 
 ```typescript
-const signerSolana = new SignerSolanaBuilder({ dmk, sessionId }).build();
+const signerSolana = new SignerSolanaBuilder({
+  dmk,
+  sessionId,
+  solanaRPCURL: "https://api.mainnet-beta.solana.com/",
+}).build();
 ```
+
+- **solanaRPCURL** _(optional)_ — Default Solana RPC endpoint for transaction inspection (SPL token resolution) and fetching a fresh `recentBlockhash` during delayed signing. You can override it per `signTransaction` call via `SolanaTransactionOptionalConfig.solanaRPCURL`. In browser environments, use a CORS-enabled RPC URL.
 
 ## 🔹 Use Cases
 
@@ -119,6 +125,9 @@ const { observable, cancel } = signerSolana.signTransaction(
 - **transactionOptions** `SolanaTransactionOptionalConfig`  
   Provides additional context for transaction signing.
 
+  - **solanaRPCURL** `string` _(optional)_  
+    Overrides the RPC URL from `SignerSolanaBuilder` for this call (inspection and delayed signing).
+
   - **transactionResolutionContext** `object`  
     Lets you explicitly pass `tokenAddress` and ATA details, bypassing extraction from the transaction itself.
 
@@ -134,13 +143,8 @@ const { observable, cancel } = signerSolana.signTransaction(
     - **tokenInternalId** `string`
       Ledger internal token ID
 
-  - **solanaRPCURL** `string`  
-    RPC endpoint used for address-lookup table resolution in versioned (v0) transactions.
-    Defaults to `https://api.mainnet-beta.solana.com/`. Override this to use a private RPC
-    or to avoid CORS issues in browser environments.
-
-  - **skipOpenApp** `boolean`  
-    If `true`, skips opening the Solana app on the device.
+- **skipOpenApp** `boolean`  
+  If `true`, skips opening the Solana app on the device.
 
 ---
 

--- a/packages/signer/signer-solana/src/api/SignerSolanaBuilder.ts
+++ b/packages/signer/signer-solana/src/api/SignerSolanaBuilder.ts
@@ -13,6 +13,7 @@ type SignerSolanaBuilderConstructorArgs = {
   dmk: DeviceManagementKit;
   sessionId: DeviceSessionId;
   originToken?: string;
+  solanaRPCURL?: string;
 };
 
 /**
@@ -29,15 +30,18 @@ export class SignerSolanaBuilder {
   private _sessionId: DeviceSessionId;
   private _customContextModule: ContextModule | undefined;
   private _originToken: string | undefined;
+  private readonly _solanaRPCURL: string | undefined;
 
   constructor({
     dmk,
     sessionId,
     originToken,
+    solanaRPCURL,
   }: SignerSolanaBuilderConstructorArgs) {
     this._dmk = dmk;
     this._sessionId = sessionId;
     this._originToken = originToken;
+    this._solanaRPCURL = solanaRPCURL;
   }
 
   /**
@@ -60,6 +64,7 @@ export class SignerSolanaBuilder {
     return new DefaultSignerSolana({
       dmk: this._dmk,
       sessionId: this._sessionId,
+      solanaRPCURL: this._solanaRPCURL,
       contextModule:
         this._customContextModule ??
         new ContextModuleBuilder({

--- a/packages/signer/signer-solana/src/api/app-binder/DelayedSignTransactionDeviceActionTypes.ts
+++ b/packages/signer/signer-solana/src/api/app-binder/DelayedSignTransactionDeviceActionTypes.ts
@@ -1,0 +1,70 @@
+import {
+  type DeviceActionState,
+  type ExecuteDeviceActionReturnType,
+  type OpenAppDAError,
+  type OpenAppDARequiredInteraction,
+  type SendCommandInAppDAError,
+  type UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import { type Signature } from "@api/model/Signature";
+import { type UserInputType } from "@api/model/TransactionResolutionContext";
+import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+import { type BlockhashService } from "@internal/app-binder/services/BlockhashService";
+
+export const delayedSignDAStateSteps = Object.freeze({
+  ZERO_BLOCKHASH: "signer.sol.steps.zeroBlockhash",
+  PREVIEW_TRANSACTION: "signer.sol.steps.previewTransaction",
+  FETCH_BLOCKHASH: "signer.sol.steps.fetchBlockhash",
+  PATCH_TRANSACTION: "signer.sol.steps.patchTransaction",
+  DELAYED_SIGN: "signer.sol.steps.delayedSign",
+  FALLBACK_TO_NON_DELAYED_SIGN: "signer.sol.steps.fallbackToNonDelayedSign",
+} as const);
+
+export type DelayedSignDAStateStep =
+  (typeof delayedSignDAStateSteps)[keyof typeof delayedSignDAStateSteps];
+
+export type DelayedSignDAOutput = Signature;
+
+export type DelayedSignDAInput = {
+  readonly derivationPath: string;
+  readonly transaction: Uint8Array;
+  readonly rpcUrl?: string;
+  readonly fetchBlockhash?: () => Promise<Uint8Array>;
+  readonly userInputType?: UserInputType;
+  readonly blockhashService?: BlockhashService;
+};
+
+export type DelayedSignDAError =
+  | OpenAppDAError
+  | SendCommandInAppDAError<SolanaAppErrorCodes>;
+
+type DelayedSignDARequiredInteraction =
+  | UserInteractionRequired
+  | OpenAppDARequiredInteraction;
+
+export type DelayedSignDAIntermediateValue = {
+  requiredUserInteraction: DelayedSignDARequiredInteraction;
+  step: DelayedSignDAStateStep;
+};
+
+export type DelayedSignDAState = DeviceActionState<
+  DelayedSignDAOutput,
+  DelayedSignDAError,
+  DelayedSignDAIntermediateValue
+>;
+
+export type DelayedSignDAInternalState = {
+  readonly error: DelayedSignDAError | null;
+  readonly signature: Signature | null;
+  readonly zeroedTransaction: Uint8Array | null;
+  readonly freshBlockhash: Uint8Array | null;
+  readonly patchedTransaction: Uint8Array | null;
+  readonly previewFallback: boolean;
+};
+
+export type DelayedSignDAReturnType = ExecuteDeviceActionReturnType<
+  DelayedSignDAOutput,
+  DelayedSignDAError,
+  DelayedSignDAIntermediateValue
+>;

--- a/packages/signer/signer-solana/src/api/app-binder/SignTransactionDeviceActionTypes.ts
+++ b/packages/signer/signer-solana/src/api/app-binder/SignTransactionDeviceActionTypes.ts
@@ -14,7 +14,10 @@ import { type Signature } from "@api/model/Signature";
 import { type SolanaTransactionOptionalConfig } from "@api/model/SolanaTransactionOptionalConfig";
 import { type Transaction } from "@api/model/Transaction";
 import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+import { type BlockhashService } from "@internal/app-binder/services/BlockhashService";
 import { type TxInspectorResult } from "@internal/app-binder/services/TransactionInspector";
+
+import { type DelayedSignDAStateStep } from "./DelayedSignTransactionDeviceActionTypes";
 
 export const signTransactionDAStateSteps = Object.freeze({
   OPEN_APP: "signer.sol.steps.openApp",
@@ -23,10 +26,12 @@ export const signTransactionDAStateSteps = Object.freeze({
   BUILD_TRANSACTION_CONTEXT: "signer.sol.steps.buildTransactionContext",
   PROVIDE_TRANSACTION_CONTEXT: "signer.sol.steps.provideTransactionContext",
   SIGN_TRANSACTION: "signer.sol.steps.signTransaction",
+  DELAYED_SIGN: "signer.sol.steps.delayedSign",
 } as const);
 
 export type SignTransactionDAStateStep =
-  (typeof signTransactionDAStateSteps)[keyof typeof signTransactionDAStateSteps];
+  | (typeof signTransactionDAStateSteps)[keyof typeof signTransactionDAStateSteps]
+  | DelayedSignDAStateStep;
 
 export type SignTransactionDAOutput = Signature;
 
@@ -35,6 +40,8 @@ export type SignTransactionDAInput = {
   readonly transaction: Transaction;
   readonly contextModule: ContextModule;
   readonly transactionOptions?: SolanaTransactionOptionalConfig;
+  readonly solanaRPCURL?: string;
+  readonly blockhashService?: BlockhashService;
 };
 
 export type SignTransactionDAError =

--- a/packages/signer/signer-solana/src/api/model/SolanaTransactionOptionalConfig.ts
+++ b/packages/signer/signer-solana/src/api/model/SolanaTransactionOptionalConfig.ts
@@ -2,6 +2,9 @@ import { type TransactionResolutionContext } from "./TransactionResolutionContex
 
 export type SolanaTransactionOptionalConfig = {
   transactionResolutionContext?: TransactionResolutionContext;
+  /** When set, overrides the signer default RPC URL for this sign only. */
   solanaRPCURL?: string;
   skipOpenApp?: boolean;
+  delayed?: boolean;
+  fetchBlockhash?: () => Promise<Uint8Array>;
 };

--- a/packages/signer/signer-solana/src/internal/DefaultSignerSolana.ts
+++ b/packages/signer/signer-solana/src/internal/DefaultSignerSolana.ts
@@ -26,6 +26,7 @@ export type DefaultSignerSolanaConstructorArgs = {
   dmk: DeviceManagementKit;
   sessionId: DeviceSessionId;
   contextModule: ContextModule;
+  solanaRPCURL?: string;
 };
 
 export class DefaultSignerSolana implements SignerSolana {
@@ -35,8 +36,14 @@ export class DefaultSignerSolana implements SignerSolana {
     dmk,
     sessionId,
     contextModule,
+    solanaRPCURL,
   }: DefaultSignerSolanaConstructorArgs) {
-    this._container = makeContainer({ dmk, sessionId, contextModule });
+    this._container = makeContainer({
+      dmk,
+      sessionId,
+      contextModule,
+      solanaRPCURL,
+    });
   }
 
   /**
@@ -60,10 +67,23 @@ export class DefaultSignerSolana implements SignerSolana {
    *   and ensures accurate clear-signing details on the device.
    *
    *   - **solanaRPCURL** `string`
-   *     Solana RPC endpoint used when resolving address-lookup tables for
-   *     versioned (v0) transactions. Defaults to
-   *     `https://api.mainnet-beta.solana.com/`. Override this if you use a
-   *     private RPC or need to avoid CORS issues in browser environments.
+   *     Solana RPC endpoint for transaction inspection (including SPL
+   *     resolution) and for fetching a blockhash when `delayed: true`. If the
+   *     signer was built with `SignerSolanaBuilder({ solanaRPCURL })`, the
+   *     value here overrides that default for this call only.
+   *
+   *   - **delayed** `boolean`
+   *     When `true`, uses the device’s two-step signing flow (preview then
+   *     delayed sign) so review time does not race the blockhash. Requires a
+   *     Solana app version that supports delayed signing, and either a
+   *     resolved RPC URL (builder and/or **solanaRPCURL** above) or
+   *     **fetchBlockhash**. Otherwise the signer falls back to legacy signing.
+   *
+   *   - **fetchBlockhash** `() => Promise<Uint8Array>`
+   *     Optional. When `delayed: true`, use this instead of the default RPC
+   *     `getLatestBlockhash` (e.g. custom commitment or RPC). Must return the
+   *     32-byte recent blockhash. If provided, an RPC URL is not required for
+   *     the delayed path.
    *
    *   - **transactionResolutionContext** `object`
    *     Lets you explicitly pass `tokenAddress` and ATA details, bypassing

--- a/packages/signer/signer-solana/src/internal/app-binder/SolanaAppBinder.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/SolanaAppBinder.test.ts
@@ -27,6 +27,7 @@ import {
 
 import { GetAppConfigurationCommand } from "./command/GetAppConfigurationCommand";
 import { GetPubKeyCommand } from "./command/GetPubKeyCommand";
+import { BlockhashService } from "./services/BlockhashService";
 import { APP_NAME } from "./constants";
 import { SolanaAppBinder } from "./SolanaAppBinder";
 
@@ -56,6 +57,8 @@ describe("SolanaAppBinder", () => {
       {} as DeviceSessionId,
       contextModuleStub,
       mockLoggerFactory,
+      undefined,
+      new BlockhashService(),
     );
     expect(binder).toBeDefined();
   });
@@ -86,6 +89,8 @@ describe("SolanaAppBinder", () => {
           "sessionId",
           contextModuleStub,
           mockLoggerFactory,
+          undefined,
+          new BlockhashService(),
         );
         const { observable } = appBinder.getAddress({
           derivationPath: "44'/501'",
@@ -143,6 +148,8 @@ describe("SolanaAppBinder", () => {
           "sessionId",
           contextModuleStub,
           mockLoggerFactory,
+          undefined,
+          new BlockhashService(),
         );
         appBinder.getAddress(params);
 
@@ -176,6 +183,8 @@ describe("SolanaAppBinder", () => {
           "sessionId",
           contextModuleStub,
           mockLoggerFactory,
+          undefined,
+          new BlockhashService(),
         );
         appBinder.getAddress(params);
 
@@ -223,6 +232,8 @@ describe("SolanaAppBinder", () => {
           "sessionId",
           contextModuleStub,
           mockLoggerFactory,
+          undefined,
+          new BlockhashService(),
         );
         const { observable } = appBinder.signTransaction({
           derivationPath: "44'/501'",
@@ -271,6 +282,8 @@ describe("SolanaAppBinder", () => {
         "sessionId",
         contextModuleStub,
         mockLoggerFactory,
+        undefined,
+        new BlockhashService(),
       );
       appBinder.signTransaction({
         derivationPath,
@@ -283,12 +296,12 @@ describe("SolanaAppBinder", () => {
         expect.objectContaining({
           sessionId: "sessionId",
           deviceAction: expect.objectContaining({
-            input: {
+            input: expect.objectContaining({
               derivationPath,
               transaction,
               transactionOptions: { skipOpenApp },
               contextModule: contextModuleStub,
-            },
+            }),
           }),
         }),
       );
@@ -328,6 +341,8 @@ describe("SolanaAppBinder", () => {
           "sessionId",
           contextModuleStub,
           mockLoggerFactory,
+          undefined,
+          new BlockhashService(),
         );
         const { observable } = appBinder.signMessage(signMessageArgs);
 
@@ -386,6 +401,8 @@ describe("SolanaAppBinder", () => {
           "sessionId",
           contextModuleStub,
           mockLoggerFactory,
+          undefined,
+          new BlockhashService(),
         );
         const { observable } = appBinder.signMessage({
           derivationPath: "44'/501'/0'/0'",
@@ -449,6 +466,8 @@ describe("SolanaAppBinder", () => {
           "sessionId",
           contextModuleStub,
           mockLoggerFactory,
+          undefined,
+          new BlockhashService(),
         );
         const { observable } = appBinder.getAppConfiguration();
 
@@ -489,6 +508,8 @@ describe("SolanaAppBinder", () => {
         "sessionId",
         contextModuleStub,
         mockLoggerFactory,
+        undefined,
+        new BlockhashService(),
       );
 
       // WHEN

--- a/packages/signer/signer-solana/src/internal/app-binder/SolanaAppBinder.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/SolanaAppBinder.ts
@@ -22,6 +22,8 @@ import { externalTypes } from "@internal/externalTypes";
 import { GetAppConfigurationCommand } from "./command/GetAppConfigurationCommand";
 import { GetPubKeyCommand } from "./command/GetPubKeyCommand";
 import { SignTransactionDeviceAction } from "./device-action/SignTransactionDeviceAction";
+import { appBinderTypes } from "./di/appBinderTypes";
+import { BlockhashService } from "./services/BlockhashService";
 import { APP_NAME } from "./constants";
 
 @injectable()
@@ -32,6 +34,10 @@ export class SolanaAppBinder {
     @inject(externalTypes.ContextModule) private contextModule: ContextModule,
     @inject(externalTypes.DmkLoggerFactory)
     private dmkLoggerFactory: (tag: string) => LoggerPublisherService,
+    @inject(externalTypes.SolanaRPCURL)
+    private solanaRPCURL: string | undefined,
+    @inject(appBinderTypes.BlockhashService)
+    private blockhashService: BlockhashService,
   ) {}
 
   getAddress(args: {
@@ -68,6 +74,8 @@ export class SolanaAppBinder {
           transaction: args.transaction,
           transactionOptions: args.solanaTransactionOptionalConfig,
           contextModule: this.contextModule,
+          solanaRPCURL: this.solanaRPCURL,
+          blockhashService: this.blockhashService,
         },
         loggerFactory: this.dmkLoggerFactory,
       }),

--- a/packages/signer/signer-solana/src/internal/app-binder/SolanaApplicationResolver.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/SolanaApplicationResolver.ts
@@ -9,6 +9,8 @@ import {
 import { APP_NAME } from "./constants";
 
 const DEFAULT_VERSION = "0.0.1";
+export const SOLANA_MIN_SPL_VERSION = "1.9.2";
+export const SOLANA_MIN_DELAYED_SIGNING_VERSION = "1.14.0";
 
 export const SOLANA_APP_SPL_MIN_VERSION = "1.9.2";
 

--- a/packages/signer/signer-solana/src/internal/app-binder/command/DelayedSignTransactionCommand.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/DelayedSignTransactionCommand.test.ts
@@ -1,0 +1,318 @@
+import {
+  ApduResponse,
+  CommandResultFactory,
+  InvalidResponseFormatError,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { Just, Nothing } from "purify-ts";
+
+import { UserInputType } from "@api/model/TransactionResolutionContext";
+import { SolanaAppCommandError } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+
+import {
+  CLA,
+  DelayedSignTransactionCommand,
+  type DelayedSignTransactionCommandArgs,
+  INS,
+  P1,
+  P2,
+} from "./DelayedSignTransactionCommand";
+
+describe("DelayedSignTransactionCommand", () => {
+  const defaultArgs: DelayedSignTransactionCommandArgs = {
+    serializedTransaction: new Uint8Array(),
+    more: false,
+    extend: false,
+  };
+
+  describe("name", () => {
+    it("should be 'delayedSignTransaction'", () => {
+      const command = new DelayedSignTransactionCommand(defaultArgs);
+      expect(command.name).toBe("delayedSignTransaction");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("should return the correct APDU when the data is empty", () => {
+      // GIVEN
+      const command = new DelayedSignTransactionCommand(defaultArgs);
+
+      // WHEN
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.data).toStrictEqual(new Uint8Array());
+      expect(apdu.cla).toBe(CLA);
+      expect(apdu.ins).toBe(INS);
+      expect(apdu.p1).toBe(P1);
+      expect(apdu.p2).toBe(P2.INIT);
+    });
+
+    it("should return the correct APDU when the data is not empty", () => {
+      // GIVEN
+      const command = new DelayedSignTransactionCommand({
+        serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
+        more: false,
+        extend: false,
+      });
+
+      // WHEN
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.data).toStrictEqual(new Uint8Array([0x01, 0x02, 0x03]));
+      expect(apdu.cla).toBe(CLA);
+      expect(apdu.ins).toBe(INS);
+      expect(apdu.p1).toBe(P1);
+      expect(apdu.p2).toBe(P2.INIT);
+    });
+
+    it("should return the correct APDU when the more flag is set", () => {
+      // GIVEN
+      const command = new DelayedSignTransactionCommand({
+        serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
+        more: true,
+        extend: false,
+      });
+
+      // WHEN
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.data).toStrictEqual(new Uint8Array([0x01, 0x02, 0x03]));
+      expect(apdu.cla).toBe(CLA);
+      expect(apdu.ins).toBe(INS);
+      expect(apdu.p1).toBe(P1);
+      expect(apdu.p2).toBe(P2.MORE);
+    });
+
+    it("should return the correct APDU when the extend flag is set", () => {
+      // GIVEN
+      const command = new DelayedSignTransactionCommand({
+        serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
+        more: false,
+        extend: true,
+      });
+
+      // WHEN
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.data).toStrictEqual(new Uint8Array([0x01, 0x02, 0x03]));
+      expect(apdu.cla).toBe(CLA);
+      expect(apdu.ins).toBe(INS);
+      expect(apdu.p1).toBe(P1);
+      expect(apdu.p2).toBe(P2.EXTEND);
+    });
+
+    it("should return the correct APDU when the more and extend flags are set", () => {
+      // GIVEN
+      const command = new DelayedSignTransactionCommand({
+        serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
+        more: true,
+        extend: true,
+      });
+
+      // WHEN
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.data).toStrictEqual(new Uint8Array([0x01, 0x02, 0x03]));
+      expect(apdu.cla).toBe(CLA);
+      expect(apdu.ins).toBe(INS);
+      expect(apdu.p1).toBe(P1);
+      expect(apdu.p2).toBe(P2.MORE | P2.EXTEND);
+    });
+
+    it("should set the ATA userInputType flag in p2", () => {
+      // GIVEN
+      const command = new DelayedSignTransactionCommand({
+        ...defaultArgs,
+        userInputType: UserInputType.ATA,
+      });
+
+      // WHEN
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.data).toStrictEqual(new Uint8Array());
+      expect(apdu.cla).toBe(CLA);
+      expect(apdu.ins).toBe(INS);
+      expect(apdu.p1).toBe(P1);
+      expect(apdu.p2).toBe(P2.ATA);
+    });
+
+    it("should combine ATA userInputType flag with more and extend flags in p2", () => {
+      // GIVEN
+      const command = new DelayedSignTransactionCommand({
+        serializedTransaction: new Uint8Array([0x01, 0x02]),
+        more: true,
+        extend: true,
+        userInputType: UserInputType.ATA,
+      });
+
+      // WHEN
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.data).toStrictEqual(new Uint8Array([0x01, 0x02]));
+      expect(apdu.cla).toBe(CLA);
+      expect(apdu.ins).toBe(INS);
+      expect(apdu.p1).toBe(P1);
+      expect(apdu.p2).toBe(P2.ATA | P2.MORE | P2.EXTEND);
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("should return Nothing when the response is empty", () => {
+      // GIVEN
+      const command = new DelayedSignTransactionCommand(defaultArgs);
+
+      // WHEN
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x90, 0x00]),
+          data: new Uint8Array([]),
+        }),
+      );
+
+      // THEN
+      expect(result).toStrictEqual(CommandResultFactory({ data: Nothing }));
+    });
+
+    it("should return the signature when the response is not empty", () => {
+      // GIVEN
+      const command = new DelayedSignTransactionCommand(defaultArgs);
+      const data = new Uint8Array(Array.from({ length: 64 }, (_, i) => i + 1));
+
+      // WHEN
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x90, 0x00]),
+          data,
+        }),
+      );
+
+      // THEN
+      expect(result).toStrictEqual(
+        CommandResultFactory({
+          data: Just(data),
+        }),
+      );
+    });
+
+    it("should return an error when the response data is not valid", () => {
+      // GIVEN
+      const command = new DelayedSignTransactionCommand(defaultArgs);
+
+      // WHEN
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x90, 0x00]),
+          data: new Uint8Array([0x01]),
+        }),
+      );
+
+      // THEN
+      if (isSuccessCommandResult(result))
+        assert.fail("The result should be an error.");
+      else {
+        expect(result.error).toEqual(
+          new InvalidResponseFormatError("Signature is missing"),
+        );
+      }
+    });
+
+    it("should return an error for delayed preview not found (0x6f10)", () => {
+      // GIVEN
+      const command = new DelayedSignTransactionCommand(defaultArgs);
+
+      // WHEN
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x6f, 0x10]),
+          data: new Uint8Array(),
+        }),
+      );
+
+      // THEN
+      if (isSuccessCommandResult(result))
+        assert.fail("The result should be an error.");
+      else {
+        expect(result.error).toBeInstanceOf(SolanaAppCommandError);
+        expect((result.error as SolanaAppCommandError).message).toBe(
+          "Delayed signing preview not found",
+        );
+      }
+    });
+
+    it("should return an error for delayed hash mismatch (0x6f11)", () => {
+      // GIVEN
+      const command = new DelayedSignTransactionCommand(defaultArgs);
+
+      // WHEN
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x6f, 0x11]),
+          data: new Uint8Array(),
+        }),
+      );
+
+      // THEN
+      if (isSuccessCommandResult(result))
+        assert.fail("The result should be an error.");
+      else {
+        expect(result.error).toBeInstanceOf(SolanaAppCommandError);
+        expect((result.error as SolanaAppCommandError).message).toBe(
+          "Delayed signing hash mismatch",
+        );
+      }
+    });
+
+    it("should return an error for delayed length mismatch (0x6f12)", () => {
+      // GIVEN
+      const command = new DelayedSignTransactionCommand(defaultArgs);
+
+      // WHEN
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x6f, 0x12]),
+          data: new Uint8Array(),
+        }),
+      );
+
+      // THEN
+      if (isSuccessCommandResult(result))
+        assert.fail("The result should be an error.");
+      else {
+        expect(result.error).toBeInstanceOf(SolanaAppCommandError);
+        expect((result.error as SolanaAppCommandError).message).toBe(
+          "Delayed signing length mismatch",
+        );
+      }
+    });
+
+    it("should return an error for delayed derivation mismatch (0x6f13)", () => {
+      // GIVEN
+      const command = new DelayedSignTransactionCommand(defaultArgs);
+
+      // WHEN
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x6f, 0x13]),
+          data: new Uint8Array(),
+        }),
+      );
+
+      // THEN
+      if (isSuccessCommandResult(result))
+        assert.fail("The result should be an error.");
+      else {
+        expect(result.error).toBeInstanceOf(SolanaAppCommandError);
+        expect((result.error as SolanaAppCommandError).message).toBe(
+          "Delayed signing derivation mismatch",
+        );
+      }
+    });
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/command/DelayedSignTransactionCommand.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/DelayedSignTransactionCommand.ts
@@ -1,0 +1,104 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  InvalidResponseFormatError,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Just, Maybe, Nothing } from "purify-ts";
+
+import { type Signature } from "@api/model/Signature";
+import { UserInputType } from "@api/model/TransactionResolutionContext";
+
+import {
+  SOLANA_APP_ERRORS,
+  SolanaAppCommandErrorFactory,
+  type SolanaAppErrorCodes,
+} from "./utils/SolanaApplicationErrors";
+
+export const CLA = 0xe0;
+export const INS = 0x09;
+export const P1 = 0x01;
+
+export const P2 = {
+  INIT: 0x00,
+  EXTEND: 0x01,
+  MORE: 0x02,
+  ATA: 0x08,
+};
+
+const SIGNATURE_LENGTH = 64;
+
+export type DelayedSignTransactionCommandResponse = Maybe<Signature>;
+export type DelayedSignTransactionCommandArgs = {
+  readonly serializedTransaction: Uint8Array;
+  readonly more: boolean;
+  readonly extend: boolean;
+  readonly userInputType?: UserInputType;
+};
+
+export class DelayedSignTransactionCommand
+  implements
+    Command<
+      DelayedSignTransactionCommandResponse,
+      DelayedSignTransactionCommandArgs,
+      SolanaAppErrorCodes
+    >
+{
+  readonly name = "delayedSignTransaction";
+  private readonly errorHelper = new CommandErrorHelper<
+    DelayedSignTransactionCommandResponse,
+    SolanaAppErrorCodes
+  >(SOLANA_APP_ERRORS, SolanaAppCommandErrorFactory);
+
+  args: DelayedSignTransactionCommandArgs;
+
+  constructor(args: DelayedSignTransactionCommandArgs) {
+    this.args = args;
+  }
+
+  getApdu(): Apdu {
+    const { more, extend, serializedTransaction, userInputType } = this.args;
+    let p2 = P2.INIT;
+    if (more) p2 |= P2.MORE;
+    if (extend) p2 |= P2.EXTEND;
+    if (userInputType === UserInputType.ATA) {
+      p2 |= P2.ATA;
+    }
+
+    return new ApduBuilder({ cla: CLA, ins: INS, p1: P1, p2 })
+      .addBufferToData(serializedTransaction)
+      .build();
+  }
+
+  parseResponse(
+    response: ApduResponse,
+  ): CommandResult<DelayedSignTransactionCommandResponse, SolanaAppErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(response),
+    ).orDefaultLazy(() => {
+      const parser = new ApduParser(response);
+
+      if (parser.getUnparsedRemainingLength() === 0) {
+        return CommandResultFactory({
+          data: Nothing,
+        });
+      }
+
+      const signature = parser.extractFieldByLength(SIGNATURE_LENGTH);
+      if (!signature) {
+        return CommandResultFactory({
+          error: new InvalidResponseFormatError("Signature is missing"),
+        });
+      }
+
+      return CommandResultFactory({
+        data: Just(signature),
+      });
+    });
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/command/SignTransactionPreviewCommand.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/SignTransactionPreviewCommand.test.ts
@@ -1,0 +1,225 @@
+import {
+  ApduResponse,
+  CommandResultFactory,
+  InvalidResponseFormatError,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { Just, Nothing } from "purify-ts";
+
+import { UserInputType } from "@api/model/TransactionResolutionContext";
+
+import {
+  CLA,
+  INS,
+  P1,
+  P2,
+  SignTransactionPreviewCommand,
+  type SignTransactionPreviewCommandArgs,
+} from "./SignTransactionPreviewCommand";
+
+describe("SignTransactionPreviewCommand", () => {
+  const defaultArgs: SignTransactionPreviewCommandArgs = {
+    serializedTransaction: new Uint8Array(),
+    more: false,
+    extend: false,
+  };
+
+  describe("name", () => {
+    it("should be 'signTransactionPreview'", () => {
+      const command = new SignTransactionPreviewCommand(defaultArgs);
+      expect(command.name).toBe("signTransactionPreview");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("should return the correct APDU when the data is empty", () => {
+      // GIVEN
+      const command = new SignTransactionPreviewCommand(defaultArgs);
+
+      // WHEN
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.data).toStrictEqual(new Uint8Array());
+      expect(apdu.cla).toBe(CLA);
+      expect(apdu.ins).toBe(INS);
+      expect(apdu.p1).toBe(P1);
+      expect(apdu.p2).toBe(P2.INIT);
+    });
+
+    it("should return the correct APDU when the data is not empty", () => {
+      // GIVEN
+      const command = new SignTransactionPreviewCommand({
+        serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
+        more: false,
+        extend: false,
+      });
+
+      // WHEN
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.data).toStrictEqual(new Uint8Array([0x01, 0x02, 0x03]));
+      expect(apdu.cla).toBe(CLA);
+      expect(apdu.ins).toBe(INS);
+      expect(apdu.p1).toBe(P1);
+      expect(apdu.p2).toBe(P2.INIT);
+    });
+
+    it("should return the correct APDU when the more flag is set", () => {
+      // GIVEN
+      const command = new SignTransactionPreviewCommand({
+        serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
+        more: true,
+        extend: false,
+      });
+
+      // WHEN
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.data).toStrictEqual(new Uint8Array([0x01, 0x02, 0x03]));
+      expect(apdu.cla).toBe(CLA);
+      expect(apdu.ins).toBe(INS);
+      expect(apdu.p1).toBe(P1);
+      expect(apdu.p2).toBe(P2.MORE);
+    });
+
+    it("should return the correct APDU when the extend flag is set", () => {
+      // GIVEN
+      const command = new SignTransactionPreviewCommand({
+        serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
+        more: false,
+        extend: true,
+      });
+
+      // WHEN
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.data).toStrictEqual(new Uint8Array([0x01, 0x02, 0x03]));
+      expect(apdu.cla).toBe(CLA);
+      expect(apdu.ins).toBe(INS);
+      expect(apdu.p1).toBe(P1);
+      expect(apdu.p2).toBe(P2.EXTEND);
+    });
+
+    it("should return the correct APDU when the more and extend flags are set", () => {
+      // GIVEN
+      const command = new SignTransactionPreviewCommand({
+        serializedTransaction: new Uint8Array([0x01, 0x02, 0x03]),
+        more: true,
+        extend: true,
+      });
+
+      // WHEN
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.data).toStrictEqual(new Uint8Array([0x01, 0x02, 0x03]));
+      expect(apdu.cla).toBe(CLA);
+      expect(apdu.ins).toBe(INS);
+      expect(apdu.p1).toBe(P1);
+      expect(apdu.p2).toBe(P2.MORE | P2.EXTEND);
+    });
+
+    it("should set the ATA userInputType flag in p2", () => {
+      // GIVEN
+      const command = new SignTransactionPreviewCommand({
+        ...defaultArgs,
+        userInputType: UserInputType.ATA,
+      });
+
+      // WHEN
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.data).toStrictEqual(new Uint8Array());
+      expect(apdu.cla).toBe(CLA);
+      expect(apdu.ins).toBe(INS);
+      expect(apdu.p1).toBe(P1);
+      expect(apdu.p2).toBe(P2.ATA);
+    });
+
+    it("should combine ATA userInputType flag with more and extend flags in p2", () => {
+      // GIVEN
+      const command = new SignTransactionPreviewCommand({
+        serializedTransaction: new Uint8Array([0x01, 0x02]),
+        more: true,
+        extend: true,
+        userInputType: UserInputType.ATA,
+      });
+
+      // WHEN
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.data).toStrictEqual(new Uint8Array([0x01, 0x02]));
+      expect(apdu.cla).toBe(CLA);
+      expect(apdu.ins).toBe(INS);
+      expect(apdu.p1).toBe(P1);
+      expect(apdu.p2).toBe(P2.ATA | P2.MORE | P2.EXTEND);
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("should return Nothing when the response is empty", () => {
+      // GIVEN
+      const command = new SignTransactionPreviewCommand(defaultArgs);
+
+      // WHEN
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x90, 0x00]),
+          data: new Uint8Array([]),
+        }),
+      );
+
+      // THEN
+      expect(result).toStrictEqual(CommandResultFactory({ data: Nothing }));
+    });
+
+    it("should return the signature when the response is not empty", () => {
+      // GIVEN
+      const command = new SignTransactionPreviewCommand(defaultArgs);
+      const data = new Uint8Array(Array.from({ length: 64 }, (_, i) => i + 1));
+
+      // WHEN
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x90, 0x00]),
+          data,
+        }),
+      );
+
+      // THEN
+      expect(result).toStrictEqual(
+        CommandResultFactory({
+          data: Just(data),
+        }),
+      );
+    });
+
+    it("should return an error when the response data is not valid", () => {
+      // GIVEN
+      const command = new SignTransactionPreviewCommand(defaultArgs);
+
+      // WHEN
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x90, 0x00]),
+          data: new Uint8Array([0x01]),
+        }),
+      );
+
+      // THEN
+      if (isSuccessCommandResult(result))
+        assert.fail("The result should be an error.");
+      else {
+        expect(result.error).toEqual(
+          new InvalidResponseFormatError("Signature is missing"),
+        );
+      }
+    });
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/command/SignTransactionPreviewCommand.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/SignTransactionPreviewCommand.ts
@@ -1,0 +1,104 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  InvalidResponseFormatError,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Just, Maybe, Nothing } from "purify-ts";
+
+import { type Signature } from "@api/model/Signature";
+import { UserInputType } from "@api/model/TransactionResolutionContext";
+
+import {
+  SOLANA_APP_ERRORS,
+  SolanaAppCommandErrorFactory,
+  type SolanaAppErrorCodes,
+} from "./utils/SolanaApplicationErrors";
+
+export const CLA = 0xe0;
+export const INS = 0x08;
+export const P1 = 0x01;
+
+export const P2 = {
+  INIT: 0x00,
+  EXTEND: 0x01,
+  MORE: 0x02,
+  ATA: 0x08,
+};
+
+const SIGNATURE_LENGTH = 64;
+
+export type SignTransactionPreviewCommandResponse = Maybe<Signature>;
+export type SignTransactionPreviewCommandArgs = {
+  readonly serializedTransaction: Uint8Array;
+  readonly more: boolean;
+  readonly extend: boolean;
+  readonly userInputType?: UserInputType;
+};
+
+export class SignTransactionPreviewCommand
+  implements
+    Command<
+      SignTransactionPreviewCommandResponse,
+      SignTransactionPreviewCommandArgs,
+      SolanaAppErrorCodes
+    >
+{
+  readonly name = "signTransactionPreview";
+  private readonly errorHelper = new CommandErrorHelper<
+    SignTransactionPreviewCommandResponse,
+    SolanaAppErrorCodes
+  >(SOLANA_APP_ERRORS, SolanaAppCommandErrorFactory);
+
+  args: SignTransactionPreviewCommandArgs;
+
+  constructor(args: SignTransactionPreviewCommandArgs) {
+    this.args = args;
+  }
+
+  getApdu(): Apdu {
+    const { more, extend, serializedTransaction, userInputType } = this.args;
+    let p2 = P2.INIT;
+    if (more) p2 |= P2.MORE;
+    if (extend) p2 |= P2.EXTEND;
+    if (userInputType === UserInputType.ATA) {
+      p2 |= P2.ATA;
+    }
+
+    return new ApduBuilder({ cla: CLA, ins: INS, p1: P1, p2 })
+      .addBufferToData(serializedTransaction)
+      .build();
+  }
+
+  parseResponse(
+    response: ApduResponse,
+  ): CommandResult<SignTransactionPreviewCommandResponse, SolanaAppErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(response),
+    ).orDefaultLazy(() => {
+      const parser = new ApduParser(response);
+
+      if (parser.getUnparsedRemainingLength() === 0) {
+        return CommandResultFactory({
+          data: Nothing,
+        });
+      }
+
+      const signature = parser.extractFieldByLength(SIGNATURE_LENGTH);
+      if (!signature) {
+        return CommandResultFactory({
+          error: new InvalidResponseFormatError("Signature is missing"),
+        });
+      }
+
+      return CommandResultFactory({
+        data: Just(signature),
+      });
+    });
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/command/utils/SolanaApplicationErrors.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/utils/SolanaApplicationErrors.ts
@@ -7,18 +7,30 @@ import {
 export type SolanaAppErrorCodes =
   | "6700"
   | "6982"
+  | "6985"
   | "6a80"
   | "6a81"
   | "6a82"
-  | "6b00";
+  | "6b00"
+  | "6d00"
+  | "6f10"
+  | "6f11"
+  | "6f12"
+  | "6f13";
 
 export const SOLANA_APP_ERRORS: CommandErrors<SolanaAppErrorCodes> = {
   "6700": { message: "Incorrect length" },
-  "6982": { message: "Security status not satisfied (Canceled by user)" },
+  "6982": { message: "No APDU received" },
+  "6985": { message: "Canceled by user" },
   "6a80": { message: "Invalid data" },
   "6a81": { message: "Invalid off-chain message header" },
   "6a82": { message: "Invalid off-chain message format" },
   "6b00": { message: "Invalid instruction descriptor" },
+  "6d00": { message: "Instruction not supported" },
+  "6f10": { message: "Delayed signing preview not found" },
+  "6f11": { message: "Delayed signing hash mismatch" },
+  "6f12": { message: "Delayed signing length mismatch" },
+  "6f13": { message: "Delayed signing derivation mismatch" },
 };
 
 export class SolanaAppCommandError extends DeviceExchangeError<SolanaAppErrorCodes> {

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/DelayedSignTransactionDeviceAction.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/DelayedSignTransactionDeviceAction.test.ts
@@ -1,0 +1,615 @@
+import {
+  CommandResultFactory,
+  type DeviceActionState,
+  DeviceActionStatus,
+  InvalidStatusWordError,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+import { Just, Nothing } from "purify-ts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type DelayedSignDAError,
+  type DelayedSignDAInput,
+  type DelayedSignDAIntermediateValue,
+  delayedSignDAStateSteps,
+} from "@api/app-binder/DelayedSignTransactionDeviceActionTypes";
+import { SolanaAppCommandError } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+
+import { makeDeviceActionInternalApiMock } from "./__test-utils__/makeInternalApi";
+import { testDeviceActionStates } from "./__test-utils__/testDeviceActionStates";
+import { DelayedSignTransactionDeviceAction } from "./DelayedSignTransactionDeviceAction";
+
+const defaultDerivation = "44'/501'/0'/0'";
+const exampleTx = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+const exampleBlockhash = new Uint8Array(32).fill(0xab);
+const exampleSignature = new Uint8Array([0xaa, 0xbb]);
+
+const zeroedTx = new Uint8Array([0x00, 0x00, 0x00, 0x00]);
+const patchedTx = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+
+let apiMock: ReturnType<typeof makeDeviceActionInternalApiMock>;
+let previewMock: ReturnType<typeof vi.fn>;
+let delayedSignMock: ReturnType<typeof vi.fn>;
+let fallbackSignMock: ReturnType<typeof vi.fn>;
+let fetchBlockhashMock: ReturnType<typeof vi.fn>;
+let zeroBlockhashMock: ReturnType<typeof vi.fn>;
+let patchBlockhashMock: ReturnType<typeof vi.fn>;
+
+function extractDeps() {
+  return {
+    previewTransaction: previewMock,
+    delayedSignTransaction: delayedSignMock,
+    fallbackSignTransaction: fallbackSignMock,
+    fetchBlockhashFn: fetchBlockhashMock,
+    zeroBlockhashFn: zeroBlockhashMock,
+    patchBlockhashFn: patchBlockhashMock,
+  };
+}
+
+describe("DelayedSignTransactionDeviceAction", () => {
+  beforeEach(() => {
+    apiMock = makeDeviceActionInternalApiMock();
+    previewMock = vi.fn();
+    delayedSignMock = vi.fn();
+    fallbackSignMock = vi.fn();
+    fetchBlockhashMock = vi.fn();
+    zeroBlockhashMock = vi.fn().mockResolvedValue(zeroedTx);
+    patchBlockhashMock = vi.fn().mockResolvedValue(patchedTx);
+  });
+
+  it("happy path: preview accepted -> delayed sign (INS 0x09)", () =>
+    new Promise<void>((resolve, reject) => {
+      previewMock.mockResolvedValue(CommandResultFactory({ data: Nothing }));
+      fetchBlockhashMock.mockResolvedValue(exampleBlockhash);
+      delayedSignMock.mockResolvedValue(
+        CommandResultFactory({ data: Just(exampleSignature) }),
+      );
+
+      const input: DelayedSignDAInput = {
+        derivationPath: defaultDerivation,
+        transaction: exampleTx,
+        rpcUrl: "https://api.devnet.solana.com",
+      };
+
+      const action = new DelayedSignTransactionDeviceAction({ input });
+      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.SignTransaction,
+            step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.FETCH_BLOCKHASH,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.PATCH_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.DELAYED_SIGN,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        { output: exampleSignature, status: DeviceActionStatus.Completed },
+      ] as DeviceActionState<
+        Uint8Array,
+        DelayedSignDAError,
+        DelayedSignDAIntermediateValue
+      >[];
+
+      testDeviceActionStates<
+        Uint8Array,
+        DelayedSignDAInput,
+        DelayedSignDAError,
+        DelayedSignDAIntermediateValue
+      >(action, expected, apiMock, {
+        onDone: () => {
+          expect(previewMock).toHaveBeenCalledTimes(1);
+          expect(delayedSignMock).toHaveBeenCalledTimes(1);
+          expect(fallbackSignMock).not.toHaveBeenCalled();
+          resolve();
+        },
+        onError: reject,
+      });
+    }));
+
+  it("protocol fallback (0x6d00): preview unsupported -> fallback sign (INS 0x06)", () =>
+    new Promise<void>((resolve, reject) => {
+      previewMock.mockResolvedValue(
+        CommandResultFactory({
+          error: new SolanaAppCommandError({
+            errorCode: "6d00",
+            message: "Instruction not supported",
+          }),
+        }),
+      );
+      fetchBlockhashMock.mockResolvedValue(exampleBlockhash);
+      fallbackSignMock.mockResolvedValue(
+        CommandResultFactory({ data: Just(exampleSignature) }),
+      );
+
+      const action = new DelayedSignTransactionDeviceAction({
+        input: {
+          derivationPath: defaultDerivation,
+          transaction: exampleTx,
+          rpcUrl: "https://api.devnet.solana.com",
+        },
+      });
+      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.SignTransaction,
+            step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.FETCH_BLOCKHASH,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.PATCH_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.SignTransaction,
+            step: delayedSignDAStateSteps.FALLBACK_TO_NON_DELAYED_SIGN,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        { output: exampleSignature, status: DeviceActionStatus.Completed },
+      ] as DeviceActionState<
+        Uint8Array,
+        DelayedSignDAError,
+        DelayedSignDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: () => {
+          expect(delayedSignMock).not.toHaveBeenCalled();
+          expect(fallbackSignMock).toHaveBeenCalledTimes(1);
+          resolve();
+        },
+        onError: reject,
+      });
+    }));
+
+  it("user rejection (0x6985) during preview -> error (no fallback)", () =>
+    new Promise<void>((resolve, reject) => {
+      previewMock.mockResolvedValue(
+        CommandResultFactory({
+          error: new SolanaAppCommandError({
+            errorCode: "6985",
+            message: "Canceled by user",
+          }),
+        }),
+      );
+
+      const action = new DelayedSignTransactionDeviceAction({
+        input: {
+          derivationPath: defaultDerivation,
+          transaction: exampleTx,
+          rpcUrl: "https://api.devnet.solana.com",
+        },
+      });
+      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.SignTransaction,
+            step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: expect.objectContaining({
+            _tag: "SolanaAppCommandError",
+          }),
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        Uint8Array,
+        DelayedSignDAError,
+        DelayedSignDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: () => {
+          expect(delayedSignMock).not.toHaveBeenCalled();
+          expect(fallbackSignMock).not.toHaveBeenCalled();
+          expect(fetchBlockhashMock).not.toHaveBeenCalled();
+          resolve();
+        },
+        onError: reject,
+      });
+    }));
+
+  it("user rejection (0x6985) during preview -> error (no fallback)", () =>
+    new Promise<void>((resolve, reject) => {
+      previewMock.mockResolvedValue(
+        CommandResultFactory({
+          error: new SolanaAppCommandError({
+            errorCode: "6985",
+            message: "Conditions of use not satisfied (Canceled by user)",
+          }),
+        }),
+      );
+
+      const action = new DelayedSignTransactionDeviceAction({
+        input: {
+          derivationPath: defaultDerivation,
+          transaction: exampleTx,
+          rpcUrl: "https://api.devnet.solana.com",
+        },
+      });
+      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.SignTransaction,
+            step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: expect.objectContaining({
+            _tag: "SolanaAppCommandError",
+          }),
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        Uint8Array,
+        DelayedSignDAError,
+        DelayedSignDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: () => {
+          expect(delayedSignMock).not.toHaveBeenCalled();
+          expect(fallbackSignMock).not.toHaveBeenCalled();
+          expect(fetchBlockhashMock).not.toHaveBeenCalled();
+          resolve();
+        },
+        onError: reject,
+      });
+    }));
+
+  it("generic preview error -> fallback sign", () =>
+    new Promise<void>((resolve, reject) => {
+      previewMock.mockResolvedValue(
+        CommandResultFactory({
+          error: new InvalidStatusWordError("unexpected"),
+        }),
+      );
+      fetchBlockhashMock.mockResolvedValue(exampleBlockhash);
+      fallbackSignMock.mockResolvedValue(
+        CommandResultFactory({ data: Just(exampleSignature) }),
+      );
+
+      const action = new DelayedSignTransactionDeviceAction({
+        input: {
+          derivationPath: defaultDerivation,
+          transaction: exampleTx,
+          rpcUrl: "https://api.devnet.solana.com",
+        },
+      });
+      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.SignTransaction,
+            step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.FETCH_BLOCKHASH,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.PATCH_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.SignTransaction,
+            step: delayedSignDAStateSteps.FALLBACK_TO_NON_DELAYED_SIGN,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        { output: exampleSignature, status: DeviceActionStatus.Completed },
+      ] as DeviceActionState<
+        Uint8Array,
+        DelayedSignDAError,
+        DelayedSignDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: () => {
+          expect(fallbackSignMock).toHaveBeenCalledTimes(1);
+          resolve();
+        },
+        onError: reject,
+      });
+    }));
+
+  it("fetch blockhash failure -> error", () =>
+    new Promise<void>((resolve, reject) => {
+      previewMock.mockResolvedValue(CommandResultFactory({ data: Nothing }));
+      fetchBlockhashMock.mockRejectedValue(new Error("network error"));
+
+      const action = new DelayedSignTransactionDeviceAction({
+        input: {
+          derivationPath: defaultDerivation,
+          transaction: exampleTx,
+          rpcUrl: "https://api.devnet.solana.com",
+        },
+      });
+      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.SignTransaction,
+            step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.FETCH_BLOCKHASH,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: expect.objectContaining({
+            _tag: "UnknownDAError",
+          }),
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        Uint8Array,
+        DelayedSignDAError,
+        DelayedSignDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+    }));
+
+  it("delayed sign failure (0x6f11 hash mismatch) -> error", () =>
+    new Promise<void>((resolve, reject) => {
+      previewMock.mockResolvedValue(CommandResultFactory({ data: Nothing }));
+      fetchBlockhashMock.mockResolvedValue(exampleBlockhash);
+      delayedSignMock.mockResolvedValue(
+        CommandResultFactory({
+          error: new SolanaAppCommandError({
+            errorCode: "6f11",
+            message: "Delayed signing hash mismatch",
+          }),
+        }),
+      );
+
+      const action = new DelayedSignTransactionDeviceAction({
+        input: {
+          derivationPath: defaultDerivation,
+          transaction: exampleTx,
+          rpcUrl: "https://api.devnet.solana.com",
+        },
+      });
+      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.SignTransaction,
+            step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.FETCH_BLOCKHASH,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.PATCH_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.DELAYED_SIGN,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: expect.objectContaining({
+            _tag: "SolanaAppCommandError",
+          }),
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        Uint8Array,
+        DelayedSignDAError,
+        DelayedSignDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+    }));
+
+  it("uses custom fetchBlockhash callback when provided", () =>
+    new Promise<void>((resolve, reject) => {
+      const customFetchBlockhash = vi.fn().mockResolvedValue(exampleBlockhash);
+
+      previewMock.mockResolvedValue(CommandResultFactory({ data: Nothing }));
+      delayedSignMock.mockResolvedValue(
+        CommandResultFactory({ data: Just(exampleSignature) }),
+      );
+
+      const action = new DelayedSignTransactionDeviceAction({
+        input: {
+          derivationPath: defaultDerivation,
+          transaction: exampleTx,
+          fetchBlockhash: customFetchBlockhash,
+        },
+      });
+      vi.spyOn(action, "extractDependencies").mockReturnValue({
+        ...extractDeps(),
+        fetchBlockhashFn: async (arg0: {
+          input: {
+            rpcUrl?: string;
+            fetchBlockhash?: () => Promise<Uint8Array>;
+          };
+        }) => {
+          if (arg0.input.fetchBlockhash) {
+            return arg0.input.fetchBlockhash();
+          }
+          throw new Error("No rpcUrl provided");
+        },
+      });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.SignTransaction,
+            step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.FETCH_BLOCKHASH,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.PATCH_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: delayedSignDAStateSteps.DELAYED_SIGN,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        { output: exampleSignature, status: DeviceActionStatus.Completed },
+      ] as DeviceActionState<
+        Uint8Array,
+        DelayedSignDAError,
+        DelayedSignDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: () => {
+          expect(customFetchBlockhash).toHaveBeenCalledTimes(1);
+          resolve();
+        },
+        onError: reject,
+      });
+    }));
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/DelayedSignTransactionDeviceAction.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/DelayedSignTransactionDeviceAction.ts
@@ -1,0 +1,511 @@
+import {
+  type CommandResult,
+  type DeviceActionStateMachine,
+  type InternalApi,
+  isSuccessCommandResult,
+  type StateMachineTypes,
+  UnknownDAError,
+  UserInteractionRequired,
+  XStateDeviceAction,
+} from "@ledgerhq/device-management-kit";
+import { Left, type Maybe, Right } from "purify-ts";
+import { assign, fromPromise, setup } from "xstate";
+
+import {
+  type DelayedSignDAError,
+  type DelayedSignDAInput,
+  type DelayedSignDAIntermediateValue,
+  type DelayedSignDAInternalState,
+  type DelayedSignDAOutput,
+  delayedSignDAStateSteps,
+} from "@api/app-binder/DelayedSignTransactionDeviceActionTypes";
+import { type Signature } from "@api/model/Signature";
+import { type UserInputType } from "@api/model/TransactionResolutionContext";
+import { DelayedSignTransactionCommand } from "@internal/app-binder/command/DelayedSignTransactionCommand";
+import { SignTransactionCommand } from "@internal/app-binder/command/SignTransactionCommand";
+import { SignTransactionPreviewCommand } from "@internal/app-binder/command/SignTransactionPreviewCommand";
+import {
+  SolanaAppCommandError,
+  type SolanaAppErrorCodes,
+} from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+import { BlockhashService } from "@internal/app-binder/services/BlockhashService";
+import { SignDataTask } from "@internal/app-binder/task/SendSignDataTask";
+
+export type MachineDependencies = {
+  readonly previewTransaction: (arg0: {
+    input: {
+      derivationPath: string;
+      serializedTransaction: Uint8Array;
+      userInputType?: UserInputType;
+    };
+  }) => Promise<CommandResult<Maybe<Signature>, SolanaAppErrorCodes>>;
+  readonly delayedSignTransaction: (arg0: {
+    input: {
+      derivationPath: string;
+      serializedTransaction: Uint8Array;
+      userInputType?: UserInputType;
+    };
+  }) => Promise<CommandResult<Maybe<Signature>, SolanaAppErrorCodes>>;
+  readonly fallbackSignTransaction: (arg0: {
+    input: {
+      derivationPath: string;
+      serializedTransaction: Uint8Array;
+      userInputType?: UserInputType;
+    };
+  }) => Promise<CommandResult<Maybe<Signature>, SolanaAppErrorCodes>>;
+  readonly fetchBlockhashFn: (arg0: {
+    input: {
+      rpcUrl?: string;
+      fetchBlockhash?: () => Promise<Uint8Array>;
+    };
+  }) => Promise<Uint8Array>;
+  readonly zeroBlockhashFn: (arg0: {
+    input: { transaction: Uint8Array };
+  }) => Promise<Uint8Array>;
+  readonly patchBlockhashFn: (arg0: {
+    input: { transaction: Uint8Array; freshBlockhash: Uint8Array };
+  }) => Promise<Uint8Array>;
+};
+
+const USER_REJECTION_CODE: SolanaAppErrorCodes = "6985";
+
+export class DelayedSignTransactionDeviceAction extends XStateDeviceAction<
+  DelayedSignDAOutput,
+  DelayedSignDAInput,
+  DelayedSignDAError,
+  DelayedSignDAIntermediateValue,
+  DelayedSignDAInternalState
+> {
+  makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    DelayedSignDAOutput,
+    DelayedSignDAInput,
+    DelayedSignDAError,
+    DelayedSignDAIntermediateValue,
+    DelayedSignDAInternalState
+  > {
+    type types = StateMachineTypes<
+      DelayedSignDAOutput,
+      DelayedSignDAInput,
+      DelayedSignDAError,
+      DelayedSignDAIntermediateValue,
+      DelayedSignDAInternalState
+    >;
+
+    const {
+      previewTransaction,
+      delayedSignTransaction,
+      fallbackSignTransaction,
+      fetchBlockhashFn,
+      zeroBlockhashFn,
+      patchBlockhashFn,
+    } = this.extractDependencies(internalApi);
+
+    return setup({
+      types: {
+        input: {} as types["input"],
+        context: {} as types["context"],
+        output: {} as types["output"],
+      },
+      actors: {
+        previewTransaction: fromPromise(previewTransaction),
+        delayedSignTransaction: fromPromise(delayedSignTransaction),
+        fallbackSignTransaction: fromPromise(fallbackSignTransaction),
+        fetchBlockhashFn: fromPromise(fetchBlockhashFn),
+        zeroBlockhashFn: fromPromise(zeroBlockhashFn),
+        patchBlockhashFn: fromPromise(patchBlockhashFn),
+      },
+      guards: {
+        noInternalError: ({ context }) => context._internalState.error === null,
+        isPreviewFallback: ({ context }) =>
+          context._internalState.previewFallback,
+      },
+      actions: {
+        assignErrorFromEvent: assign({
+          _internalState: (_) => ({
+            ..._.context._internalState,
+            error: new UnknownDAError(
+              _.event["error"] instanceof Error
+                ? _.event["error"].message
+                : String(_.event["error"]),
+            ),
+          }),
+        }),
+      },
+    }).createMachine({
+      id: "DelayedSignTransactionDeviceAction",
+      initial: "ZeroBlockhash",
+      context: ({ input }) => ({
+        input,
+        intermediateValue: {
+          requiredUserInteraction: UserInteractionRequired.None,
+          step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+        },
+        _internalState: {
+          error: null,
+          signature: null,
+          zeroedTransaction: null,
+          freshBlockhash: null,
+          patchedTransaction: null,
+          previewFallback: false,
+        },
+      }),
+      states: {
+        ZeroBlockhash: {
+          entry: assign({
+            intermediateValue: () => ({
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+            }),
+          }),
+          invoke: {
+            id: "zeroBlockhashFn",
+            src: "zeroBlockhashFn",
+            input: ({ context }) => ({
+              transaction: context.input.transaction,
+            }),
+            onDone: {
+              target: "PreviewTransaction",
+              actions: assign({
+                _internalState: ({ event, context }) => ({
+                  ...context._internalState,
+                  zeroedTransaction: event.output,
+                }),
+              }),
+            },
+            onError: {
+              target: "Error",
+              actions: "assignErrorFromEvent",
+            },
+          },
+        },
+        PreviewTransaction: {
+          entry: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.SignTransaction,
+              step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+            },
+          }),
+          invoke: {
+            id: "previewTransaction",
+            src: "previewTransaction",
+            input: ({ context }) => ({
+              derivationPath: context.input.derivationPath,
+              serializedTransaction: context._internalState.zeroedTransaction!,
+              userInputType: context.input.userInputType,
+            }),
+            onDone: {
+              target: "PreviewResultCheck",
+              actions: assign({
+                _internalState: ({ event, context }) => {
+                  if (isSuccessCommandResult(event.output)) {
+                    return {
+                      ...context._internalState,
+                      previewFallback: false,
+                    };
+                  }
+                  const error = event.output.error;
+                  if (
+                    error instanceof SolanaAppCommandError &&
+                    error.errorCode === USER_REJECTION_CODE
+                  ) {
+                    return { ...context._internalState, error };
+                  }
+                  return {
+                    ...context._internalState,
+                    previewFallback: true,
+                  };
+                },
+                intermediateValue: {
+                  requiredUserInteraction: UserInteractionRequired.None,
+                  step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+                },
+              }),
+            },
+            onError: {
+              target: "Error",
+              actions: "assignErrorFromEvent",
+            },
+          },
+        },
+        PreviewResultCheck: {
+          always: [
+            { guard: "noInternalError", target: "FetchBlockhash" },
+            { target: "Error" },
+          ],
+        },
+        FetchBlockhash: {
+          entry: assign({
+            intermediateValue: () => ({
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: delayedSignDAStateSteps.FETCH_BLOCKHASH,
+            }),
+          }),
+          invoke: {
+            id: "fetchBlockhashFn",
+            src: "fetchBlockhashFn",
+            input: ({ context }) => ({
+              rpcUrl: context.input.rpcUrl,
+              fetchBlockhash: context.input.fetchBlockhash,
+            }),
+            onDone: {
+              target: "PatchTransaction",
+              actions: assign({
+                _internalState: ({ event, context }) => ({
+                  ...context._internalState,
+                  freshBlockhash: event.output,
+                }),
+              }),
+            },
+            onError: {
+              target: "Error",
+              actions: "assignErrorFromEvent",
+            },
+          },
+        },
+        PatchTransaction: {
+          entry: assign({
+            intermediateValue: () => ({
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: delayedSignDAStateSteps.PATCH_TRANSACTION,
+            }),
+          }),
+          invoke: {
+            id: "patchBlockhashFn",
+            src: "patchBlockhashFn",
+            input: ({ context }) => ({
+              transaction: context.input.transaction,
+              freshBlockhash: context._internalState.freshBlockhash!,
+            }),
+            onDone: {
+              target: "PatchResultCheck",
+              actions: assign({
+                _internalState: ({ event, context }) => ({
+                  ...context._internalState,
+                  patchedTransaction: event.output,
+                }),
+              }),
+            },
+            onError: {
+              target: "Error",
+              actions: "assignErrorFromEvent",
+            },
+          },
+        },
+        PatchResultCheck: {
+          always: [
+            { target: "FallbackSign", guard: "isPreviewFallback" },
+            { target: "DelayedSign" },
+          ],
+        },
+        DelayedSign: {
+          entry: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: delayedSignDAStateSteps.DELAYED_SIGN,
+            },
+          }),
+          invoke: {
+            id: "delayedSignTransaction",
+            src: "delayedSignTransaction",
+            input: ({ context }) => ({
+              derivationPath: context.input.derivationPath,
+              serializedTransaction: context._internalState.patchedTransaction!,
+              userInputType: context.input.userInputType,
+            }),
+            onDone: {
+              target: "ResultCheck",
+              actions: assign({
+                _internalState: ({ event, context }) => {
+                  if (!isSuccessCommandResult(event.output))
+                    return {
+                      ...context._internalState,
+                      error: event.output.error,
+                    };
+
+                  const data = event.output.data.extract();
+                  if (event.output.data.isJust() && data instanceof Uint8Array)
+                    return {
+                      ...context._internalState,
+                      signature: data,
+                    };
+
+                  return {
+                    ...context._internalState,
+                    error: new UnknownDAError("No signature available"),
+                  };
+                },
+              }),
+            },
+            onError: {
+              target: "Error",
+              actions: "assignErrorFromEvent",
+            },
+          },
+        },
+        FallbackSign: {
+          entry: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.SignTransaction,
+              step: delayedSignDAStateSteps.FALLBACK_TO_NON_DELAYED_SIGN,
+            },
+          }),
+          invoke: {
+            id: "fallbackSignTransaction",
+            src: "fallbackSignTransaction",
+            input: ({ context }) => ({
+              derivationPath: context.input.derivationPath,
+              serializedTransaction: context._internalState.patchedTransaction!,
+              userInputType: context.input.userInputType,
+            }),
+            onDone: {
+              target: "ResultCheck",
+              actions: assign({
+                _internalState: ({ event, context }) => {
+                  if (!isSuccessCommandResult(event.output))
+                    return {
+                      ...context._internalState,
+                      error: event.output.error,
+                    };
+
+                  const data = event.output.data.extract();
+                  if (event.output.data.isJust() && data instanceof Uint8Array)
+                    return {
+                      ...context._internalState,
+                      signature: data,
+                    };
+
+                  return {
+                    ...context._internalState,
+                    error: new UnknownDAError("No signature available"),
+                  };
+                },
+              }),
+            },
+            onError: {
+              target: "Error",
+              actions: "assignErrorFromEvent",
+            },
+          },
+        },
+        ResultCheck: {
+          always: [
+            { guard: "noInternalError", target: "Success" },
+            { target: "Error" },
+          ],
+        },
+        Success: { type: "final" },
+        Error: { type: "final" },
+      },
+      output: ({ context }) =>
+        context._internalState.signature
+          ? Right(context._internalState.signature)
+          : Left(
+              context._internalState.error ||
+                new UnknownDAError("No error or signature available"),
+            ),
+    });
+  }
+
+  extractDependencies(internalApi: InternalApi): MachineDependencies {
+    const blockhashService =
+      this.input.blockhashService ?? new BlockhashService();
+
+    const previewTransaction = async (arg0: {
+      input: {
+        derivationPath: string;
+        serializedTransaction: Uint8Array;
+        userInputType?: UserInputType;
+      };
+    }) =>
+      new SignDataTask(internalApi, {
+        commandFactory: (args) =>
+          new SignTransactionPreviewCommand({
+            serializedTransaction: args.chunkedData,
+            more: args.more,
+            extend: args.extend,
+            userInputType: arg0.input.userInputType,
+          }),
+        derivationPath: arg0.input.derivationPath,
+        sendingData: arg0.input.serializedTransaction,
+      }).run();
+
+    const delayedSignTransaction = async (arg0: {
+      input: {
+        derivationPath: string;
+        serializedTransaction: Uint8Array;
+        userInputType?: UserInputType;
+      };
+    }) =>
+      new SignDataTask(internalApi, {
+        commandFactory: (args) =>
+          new DelayedSignTransactionCommand({
+            serializedTransaction: args.chunkedData,
+            more: args.more,
+            extend: args.extend,
+            userInputType: arg0.input.userInputType,
+          }),
+        derivationPath: arg0.input.derivationPath,
+        sendingData: arg0.input.serializedTransaction,
+      }).run();
+
+    const fallbackSignTransaction = async (arg0: {
+      input: {
+        derivationPath: string;
+        serializedTransaction: Uint8Array;
+        userInputType?: UserInputType;
+      };
+    }) =>
+      new SignDataTask(internalApi, {
+        commandFactory: (args) =>
+          new SignTransactionCommand({
+            serializedTransaction: args.chunkedData,
+            more: args.more,
+            extend: args.extend,
+            userInputType: arg0.input.userInputType,
+          }),
+        derivationPath: arg0.input.derivationPath,
+        sendingData: arg0.input.serializedTransaction,
+      }).run();
+
+    const fetchBlockhashFn = async (arg0: {
+      input: {
+        rpcUrl?: string;
+        fetchBlockhash?: () => Promise<Uint8Array>;
+      };
+    }) => {
+      if (arg0.input.fetchBlockhash) {
+        return arg0.input.fetchBlockhash();
+      }
+      if (!arg0.input.rpcUrl) {
+        throw new Error("No rpcUrl or fetchBlockhash callback provided");
+      }
+      return blockhashService.fetchLatestBlockhash(arg0.input.rpcUrl);
+    };
+
+    const zeroBlockhashFn = async (arg0: {
+      input: { transaction: Uint8Array };
+    }) =>
+      Promise.resolve(blockhashService.zeroBlockhash(arg0.input.transaction));
+
+    const patchBlockhashFn = async (arg0: {
+      input: { transaction: Uint8Array; freshBlockhash: Uint8Array };
+    }) =>
+      Promise.resolve(
+        blockhashService.patchBlockhash(
+          arg0.input.transaction,
+          arg0.input.freshBlockhash,
+        ),
+      );
+
+    return {
+      previewTransaction,
+      delayedSignTransaction,
+      fallbackSignTransaction,
+      fetchBlockhashFn,
+      zeroBlockhashFn,
+      patchBlockhashFn,
+    };
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceAction.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceAction.test.ts
@@ -10,7 +10,7 @@ import {
   UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
 import { Just, Nothing } from "purify-ts";
-import { beforeEach, describe, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   type SignTransactionDAError,
@@ -18,12 +18,17 @@ import {
   type SignTransactionDAIntermediateValue,
   signTransactionDAStateSteps,
 } from "@api/app-binder/SignTransactionDeviceActionTypes";
+import { SolanaAppCommandError } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
 import { testDeviceActionStates } from "@internal/app-binder/device-action/__test-utils__/testDeviceActionStates";
 import { SolanaTransactionTypes } from "@internal/app-binder/services/TransactionInspector";
-import { SOLANA_APP_SPL_MIN_VERSION } from "@internal/app-binder/SolanaApplicationResolver";
+import {
+  SOLANA_APP_SPL_MIN_VERSION,
+  SOLANA_MIN_DELAYED_SIGNING_VERSION,
+} from "@internal/app-binder/SolanaApplicationResolver";
 import { type SolanaBuildContextResult } from "@internal/app-binder/task/BuildTransactionContextTask";
 
 import { makeDeviceActionInternalApiMock } from "./__test-utils__/makeInternalApi";
+import { DelayedSignTransactionDeviceAction } from "./DelayedSignTransactionDeviceAction";
 import { SignTransactionDeviceAction } from "./SignTransactionDeviceAction";
 
 const defaultDerivation = "44'/501'/0'/0'";
@@ -63,13 +68,88 @@ describe("SignTransactionDeviceAction (Solana)", () => {
     });
   });
 
+  it("passes transactionOptions.solanaRPCURL to inspectTransaction when it overrides builder solanaRPCURL", () =>
+    new Promise<void>((resolve, reject) => {
+      apiMock.getDeviceSessionState.mockReturnValue({
+        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+        deviceStatus: DeviceStatus.CONNECTED,
+        installedApps: [],
+        currentApp: { name: "Solana", version: "1.10.0" },
+        deviceModelId: DeviceModelId.NANO_X,
+        isSecureConnectionAllowed: true,
+      });
+
+      getAppConfigMock.mockResolvedValue(CommandResultFactory({ data: {} }));
+      inspectTransactionMock.mockImplementation(
+        async (arg: { rpcUrl?: string }) => {
+          expect(arg.rpcUrl).toBe("https://per-call.example.com");
+          return {
+            transactionType: SolanaTransactionTypes.STANDARD,
+          };
+        },
+      );
+
+      const signature = new Uint8Array([0xaa, 0xbb]);
+      signMock.mockResolvedValue(
+        CommandResultFactory({ data: Just(signature) }),
+      );
+
+      const input: SignTransactionDAInput = {
+        derivationPath: defaultDerivation,
+        transaction: exampleTx,
+        transactionOptions: {
+          skipOpenApp: true,
+          solanaRPCURL: "https://per-call.example.com",
+        },
+        solanaRPCURL: "https://builder.example.com",
+        contextModule: contextModuleStub,
+      };
+
+      const action = new SignTransactionDeviceAction({ input });
+      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: signTransactionDAStateSteps.GET_APP_CONFIG,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.SignTransaction,
+            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        { output: signature, status: DeviceActionStatus.Completed },
+      ] as DeviceActionState<
+        Uint8Array,
+        SignTransactionDAError,
+        SignTransactionDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+    }));
+
   it("happy path (skip open): getAppConfig -> inspect -> build -> provide -> sign", () =>
     new Promise<void>((resolve, reject) => {
       apiMock.getDeviceSessionState.mockReturnValue({
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.CONNECTED,
         installedApps: [],
-        currentApp: { name: "Solana", version: SOLANA_APP_SPL_MIN_VERSION },
+        currentApp: { name: "Solana", version: "1.10.0" },
         deviceModelId: DeviceModelId.NANO_X,
         isSecureConnectionAllowed: true,
       });
@@ -170,7 +250,7 @@ describe("SignTransactionDeviceAction (Solana)", () => {
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.CONNECTED,
         installedApps: [],
-        currentApp: { name: "Solana", version: SOLANA_APP_SPL_MIN_VERSION },
+        currentApp: { name: "Solana", version: "1.10.0" },
         deviceModelId: DeviceModelId.NANO_X,
         isSecureConnectionAllowed: true,
       });
@@ -245,7 +325,7 @@ describe("SignTransactionDeviceAction (Solana)", () => {
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.CONNECTED,
         installedApps: [],
-        currentApp: { name: "Solana", version: SOLANA_APP_SPL_MIN_VERSION },
+        currentApp: { name: "Solana", version: "1.10.0" },
         deviceModelId: DeviceModelId.NANO_X,
         isSecureConnectionAllowed: true,
       });
@@ -326,7 +406,7 @@ describe("SignTransactionDeviceAction (Solana)", () => {
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.CONNECTED,
         installedApps: [],
-        currentApp: { name: "Solana", version: SOLANA_APP_SPL_MIN_VERSION },
+        currentApp: { name: "Solana", version: "1.10.0" },
         deviceModelId: DeviceModelId.NANO_X,
         isSecureConnectionAllowed: true,
       });
@@ -430,7 +510,7 @@ describe("SignTransactionDeviceAction (Solana)", () => {
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.CONNECTED,
         installedApps: [],
-        currentApp: { name: "Solana", version: SOLANA_APP_SPL_MIN_VERSION },
+        currentApp: { name: "Solana", version: "1.10.0" },
         deviceModelId: DeviceModelId.NANO_X,
         isSecureConnectionAllowed: true,
       });
@@ -531,7 +611,7 @@ describe("SignTransactionDeviceAction (Solana)", () => {
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.CONNECTED,
         installedApps: [],
-        currentApp: { name: "Solana", version: SOLANA_APP_SPL_MIN_VERSION },
+        currentApp: { name: "Solana", version: "1.10.0" },
         deviceModelId: DeviceModelId.NANO_X,
         isSecureConnectionAllowed: true,
       });
@@ -639,7 +719,7 @@ describe("SignTransactionDeviceAction (Solana)", () => {
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.CONNECTED,
         installedApps: [],
-        currentApp: { name: "Solana", version: SOLANA_APP_SPL_MIN_VERSION },
+        currentApp: { name: "Solana", version: "1.10.0" },
         deviceModelId: DeviceModelId.NANO_X,
         isSecureConnectionAllowed: true,
       });
@@ -715,30 +795,171 @@ describe("SignTransactionDeviceAction (Solana)", () => {
       >(action, expected, apiMock, { onDone: resolve, onError: reject });
     }));
 
-  it("Nano S: skips resolution, signs directly", () =>
+  it("delayed=true with missing config falls back to legacy sign", () =>
     new Promise<void>((resolve, reject) => {
       apiMock.getDeviceSessionState.mockReturnValue({
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.CONNECTED,
         installedApps: [],
-        currentApp: { name: "Solana", version: "1.3.0" },
-        deviceModelId: DeviceModelId.NANO_S,
+        currentApp: { name: "Solana", version: "1.10.0" },
+        deviceModelId: DeviceModelId.NANO_X,
+        isSecureConnectionAllowed: true,
+      });
+
+      getAppConfigMock.mockResolvedValue(CommandResultFactory({ data: {} }));
+      inspectTransactionMock.mockRejectedValue(
+        new InvalidStatusWordError("inspErr"),
+      );
+
+      const sig = new Uint8Array([0xdd, 0xee]);
+      signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
+
+      const input: SignTransactionDAInput = {
+        derivationPath: defaultDerivation,
+        transaction: exampleTx,
+        transactionOptions: {
+          skipOpenApp: true,
+          delayed: true,
+        },
+        contextModule: contextModuleStub,
+      };
+
+      const action = new SignTransactionDeviceAction({ input });
+      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: signTransactionDAStateSteps.GET_APP_CONFIG,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.SignTransaction,
+            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        { output: sig, status: DeviceActionStatus.Completed },
+      ] as DeviceActionState<
+        Uint8Array,
+        SignTransactionDAError,
+        SignTransactionDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+    }));
+
+  it(`delayed=true with app version < ${SOLANA_MIN_DELAYED_SIGNING_VERSION} falls back to legacy sign`, () => {
+    const [major, minor, patch] = SOLANA_MIN_DELAYED_SIGNING_VERSION.split(
+      ".",
+    ).map(Number) as [number, number, number];
+    const belowDelayedVersion = `${major}.${minor - 1}.${patch}`;
+
+    return new Promise<void>((resolve, reject) => {
+      apiMock.getDeviceSessionState.mockReturnValue({
+        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+        deviceStatus: DeviceStatus.CONNECTED,
+        installedApps: [],
+        currentApp: { name: "Solana", version: belowDelayedVersion },
+        deviceModelId: DeviceModelId.NANO_X,
+        isSecureConnectionAllowed: true,
+      });
+
+      getAppConfigMock.mockResolvedValue(CommandResultFactory({ data: {} }));
+      inspectTransactionMock.mockRejectedValue(
+        new InvalidStatusWordError("inspErr"),
+      );
+
+      const sig = new Uint8Array([0xaa, 0xbb]);
+      signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
+
+      const input: SignTransactionDAInput = {
+        derivationPath: defaultDerivation,
+        transaction: exampleTx,
+        transactionOptions: {
+          skipOpenApp: true,
+          delayed: true,
+        },
+        solanaRPCURL: "https://api.devnet.solana.com",
+        contextModule: contextModuleStub,
+      };
+
+      const action = new SignTransactionDeviceAction({ input });
+      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: signTransactionDAStateSteps.GET_APP_CONFIG,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.SignTransaction,
+            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        { output: sig, status: DeviceActionStatus.Completed },
+      ] as DeviceActionState<
+        Uint8Array,
+        SignTransactionDAError,
+        SignTransactionDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+    });
+  });
+
+  it(`app version strictly below ${SOLANA_APP_SPL_MIN_VERSION} skips SPL pipeline and signs directly`, () =>
+    new Promise<void>((resolve, reject) => {
+      apiMock.getDeviceSessionState.mockReturnValue({
+        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+        deviceStatus: DeviceStatus.CONNECTED,
+        installedApps: [],
+        currentApp: { name: "Solana", version: "1.9.1" },
+        deviceModelId: DeviceModelId.NANO_X,
         isSecureConnectionAllowed: true,
       });
 
       getAppConfigMock.mockResolvedValue(CommandResultFactory({ data: {} }));
 
-      const sig = new Uint8Array([0xaa, 0xbb]);
+      const sig = new Uint8Array([0xa1, 0xb2]);
       signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
 
-      const action = new SignTransactionDeviceAction({
-        input: {
-          derivationPath: defaultDerivation,
-          transaction: exampleTx,
-          transactionOptions: { skipOpenApp: true },
-          contextModule: contextModuleStub,
-        },
-      });
+      const input: SignTransactionDAInput = {
+        derivationPath: defaultDerivation,
+        transaction: exampleTx,
+        transactionOptions: { skipOpenApp: true },
+        contextModule: contextModuleStub,
+      };
+
+      const action = new SignTransactionDeviceAction({ input });
       vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
 
       const expected = [
@@ -774,30 +995,30 @@ describe("SignTransactionDeviceAction (Solana)", () => {
       });
     }));
 
-  it("non-Nano S with outdated version: skips resolution, falls back to blind sign", () =>
+  it(`Nano S skips SPL pipeline regardless of app version`, () =>
     new Promise<void>((resolve, reject) => {
       apiMock.getDeviceSessionState.mockReturnValue({
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.CONNECTED,
         installedApps: [],
-        currentApp: { name: "Solana", version: "1.4.1" },
-        deviceModelId: DeviceModelId.NANO_X,
+        currentApp: { name: "Solana", version: "1.10.0" },
+        deviceModelId: DeviceModelId.NANO_S,
         isSecureConnectionAllowed: true,
       });
 
       getAppConfigMock.mockResolvedValue(CommandResultFactory({ data: {} }));
 
-      const sig = new Uint8Array([0xcc, 0xdd]);
+      const sig = new Uint8Array([0xc3, 0xd4]);
       signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
 
-      const action = new SignTransactionDeviceAction({
-        input: {
-          derivationPath: defaultDerivation,
-          transaction: exampleTx,
-          transactionOptions: { skipOpenApp: true },
-          contextModule: contextModuleStub,
-        },
-      });
+      const input: SignTransactionDAInput = {
+        derivationPath: defaultDerivation,
+        transaction: exampleTx,
+        transactionOptions: { skipOpenApp: true },
+        contextModule: contextModuleStub,
+      };
+
+      const action = new SignTransactionDeviceAction({ input });
       vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
 
       const expected = [
@@ -830,6 +1051,275 @@ describe("SignTransactionDeviceAction (Solana)", () => {
           resolve();
         },
         onError: reject,
+      });
+    }));
+
+  it("delayed=false routes to legacy sign (unchanged behavior)", () =>
+    new Promise<void>((resolve, reject) => {
+      apiMock.getDeviceSessionState.mockReturnValue({
+        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+        deviceStatus: DeviceStatus.CONNECTED,
+        installedApps: [],
+        currentApp: { name: "Solana", version: "1.10.0" },
+        deviceModelId: DeviceModelId.NANO_X,
+        isSecureConnectionAllowed: true,
+      });
+
+      getAppConfigMock.mockResolvedValue(CommandResultFactory({ data: {} }));
+      inspectTransactionMock.mockRejectedValue(
+        new InvalidStatusWordError("inspErr"),
+      );
+
+      const sig = new Uint8Array([0xff, 0x00]);
+      signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
+
+      const input: SignTransactionDAInput = {
+        derivationPath: defaultDerivation,
+        transaction: exampleTx,
+        transactionOptions: {
+          skipOpenApp: true,
+          delayed: false,
+        },
+        solanaRPCURL: "https://api.devnet.solana.com",
+        contextModule: contextModuleStub,
+      };
+
+      const action = new SignTransactionDeviceAction({ input });
+      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: signTransactionDAStateSteps.GET_APP_CONFIG,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.SignTransaction,
+            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        { output: sig, status: DeviceActionStatus.Completed },
+      ] as DeviceActionState<
+        Uint8Array,
+        SignTransactionDAError,
+        SignTransactionDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+    }));
+});
+
+describe("SignTransactionDeviceAction – child machine integration", () => {
+  let childExtractDepsSpy: ReturnType<typeof vi.spyOn>;
+  let childPreviewMock: ReturnType<typeof vi.fn>;
+  let childDelayedSignMock: ReturnType<typeof vi.fn>;
+  let childFallbackSignMock: ReturnType<typeof vi.fn>;
+  let childFetchBlockhashMock: ReturnType<typeof vi.fn>;
+  let childZeroBlockhashMock: ReturnType<typeof vi.fn>;
+  let childPatchBlockhashMock: ReturnType<typeof vi.fn>;
+
+  const zeroedTx = new Uint8Array([0x00, 0x00, 0x00, 0x00]);
+  const patchedTx = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+  const freshBlockhash = new Uint8Array(32).fill(0xab);
+  const delayedSig = new Uint8Array([0xcc, 0xdd]);
+
+  function childDeps() {
+    return {
+      previewTransaction: childPreviewMock,
+      delayedSignTransaction: childDelayedSignMock,
+      fallbackSignTransaction: childFallbackSignMock,
+      fetchBlockhashFn: childFetchBlockhashMock,
+      zeroBlockhashFn: childZeroBlockhashMock,
+      patchBlockhashFn: childPatchBlockhashMock,
+    };
+  }
+
+  function delayedInput(): SignTransactionDAInput {
+    return {
+      derivationPath: defaultDerivation,
+      transaction: exampleTx,
+      transactionOptions: {
+        skipOpenApp: true,
+        delayed: true,
+      },
+      solanaRPCURL: "https://api.devnet.solana.com",
+      contextModule: contextModuleStub,
+    };
+  }
+
+  beforeEach(() => {
+    apiMock = makeDeviceActionInternalApiMock();
+    apiMock.getDeviceSessionState.mockReturnValue({
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Solana", version: "1.14.0" },
+      deviceModelId: DeviceModelId.NANO_X,
+      isSecureConnectionAllowed: true,
+    });
+
+    getAppConfigMock = vi
+      .fn()
+      .mockResolvedValue(CommandResultFactory({ data: {} }));
+    buildContextMock = vi.fn();
+    provideContextMock = vi.fn();
+    signMock = vi.fn();
+    inspectTransactionMock = vi
+      .fn()
+      .mockRejectedValue(new InvalidStatusWordError("inspErr"));
+
+    childPreviewMock = vi.fn();
+    childDelayedSignMock = vi.fn();
+    childFallbackSignMock = vi.fn();
+    childFetchBlockhashMock = vi.fn();
+    childZeroBlockhashMock = vi.fn().mockResolvedValue(zeroedTx);
+    childPatchBlockhashMock = vi.fn().mockResolvedValue(patchedTx);
+
+    childExtractDepsSpy = vi.spyOn(
+      DelayedSignTransactionDeviceAction.prototype,
+      "extractDependencies",
+    ) as unknown as ReturnType<typeof vi.spyOn>;
+    childExtractDepsSpy.mockReturnValue(childDeps());
+  });
+
+  afterEach(() => {
+    childExtractDepsSpy.mockRestore();
+  });
+
+  it("child returns Right(signature) → parent completes with that signature", () =>
+    new Promise<void>((resolve, reject) => {
+      childPreviewMock.mockResolvedValue(
+        CommandResultFactory({ data: Nothing }),
+      );
+      childFetchBlockhashMock.mockResolvedValue(freshBlockhash);
+      childDelayedSignMock.mockResolvedValue(
+        CommandResultFactory({ data: Just(delayedSig) }),
+      );
+
+      const action = new SignTransactionDeviceAction({
+        input: delayedInput(),
+      });
+      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+
+      const { observable } = action._execute(apiMock);
+      const states: DeviceActionState<
+        Uint8Array,
+        SignTransactionDAError,
+        SignTransactionDAIntermediateValue
+      >[] = [];
+
+      observable.subscribe({
+        next: (state) => states.push(state),
+        error: reject,
+        complete: () => {
+          try {
+            const last = states[states.length - 1]!;
+            expect(last.status).toBe(DeviceActionStatus.Completed);
+            expect(
+              last.status === DeviceActionStatus.Completed && last.output,
+            ).toEqual(delayedSig);
+            expect(signMock).not.toHaveBeenCalled();
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+      });
+    }));
+
+  it("child returns Left(UnknownDAError) → parent falls back to legacy sign", () =>
+    new Promise<void>((resolve, reject) => {
+      childPreviewMock.mockResolvedValue(
+        CommandResultFactory({ data: Nothing }),
+      );
+      childFetchBlockhashMock.mockRejectedValue(new Error("network error"));
+
+      const legacySig = new Uint8Array([0xee, 0xff]);
+      signMock.mockResolvedValue(
+        CommandResultFactory({ data: Just(legacySig) }),
+      );
+
+      const action = new SignTransactionDeviceAction({
+        input: delayedInput(),
+      });
+      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+
+      const { observable } = action._execute(apiMock);
+      const states: DeviceActionState<
+        Uint8Array,
+        SignTransactionDAError,
+        SignTransactionDAIntermediateValue
+      >[] = [];
+
+      observable.subscribe({
+        next: (state) => states.push(state),
+        error: reject,
+        complete: () => {
+          try {
+            const last = states[states.length - 1]!;
+            expect(last.status).toBe(DeviceActionStatus.Completed);
+            expect(
+              last.status === DeviceActionStatus.Completed && last.output,
+            ).toEqual(legacySig);
+            expect(signMock).toHaveBeenCalled();
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+      });
+    }));
+
+  it("child returns Left(SolanaAppCommandError) for user rejection → parent errors", () =>
+    new Promise<void>((resolve, reject) => {
+      childPreviewMock.mockResolvedValue(
+        CommandResultFactory({
+          error: new SolanaAppCommandError({
+            errorCode: "6985",
+            message: "Canceled by user",
+          }),
+        }),
+      );
+
+      const action = new SignTransactionDeviceAction({
+        input: delayedInput(),
+      });
+      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+
+      const { observable } = action._execute(apiMock);
+      const states: DeviceActionState<
+        Uint8Array,
+        SignTransactionDAError,
+        SignTransactionDAIntermediateValue
+      >[] = [];
+
+      observable.subscribe({
+        next: (state) => states.push(state),
+        error: reject,
+        complete: () => {
+          try {
+            const last = states[states.length - 1]!;
+            expect(last.status).toBe(DeviceActionStatus.Error);
+            expect(signMock).not.toHaveBeenCalled();
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
       });
     }));
 });

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceAction.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceAction.ts
@@ -13,7 +13,7 @@ import {
   XStateDeviceAction,
 } from "@ledgerhq/device-management-kit";
 import { Left, type Maybe, Right } from "purify-ts";
-import { and, assign, fromPromise, setup } from "xstate";
+import { assign, fromPromise, setup } from "xstate";
 
 import {
   type SignTransactionDAError,
@@ -21,6 +21,7 @@ import {
   type SignTransactionDAIntermediateValue,
   type SignTransactionDAInternalState,
   type SignTransactionDAOutput,
+  type SignTransactionDAStateStep,
   signTransactionDAStateSteps,
 } from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { type AppConfiguration } from "@api/model/AppConfiguration";
@@ -40,6 +41,7 @@ import {
 import { type TxInspectorResult } from "@internal/app-binder/services/TransactionInspector";
 import {
   SOLANA_APP_SPL_MIN_VERSION,
+  SOLANA_MIN_DELAYED_SIGNING_VERSION,
   SolanaApplicationResolver,
 } from "@internal/app-binder/SolanaApplicationResolver";
 import {
@@ -52,6 +54,18 @@ import {
   type ProvideSolanaTransactionContextTaskArgs,
 } from "@internal/app-binder/task/ProvideTransactionContextTask";
 import { SignDataTask } from "@internal/app-binder/task/SendSignDataTask";
+
+import { DelayedSignTransactionDeviceAction } from "./DelayedSignTransactionDeviceAction";
+
+/**
+ * Per-sign `transactionOptions.solanaRPCURL` overrides the builder default
+ * (`input.solanaRPCURL`) for inspection and delayed signing.
+ */
+function resolveSolanaRpcUrl(
+  input: SignTransactionDAInput,
+): string | undefined {
+  return input.transactionOptions?.solanaRPCURL ?? input.solanaRPCURL;
+}
 
 export type MachineDependencies = {
   readonly getAppConfig: () => Promise<
@@ -73,9 +87,7 @@ export type MachineDependencies = {
       derivationPath: string;
       serializedTransaction: Uint8Array;
     };
-  }) => Promise<
-    CommandResult<Maybe<Signature | SolanaAppErrorCodes>, SolanaAppErrorCodes>
-  >;
+  }) => Promise<CommandResult<Maybe<Signature>, SolanaAppErrorCodes>>;
 };
 
 export class SignTransactionDeviceAction extends XStateDeviceAction<
@@ -140,12 +152,18 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
         buildContext: fromPromise(buildContext),
         provideContext: fromPromise(provideContext),
         signTransaction: fromPromise(signTransaction),
+        delayedSignStateMachine: new DelayedSignTransactionDeviceAction({
+          input: {
+            derivationPath: "",
+            transaction: new Uint8Array(),
+          },
+        }).makeStateMachine(internalApi),
       },
       guards: {
         noInternalError: ({ context }) => context._internalState.error === null,
         skipOpenApp: ({ context }) =>
           context.input.transactionOptions?.skipOpenApp || false,
-        isSplSupported: ({ context }) =>
+        isSPLSupported: ({ context }) =>
           new ApplicationChecker(
             internalApi.getDeviceSessionState(),
             context._internalState.appConfig!,
@@ -154,16 +172,26 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
             .excludeDeviceModel(DeviceModelId.NANO_S)
             .withMinVersionInclusive(SOLANA_APP_SPL_MIN_VERSION)
             .check(),
-        isAnSPLTransaction: ({ context }) =>
+        shouldBuildContext: ({ context }) =>
           context._internalState.inspectorResult?.transactionType ===
             SolanaTransactionTypes.SPL ||
           context._internalState.inspectorResult?.transactionType ===
             SolanaTransactionTypes.SWAP,
-        shouldSkipInspection: ({ context }) =>
-          context._internalState.error === null &&
-          !!context.input.transactionOptions?.transactionResolutionContext &&
-          !context.input.transactionOptions?.transactionResolutionContext
-            ?.templateId,
+        isDelayedWithConfigAndSupported: ({ context }) =>
+          context.input.transactionOptions?.delayed === true &&
+          !!(
+            resolveSolanaRpcUrl(context.input) ||
+            context.input.transactionOptions?.fetchBlockhash
+          ) &&
+          new ApplicationChecker(
+            internalApi.getDeviceSessionState(),
+            context._internalState.appConfig!,
+            new SolanaApplicationResolver(),
+          )
+            .withMinVersionInclusive(SOLANA_MIN_DELAYED_SIGNING_VERSION)
+            .check(),
+        hasSignature: ({ context }) =>
+          context._internalState.signature !== null,
       },
       actions: {
         assignErrorFromEvent: assign({
@@ -272,12 +300,14 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
         },
         GetAppConfigResultCheck: {
           always: [
-            {
-              target: "InspectTransaction",
-              guard: and(["noInternalError", "isSplSupported"]),
-            },
-            { target: "SignTransaction", guard: "noInternalError" },
+            { target: "CheckSPLSupported", guard: "noInternalError" },
             { target: "Error" },
+          ],
+        },
+        CheckSPLSupported: {
+          always: [
+            { target: "InspectTransaction", guard: "isSPLSupported" },
+            { target: "CheckDelayed" },
           ],
         },
         InspectTransaction: {
@@ -295,7 +325,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
               serializedTransaction: context.input.transaction,
               resolutionContext:
                 context.input.transactionOptions?.transactionResolutionContext,
-              rpcUrl: context.input.transactionOptions?.solanaRPCURL,
+              rpcUrl: resolveSolanaRpcUrl(context.input),
             }),
             onDone: {
               target: "AfterInspect",
@@ -307,14 +337,14 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
               }),
             },
             onError: {
-              target: "SignTransaction",
+              target: "CheckDelayed",
             },
           },
         },
         AfterInspect: {
           always: [
-            { target: "BuildContext", guard: "isAnSPLTransaction" },
-            { target: "SignTransaction" },
+            { target: "BuildContext", guard: "shouldBuildContext" },
+            { target: "CheckDelayed" },
           ],
         },
         BuildContext: {
@@ -360,7 +390,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
               }),
             },
             onError: {
-              target: "SignTransaction",
+              target: "CheckDelayed",
             },
           },
         },
@@ -387,12 +417,108 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
               };
             },
             onDone: {
-              target: "SignTransaction",
+              target: "CheckDelayed",
             },
             onError: {
-              target: "SignTransaction",
+              target: "CheckDelayed",
             },
           },
+        },
+        CheckDelayed: {
+          always: [
+            {
+              target: "InvokeDelayedSign",
+              guard: "isDelayedWithConfigAndSupported",
+            },
+            { target: "SignTransaction" },
+          ],
+        },
+        InvokeDelayedSign: {
+          entry: assign({
+            intermediateValue: () => ({
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: signTransactionDAStateSteps.DELAYED_SIGN,
+            }),
+          }),
+          invoke: {
+            id: "delayedSignStateMachine",
+            src: "delayedSignStateMachine",
+            input: ({ context }) => ({
+              derivationPath: context.input.derivationPath,
+              transaction: context.input.transaction,
+              rpcUrl: resolveSolanaRpcUrl(context.input),
+              fetchBlockhash: context.input.transactionOptions?.fetchBlockhash,
+              userInputType:
+                context.input.transactionOptions?.transactionResolutionContext
+                  ?.userInputType,
+              blockhashService: context.input.blockhashService,
+            }),
+            onSnapshot: {
+              actions: [
+                assign({
+                  intermediateValue: ({ event }) => ({
+                    requiredUserInteraction:
+                      event.snapshot.context.intermediateValue
+                        .requiredUserInteraction,
+                    step: event.snapshot.context.intermediateValue
+                      .step as SignTransactionDAStateStep,
+                  }),
+                }),
+                ({ event }) => {
+                  const stateValue =
+                    typeof event.snapshot.value === "string"
+                      ? event.snapshot.value
+                      : JSON.stringify(event.snapshot.value);
+                  this.logger?.debug(
+                    `[DelayedSign] Child state: ${stateValue}`,
+                    {
+                      data: {
+                        internalState: event.snapshot.context._internalState,
+                        intermediateValue:
+                          event.snapshot.context.intermediateValue,
+                      },
+                    },
+                  );
+                },
+              ],
+            },
+            onDone: {
+              target: "CheckDelayedResult",
+              actions: assign({
+                _internalState: ({ event, context }) =>
+                  event.output.caseOf({
+                    Right: (signature: Uint8Array) => ({
+                      ...context._internalState,
+                      signature,
+                    }),
+                    Left: (error) => {
+                      if (error instanceof UnknownDAError) {
+                        this.logger?.debug(
+                          "Delayed signing failed, falling back to legacy signing",
+                          {
+                            data: {
+                              error: error.originalError?.message,
+                            },
+                          },
+                        );
+                        return context._internalState;
+                      }
+                      return {
+                        ...context._internalState,
+                        error,
+                      };
+                    },
+                  }),
+              }),
+            },
+          },
+        },
+        CheckDelayedResult: {
+          always: [
+            { target: "SignTransactionResultCheck", guard: "hasSignature" },
+            { target: "SignTransaction", guard: "noInternalError" },
+            { target: "Error" },
+          ],
         },
         SignTransaction: {
           entry: assign({

--- a/packages/signer/signer-solana/src/internal/app-binder/di/appBinderModule.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/di/appBinderModule.ts
@@ -1,9 +1,11 @@
 import { ContainerModule } from "inversify";
 
 import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
+import { BlockhashService } from "@internal/app-binder/services/BlockhashService";
 import { SolanaAppBinder } from "@internal/app-binder/SolanaAppBinder";
 
 export const appBinderModuleFactory = () =>
   new ContainerModule(({ bind }) => {
     bind(appBinderTypes.AppBinder).to(SolanaAppBinder);
+    bind(appBinderTypes.BlockhashService).to(BlockhashService);
   });

--- a/packages/signer/signer-solana/src/internal/app-binder/di/appBinderTypes.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/di/appBinderTypes.ts
@@ -1,3 +1,4 @@
 export const appBinderTypes = {
   AppBinder: Symbol.for("AppBinder"),
+  BlockhashService: Symbol.for("BlockhashService"),
 };

--- a/packages/signer/signer-solana/src/internal/app-binder/services/BlockhashService.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/services/BlockhashService.test.ts
@@ -1,0 +1,234 @@
+import { PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
+import bs58 from "bs58";
+
+import { BlockhashService } from "./BlockhashService";
+
+vi.mock("@solana/web3.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@solana/web3.js")>();
+  return {
+    ...actual,
+    Connection: vi.fn(),
+  };
+});
+
+const BLOCKHASH = "a3PD566oU2nE9JHwuC897aaT7ispdqaQ63Si6jzyKAg";
+const BLOCKHASH_BYTES = bs58.decode(BLOCKHASH);
+
+const payer = new PublicKey("2cHm11EeTGQixAkyaqNRFczpi1XB1n6rK7bSwNiZbCdB");
+const recipient = new PublicKey("7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2");
+
+function buildLegacyMessage(): Uint8Array {
+  const tx = new Transaction({
+    recentBlockhash: BLOCKHASH,
+    feePayer: payer,
+  });
+  tx.add(
+    SystemProgram.transfer({
+      fromPubkey: payer,
+      toPubkey: recipient,
+      lamports: 1_000_000,
+    }),
+  );
+  // Ensure plain Uint8Array (serializeMessage returns Buffer in Node)
+  return Uint8Array.from(tx.serializeMessage());
+}
+
+function buildV0Message(): Uint8Array {
+  const legacyBytes = buildLegacyMessage();
+  const v0Bytes = new Uint8Array(legacyBytes.length + 1);
+  v0Bytes[0] = 0x80; // version 0 prefix
+  v0Bytes.set(legacyBytes, 1);
+  return v0Bytes;
+}
+
+describe("BlockhashService", () => {
+  let service: BlockhashService;
+
+  beforeEach(() => {
+    service = new BlockhashService();
+  });
+
+  describe("locateBlockhashOffset", () => {
+    it("should find the blockhash offset in a legacy message", () => {
+      const msg = buildLegacyMessage();
+      const offset = service.locateBlockhashOffset(msg);
+
+      const foundBlockhash = msg.slice(offset, offset + 32);
+      expect(foundBlockhash).toEqual(BLOCKHASH_BYTES);
+    });
+
+    it("should find the blockhash offset in a v0 message", () => {
+      const msg = buildV0Message();
+      const offset = service.locateBlockhashOffset(msg);
+
+      const foundBlockhash = msg.slice(offset, offset + 32);
+      expect(foundBlockhash).toEqual(BLOCKHASH_BYTES);
+    });
+
+    it("should throw on truncated input", () => {
+      expect(() =>
+        service.locateBlockhashOffset(new Uint8Array([0x01])),
+      ).toThrow();
+    });
+
+    it("should throw on empty input", () => {
+      expect(() => service.locateBlockhashOffset(new Uint8Array([]))).toThrow();
+    });
+
+    it("should throw when message is too short for the declared accounts", () => {
+      // Header says 1 required sig, 0 readonly signed, 0 readonly unsigned, 255 accounts
+      // but message is only 7 bytes
+      const msg = new Uint8Array([0x01, 0x00, 0x00, 0x81, 0x01, 0x00, 0x00]);
+      expect(() => service.locateBlockhashOffset(msg)).toThrow(
+        "Message too short to contain a blockhash",
+      );
+    });
+  });
+
+  describe("zeroBlockhash", () => {
+    it("should zero the blockhash in a legacy message", () => {
+      const msg = buildLegacyMessage();
+      const offset = service.locateBlockhashOffset(msg);
+
+      const zeroed = service.zeroBlockhash(msg);
+
+      const zeroedBlockhash = zeroed.slice(offset, offset + 32);
+      expect(zeroedBlockhash).toEqual(new Uint8Array(32));
+    });
+
+    it("should zero the blockhash in a v0 message", () => {
+      const msg = buildV0Message();
+      const offset = service.locateBlockhashOffset(msg);
+
+      const zeroed = service.zeroBlockhash(msg);
+
+      const zeroedBlockhash = zeroed.slice(offset, offset + 32);
+      expect(zeroedBlockhash).toEqual(new Uint8Array(32));
+    });
+
+    it("should not modify bytes outside the blockhash region", () => {
+      const msg = buildLegacyMessage();
+      const offset = service.locateBlockhashOffset(msg);
+
+      const zeroed = service.zeroBlockhash(msg);
+
+      const beforeOriginal = msg.slice(0, offset);
+      const beforeZeroed = zeroed.slice(0, offset);
+      expect(beforeZeroed).toEqual(beforeOriginal);
+
+      const afterOriginal = msg.slice(offset + 32);
+      const afterZeroed = zeroed.slice(offset + 32);
+      expect(afterZeroed).toEqual(afterOriginal);
+    });
+
+    it("should not mutate the original message", () => {
+      const msg = buildLegacyMessage();
+      const originalCopy = new Uint8Array(msg);
+
+      service.zeroBlockhash(msg);
+
+      expect(msg).toEqual(originalCopy);
+    });
+  });
+
+  describe("patchBlockhash", () => {
+    it("should replace the blockhash in a legacy message", () => {
+      const msg = buildLegacyMessage();
+      const offset = service.locateBlockhashOffset(msg);
+      const newHash = new Uint8Array(32).fill(0xab);
+
+      const patched = service.patchBlockhash(msg, newHash);
+
+      const patchedBlockhash = patched.slice(offset, offset + 32);
+      expect(patchedBlockhash).toEqual(newHash);
+    });
+
+    it("should replace the blockhash in a v0 message", () => {
+      const msg = buildV0Message();
+      const offset = service.locateBlockhashOffset(msg);
+      const newHash = new Uint8Array(32).fill(0xcd);
+
+      const patched = service.patchBlockhash(msg, newHash);
+
+      const patchedBlockhash = patched.slice(offset, offset + 32);
+      expect(patchedBlockhash).toEqual(newHash);
+    });
+
+    it("should not modify bytes outside the blockhash region", () => {
+      const msg = buildLegacyMessage();
+      const offset = service.locateBlockhashOffset(msg);
+      const newHash = new Uint8Array(32).fill(0xff);
+
+      const patched = service.patchBlockhash(msg, newHash);
+
+      const beforeOriginal = msg.slice(0, offset);
+      const beforePatched = patched.slice(0, offset);
+      expect(beforePatched).toEqual(beforeOriginal);
+
+      const afterOriginal = msg.slice(offset + 32);
+      const afterPatched = patched.slice(offset + 32);
+      expect(afterPatched).toEqual(afterOriginal);
+    });
+
+    it("should not mutate the original message", () => {
+      const msg = buildLegacyMessage();
+      const originalCopy = new Uint8Array(msg);
+      const newHash = new Uint8Array(32).fill(0xaa);
+
+      service.patchBlockhash(msg, newHash);
+
+      expect(msg).toEqual(originalCopy);
+    });
+
+    it("should throw if newBlockhash is not 32 bytes", () => {
+      const msg = buildLegacyMessage();
+
+      expect(() => service.patchBlockhash(msg, new Uint8Array(16))).toThrow(
+        "newBlockhash must be 32 bytes",
+      );
+      expect(() => service.patchBlockhash(msg, new Uint8Array(64))).toThrow(
+        "newBlockhash must be 32 bytes",
+      );
+    });
+  });
+
+  describe("zeroBlockhash + patchBlockhash roundtrip", () => {
+    it("should restore the original message after zero then patch with original blockhash", () => {
+      const msg = buildLegacyMessage();
+      const offset = service.locateBlockhashOffset(msg);
+      const originalBlockhash = msg.slice(offset, offset + 32);
+
+      const zeroed = service.zeroBlockhash(msg);
+      const restored = service.patchBlockhash(zeroed, originalBlockhash);
+
+      expect(restored).toEqual(msg);
+    });
+  });
+
+  describe("fetchLatestBlockhash", () => {
+    it("should fetch and decode a blockhash from the RPC", async () => {
+      const { Connection } = await import("@solana/web3.js");
+      const mockGetLatestBlockhash = vi.fn().mockResolvedValue({
+        blockhash: BLOCKHASH,
+        lastValidBlockHeight: 100,
+      });
+      vi.mocked(Connection).mockImplementation(
+        () =>
+          ({
+            getLatestBlockhash: mockGetLatestBlockhash,
+          }) as unknown as InstanceType<typeof Connection>,
+      );
+
+      const result = await service.fetchLatestBlockhash(
+        "https://api.mainnet-beta.solana.com",
+      );
+
+      expect(result).toEqual(BLOCKHASH_BYTES);
+      expect(Connection).toHaveBeenCalledWith(
+        "https://api.mainnet-beta.solana.com",
+        { commitment: "finalized" },
+      );
+      expect(mockGetLatestBlockhash).toHaveBeenCalledWith("finalized");
+    });
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/services/BlockhashService.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/services/BlockhashService.ts
@@ -1,0 +1,140 @@
+import { Connection } from "@solana/web3.js";
+import bs58 from "bs58";
+import { injectable } from "inversify";
+
+const PUBLIC_KEY_LENGTH = 32;
+const BLOCKHASH_LENGTH = 32;
+const HEADER_SIZE = 3;
+const MIN_MESSAGE_LENGTH = 4;
+const V0_VERSION_MASK = 0x80;
+const SHORTVEC_DATA_MASK = 0x7f;
+const SHORTVEC_CONTINUATION_BIT = 0x80;
+const SHORTVEC_MAX_SHIFT = 35;
+
+/**
+ * Bytewise blockhash manipulation for Solana serialized messages.
+ *
+ * Operates directly on the raw bytes.
+ *
+ * Solana message layout:
+ *   Legacy: [3 header][compact-u16 numAccounts][numAccounts × 32B keys][32B BLOCKHASH]…
+ *   V0:     [1 version][3 header][compact-u16 numAccounts][numAccounts × 32B keys][32B BLOCKHASH]…
+ */
+@injectable()
+export class BlockhashService {
+  /**
+   * Decode a Solana compact-u16 (shortvec) at the given offset.
+   * @returns The decoded value and the number of bytes consumed.
+   */
+  private decodeShortVec(
+    bytes: Uint8Array,
+    offset: number,
+  ): { length: number; size: number } {
+    let value = 0;
+    let size = 0;
+    let shift = 0;
+
+    while (true) {
+      const byte = bytes[offset + size];
+      if (byte === undefined) {
+        throw new Error("shortvec decode overflow");
+      }
+
+      value |= (byte & SHORTVEC_DATA_MASK) << shift;
+      size += 1;
+
+      if ((byte & SHORTVEC_CONTINUATION_BIT) === 0) {
+        break;
+      }
+
+      shift += 7;
+
+      if (shift >= SHORTVEC_MAX_SHIFT) {
+        throw new Error("shortvec too long");
+      }
+    }
+
+    return { length: value, size };
+  }
+
+  /**
+   * Find the byte offset of the 32-byte `recentBlockhash` field in a
+   * serialised Solana message. Handles both legacy and v0 messages by
+   * detecting the version prefix (high bit set = v0).
+   *
+   * @throws If the message is too short or malformed.
+   */
+  locateBlockhashOffset(serializedMessage: Uint8Array): number {
+    if (serializedMessage.length < MIN_MESSAGE_LENGTH) {
+      throw new Error("Message too short to contain a valid header");
+    }
+
+    let cursor = 0;
+
+    if ((serializedMessage[cursor]! & V0_VERSION_MASK) !== 0) {
+      cursor += 1;
+    }
+
+    cursor += HEADER_SIZE;
+
+    const { length: numAccounts, size: shortVecSize } = this.decodeShortVec(
+      serializedMessage,
+      cursor,
+    );
+    cursor += shortVecSize;
+    cursor += numAccounts * PUBLIC_KEY_LENGTH;
+
+    if (cursor + BLOCKHASH_LENGTH > serializedMessage.length) {
+      throw new Error(
+        "Message too short to contain a blockhash at expected offset",
+      );
+    }
+
+    return cursor;
+  }
+
+  /**
+   * Return a copy of the serialised message with the `recentBlockhash`
+   * field replaced by 32 zero bytes. The original is not mutated.
+   */
+  zeroBlockhash(serializedMessage: Uint8Array): Uint8Array {
+    const offset = this.locateBlockhashOffset(serializedMessage);
+    const output = new Uint8Array(serializedMessage);
+    output.fill(0, offset, offset + BLOCKHASH_LENGTH);
+    return output;
+  }
+
+  /**
+   * Return a copy of the serialised message with the `recentBlockhash`
+   * field replaced by `newBlockhash`. The original is not mutated.
+   *
+   * @param newBlockhash - Must be exactly 32 bytes.
+   * @throws If `newBlockhash` is not 32 bytes.
+   */
+  patchBlockhash(
+    serializedMessage: Uint8Array,
+    newBlockhash: Uint8Array,
+  ): Uint8Array {
+    if (newBlockhash.length !== BLOCKHASH_LENGTH) {
+      throw new Error(
+        `newBlockhash must be ${BLOCKHASH_LENGTH} bytes, got ${newBlockhash.length}`,
+      );
+    }
+    const offset = this.locateBlockhashOffset(serializedMessage);
+    const output = new Uint8Array(serializedMessage);
+    output.set(newBlockhash, offset);
+    return output;
+  }
+
+  /**
+   * Fetch the latest blockhash from a Solana RPC endpoint using
+   * "finalized" commitment.
+   *
+   * @returns The 32-byte blockhash as a raw `Uint8Array`.
+   */
+  async fetchLatestBlockhash(rpcUrl: string): Promise<Uint8Array> {
+    const connection = new Connection(rpcUrl, { commitment: "finalized" });
+    const { blockhash } = await connection.getLatestBlockhash("finalized");
+    return bs58.decode(blockhash);
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/task/SendSignDataTask.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/SendSignDataTask.ts
@@ -19,7 +19,7 @@ const PATH_SIZE = 4;
 type SignDataTaskArgs = {
   sendingData: Uint8Array;
   derivationPath: string;
-  commandFactory: CommandFactory<Maybe<Signature | SolanaAppErrorCodes>>;
+  commandFactory: CommandFactory<Maybe<Signature>>;
 };
 
 export class SignDataTask {
@@ -28,9 +28,7 @@ export class SignDataTask {
     private args: SignDataTaskArgs,
   ) {}
 
-  async run(): Promise<
-    CommandResult<Maybe<Signature | SolanaAppErrorCodes>, SolanaAppErrorCodes>
-  > {
+  async run(): Promise<CommandResult<Maybe<Signature>, SolanaAppErrorCodes>> {
     const { sendingData, derivationPath, commandFactory } = this.args;
 
     const paths = DerivationPathUtils.splitPath(derivationPath);
@@ -46,9 +44,7 @@ export class SignDataTask {
     builder.addBufferToData(sendingData);
     const buffer = builder.build();
 
-    return await new SendCommandInChunksTask<
-      Maybe<Signature | SolanaAppErrorCodes>
-    >(this.api, {
+    return await new SendCommandInChunksTask<Maybe<Signature>>(this.api, {
       data: buffer,
       commandFactory,
     }).run();

--- a/packages/signer/signer-solana/src/internal/di.ts
+++ b/packages/signer/signer-solana/src/internal/di.ts
@@ -14,12 +14,14 @@ export type MakeContainerProps = {
   dmk: DeviceManagementKit;
   sessionId: DeviceSessionId;
   contextModule: ContextModule;
+  solanaRPCURL?: string;
 };
 
 export const makeContainer = ({
   dmk,
   sessionId,
   contextModule,
+  solanaRPCURL,
 }: MakeContainerProps) => {
   const container = new Container();
 
@@ -30,6 +32,9 @@ export const makeContainer = ({
   container
     .bind<ContextModule>(externalTypes.ContextModule)
     .toConstantValue(contextModule);
+  container
+    .bind<string | undefined>(externalTypes.SolanaRPCURL)
+    .toConstantValue(solanaRPCURL);
 
   container
     .bind<

--- a/packages/signer/signer-solana/src/internal/externalTypes.ts
+++ b/packages/signer/signer-solana/src/internal/externalTypes.ts
@@ -3,4 +3,5 @@ export const externalTypes = {
   SessionId: Symbol.for("SessionId"),
   ContextModule: Symbol.for("ContextModule"),
   DmkLoggerFactory: Symbol.for("DmkLoggerFactory"),
+  SolanaRPCURL: Symbol.for("SolanaRPCURL"),
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Solana transactions contain a recentBlockhash that expires after ~60–90 seconds. If the user takes time reviewing a transaction on the Ledger device, the blockhash may expire and the network will reject it.

<img width="930" height="577" alt="Screenshot 2026-03-17 at 11 32 20" src="https://github.com/user-attachments/assets/b5c629a5-3de1-40e8-8be9-8ab59ccb5f71" />

---

This PR adds support for the two-phase delayed signing protocol introduced in app-solana (`INS 0x08` preview, `INS 0x09` delayed sign). The SDK now handles everything internally: it zeroes the blockhash, sends the transaction for on-device preview, fetches a fresh blockhash from the Solana RPC, patches the transaction, and sends it for instant signing. The feature is fully opt-in via `delayed: true` and a `solanaRPCURL` (or custom `fetchBlockhash` callback) in the transaction options.

The implementation lives in a new child state machine (`DelayedSignTransactionDeviceAction`) invoked from the existing `SignTransactionDeviceAction`. The parent gates delayed signing on app version `>= 1.4.0`. If anything goes wrong (unsupported firmware, protocol error, fetch failure), the flow falls back to legacy signing (`INS 0x06`) transparently. 

<img width="934" height="825" alt="Screenshot 2026-03-17 at 10 38 27" src="https://github.com/user-attachments/assets/cd84afb3-3b71-4e63-8a9e-a8c3ac78547c" />


---

Also includes a small improvement to `XStateDeviceAction` logging: terminal states are now logged, repeated state entries are deduplicated, and intermediateValue is included in debug output.

---

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [DSDK-1054](https://ledgerhq.atlassian.net/browse/DSDK-1054)

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
