### PR TITLE
🐛 (clear-signing-tester) [NO-ISSUE]: Fix stale image detection and EIP712 descriptor grouping

### DIFF
--- a/apps/clear-signing-tester/src/infrastructure/service-controllers/SpeculosServiceController.ts
+++ b/apps/clear-signing-tester/src/infrastructure/service-controllers/SpeculosServiceController.ts
@@ -336,22 +336,22 @@ export class SpeculosServiceController implements ServiceController {
 
   private runCommand(command: string, args: string[]): Promise<string> {
     return new Promise((resolve, reject) => {
-      const process = spawn(command, args, {
+      const childProcess = spawn(command, args, {
         stdio: ["ignore", "pipe", "pipe"],
       });
 
       let stdout = "";
       let stderr = "";
 
-      process.stdout.on("data", (data: Buffer) => {
+      childProcess.stdout.on("data", (data: Buffer) => {
         stdout += data.toString();
       });
 
-      process.stderr.on("data", (data: Buffer) => {
+      childProcess.stderr.on("data", (data: Buffer) => {
         stderr += data.toString();
       });
 
-      process.on("close", (code) => {
+      childProcess.on("close", (code) => {
         if (code === 0) {
           resolve(stdout);
         } else {
@@ -363,7 +363,7 @@ export class SpeculosServiceController implements ServiceController {
         }
       });
 
-      process.on("error", (error) => {
+      childProcess.on("error", (error) => {
         reject(error);
       });
     });

--- a/apps/clear-signing-tester/src/infrastructure/service-controllers/SpeculosServiceController.ts
+++ b/apps/clear-signing-tester/src/infrastructure/service-controllers/SpeculosServiceController.ts
@@ -326,9 +326,12 @@ export class SpeculosServiceController implements ServiceController {
   }
 
   private getDockerPlatformKey(): string {
-    const platform = process.platform;
+    // Docker platform keys for these images always use "linux" as the OS
+    // component, regardless of the host OS. We normalize the architecture
+    // to match Docker naming (e.g. "amd64" instead of Node's "x64").
+    const dockerOs = "linux";
     const arch = process.arch === "x64" ? "amd64" : process.arch;
-    return `${platform}/${arch}`;
+    return `${dockerOs}/${arch}`;
   }
 
   private runCommand(command: string, args: string[]): Promise<string> {

--- a/apps/clear-signing-tester/src/infrastructure/service-controllers/SpeculosServiceController.ts
+++ b/apps/clear-signing-tester/src/infrastructure/service-controllers/SpeculosServiceController.ts
@@ -192,7 +192,7 @@ export class SpeculosServiceController implements ServiceController {
     });
 
     // Wait for the container to fully initialize before proceeding
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, 3000));
   }
 
   async stop(): Promise<void> {

--- a/apps/clear-signing-tester/src/infrastructure/service-controllers/SpeculosServiceController.ts
+++ b/apps/clear-signing-tester/src/infrastructure/service-controllers/SpeculosServiceController.ts
@@ -1,4 +1,5 @@
 import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
+import { spawn } from "child_process";
 import { inject, injectable } from "inversify";
 
 import { TYPES } from "@root/src/di/types";
@@ -163,6 +164,7 @@ export class SpeculosServiceController implements ServiceController {
     }
 
     const dockerImage = `${SPECULOS_DOCKER_IMAGE_BASE}:${this.config.dockerImageTag}`;
+    await this.warnIfLatestImageIsStale(dockerImage);
 
     if (
       this.config.forcePull ||
@@ -195,5 +197,172 @@ export class SpeculosServiceController implements ServiceController {
 
   async stop(): Promise<void> {
     await this.dockerContainer.stop();
+  }
+
+  private async warnIfLatestImageIsStale(dockerImage: string): Promise<void> {
+    if (this.config.dockerImageTag !== "latest") {
+      return;
+    }
+
+    const [localDigest, remoteDigest, localVersion, remoteVersion] =
+      await Promise.all([
+        this.getLocalManifestDigest(dockerImage),
+        this.getRemoteManifestDigest(dockerImage),
+        this.getLocalImageVersion(dockerImage),
+        this.getRemoteImageVersion(dockerImage),
+      ]);
+
+    if (!localDigest || !remoteDigest || localDigest === remoteDigest) {
+      return;
+    }
+
+    const localVersionLabel = localVersion ?? "unknown";
+    const remoteVersionLabel = remoteVersion ?? "unknown";
+
+    this.logger.warn(
+      `Docker image "${dockerImage}" is stale locally (localDigest=${localDigest}, remoteDigest=${remoteDigest}, localVersion=${localVersionLabel}, remoteVersion=${remoteVersionLabel}). Run "docker pull ${dockerImage}" to update.`,
+    );
+  }
+
+  private async getLocalManifestDigest(
+    dockerImage: string,
+  ): Promise<string | null> {
+    try {
+      const output = await this.runCommand("docker", [
+        "image",
+        "inspect",
+        "--format",
+        "{{index .RepoDigests 0}}",
+        dockerImage,
+      ]);
+      const repoDigest = output.trim();
+      const digest = repoDigest.split("@")[1]?.trim();
+      return digest ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async getRemoteManifestDigest(
+    dockerImage: string,
+  ): Promise<string | null> {
+    try {
+      const output = await this.runCommand("docker", [
+        "buildx",
+        "imagetools",
+        "inspect",
+        dockerImage,
+        "--format",
+        "{{json .Manifest.Digest}}",
+      ]);
+      const rawDigest = output.trim();
+      // Output is JSON encoded, e.g. "sha256:..."
+      const digest = JSON.parse(rawDigest) as string;
+      return digest || null;
+    } catch (error) {
+      this.logger.debug(
+        `Unable to resolve remote digest for "${dockerImage}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return null;
+    }
+  }
+
+  private async getLocalImageVersion(
+    dockerImage: string,
+  ): Promise<string | null> {
+    try {
+      const output = await this.runCommand("docker", [
+        "image",
+        "inspect",
+        "--format",
+        '{{index .Config.Labels "org.opencontainers.image.version"}}',
+        dockerImage,
+      ]);
+      const version = output.trim();
+      return version.length > 0 ? version : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async getRemoteImageVersion(
+    dockerImage: string,
+  ): Promise<string | null> {
+    try {
+      const output = await this.runCommand("docker", [
+        "buildx",
+        "imagetools",
+        "inspect",
+        dockerImage,
+        "--format",
+        "{{json .Image}}",
+      ]);
+      const imageData = JSON.parse(output) as Record<
+        string,
+        { config?: { Labels?: Record<string, string> } }
+      >;
+
+      const preferredPlatform = this.getDockerPlatformKey();
+      const platformData =
+        imageData[preferredPlatform] ??
+        imageData["linux/amd64"] ??
+        imageData["linux/arm64"] ??
+        Object.values(imageData)[0];
+
+      return (
+        platformData?.config?.Labels?.["org.opencontainers.image.version"] ??
+        null
+      );
+    } catch (error) {
+      this.logger.debug(
+        `Unable to resolve remote image version for "${dockerImage}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return null;
+    }
+  }
+
+  private getDockerPlatformKey(): string {
+    const platform = process.platform;
+    const arch = process.arch === "x64" ? "amd64" : process.arch;
+    return `${platform}/${arch}`;
+  }
+
+  private runCommand(command: string, args: string[]): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const process = spawn(command, args, {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+
+      process.stdout.on("data", (data: Buffer) => {
+        stdout += data.toString();
+      });
+
+      process.stderr.on("data", (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      process.on("close", (code) => {
+        if (code === 0) {
+          resolve(stdout);
+        } else {
+          reject(
+            new Error(
+              `Command failed (${command} ${args.join(" ")}): ${stderr.trim()}`,
+            ),
+          );
+        }
+      });
+
+      process.on("error", (error) => {
+        reject(error);
+      });
+    });
   }
 }

--- a/apps/sample/api/index.py
+++ b/apps/sample/api/index.py
@@ -273,25 +273,23 @@ def convert_erc7730_to_eip712_descriptor(descriptor: InputEIP712DAppDescriptor) 
     # instructions structure: {address: {schema_hash: [instruction_list]}}
     result = {}
     for (address, instruction_dict) in instructions.items():
-        # For each schema_hash, extract chain_id from instructions
         for (schema_hash, instructions_list) in instruction_dict.items():
             if not instructions_list:
                 continue
 
-            # Extract chain_id from first instruction (all instructions with same schema_hash have same chain_id)
             first_instruction = instructions_list[0]
             chain_id = first_instruction.chain_id
 
             key = f"{chain_id}:{address}"
-            result[key] = {
-                address: {
-                    schema_hash: {
-                        "instructions": [
-                            format_and_sign_eip712_instruction(instruction)
-                            for instruction in instructions_list
-                        ]
-                    }
-                }
+            if key not in result:
+                result[key] = {}
+            if address not in result[key]:
+                result[key][address] = {}
+            result[key][address][schema_hash] = {
+                "instructions": [
+                    format_and_sign_eip712_instruction(instruction)
+                    for instruction in instructions_list
+                ]
             }
 
     return result


### PR DESCRIPTION
## Summary

- Detect digest and version mismatches between local and remote Docker latest tags and log a warning so outdated Speculos toolchains are visible before startup failures
- Fix EIP712 descriptor grouping that was overwriting entries when multiple schema hashes existed for the same `(chain_id, address)` key — now accumulates all schema hashes correctly

## Commits

- ⚠️ Warn when local latest image is stale
- 🐛 Fix EIP712 descriptor grouping overwriting entries

## Test plan

- [ ] Test EIP712 clear-signing with a descriptor containing multiple message types for the same contract
- [ ] Verify Docker image staleness warning appears when local image is outdated