### PR TITLE
🐛 (cs-tester) [NO-ISSUE]: Exclude RC OS versions from auto-resolution

### DIFF
--- a/apps/clear-signing-tester/src/infrastructure/services/AppVersionResolverService.ts
+++ b/apps/clear-signing-tester/src/infrastructure/services/AppVersionResolverService.ts
@@ -85,29 +85,31 @@ export class AppVersionResolverService implements AppVersionResolver {
       resolvedOs = requestedOs;
       resolvedVersion = this.getLatestVersion(versions);
     } else if (requestedVersion) {
-      // Only version specified: find latest OS with this app version
+      // Only version specified: find latest stable OS with this app version
       const compatibleOs = this.findOsWithAppVersion(
         device,
         appName,
-        availableOsVersions,
+        this.getStableOsVersions(availableOsVersions),
         requestedVersion,
       );
       if (!compatibleOs) {
         throw new Error(
-          `No OS version found with ${appName} app version ${requestedVersion} for device ${device}`,
+          `No stable OS version found with ${appName} app version ${requestedVersion} for device ${device}. Use --os-version to target a specific OS including RC versions.`,
         );
       }
       resolvedOs = compatibleOs;
       resolvedVersion = requestedVersion;
     } else {
-      // Neither specified: find latest OS and latest app version
+      // Neither specified: find latest stable OS and latest app version
       const result = this.findLatestOsAndAppVersion(
         devicePath,
         appName,
-        availableOsVersions,
+        this.getStableOsVersions(availableOsVersions),
       );
       if (!result) {
-        throw new Error(`No ${appName} app found for device ${device}`);
+        throw new Error(
+          `No ${appName} app found for device ${device} on a stable OS version. Use --os-version to target a specific OS including RC versions.`,
+        );
       }
       resolvedOs = result.os;
       resolvedVersion = result.version;
@@ -222,6 +224,10 @@ export class AppVersionResolverService implements AppVersionResolver {
     }
 
     return null;
+  }
+
+  private getStableOsVersions(osVersions: string[]): string[] {
+    return osVersions.filter((v) => semver.prerelease(v) === null);
   }
 
   private getLatestVersion(versions: string[]): string {


### PR DESCRIPTION
### 📝 Description

When auto-resolving the latest OS version for a device (no `--os-version` specified), prerelease OS versions such as `1.6.0-rc1` were being picked over any prior stable release because semver ranks `1.6.0-rc1 > 1.5.0`.

This caused Speculos to fail silently with `invalid SDK api_level: 26` because the RC app requires an API level not supported by the Docker image being used.

**Fix:** In `AppVersionResolverService`, the two auto-resolution branches now filter `availableOsVersions` to stable-only versions (`semver.prerelease(v) === null`) before searching for the latest OS. Explicitly passing `--os-version 1.6.0-rc1` continues to work as before since those branches are only reached when `requestedOs` is `undefined`.

Error messages in both branches now also hint that `--os-version` can be used to target RC versions explicitly.

### ❓ Context

- **JIRA or GitHub link**: NO-ISSUE

### ✅ Checklist

- [ ] **Covered by automatic tests** <!-- No regression test added — the logic is straightforward and covered by the existing unit test suite -->
- [ ] **Changeset is provided** <!-- No changeset needed — changes only affect the private `clear-signing-tester` app -->
- [x] **Documentation is up-to-date** <!-- Error messages updated to guide users -->
- [x] **Impact of the changes:**
  - Auto-resolution of OS version now skips RC/prerelease OS directories
  - Explicit `--os-version` flag still supports RC versions

Made with [Cursor](https://cursor.com)