### PR TITLE
🎨 (clear-sign-tester): Add --external-speculos flag to skip Docker lifecycle

### DIFF
--- a/apps/clear-signing-tester/src/cli/EthereumTransactionTesterCli.ts
+++ b/apps/clear-signing-tester/src/cli/EthereumTransactionTesterCli.ts
@@ -36,6 +36,7 @@ export type CliConfig = {
   screenshotFolderPath?: string;
   customApp?: string;
   forcePull?: boolean;
+  externalSpeculos?: boolean;
 
   // config.signer
   skipCal?: boolean;
@@ -70,8 +71,15 @@ export class EthereumTransactionTesterCli {
   constructor(config: CliConfig) {
     this.config = config;
 
+    const SPECULOS_DEFAULT_API_PORT = 5000;
+    const SPECULOS_DEFAULT_VNC_PORT = 8000;
     const randomPort = Math.floor(Math.random() * 10000) + 10000;
     const randomVncPort = Math.floor(Math.random() * 10000) + 20000;
+
+    const speculosPort = config.speculosPort
+      || (config.externalSpeculos ? SPECULOS_DEFAULT_API_PORT : randomPort);
+    const speculosVncPort = config.speculosVncPort
+      || (config.externalSpeculos ? SPECULOS_DEFAULT_VNC_PORT : randomVncPort);
 
     // Use test signatures when custom ERC7730 files are provided
     const calMode =
@@ -81,8 +89,8 @@ export class EthereumTransactionTesterCli {
     const diConfig: ClearSigningTesterConfig = {
       speculos: {
         url: config.speculosUrl || `http://localhost`,
-        port: config.speculosPort || randomPort,
-        vncPort: config.speculosVncPort || randomVncPort,
+        port: speculosPort,
+        vncPort: speculosVncPort,
         dockerImageTag: config.dockerImageTag || "latest",
         device: config.device,
         os: config.osVersion,
@@ -92,6 +100,7 @@ export class EthereumTransactionTesterCli {
         screenshotPath: config.screenshotFolderPath,
         customAppPath: config.customApp,
         forcePull: config.forcePull,
+        externalSpeculos: config.externalSpeculos,
       },
       signer: {
         originToken: process.env["GATING_TOKEN"] || "test-origin-token",
@@ -290,6 +299,13 @@ export class EthereumTransactionTesterCli {
       .option(
         "--force-pull",
         "Force pulling the Docker image even if it already exists locally",
+        false,
+      )
+      .option(
+        "--external-speculos",
+        "Skip Docker Speculos lifecycle and connect to an already-running Speculos instance. " +
+        "Defaults to port 5000 (API) and 8000 (VNC) matching native Speculos; " +
+        "override with --speculos-port / --speculos-vnc-port if needed.",
         false,
       )
       .option(

--- a/apps/clear-signing-tester/src/di/modules/infrastructureModuleFactory.ts
+++ b/apps/clear-signing-tester/src/di/modules/infrastructureModuleFactory.ts
@@ -129,10 +129,12 @@ export const infrastructureModuleFactory = (config: ClearSigningTesterConfig) =>
     // Service Controllers Array (ordered for startup/shutdown)
     bind<ServiceController[]>(TYPES.ServiceControllers)
       .toDynamicValue((context) => {
-        const controllers: ServiceController[] = [
-          context.get<ServiceController>(TYPES.SpeculosServiceController),
-        ];
-        // Only add DMK controller if not in onlySpeculos mode
+        const controllers: ServiceController[] = [];
+        if (!config.speculos.externalSpeculos) {
+          controllers.push(
+            context.get<ServiceController>(TYPES.SpeculosServiceController),
+          );
+        }
         if (!config.onlySpeculos) {
           controllers.push(
             context.get<ServiceController>(TYPES.DMKServiceController),

--- a/apps/clear-signing-tester/src/domain/models/config/SpeculosConfig.ts
+++ b/apps/clear-signing-tester/src/domain/models/config/SpeculosConfig.ts
@@ -24,4 +24,11 @@ export type SpeculosConfig = {
    * When true, always pull the Docker image even if it already exists locally.
    */
   forcePull?: boolean;
+  /**
+   * When true, skip Docker container lifecycle entirely and assume Speculos
+   * is already running externally on the configured port.  Useful when a
+   * long-lived Speculos instance is managed outside cs-tester (e.g. native
+   * install on CI, sidecar container).
+   */
+  externalSpeculos?: boolean;
 };


### PR DESCRIPTION
## Summary

- Add `--external-speculos` CLI option to `cs-tester` that skips the internal Docker Speculos lifecycle and connects to an already-running Speculos instance.
- When the flag is set, `SpeculosServiceController` is excluded from the service controllers array so no Docker container is started/stopped.
- In external mode, ports default to Speculos' standard values (5000 API / 8000 VNC) instead of random host ports; override with `--speculos-port` / `--speculos-vnc-port` if needed.
- Enables deployments where Speculos runs natively (e.g. CI runners, AWS App Runner containers with `qemu-user-static`) to avoid Docker-in-Docker overhead.

## Context

We are deploying [erc7730-analyzer](https://github.com/LedgerHQ/erc7730-analyzer) on a server that cannot run Docker. The cs-tester currently always spawns Docker-based Speculos instances via `SpeculosServiceController`, even when a Speculos instance is already provided via `--speculos-port`. This PR adds `--external-speculos` to bypass that behavior entirely.

## Changes

| File | Change |
|------|--------|
| `SpeculosConfig.ts` | New `externalSpeculos?: boolean` field |
| `EthereumTransactionTesterCli.ts` | New `--external-speculos` CLI option; sensible port defaults in external mode |
| `infrastructureModuleFactory.ts` | Conditionally skip `SpeculosServiceController` when flag is set |

## Test plan

- [ ] Run `cs-tester` **without** `--external-speculos` → Docker Speculos lifecycle unchanged (no regression)
- [ ] Start Speculos natively, run `cs-tester --external-speculos --speculos-port 5555` → connects to external instance, produces screenshots
- [ ] Run `cs-tester --external-speculos` without explicit port → defaults to 5000
- [ ] Verify `--help` output includes the new flag with updated documentation


Made with [Cursor](https://cursor.com)