### PR TITLE
🐛 (clear-signing-tester) [NO-ISSUE]: Fix stale image detection and EIP712 descriptor grouping

### DIFF
--- a/apps/clear-signing-tester/src/domain/adapters/DockerContainer.ts
+++ b/apps/clear-signing-tester/src/domain/adapters/DockerContainer.ts
@@ -38,6 +38,37 @@ export interface DockerContainer {
    * @returns Promise resolving to the image ID if found, null otherwise
    */
   getImageId(image: string): Promise<string | null>;
+
+  /**
+   * Get the repo digest of a locally cached Docker image.
+   * @param image - The Docker image name and tag
+   * @returns Promise resolving to the digest string (e.g. "sha256:..."), or null
+   */
+  getLocalImageRepoDigest(image: string): Promise<string | null>;
+
+  /**
+   * Get the manifest digest of a Docker image from the remote registry.
+   * @param image - The Docker image name and tag
+   * @returns Promise resolving to the digest string (e.g. "sha256:..."), or null
+   */
+  getRemoteImageManifestDigest(image: string): Promise<string | null>;
+
+  /**
+   * Get a metadata label value from a locally cached Docker image.
+   * @param image - The Docker image name and tag
+   * @param label - The label key (e.g. "org.opencontainers.image.version")
+   * @returns Promise resolving to the label value, or null
+   */
+  getLocalImageLabel(image: string, label: string): Promise<string | null>;
+
+  /**
+   * Get a metadata label value from a Docker image in the remote registry,
+   * selecting the platform matching the current host architecture.
+   * @param image - The Docker image name and tag
+   * @param label - The label key (e.g. "org.opencontainers.image.version")
+   * @returns Promise resolving to the label value, or null
+   */
+  getRemoteImageLabel(image: string, label: string): Promise<string | null>;
 }
 
 export type DockerRunOptions = {

--- a/apps/clear-signing-tester/src/infrastructure/adapters/system/NodeDockerContainer.ts
+++ b/apps/clear-signing-tester/src/infrastructure/adapters/system/NodeDockerContainer.ts
@@ -262,6 +262,140 @@ export class NodeDockerContainer implements DockerContainer {
     });
   }
 
+  async getLocalImageRepoDigest(image: string): Promise<string | null> {
+    try {
+      const output = await this.runCommand("docker", [
+        "image",
+        "inspect",
+        "--format",
+        "{{index .RepoDigests 0}}",
+        image,
+      ]);
+      const digest = output.trim().split("@")[1]?.trim();
+      return digest ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  async getRemoteImageManifestDigest(image: string): Promise<string | null> {
+    try {
+      const output = await this.runCommand("docker", [
+        "buildx",
+        "imagetools",
+        "inspect",
+        image,
+        "--format",
+        "{{json .Manifest.Digest}}",
+      ]);
+      const digest = JSON.parse(output.trim()) as string;
+      return digest || null;
+    } catch (error) {
+      this.logger.debug(
+        `Unable to resolve remote digest for "${image}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return null;
+    }
+  }
+
+  async getLocalImageLabel(
+    image: string,
+    label: string,
+  ): Promise<string | null> {
+    try {
+      const output = await this.runCommand("docker", [
+        "image",
+        "inspect",
+        "--format",
+        `{{index .Config.Labels "${label}"}}`,
+        image,
+      ]);
+      const value = output.trim();
+      return value.length > 0 ? value : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async getRemoteImageLabel(
+    image: string,
+    label: string,
+  ): Promise<string | null> {
+    try {
+      const output = await this.runCommand("docker", [
+        "buildx",
+        "imagetools",
+        "inspect",
+        image,
+        "--format",
+        "{{json .Image}}",
+      ]);
+      const imageData = JSON.parse(output) as Record<
+        string,
+        { config?: { Labels?: Record<string, string> } }
+      >;
+
+      const preferredPlatform = this.getDockerPlatformKey();
+      const platformData =
+        imageData[preferredPlatform] ??
+        imageData["linux/amd64"] ??
+        imageData["linux/arm64"] ??
+        Object.values(imageData)[0];
+
+      return platformData?.config?.Labels?.[label] ?? null;
+    } catch (error) {
+      this.logger.debug(
+        `Unable to resolve remote image label "${label}" for "${image}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return null;
+    }
+  }
+
+  private getDockerPlatformKey(): string {
+    const dockerOs = "linux";
+    const arch = process.arch === "x64" ? "amd64" : process.arch;
+    return `${dockerOs}/${arch}`;
+  }
+
+  private runCommand(command: string, args: string[]): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const childProcess = spawn(command, args, {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+
+      childProcess.stdout.on("data", (data: Buffer) => {
+        stdout += data.toString();
+      });
+
+      childProcess.stderr.on("data", (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      childProcess.on("close", (code) => {
+        if (code === 0) {
+          resolve(stdout);
+        } else {
+          reject(
+            new Error(
+              `Command failed (${command} ${args.join(" ")}): ${stderr.trim()}`,
+            ),
+          );
+        }
+      });
+
+      childProcess.on("error", (error) => {
+        reject(error);
+      });
+    });
+  }
+
   private buildDockerRunArgs(
     imageName: string,
     options: DockerRunOptions,

--- a/apps/clear-signing-tester/src/infrastructure/service-controllers/SpeculosServiceController.ts
+++ b/apps/clear-signing-tester/src/infrastructure/service-controllers/SpeculosServiceController.ts
@@ -1,4 +1,5 @@
 import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
+import { spawn } from "child_process";
 import { inject, injectable } from "inversify";
 
 import { TYPES } from "@root/src/di/types";
@@ -163,6 +164,7 @@ export class SpeculosServiceController implements ServiceController {
     }
 
     const dockerImage = `${SPECULOS_DOCKER_IMAGE_BASE}:${this.config.dockerImageTag}`;
+    await this.warnIfLatestImageIsStale(dockerImage);
 
     if (
       this.config.forcePull ||
@@ -190,10 +192,180 @@ export class SpeculosServiceController implements ServiceController {
     });
 
     // Wait for the container to fully initialize before proceeding
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, 3000));
   }
 
   async stop(): Promise<void> {
     await this.dockerContainer.stop();
+  }
+
+  private async warnIfLatestImageIsStale(dockerImage: string): Promise<void> {
+    if (this.config.dockerImageTag !== "latest") {
+      return;
+    }
+
+    const [localDigest, remoteDigest, localVersion, remoteVersion] =
+      await Promise.all([
+        this.getLocalManifestDigest(dockerImage),
+        this.getRemoteManifestDigest(dockerImage),
+        this.getLocalImageVersion(dockerImage),
+        this.getRemoteImageVersion(dockerImage),
+      ]);
+
+    if (!localDigest || !remoteDigest || localDigest === remoteDigest) {
+      return;
+    }
+
+    const localVersionLabel = localVersion ?? "unknown";
+    const remoteVersionLabel = remoteVersion ?? "unknown";
+
+    this.logger.warn(
+      `Docker image "${dockerImage}" is stale locally (localDigest=${localDigest}, remoteDigest=${remoteDigest}, localVersion=${localVersionLabel}, remoteVersion=${remoteVersionLabel}). Run "docker pull ${dockerImage}" to update.`,
+    );
+  }
+
+  private async getLocalManifestDigest(
+    dockerImage: string,
+  ): Promise<string | null> {
+    try {
+      const output = await this.runCommand("docker", [
+        "image",
+        "inspect",
+        "--format",
+        "{{index .RepoDigests 0}}",
+        dockerImage,
+      ]);
+      const repoDigest = output.trim();
+      const digest = repoDigest.split("@")[1]?.trim();
+      return digest ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async getRemoteManifestDigest(
+    dockerImage: string,
+  ): Promise<string | null> {
+    try {
+      const output = await this.runCommand("docker", [
+        "buildx",
+        "imagetools",
+        "inspect",
+        dockerImage,
+        "--format",
+        "{{json .Manifest.Digest}}",
+      ]);
+      const rawDigest = output.trim();
+      // Output is JSON encoded, e.g. "sha256:..."
+      const digest = JSON.parse(rawDigest) as string;
+      return digest || null;
+    } catch (error) {
+      this.logger.debug(
+        `Unable to resolve remote digest for "${dockerImage}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return null;
+    }
+  }
+
+  private async getLocalImageVersion(
+    dockerImage: string,
+  ): Promise<string | null> {
+    try {
+      const output = await this.runCommand("docker", [
+        "image",
+        "inspect",
+        "--format",
+        '{{index .Config.Labels "org.opencontainers.image.version"}}',
+        dockerImage,
+      ]);
+      const version = output.trim();
+      return version.length > 0 ? version : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async getRemoteImageVersion(
+    dockerImage: string,
+  ): Promise<string | null> {
+    try {
+      const output = await this.runCommand("docker", [
+        "buildx",
+        "imagetools",
+        "inspect",
+        dockerImage,
+        "--format",
+        "{{json .Image}}",
+      ]);
+      const imageData = JSON.parse(output) as Record<
+        string,
+        { config?: { Labels?: Record<string, string> } }
+      >;
+
+      const preferredPlatform = this.getDockerPlatformKey();
+      const platformData =
+        imageData[preferredPlatform] ??
+        imageData["linux/amd64"] ??
+        imageData["linux/arm64"] ??
+        Object.values(imageData)[0];
+
+      return (
+        platformData?.config?.Labels?.["org.opencontainers.image.version"] ??
+        null
+      );
+    } catch (error) {
+      this.logger.debug(
+        `Unable to resolve remote image version for "${dockerImage}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return null;
+    }
+  }
+
+  private getDockerPlatformKey(): string {
+    // Docker platform keys for these images always use "linux" as the OS
+    // component, regardless of the host OS. We normalize the architecture
+    // to match Docker naming (e.g. "amd64" instead of Node's "x64").
+    const dockerOs = "linux";
+    const arch = process.arch === "x64" ? "amd64" : process.arch;
+    return `${dockerOs}/${arch}`;
+  }
+
+  private runCommand(command: string, args: string[]): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const childProcess = spawn(command, args, {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+
+      childProcess.stdout.on("data", (data: Buffer) => {
+        stdout += data.toString();
+      });
+
+      childProcess.stderr.on("data", (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      childProcess.on("close", (code) => {
+        if (code === 0) {
+          resolve(stdout);
+        } else {
+          reject(
+            new Error(
+              `Command failed (${command} ${args.join(" ")}): ${stderr.trim()}`,
+            ),
+          );
+        }
+      });
+
+      childProcess.on("error", (error) => {
+        reject(error);
+      });
+    });
   }
 }

--- a/apps/clear-signing-tester/src/infrastructure/service-controllers/SpeculosServiceController.ts
+++ b/apps/clear-signing-tester/src/infrastructure/service-controllers/SpeculosServiceController.ts
@@ -164,13 +164,13 @@ export class SpeculosServiceController implements ServiceController {
     }
 
     const dockerImage = `${SPECULOS_DOCKER_IMAGE_BASE}:${this.config.dockerImageTag}`;
-    await this.warnIfLatestImageIsStale(dockerImage);
 
-    if (
-      this.config.forcePull ||
-      (await this.dockerContainer.getImageId(dockerImage)) === null
-    ) {
+    if (this.config.forcePull) {
       await this.dockerContainer.pull(dockerImage);
+    } else if ((await this.dockerContainer.getImageId(dockerImage)) === null) {
+      await this.dockerContainer.pull(dockerImage);
+    } else {
+      await this.warnIfLatestImageIsStale(dockerImage);
     }
 
     // Build volumes array

--- a/apps/clear-signing-tester/src/infrastructure/service-controllers/SpeculosServiceController.ts
+++ b/apps/clear-signing-tester/src/infrastructure/service-controllers/SpeculosServiceController.ts
@@ -192,7 +192,7 @@ export class SpeculosServiceController implements ServiceController {
     });
 
     // Wait for the container to fully initialize before proceeding
-    await new Promise((resolve) => setTimeout(resolve, 3000));
+    await new Promise((resolve) => setTimeout(resolve, 2000));
   }
 
   async stop(): Promise<void> {

--- a/apps/clear-signing-tester/src/infrastructure/service-controllers/SpeculosServiceController.ts
+++ b/apps/clear-signing-tester/src/infrastructure/service-controllers/SpeculosServiceController.ts
@@ -1,5 +1,4 @@
 import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
-import { spawn } from "child_process";
 import { inject, injectable } from "inversify";
 
 import { TYPES } from "@root/src/di/types";
@@ -199,6 +198,8 @@ export class SpeculosServiceController implements ServiceController {
     await this.dockerContainer.stop();
   }
 
+  private static readonly VERSION_LABEL = "org.opencontainers.image.version";
+
   private async warnIfLatestImageIsStale(dockerImage: string): Promise<void> {
     if (this.config.dockerImageTag !== "latest") {
       return;
@@ -206,10 +207,16 @@ export class SpeculosServiceController implements ServiceController {
 
     const [localDigest, remoteDigest, localVersion, remoteVersion] =
       await Promise.all([
-        this.getLocalManifestDigest(dockerImage),
-        this.getRemoteManifestDigest(dockerImage),
-        this.getLocalImageVersion(dockerImage),
-        this.getRemoteImageVersion(dockerImage),
+        this.dockerContainer.getLocalImageRepoDigest(dockerImage),
+        this.dockerContainer.getRemoteImageManifestDigest(dockerImage),
+        this.dockerContainer.getLocalImageLabel(
+          dockerImage,
+          SpeculosServiceController.VERSION_LABEL,
+        ),
+        this.dockerContainer.getRemoteImageLabel(
+          dockerImage,
+          SpeculosServiceController.VERSION_LABEL,
+        ),
       ]);
 
     if (!localDigest || !remoteDigest || localDigest === remoteDigest) {
@@ -222,150 +229,5 @@ export class SpeculosServiceController implements ServiceController {
     this.logger.warn(
       `Docker image "${dockerImage}" is stale locally (localDigest=${localDigest}, remoteDigest=${remoteDigest}, localVersion=${localVersionLabel}, remoteVersion=${remoteVersionLabel}). Run "docker pull ${dockerImage}" to update.`,
     );
-  }
-
-  private async getLocalManifestDigest(
-    dockerImage: string,
-  ): Promise<string | null> {
-    try {
-      const output = await this.runCommand("docker", [
-        "image",
-        "inspect",
-        "--format",
-        "{{index .RepoDigests 0}}",
-        dockerImage,
-      ]);
-      const repoDigest = output.trim();
-      const digest = repoDigest.split("@")[1]?.trim();
-      return digest ?? null;
-    } catch {
-      return null;
-    }
-  }
-
-  private async getRemoteManifestDigest(
-    dockerImage: string,
-  ): Promise<string | null> {
-    try {
-      const output = await this.runCommand("docker", [
-        "buildx",
-        "imagetools",
-        "inspect",
-        dockerImage,
-        "--format",
-        "{{json .Manifest.Digest}}",
-      ]);
-      const rawDigest = output.trim();
-      // Output is JSON encoded, e.g. "sha256:..."
-      const digest = JSON.parse(rawDigest) as string;
-      return digest || null;
-    } catch (error) {
-      this.logger.debug(
-        `Unable to resolve remote digest for "${dockerImage}": ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-      return null;
-    }
-  }
-
-  private async getLocalImageVersion(
-    dockerImage: string,
-  ): Promise<string | null> {
-    try {
-      const output = await this.runCommand("docker", [
-        "image",
-        "inspect",
-        "--format",
-        '{{index .Config.Labels "org.opencontainers.image.version"}}',
-        dockerImage,
-      ]);
-      const version = output.trim();
-      return version.length > 0 ? version : null;
-    } catch {
-      return null;
-    }
-  }
-
-  private async getRemoteImageVersion(
-    dockerImage: string,
-  ): Promise<string | null> {
-    try {
-      const output = await this.runCommand("docker", [
-        "buildx",
-        "imagetools",
-        "inspect",
-        dockerImage,
-        "--format",
-        "{{json .Image}}",
-      ]);
-      const imageData = JSON.parse(output) as Record<
-        string,
-        { config?: { Labels?: Record<string, string> } }
-      >;
-
-      const preferredPlatform = this.getDockerPlatformKey();
-      const platformData =
-        imageData[preferredPlatform] ??
-        imageData["linux/amd64"] ??
-        imageData["linux/arm64"] ??
-        Object.values(imageData)[0];
-
-      return (
-        platformData?.config?.Labels?.["org.opencontainers.image.version"] ??
-        null
-      );
-    } catch (error) {
-      this.logger.debug(
-        `Unable to resolve remote image version for "${dockerImage}": ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-      return null;
-    }
-  }
-
-  private getDockerPlatformKey(): string {
-    // Docker platform keys for these images always use "linux" as the OS
-    // component, regardless of the host OS. We normalize the architecture
-    // to match Docker naming (e.g. "amd64" instead of Node's "x64").
-    const dockerOs = "linux";
-    const arch = process.arch === "x64" ? "amd64" : process.arch;
-    return `${dockerOs}/${arch}`;
-  }
-
-  private runCommand(command: string, args: string[]): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const childProcess = spawn(command, args, {
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-
-      let stdout = "";
-      let stderr = "";
-
-      childProcess.stdout.on("data", (data: Buffer) => {
-        stdout += data.toString();
-      });
-
-      childProcess.stderr.on("data", (data: Buffer) => {
-        stderr += data.toString();
-      });
-
-      childProcess.on("close", (code) => {
-        if (code === 0) {
-          resolve(stdout);
-        } else {
-          reject(
-            new Error(
-              `Command failed (${command} ${args.join(" ")}): ${stderr.trim()}`,
-            ),
-          );
-        }
-      });
-
-      childProcess.on("error", (error) => {
-        reject(error);
-      });
-    });
   }
 }

--- a/apps/clear-signing-tester/src/infrastructure/services/AppVersionResolverService.ts
+++ b/apps/clear-signing-tester/src/infrastructure/services/AppVersionResolverService.ts
@@ -202,8 +202,14 @@ export class AppVersionResolverService implements AppVersionResolver {
     appName: string,
     osVersions: string[],
   ): { os: string; version: string } | null {
-    // Sort OS versions in descending order
-    const sortedOsVersions = this.sortVersionsDescending(osVersions);
+    // Prefer stable releases over pre-releases (e.g. rc, alpha, beta) to
+    // avoid picking firmware versions that the current Speculos may not support.
+    const stableVersions = osVersions.filter(
+      (v) => semver.valid(v) !== null && semver.prerelease(v) === null,
+    );
+    const sortedOsVersions = this.sortVersionsDescending(
+      stableVersions.length > 0 ? stableVersions : osVersions,
+    );
 
     // For each OS version (starting with the latest), find the latest app version
     for (const osVersion of sortedOsVersions) {

--- a/apps/sample/api/index.py
+++ b/apps/sample/api/index.py
@@ -273,25 +273,23 @@ def convert_erc7730_to_eip712_descriptor(descriptor: InputEIP712DAppDescriptor) 
     # instructions structure: {address: {schema_hash: [instruction_list]}}
     result = {}
     for (address, instruction_dict) in instructions.items():
-        # For each schema_hash, extract chain_id from instructions
         for (schema_hash, instructions_list) in instruction_dict.items():
             if not instructions_list:
                 continue
 
-            # Extract chain_id from first instruction (all instructions with same schema_hash have same chain_id)
             first_instruction = instructions_list[0]
             chain_id = first_instruction.chain_id
 
             key = f"{chain_id}:{address}"
-            result[key] = {
-                address: {
-                    schema_hash: {
-                        "instructions": [
-                            format_and_sign_eip712_instruction(instruction)
-                            for instruction in instructions_list
-                        ]
-                    }
-                }
+            if key not in result:
+                result[key] = {}
+            if address not in result[key]:
+                result[key][address] = {}
+            result[key][address][schema_hash] = {
+                "instructions": [
+                    format_and_sign_eip712_instruction(instruction)
+                    for instruction in instructions_list
+                ]
             }
 
     return result


### PR DESCRIPTION
## Summary

- Detect digest and version mismatches between local and remote Docker latest tags and log a warning so outdated Speculos toolchains are visible before startup failures
- Fix EIP712 descriptor grouping that was overwriting entries when multiple schema hashes existed for the same `(chain_id, address)` key — now accumulates all schema hashes correctly
- Skip pre-release OS firmware versions (e.g. `2.7.0-rc1`) during auto-resolution to avoid picking firmware not yet supported by the current Speculos image
- Increase Speculos container initialization delay from 1s to 2s for more reliable startup

Supersedes #1361 (branch renamed for Danger check compliance, copilot suggestion commits squashed to fix commit message convention).

## Test plan

- [x] All 6 Clear Signing Tester CI jobs pass (nanox + stax, raw + typed-data + multisig)
- [x] Danger check passes (branch name + commit messages)
- [ ] Test EIP712 clear-signing with a descriptor containing multiple message types for the same contract
- [ ] Verify Docker image staleness warning appears when local image is outdated