### PR TITLE
🎨 (clear-sign-tester) [NO-ISSUE]: Add --external-speculos flag to skip Docker lifecycle

### DIFF
--- a/apps/clear-signing-tester/src/cli/EthereumTransactionTesterCli.ts
+++ b/apps/clear-signing-tester/src/cli/EthereumTransactionTesterCli.ts
@@ -36,6 +36,7 @@ export type CliConfig = {
   screenshotFolderPath?: string;
   customApp?: string;
   forcePull?: boolean;
+  externalSpeculos?: boolean;
 
   // config.signer
   skipCal?: boolean;
@@ -92,6 +93,7 @@ export class EthereumTransactionTesterCli {
         screenshotPath: config.screenshotFolderPath,
         customAppPath: config.customApp,
         forcePull: config.forcePull,
+        externalSpeculos: config.externalSpeculos,
       },
       signer: {
         originToken: process.env["GATING_TOKEN"] || "test-origin-token",
@@ -293,6 +295,11 @@ export class EthereumTransactionTesterCli {
         false,
       )
       .option(
+        "--external-speculos",
+        "Skip Docker Speculos lifecycle and connect to an already-running Speculos instance on the configured --speculos-port.",
+        false,
+      )
+      .option(
         "--log-level <level>",
         `Console log level: ${CLI_LOG_LEVELS.join(", ")} (default: info)`,
         (value: string) => {
@@ -331,8 +338,16 @@ export class EthereumTransactionTesterCli {
 
     program.hook("preAction", async (_, command) => {
       const config = command.parent!.opts() as CliConfig;
-      // Set onlySpeculos flag when running start-speculos command
       config.onlySpeculos = command.name() === "start-speculos";
+
+      if (config.onlySpeculos && config.externalSpeculos) {
+        throw new Error(
+          "--external-speculos cannot be used with start-speculos. " +
+            "Use start-speculos to let cs-tester manage Speculos, " +
+            "or use other commands with --external-speculos to connect to an already-running instance.",
+        );
+      }
+
       cli = new EthereumTransactionTesterCli(config);
       await cli.initialize();
     });

--- a/apps/clear-signing-tester/src/di/modules/infrastructureModuleFactory.ts
+++ b/apps/clear-signing-tester/src/di/modules/infrastructureModuleFactory.ts
@@ -129,10 +129,12 @@ export const infrastructureModuleFactory = (config: ClearSigningTesterConfig) =>
     // Service Controllers Array (ordered for startup/shutdown)
     bind<ServiceController[]>(TYPES.ServiceControllers)
       .toDynamicValue((context) => {
-        const controllers: ServiceController[] = [
-          context.get<ServiceController>(TYPES.SpeculosServiceController),
-        ];
-        // Only add DMK controller if not in onlySpeculos mode
+        const controllers: ServiceController[] = [];
+        if (!config.speculos.externalSpeculos) {
+          controllers.push(
+            context.get<ServiceController>(TYPES.SpeculosServiceController),
+          );
+        }
         if (!config.onlySpeculos) {
           controllers.push(
             context.get<ServiceController>(TYPES.DMKServiceController),

--- a/apps/clear-signing-tester/src/domain/models/config/SpeculosConfig.ts
+++ b/apps/clear-signing-tester/src/domain/models/config/SpeculosConfig.ts
@@ -24,4 +24,12 @@ export type SpeculosConfig = {
    * When true, always pull the Docker image even if it already exists locally.
    */
   forcePull?: boolean;
+  /**
+   * When true, skip Docker container lifecycle entirely and assume Speculos
+   * is already running externally and reachable on the configured API `port`
+   * (and, if used, VNC `vncPort`).  Useful when a long-lived Speculos
+   * instance is managed outside cs-tester (e.g. native install on CI,
+   * sidecar container).
+   */
+  externalSpeculos?: boolean;
 };


### PR DESCRIPTION
## Summary

- Add `--external-speculos` CLI option to `cs-tester` that skips the internal Docker Speculos lifecycle and connects to an already-running Speculos instance on the configured `--speculos-port`.
- When the flag is set, `SpeculosServiceController` is excluded from the service controllers array so no Docker container is started/stopped.
- Fail-fast guard prevents using `--external-speculos` with the `start-speculos` command (which would result in a no-op).
- Enables deployments where Speculos runs natively (e.g. CI runners, AWS App Runner containers with `qemu-user-static`) to avoid Docker-in-Docker overhead.

## Context

We are deploying [erc7730-analyzer](https://github.com/LedgerHQ/erc7730-analyzer) on a server that cannot run Docker. The cs-tester currently always spawns Docker-based Speculos instances via `SpeculosServiceController`, even when a Speculos instance is already provided via `--speculos-port`. This PR adds `--external-speculos` to bypass that behavior entirely.

## Changes

| File | Change |
|------|--------|
| `SpeculosConfig.ts` | New `externalSpeculos?: boolean` field with updated docstring |
| `EthereumTransactionTesterCli.ts` | New `--external-speculos` CLI option, wired to config; `start-speculos` guard |
| `infrastructureModuleFactory.ts` | Conditionally skip `SpeculosServiceController` when flag is set |

## Test plan

- [ ] Run `cs-tester` **without** `--external-speculos` → Docker Speculos lifecycle unchanged (no regression)
- [ ] Start Speculos natively, run `cs-tester --external-speculos --speculos-port 5555` → connects to external instance, produces screenshots
- [ ] Run `cs-tester --external-speculos start-speculos` → fails fast with clear error
- [ ] Verify `--help` output includes the new flag


Made with [Cursor](https://cursor.com)