### PR TITLE
fix(node-hid): filter Ledger devices to the APDU interface

### DIFF
--- a/packages/transport/node-hid/src/api/transport/NodeHidTransport.test.ts
+++ b/packages/transport/node-hid/src/api/transport/NodeHidTransport.test.ts
@@ -368,6 +368,37 @@ describe("NodeHidTransport", () => {
       ).toBe("/dev/hidraw1");
     });
 
+    it("should ignore non-APDU ledger interfaces on win32", async () => {
+      setProcessPlatform("win32");
+
+      const genericInterface = nodeHidDeviceStubBuilder({
+        path: "\\\\?\\hid#vid_2c97&pid_0001&mi_01#generic",
+        interface: 2,
+        usagePage: 0xf1d0,
+      });
+      const apduInterface = nodeHidDeviceStubBuilder({
+        path: "\\\\?\\hid#vid_2c97&pid_0001&mi_00#apdu",
+        interface: 0,
+        usagePage: 0xffa0,
+      });
+
+      mockDevicesAsync.mockResolvedValueOnce([genericInterface, apduInterface]);
+      mockDevicesAsync.mockResolvedValue([genericInterface, apduInterface]);
+
+      const discoveredDevices = await lastValueFrom(
+        transport.startDiscovering().pipe(toArray()),
+      );
+
+      expect(discoveredDevices).toHaveLength(1);
+      expect(
+        (
+          discoveredDevices[0] as TransportDiscoveredDevice & {
+            hidDevice: NodeHIDDevice;
+          }
+        ).hidDevice.path,
+      ).toBe("\\\\?\\hid#vid_2c97&pid_0001&mi_00#apdu");
+    });
+
     it("should throw DeviceNotRecognizedError if the device is not recognized", () =>
       new Promise<void>((resolve, reject) => {
         mockDevicesAsync.mockResolvedValueOnce([

--- a/packages/transport/node-hid/src/api/transport/NodeHidTransport.test.ts
+++ b/packages/transport/node-hid/src/api/transport/NodeHidTransport.test.ts
@@ -88,6 +88,13 @@ const flushPromises = async () => {
   return new Promise(timers.setImmediate);
 };
 
+const setProcessPlatform = (platform: NodeJS.Platform) => {
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true,
+  });
+};
+
 /**
  * Helper to create a USB device event object matching the usb module's Device type
  */
@@ -115,6 +122,7 @@ const emitUsbDetachEvent = (vendorId: number, productId: number) => {
 };
 
 describe("NodeHidTransport", () => {
+  const originalPlatform = process.platform;
   let transport: NodeHidTransport;
   let apduReceiverServiceFactoryStub: ApduReceiverServiceFactory;
   let apduSenderServiceFactoryStub: ApduSenderServiceFactory;
@@ -195,6 +203,7 @@ describe("NodeHidTransport", () => {
   });
 
   afterEach(() => {
+    setProcessPlatform(originalPlatform);
     vi.restoreAllMocks();
     vi.clearAllMocks();
     vi.useRealTimers();
@@ -327,6 +336,37 @@ describe("NodeHidTransport", () => {
           },
         );
       }));
+
+    it("should ignore non-APDU ledger interfaces on darwin", async () => {
+      setProcessPlatform("darwin");
+
+      const genericInterface = nodeHidDeviceStubBuilder({
+        path: "/dev/hidraw0",
+        interface: 2,
+        usagePage: 0xf1d0,
+      });
+      const apduInterface = nodeHidDeviceStubBuilder({
+        path: "/dev/hidraw1",
+        interface: 0,
+        usagePage: 0xffa0,
+      });
+
+      mockDevicesAsync.mockResolvedValueOnce([genericInterface, apduInterface]);
+      mockDevicesAsync.mockResolvedValue([genericInterface, apduInterface]);
+
+      const discoveredDevices = await lastValueFrom(
+        transport.startDiscovering().pipe(toArray()),
+      );
+
+      expect(discoveredDevices).toHaveLength(1);
+      expect(
+        (
+          discoveredDevices[0] as TransportDiscoveredDevice & {
+            hidDevice: NodeHIDDevice;
+          }
+        ).hidDevice.path,
+      ).toBe("/dev/hidraw1");
+    });
 
     it("should throw DeviceNotRecognizedError if the device is not recognized", () =>
       new Promise<void>((resolve, reject) => {

--- a/packages/transport/node-hid/src/api/transport/NodeHidTransport.ts
+++ b/packages/transport/node-hid/src/api/transport/NodeHidTransport.ts
@@ -47,6 +47,18 @@ import {
 type NodeHIDAPI = typeof NodeHIDAPI;
 const NodeHIDAPI = { devicesAsync, HIDAsync } as const;
 
+const isLedgerApduInterface = (hidDevice: NodeHIDDevice) => {
+  if (hidDevice.vendorId !== LEDGER_VENDOR_ID) {
+    return false;
+  }
+
+  if (process.platform === "darwin" || process.platform === "win32") {
+    return hidDevice.usagePage === 0xffa0;
+  }
+
+  return true;
+};
+
 type PromptDeviceAccessError =
   | NoAccessibleDeviceError
   | NodeHidTransportNotSupportedError;
@@ -136,9 +148,7 @@ export class NodeHidTransport implements Transport {
       try {
         const allDevices = await hidApi.devicesAsync();
 
-        const ledgerDevices = allDevices.filter(
-          (hidDevice) => hidDevice.vendorId === LEDGER_VENDOR_ID,
-        );
+        const ledgerDevices = allDevices.filter(isLedgerApduInterface);
 
         // Remove duplicates from same device with different interfaces by keeping only one device per vendorId:productId combination
         const uniqueDevices = Array.from(
@@ -251,9 +261,7 @@ export class NodeHidTransport implements Transport {
         try {
           const allDevices = await hidApi.devicesAsync();
 
-          hidDevices = allDevices.filter(
-            (d) => d.vendorId === LEDGER_VENDOR_ID,
-          );
+          hidDevices = allDevices.filter(isLedgerApduInterface);
           await this.updateTransportDiscoveredDevices();
         } catch (error) {
           const deviceError = new NoAccessibleDeviceError(error);

--- a/packages/transport/node-hid/src/api/transport/NodeHidTransport.ts
+++ b/packages/transport/node-hid/src/api/transport/NodeHidTransport.ts
@@ -47,13 +47,16 @@ import {
 type NodeHIDAPI = typeof NodeHIDAPI;
 const NodeHIDAPI = { devicesAsync, HIDAsync } as const;
 
+// HID usage page used by Ledger devices for the APDU channel on macOS and Windows.
+const LEDGER_APDU_USAGE_PAGE = 0xffa0;
+
 const isLedgerApduInterface = (hidDevice: NodeHIDDevice) => {
   if (hidDevice.vendorId !== LEDGER_VENDOR_ID) {
     return false;
   }
 
   if (process.platform === "darwin" || process.platform === "win32") {
-    return hidDevice.usagePage === 0xffa0;
+    return hidDevice.usagePage === LEDGER_APDU_USAGE_PAGE;
   }
 
   return true;


### PR DESCRIPTION
## Summary
- filter Node HID Ledger devices to the APDU HID interface on macOS and Windows
- apply the same filter during both device discovery paths in `NodeHidTransport`
- add regression tests covering duplicate Ledger HID interfaces on macOS and Windows

## Why
On macOS and Windows, some Ledger devices expose multiple HID interfaces. Legacy LedgerJS filters these devices to the APDU interface (`usagePage === 0xffa0`) before transport selection, but `@ledgerhq/device-transport-kit-node-hid` currently filters only by `vendorId`.

In local testing, that caused `SignerEthBuilder(...).getAddress(...)` to stall on a Ledger Nano X over Node HID with firmware `2.6.1` and Ethereum app `1.21.3`. Applying the same APDU-interface filter restored correct behavior.

Other device families already worked before this filter and continued to work after it, which suggests the underlying Node HID interface-selection behavior differs across device families and/or firmware/app-version combinations.

## Validation
- verified locally against the affected Nano X combination above via DMK Node HID
- verified locally against other device families via DMK Node HID
- added unit tests for ignoring the non-APDU Ledger interface on `darwin` and `win32`

## Notes
- the currently published stable `@ledgerhq/device-transport-kit-node-hid@1.0.0` still advertises `@ledgerhq/device-management-kit: 1.1.0` as a peer, while the rest of the published signer stack is already on the `^1.2.0` line; the current repo source appears broader/aligned, so a new stable publish from current source would also help downstream consumers avoid `--legacy-peer-deps`
- I was not able to run the upstream package test suite in this environment because the clone does not have its pnpm toolchain installed locally, but the new tests are included in this patch.
