### PR TITLE
♻️ (context-module) [NO-ISSUE]: Refactor config initialization with resolveConfig and ResolvedContextModuleConfig

### DIFF
--- a/.changeset/metal-wasps-stand.md
+++ b/.changeset/metal-wasps-stand.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/context-module": patch
+---
+
+Rename InternalContextModuleConfig to ResolvedContextModuleConfig and introduce a resolveConfig function for cleaner config initialization in ContextModuleBuilder.

--- a/packages/signer/context-module/src/ContextModuleBuilder.test.ts
+++ b/packages/signer/context-module/src/ContextModuleBuilder.test.ts
@@ -1,13 +1,12 @@
 import { type LoggerPublisherService } from "@ledgerhq/device-management-kit";
-import { type Container } from "inversify";
 
 import { configTypes } from "./config/di/configTypes";
 import { type ContextModuleConstructorArgs } from "./config/model/ContextModuleBuildArgs";
 import {
   type ContextModuleCalConfig,
-  type ContextModuleConfig,
   type ContextModuleDatasourceConfig,
   type ContextModuleMetadataServiceConfig,
+  type ResolvedContextModuleConfig,
 } from "./config/model/ContextModuleConfig";
 import { type ContextLoader } from "./shared/domain/ContextLoader";
 import { HttpTrustedNameDataSource } from "./trusted-name/data/HttpTrustedNameDataSource";
@@ -86,10 +85,9 @@ describe("ContextModuleBuilder", () => {
       .setCalConfig(defaultCalConfig)
       .setWeb3ChecksConfig(defaultWeb3ChecksConfig)
       .build();
-    // @ts-expect-error _container is private
-    const config = (res["_container"] as Container).get<ContextModuleConfig>(
-      configTypes.Config,
-    );
+    const config = (res as DefaultContextModule)[
+      "_container"
+    ].get<ResolvedContextModuleConfig>(configTypes.Config);
 
     expect(res).toBeInstanceOf(DefaultContextModule);
     expect(config.cal).toEqual(defaultCalConfig);
@@ -114,7 +112,7 @@ describe("ContextModuleBuilder", () => {
         .build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ResolvedContextModuleConfig>(configTypes.Config);
 
       expect(res).toBeInstanceOf(DefaultContextModule);
       expect(config.metadataServiceDomain).toEqual(customMetadataConfig);
@@ -131,7 +129,7 @@ describe("ContextModuleBuilder", () => {
         .build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ResolvedContextModuleConfig>(configTypes.Config);
 
       expect(config.metadataServiceDomain.url).toBe(customMetadataConfig.url);
       expect(config.metadataServiceDomain.url).not.toBe(
@@ -152,7 +150,7 @@ describe("ContextModuleBuilder", () => {
       const res = contextModuleBuilder.setCalConfig(customCalConfig).build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ResolvedContextModuleConfig>(configTypes.Config);
 
       expect(res).toBeInstanceOf(DefaultContextModule);
       expect(config.cal).toEqual(customCalConfig);
@@ -169,7 +167,7 @@ describe("ContextModuleBuilder", () => {
       const res = contextModuleBuilder.setCalConfig(customCalConfig).build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ResolvedContextModuleConfig>(configTypes.Config);
 
       expect(config.cal.url).toBe(customCalConfig.url);
       expect(config.cal.mode).toBe(customCalConfig.mode);
@@ -192,7 +190,7 @@ describe("ContextModuleBuilder", () => {
         .build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ResolvedContextModuleConfig>(configTypes.Config);
 
       expect(res).toBeInstanceOf(DefaultContextModule);
       expect(config.web3checks).toEqual(customWeb3ChecksConfig);
@@ -209,7 +207,7 @@ describe("ContextModuleBuilder", () => {
         .build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ResolvedContextModuleConfig>(configTypes.Config);
 
       expect(config.web3checks.url).toBe(customWeb3ChecksConfig.url);
       expect(config.web3checks.url).not.toBe(
@@ -230,7 +228,7 @@ describe("ContextModuleBuilder", () => {
         .build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ResolvedContextModuleConfig>(configTypes.Config);
 
       expect(res).toBeInstanceOf(DefaultContextModule);
       expect(config.datasource).toEqual(customDatasourceConfig);
@@ -248,7 +246,7 @@ describe("ContextModuleBuilder", () => {
         .build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ResolvedContextModuleConfig>(configTypes.Config);
 
       expect(res).toBeInstanceOf(DefaultContextModule);
       expect(config.datasource).toEqual(customDatasourceConfig);
@@ -266,7 +264,7 @@ describe("ContextModuleBuilder", () => {
         .build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ResolvedContextModuleConfig>(configTypes.Config);
 
       expect(config.datasource?.proxy).toBe("safe");
       expect(config.datasource).not.toBeUndefined();
@@ -281,7 +279,7 @@ describe("ContextModuleBuilder", () => {
         .build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ResolvedContextModuleConfig>(configTypes.Config);
 
       expect(res).toBeInstanceOf(DefaultContextModule);
       expect(config.datasource).toEqual(customDatasourceConfig);
@@ -298,7 +296,7 @@ describe("ContextModuleBuilder", () => {
       const res = contextModuleBuilder.build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ResolvedContextModuleConfig>(configTypes.Config);
 
       expect(res).toBeInstanceOf(DefaultContextModule);
       expect(config.loggerFactory).toBeDefined();
@@ -329,7 +327,7 @@ describe("ContextModuleBuilder", () => {
       const res = contextModuleBuilder.build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ResolvedContextModuleConfig>(configTypes.Config);
 
       expect(res).toBeInstanceOf(DefaultContextModule);
       expect(config.loggerFactory).toBe(loggerFactory);
@@ -343,7 +341,7 @@ describe("ContextModuleBuilder", () => {
       const res = contextModuleBuilder.setLoggerFactory(loggerFactory).build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ResolvedContextModuleConfig>(configTypes.Config);
 
       expect(res).toBeInstanceOf(DefaultContextModule);
       expect(config.loggerFactory).toBe(loggerFactory);
@@ -365,7 +363,7 @@ describe("ContextModuleBuilder", () => {
         .build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ResolvedContextModuleConfig>(configTypes.Config);
 
       expect(config.loggerFactory).toBe(overrideLoggerFactory);
       expect(config.loggerFactory).not.toBe(constructorLoggerFactory);
@@ -385,7 +383,7 @@ describe("ContextModuleBuilder", () => {
         .build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ResolvedContextModuleConfig>(configTypes.Config);
 
       expect(res).toBeInstanceOf(DefaultContextModule);
       expect(config.customTrustedNameDataSource).toBe(customDataSource);

--- a/packages/signer/context-module/src/ContextModuleBuilder.ts
+++ b/packages/signer/context-module/src/ContextModuleBuilder.ts
@@ -11,6 +11,7 @@ import {
   type ContextModuleMetadataServiceConfig,
   type ContextModuleReporterConfig,
   type ContextModuleWeb3ChecksConfig,
+  type ResolvedContextModuleConfig,
 } from "./config/model/ContextModuleConfig";
 import { type BlindSigningReporter } from "./reporter/domain/BlindSigningReporter";
 import { type ContextLoader } from "./shared/domain/ContextLoader";
@@ -49,25 +50,23 @@ export const DEFAULT_CONFIG = {
   loggerFactory: noopLoggerFactory,
 };
 
+const resolveConfig = (
+  config: ContextModuleConfig,
+): ResolvedContextModuleConfig => ({
+  ...DEFAULT_CONFIG,
+  ...config,
+  reporter: config.reporter ?? DEFAULT_CONFIG.reporter,
+});
+
 export class ContextModuleBuilder {
   private config: ContextModuleConfig;
-  private originToken?: string;
 
   constructor({ originToken, loggerFactory }: ContextModuleConstructorArgs) {
-    this.originToken = originToken;
-
     this.config = {
       ...DEFAULT_CONFIG,
-      cal: { ...DEFAULT_CONFIG.cal },
-      web3checks: { ...DEFAULT_CONFIG.web3checks },
-      metadataServiceDomain: { ...DEFAULT_CONFIG.metadataServiceDomain },
-      reporter: { ...DEFAULT_CONFIG.reporter },
-      customLoaders: [...DEFAULT_CONFIG.customLoaders],
-      customFieldLoaders: [...DEFAULT_CONFIG.customFieldLoaders],
+      ...(loggerFactory && { loggerFactory }),
+      ...(originToken && { originToken }),
     };
-    if (loggerFactory) {
-      this.config.loggerFactory = loggerFactory;
-    }
   }
 
   /**
@@ -209,7 +208,6 @@ export class ContextModuleBuilder {
    * @returns the context module
    */
   build(): ContextModule {
-    const config = { ...this.config, originToken: this.originToken };
-    return new DefaultContextModule(config);
+    return new DefaultContextModule(resolveConfig(this.config));
   }
 }

--- a/packages/signer/context-module/src/DefaultContextModule.test.ts
+++ b/packages/signer/context-module/src/DefaultContextModule.test.ts
@@ -1,4 +1,4 @@
-import { type ContextModuleConfig } from "./config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "./config/model/ContextModuleConfig";
 import { type ContextFieldLoader } from "./shared/domain/ContextFieldLoader";
 import { type ContextLoader } from "./shared/domain/ContextLoader";
 import {
@@ -35,7 +35,7 @@ const fieldLoaderStubBuilder = (): ContextFieldLoader => {
 
 describe("DefaultContextModule", () => {
   const typedDataLoader: TypedDataContextLoader = { load: vi.fn() };
-  const defaultContextModuleConfig: ContextModuleConfig = {
+  const defaultContextModuleConfig: ResolvedContextModuleConfig = {
     customLoaders: [],
     defaultLoaders: false,
     defaultFieldLoaders: false,
@@ -54,6 +54,9 @@ describe("DefaultContextModule", () => {
     },
     originToken: "originToken",
     loggerFactory: mockLoggerFactory,
+    reporter: {
+      url: "https://reporter.example",
+    },
   };
 
   beforeEach(() => {

--- a/packages/signer/context-module/src/DefaultContextModule.ts
+++ b/packages/signer/context-module/src/DefaultContextModule.ts
@@ -10,7 +10,7 @@ import type { TypedDataClearSignContext } from "@/shared/model/TypedDataClearSig
 import type { TypedDataContext } from "@/shared/model/TypedDataContext";
 import { trustedNameTypes } from "@/trusted-name/di/trustedNameTypes";
 
-import { type ContextModuleConfig } from "./config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "./config/model/ContextModuleConfig";
 import { externalPluginTypes } from "./external-plugin/di/externalPluginTypes";
 import { gatedSigningTypes } from "./gated-signing/di/gatedSigningTypes";
 import { nftTypes } from "./nft/di/nftTypes";
@@ -41,7 +41,7 @@ export class DefaultContextModule implements ContextModule {
   private _fieldLoaders: ContextFieldLoader<unknown>[];
   private _blindSigningReporter: BlindSigningReporter;
 
-  constructor(args: ContextModuleConfig) {
+  constructor(args: ResolvedContextModuleConfig) {
     this._container = makeContainer({ config: args });
 
     this._loaders = args.defaultLoaders ? this._getDefaultLoaders() : [];

--- a/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.test.ts
+++ b/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.test.ts
@@ -7,7 +7,7 @@ import type {
   CalldataFieldV1,
   CalldataTransactionInfoV1,
 } from "@/calldata/data/dto/CalldataDto";
-import type { ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import type { ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { type CalldataDescriptorDataSource } from "@/index";
 import { type PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
 import { type PkiCertificate } from "@/pki/model/PkiCertificate";
@@ -27,7 +27,7 @@ const config = {
     branch: "main",
   },
   originToken: "originToken",
-} as ContextModuleConfig;
+} as ResolvedContextModuleConfig;
 
 describe("HttpCalldataDescriptorDataSource", () => {
   let datasource: CalldataDescriptorDataSource;

--- a/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.ts
+++ b/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.ts
@@ -5,7 +5,7 @@ import { Either, Left, Right } from "purify-ts";
 import { configTypes } from "@/config/di/configTypes";
 import {
   type ContextModuleCalMode,
-  type ContextModuleConfig,
+  type ResolvedContextModuleConfig,
 } from "@/config/model/ContextModuleConfig";
 import { pkiTypes } from "@/pki/di/pkiTypes";
 import { type PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
@@ -55,7 +55,8 @@ export class HttpCalldataDescriptorDataSource
   implements CalldataDescriptorDataSource
 {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
     @inject(pkiTypes.PkiCertificateLoader)
     private readonly _certificateLoader: PkiCertificateLoader,
     private readonly endpoint: string,

--- a/packages/signer/context-module/src/config/di/configModuleFactory.ts
+++ b/packages/signer/context-module/src/config/di/configModuleFactory.ts
@@ -1,10 +1,12 @@
 import { ContainerModule } from "inversify";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 
 import { configTypes } from "./configTypes";
 
-export const configModuleFactory = (config: ContextModuleConfig) =>
+export const configModuleFactory = (config: ResolvedContextModuleConfig) =>
   new ContainerModule(({ bind }) => {
-    bind<ContextModuleConfig>(configTypes.Config).toConstantValue(config);
+    bind<ResolvedContextModuleConfig>(configTypes.Config).toConstantValue(
+      config,
+    );
   });

--- a/packages/signer/context-module/src/config/model/ContextModuleConfig.ts
+++ b/packages/signer/context-module/src/config/model/ContextModuleConfig.ts
@@ -49,3 +49,7 @@ export type ContextModuleConfig = {
   datasource?: ContextModuleDatasourceConfig;
   reporter?: ContextModuleReporterConfig;
 };
+
+export type ResolvedContextModuleConfig = ContextModuleConfig & {
+  reporter: ContextModuleReporterConfig;
+};

--- a/packages/signer/context-module/src/di.ts
+++ b/packages/signer/context-module/src/di.ts
@@ -4,7 +4,7 @@ import { Container } from "inversify";
 import { calldataModuleFactory } from "@/calldata/di/calldataModuleFactory";
 import { configModuleFactory } from "@/config/di/configModuleFactory";
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { dynamicNetworkModuleFactory } from "@/dynamic-network/di/dynamicNetworkModuleFactory";
 import { externalPluginModuleFactory } from "@/external-plugin/di/externalPluginModuleFactory";
 import { gatedSigningModuleFactory } from "@/gated-signing/di/gatedSigningModuleFactory";
@@ -23,7 +23,7 @@ import { typedDataModuleFactory } from "@/typed-data/di/typedDataModuleFactory";
 import { uniswapModuleFactory } from "@/uniswap/di/uniswapModuleFactory";
 
 type MakeContainerArgs = {
-  config: ContextModuleConfig;
+  config: ResolvedContextModuleConfig;
 };
 
 export const makeContainer = ({ config }: MakeContainerArgs) => {

--- a/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.test.ts
+++ b/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.test.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { Left, Right } from "purify-ts";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 
 import { HttpDynamicNetworkDataSource } from "./HttpDynamicNetworkDataSource";
 
@@ -10,13 +10,13 @@ vi.mock("axios");
 
 describe("HttpNetworkDataSource", () => {
   let datasource: HttpDynamicNetworkDataSource;
-  const mockConfig: ContextModuleConfig = {
+  const mockConfig: ResolvedContextModuleConfig = {
     cal: {
       url: "https://crypto-assets-service.api.ledger.com",
       mode: "prod",
       branch: "main",
     },
-  } as ContextModuleConfig;
+  } as ResolvedContextModuleConfig;
 
   const mockNetworkResponse = {
     data: [

--- a/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.ts
+++ b/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.ts
@@ -4,7 +4,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import {
   type DynamicNetworkConfiguration,
   type DynamicNetworkDescriptor,
@@ -28,7 +28,8 @@ const LOWERCASE_KEY_TO_DEVICE_MODEL_ID: Record<string, DeviceModelId> = {
 @injectable()
 export class HttpDynamicNetworkDataSource implements DynamicNetworkDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
   ) {}
 
   async getDynamicNetworkConfiguration(

--- a/packages/signer/context-module/src/dynamic-network/domain/DynamicNetworkContextLoader.test.ts
+++ b/packages/signer/context-module/src/dynamic-network/domain/DynamicNetworkContextLoader.test.ts
@@ -1,7 +1,7 @@
 import { DeviceModelId } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { type DynamicNetworkDataSource } from "@/dynamic-network/data/DynamicNetworkDataSource";
 import {
   type DynamicNetworkContextInput,
@@ -36,7 +36,7 @@ describe("DynamicNetworkContextLoader", () => {
       mode: "prod",
       branch: "main",
     },
-  } as ContextModuleConfig;
+  } as ResolvedContextModuleConfig;
 
   const mockCertificateLoader: PkiCertificateLoader = {
     loadCertificate: vi.fn(),

--- a/packages/signer/context-module/src/dynamic-network/domain/DynamicNetworkContextLoader.ts
+++ b/packages/signer/context-module/src/dynamic-network/domain/DynamicNetworkContextLoader.ts
@@ -5,7 +5,7 @@ import {
 import { inject, injectable } from "inversify";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { type DynamicNetworkDataSource } from "@/dynamic-network/data/DynamicNetworkDataSource";
 import { dynamicNetworkTypes } from "@/dynamic-network/di/dynamicNetworkTypes";
 import { pkiTypes } from "@/pki/di/pkiTypes";
@@ -37,7 +37,7 @@ export class DynamicNetworkContextLoader
   implements ContextLoader<DynamicNetworkContextInput>
 {
   private readonly _networkDataSource: DynamicNetworkDataSource;
-  private readonly _config: ContextModuleConfig;
+  private readonly _config: ResolvedContextModuleConfig;
   private readonly _certificateLoader: PkiCertificateLoader;
   private logger: LoggerPublisherService;
 
@@ -45,7 +45,7 @@ export class DynamicNetworkContextLoader
     @inject(dynamicNetworkTypes.DynamicNetworkDataSource)
     networkDataSource: DynamicNetworkDataSource,
     @inject(configTypes.Config)
-    config: ContextModuleConfig,
+    config: ResolvedContextModuleConfig,
     @inject(pkiTypes.PkiCertificateLoader)
     certificateLoader: PkiCertificateLoader,
     @inject(configTypes.ContextModuleLoggerFactory)

--- a/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.test.ts
+++ b/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.test.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import ABI from "@/external-plugin/__tests__/abi.json";
 import {
   type Abis,
@@ -30,7 +30,7 @@ const config = {
     url: "https://crypto-assets-service.api.ledger.com/v1",
   },
   originToken: "originToken",
-} as ContextModuleConfig;
+} as ResolvedContextModuleConfig;
 
 describe("HttpExternalPuginDataSource", () => {
   let datasource: ExternalPluginDataSource;

--- a/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.ts
+++ b/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import type { ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import type { ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { DAppDto } from "@/external-plugin/data/DAppDto";
 import {
   ExternalPluginDataSource,
@@ -20,7 +20,8 @@ import PACKAGE from "@root/package.json";
 @injectable()
 export class HttpExternalPluginDataSource implements ExternalPluginDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
   ) {}
 
   async getDappInfos({

--- a/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.test.ts
+++ b/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { Left, Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { HttpGatedDescriptorDataSource } from "@/gated-signing/data/HttpGatedDescriptorDataSource";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
@@ -12,14 +12,14 @@ import PACKAGE from "@root/package.json";
 vi.mock("axios");
 
 describe("HttpGatedDescriptorDataSource", () => {
-  const config: ContextModuleConfig = {
+  const config: ResolvedContextModuleConfig = {
     cal: {
       url: "https://crypto-assets-service.api.ledger.com/v1",
       branch: "next",
       mode: "prod",
     },
     originToken: "test-origin-token",
-  } as ContextModuleConfig;
+  } as ResolvedContextModuleConfig;
 
   const contractAddress = "0x1111111254fb6c44bac0bed2854e76f90643097d";
   const selector = "0xa1251d75";
@@ -213,10 +213,10 @@ describe("HttpGatedDescriptorDataSource", () => {
     });
 
     it("should use config.cal.branch in ref param", async () => {
-      const configMain: ContextModuleConfig = {
+      const configMain: ResolvedContextModuleConfig = {
         ...config,
         cal: { ...config.cal!, branch: "main" },
-      } as ContextModuleConfig;
+      } as ResolvedContextModuleConfig;
       vi.spyOn(axios, "request").mockResolvedValue({
         status: 200,
         data: validGatedDappsResponse,

--- a/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.ts
+++ b/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -29,7 +29,8 @@ export class HttpGatedDescriptorDataSource
   implements GatedDescriptorDataSource
 {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
   ) {}
 
   async getGatedDescriptor({

--- a/packages/signer/context-module/src/nft/data/HttpNftDataSource.test.ts
+++ b/packages/signer/context-module/src/nft/data/HttpNftDataSource.test.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -20,7 +20,7 @@ const config = {
     url: "https://nft.api.live.ledger.com",
   },
   originToken: "originToken",
-} as ContextModuleConfig;
+} as ResolvedContextModuleConfig;
 describe("HttpNftDataSource", () => {
   let datasource: NftDataSource;
 

--- a/packages/signer/context-module/src/nft/data/HttpNftDataSource.ts
+++ b/packages/signer/context-module/src/nft/data/HttpNftDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import {
   GetNftInformationsParams,
   GetSetPluginPayloadParams,
@@ -18,7 +18,8 @@ import PACKAGE from "@root/package.json";
 @injectable()
 export class HttpNftDataSource implements NftDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
   ) {}
 
   public async getSetPluginPayload({

--- a/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.test.ts
+++ b/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { Left, Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { HttpPkiCertificateDataSource } from "@/pki/data/HttpPkiCertificateDataSource";
 import { KeyUsage } from "@/pki/model/KeyUsage";
 import { type PkiCertificateInfo } from "@/pki/model/PkiCertificateInfo";
@@ -15,7 +15,7 @@ describe("HttpPkiCertificateDataSource", () => {
       mode: "test",
       branch: "main",
     },
-  } as ContextModuleConfig;
+  } as ResolvedContextModuleConfig;
 
   describe("fetchCertificate", () => {
     it("should return certificate", async () => {

--- a/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.ts
+++ b/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.ts
@@ -6,7 +6,7 @@ import { Either, Left, Right } from "purify-ts";
 import { configTypes } from "@/config/di/configTypes";
 import type {
   ContextModuleCalMode,
-  ContextModuleConfig,
+  ResolvedContextModuleConfig,
 } from "@/config/model/ContextModuleConfig";
 import { PkiCertificate } from "@/pki/model/PkiCertificate";
 import { PkiCertificateInfo } from "@/pki/model/PkiCertificateInfo";
@@ -25,7 +25,8 @@ import {
 @injectable()
 export class HttpPkiCertificateDataSource implements PkiCertificateDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
   ) {}
 
   async fetchCertificate(

--- a/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.test.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.test.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { KeyId } from "@/pki/model/KeyId";
 import { KeyUsage } from "@/pki/model/KeyUsage";
 import {
@@ -20,7 +20,7 @@ const config = {
     url: "https://metadata.api.live.ledger.com",
   },
   originToken: "test-origin-token",
-} as ContextModuleConfig;
+} as ResolvedContextModuleConfig;
 
 describe("HttpProxyDataSource", () => {
   let datasource: ProxyDataSource;

--- a/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { KeyId } from "@/pki/model/KeyId";
 import { KeyUsage } from "@/pki/model/KeyUsage";
 import {
@@ -22,7 +22,8 @@ import {
 @injectable()
 export class HttpProxyDataSource implements ProxyDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
   ) {}
 
   async getProxyImplementationAddress({

--- a/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.test.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.test.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -18,7 +18,7 @@ const config = {
     url: "https://metadata.api.live.ledger.com",
   },
   originToken: "test-origin-token",
-} as ContextModuleConfig;
+} as ResolvedContextModuleConfig;
 
 describe("HttpSafeProxyDataSource", () => {
   let datasource: ProxyDataSource;

--- a/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -20,7 +20,8 @@ import {
 @injectable()
 export class HttpSafeProxyDataSource implements ProxyDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
   ) {}
 
   async getProxyImplementationAddress({

--- a/packages/signer/context-module/src/proxy/di/proxyModuleFactory.test.ts
+++ b/packages/signer/context-module/src/proxy/di/proxyModuleFactory.test.ts
@@ -1,7 +1,7 @@
 import { Container } from "inversify";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { pkiTypes } from "@/pki/di/pkiTypes";
 import { type PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
 import { HttpProxyDataSource } from "@/proxy/data/HttpProxyDataSource";
@@ -13,12 +13,12 @@ import { proxyTypes } from "./proxyTypes";
 
 describe("proxyModuleFactory", () => {
   let container: Container;
-  const mockConfig: ContextModuleConfig = {
+  const mockConfig: ResolvedContextModuleConfig = {
     metadataServiceDomain: {
       url: "https://metadata.api.live.ledger.com",
     },
     originToken: "test-origin-token",
-  } as ContextModuleConfig;
+  } as ResolvedContextModuleConfig;
 
   const mockPkiCertificateLoader: PkiCertificateLoader = {
     loadCertificate: vi.fn(),
@@ -56,11 +56,11 @@ describe("proxyModuleFactory", () => {
 
   describe("when config.datasource.proxy is 'safe'", () => {
     it("should bind HttpSafeProxyDataSource as the ProxyDataSource", () => {
-      const config: ContextModuleConfig = {
+      const config: ResolvedContextModuleConfig = {
         datasource: {
           proxy: "safe",
         },
-      } as ContextModuleConfig;
+      } as ResolvedContextModuleConfig;
 
       const module = proxyModuleFactory(config);
       container.load(module);
@@ -70,11 +70,11 @@ describe("proxyModuleFactory", () => {
     });
 
     it("should bind ProxyContextFieldLoader", () => {
-      const config: ContextModuleConfig = {
+      const config: ResolvedContextModuleConfig = {
         datasource: {
           proxy: "safe",
         },
-      } as ContextModuleConfig;
+      } as ResolvedContextModuleConfig;
 
       const module = proxyModuleFactory(config);
       container.load(module);
@@ -88,11 +88,11 @@ describe("proxyModuleFactory", () => {
 
   describe("when config.datasource.proxy is 'default'", () => {
     it("should bind HttpProxyDataSource as the ProxyDataSource", () => {
-      const config: ContextModuleConfig = {
+      const config: ResolvedContextModuleConfig = {
         datasource: {
           proxy: "default",
         },
-      } as ContextModuleConfig;
+      } as ResolvedContextModuleConfig;
 
       const module = proxyModuleFactory(config);
       container.load(module);
@@ -104,7 +104,8 @@ describe("proxyModuleFactory", () => {
 
   describe("when config.datasource is undefined", () => {
     it("should bind HttpProxyDataSource as the default ProxyDataSource", () => {
-      const config: ContextModuleConfig = {} as ContextModuleConfig;
+      const config: ResolvedContextModuleConfig =
+        {} as ResolvedContextModuleConfig;
 
       const module = proxyModuleFactory(config);
       container.load(module);
@@ -116,11 +117,11 @@ describe("proxyModuleFactory", () => {
 
   describe("when config.datasource.proxy is an unexpected value", () => {
     it("should bind HttpProxyDataSource as the default ProxyDataSource", () => {
-      const config: ContextModuleConfig = {
+      const config: ResolvedContextModuleConfig = {
         datasource: {
           proxy: "unknown" as unknown as "safe" | "default",
         },
-      } as ContextModuleConfig;
+      } as ResolvedContextModuleConfig;
 
       const module = proxyModuleFactory(config);
       container.load(module);

--- a/packages/signer/context-module/src/proxy/di/proxyModuleFactory.ts
+++ b/packages/signer/context-module/src/proxy/di/proxyModuleFactory.ts
@@ -1,12 +1,12 @@
 import { ContainerModule } from "inversify";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { HttpProxyDataSource } from "@/proxy/data/HttpProxyDataSource";
 import { HttpSafeProxyDataSource } from "@/proxy/data/HttpSafeProxyDataSource";
 import { proxyTypes } from "@/proxy/di/proxyTypes";
 import { ProxyContextFieldLoader } from "@/proxy/domain/ProxyContextFieldLoader";
 
-export const proxyModuleFactory = (config?: ContextModuleConfig) =>
+export const proxyModuleFactory = (config?: ResolvedContextModuleConfig) =>
   new ContainerModule(({ bind }) => {
     if (config?.datasource?.proxy === "safe") {
       bind(proxyTypes.ProxyDataSource).to(HttpSafeProxyDataSource);

--- a/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.test.ts
+++ b/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { Left, Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { type BlindSigningReportParams } from "@/reporter/data/BlindSigningReporterDatasource";
 import { HttpBlindSigningReporterDatasource } from "@/reporter/data/HttpBlindSigningReporterDatasource";
 import {
@@ -24,7 +24,7 @@ describe("HttpBlindSigningReporterDatasource", () => {
       url: "https://reporter.test",
     },
     originToken: "originToken",
-  } as ContextModuleConfig;
+  } as ResolvedContextModuleConfig;
 
   const params: BlindSigningReportParams = {
     signatureId: "a3f8Kb-1738850400000",

--- a/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
+++ b/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { type Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -20,14 +20,15 @@ export class HttpBlindSigningReporterDatasource
   implements BlindSigningReporterDatasource
 {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
   ) {}
 
   async report(params: BlindSigningReportParams): Promise<Either<Error, void>> {
     try {
       await axios.request({
         method: "POST",
-        url: `${this.config.reporter!.url}/v1/blind-signing-events`,
+        url: `${this.config.reporter.url}/v1/blind-signing-events`,
         data: params,
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,

--- a/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.test.ts
+++ b/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.test.ts
@@ -2,7 +2,7 @@ import { type HexaString } from "@ledgerhq/device-management-kit";
 import axios from "axios";
 import { Left, Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { HttpSafeAccountDataSource } from "@/safe/data/HttpSafeAccountDataSource";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
@@ -13,12 +13,12 @@ import PACKAGE from "@root/package.json";
 vi.mock("axios");
 
 describe("HttpSafeAccountDataSource", () => {
-  const config: ContextModuleConfig = {
+  const config: ResolvedContextModuleConfig = {
     metadataServiceDomain: {
       url: "https://metadata.ledger.com",
     },
     originToken: "test-origin-token",
-  } as ContextModuleConfig;
+  } as ResolvedContextModuleConfig;
 
   const validSafeAccountDto = {
     accountDescriptor: {
@@ -604,12 +604,12 @@ describe("HttpSafeAccountDataSource", () => {
 
     it("should use correct origin token from config", async () => {
       // GIVEN
-      const customConfig: ContextModuleConfig = {
+      const customConfig: ResolvedContextModuleConfig = {
         metadataServiceDomain: {
           url: "https://metadata.ledger.com",
         },
         originToken: "custom-origin-token",
-      } as ContextModuleConfig;
+      } as ResolvedContextModuleConfig;
       const params = {
         safeContractAddress: validsafeContractAddress,
         chainId: 1,
@@ -635,12 +635,12 @@ describe("HttpSafeAccountDataSource", () => {
 
     it("should use correct metadata service URL from config", async () => {
       // GIVEN
-      const customConfig: ContextModuleConfig = {
+      const customConfig: ResolvedContextModuleConfig = {
         metadataServiceDomain: {
           url: "https://custom-metadata.example.com",
         },
         originToken: "test-token",
-      } as ContextModuleConfig;
+      } as ResolvedContextModuleConfig;
       const params = {
         safeContractAddress: validsafeContractAddress,
         chainId: 1,

--- a/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.ts
+++ b/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.ts
@@ -3,7 +3,7 @@ import { inject } from "inversify";
 import { type Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -19,7 +19,8 @@ import {
 
 export class HttpSafeAccountDataSource implements SafeAccountDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
   ) {}
 
   async getDescriptors({

--- a/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.test.ts
+++ b/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.test.ts
@@ -6,7 +6,7 @@ import {
 import axios from "axios";
 import { Left } from "purify-ts";
 
-import type { ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import type { ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import { HttpSolanaOwnerInfoDataSource } from "@/solana/data/HttpSolanaOwnerInfoDataSource";
 import type { SolanaTransactionContext } from "@/solana/domain/solanaContextTypes";
@@ -26,7 +26,7 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
   const config = {
     metadataServiceDomain: { url: "https://some.doma.in" },
     originToken: "mock-origin-token",
-  } as ContextModuleConfig;
+  } as ResolvedContextModuleConfig;
 
   const signedDescriptorHex = stringToHex("mock-descriptor");
   const responseData = {

--- a/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.ts
+++ b/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.ts
@@ -4,7 +4,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import type { ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import type { ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -23,7 +23,8 @@ import {
 @injectable()
 export class HttpSolanaOwnerInfoDataSource implements SolanaDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
   ) {
     if (!this.config.originToken) {
       throw new Error(

--- a/packages/signer/context-module/src/solana/domain/DefaultSolanaContextLoader.test.ts
+++ b/packages/signer/context-module/src/solana/domain/DefaultSolanaContextLoader.test.ts
@@ -6,7 +6,7 @@ import { DeviceModelId } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import type { PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
 import { KeyUsage } from "@/pki/model/KeyUsage";
 import { SolanaContextTypes } from "@/shared/model/SolanaContextTypes";
@@ -59,7 +59,7 @@ describe("SolanaTokenContextLoader", () => {
   });
 
   const makeLoader = (mode?: string) => {
-    const config = { cal: { mode } } as unknown as ContextModuleConfig;
+    const config = { cal: { mode } } as unknown as ResolvedContextModuleConfig;
     return new SolanaTokenContextLoader(
       mockDataSource,
       config,

--- a/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.test.ts
+++ b/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.test.ts
@@ -4,7 +4,7 @@ import axios from "axios";
 import { Left, Right } from "purify-ts";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import PACKAGE from "@root/package.json";
 
@@ -27,13 +27,13 @@ const mockLoggerFactory = () => ({
 describe("HttpSolanaLifiDataSource", () => {
   let datasource: SolanaLifiDataSource;
   const templateId = "tpl-123";
-  const config: ContextModuleConfig = {
+  const config: ResolvedContextModuleConfig = {
     cal: {
       url: "https://crypto-assets-service.api.ledger.com/v1",
       mode: "prod",
       branch: "main",
     },
-  } as ContextModuleConfig;
+  } as ResolvedContextModuleConfig;
 
   beforeAll(() => {
     datasource = new HttpSolanaLifiDataSource(config, mockLoggerFactory);

--- a/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.ts
+++ b/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.ts
@@ -4,7 +4,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import PACKAGE from "@root/package.json";
 
@@ -19,7 +19,8 @@ export class HttpSolanaLifiDataSource implements SolanaLifiDataSource {
   private logger: LoggerPublisherService;
 
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
     @inject(configTypes.ContextModuleLoggerFactory)
     loggerFactory: (tag: string) => LoggerPublisherService,
   ) {

--- a/packages/signer/context-module/src/solanaLifi/domain/SolanaLifiContextLoader.test.ts
+++ b/packages/signer/context-module/src/solanaLifi/domain/SolanaLifiContextLoader.test.ts
@@ -5,7 +5,7 @@
 import { Left, Right } from "purify-ts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { type PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
 import {
   SolanaContextTypes,
@@ -39,7 +39,7 @@ const mockConfig = {
     mode: "test",
     branch: "main",
   },
-} as ContextModuleConfig;
+} as ResolvedContextModuleConfig;
 
 describe("SolanaLifiContextLoader", () => {
   let mockDataSource: SolanaLifiDataSource;

--- a/packages/signer/context-module/src/solanaLifi/domain/SolanaLifiContextLoader.ts
+++ b/packages/signer/context-module/src/solanaLifi/domain/SolanaLifiContextLoader.ts
@@ -2,7 +2,7 @@ import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { pkiTypes } from "@/pki/di/pkiTypes";
 import { type PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
 import { KeyId } from "@/pki/model/KeyId";
@@ -38,7 +38,7 @@ export class SolanaLifiContextLoader
     @inject(lifiTypes.SolanaLifiDataSource)
     private readonly dataSource: SolanaLifiDataSource,
     @inject(configTypes.Config)
-    private readonly config: ContextModuleConfig,
+    private readonly config: ResolvedContextModuleConfig,
     @inject(pkiTypes.PkiCertificateLoader)
     private readonly _certificateLoader: PkiCertificateLoader,
     @inject(configTypes.ContextModuleLoggerFactory)

--- a/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.test.ts
+++ b/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.test.ts
@@ -4,7 +4,7 @@ import axios from "axios";
 import { Left, Right } from "purify-ts";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import PACKAGE from "@root/package.json";
 
@@ -19,13 +19,13 @@ vi.mock("axios");
 describe("HttpSolanaTokenDataSource", () => {
   let datasource: SolanaTokenDataSource;
   const tokenInternalId = "sol:usdc";
-  const config: ContextModuleConfig = {
+  const config: ResolvedContextModuleConfig = {
     cal: {
       url: "https://crypto-assets-service.api.ledger.com/v1",
       mode: "prod",
       branch: "main",
     },
-  } as ContextModuleConfig;
+  } as ResolvedContextModuleConfig;
 
   const errorMessage = (id: string) =>
     `[ContextModule] HttpSolanaTokenDataSource: no token metadata for id ${id}`;

--- a/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.ts
+++ b/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import PACKAGE from "@root/package.json";
 
@@ -16,7 +16,8 @@ import {
 @injectable()
 export class HttpSolanaTokenDataSource implements SolanaTokenDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
   ) {}
   public async getTokenInfosPayload({
     tokenInternalId,

--- a/packages/signer/context-module/src/solanaToken/domain/SolanaTokenContextLoader.test.ts
+++ b/packages/signer/context-module/src/solanaToken/domain/SolanaTokenContextLoader.test.ts
@@ -6,7 +6,7 @@ import { DeviceModelId } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import type { PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
 import { KeyUsage } from "@/pki/model/KeyUsage";
 import { SolanaContextTypes } from "@/shared/model/SolanaContextTypes";
@@ -61,7 +61,7 @@ describe("SolanaTokenContextLoader", () => {
   });
 
   const makeLoader = (mode?: string) => {
-    const config = { cal: { mode } } as unknown as ContextModuleConfig;
+    const config = { cal: { mode } } as unknown as ResolvedContextModuleConfig;
     return new SolanaTokenContextLoader(
       mockDataSource,
       config,

--- a/packages/signer/context-module/src/solanaToken/domain/SolanaTokenContextLoader.ts
+++ b/packages/signer/context-module/src/solanaToken/domain/SolanaTokenContextLoader.ts
@@ -2,7 +2,7 @@ import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { pkiTypes } from "@/pki/di/pkiTypes";
 import { type PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
 import { KeyUsage } from "@/pki/model/KeyUsage";
@@ -34,7 +34,8 @@ export class SolanaTokenContextLoader
   constructor(
     @inject(solanaTokenTypes.SolanaTokenDataSource)
     private readonly dataSource: SolanaTokenDataSource,
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
     @inject(pkiTypes.PkiCertificateLoader)
     private readonly _certificateLoader: PkiCertificateLoader,
     @inject(configTypes.ContextModuleLoggerFactory)

--- a/packages/signer/context-module/src/token/data/HttpTokenDataSource.test.ts
+++ b/packages/signer/context-module/src/token/data/HttpTokenDataSource.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { Left } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import { HttpTokenDataSource } from "@/token/data/HttpTokenDataSource";
 import { type TokenDataSource } from "@/token/data/TokenDataSource";
@@ -20,7 +20,7 @@ describe("HttpTokenDataSource", () => {
         mode: "prod",
         branch: "main",
       },
-    } as ContextModuleConfig;
+    } as ResolvedContextModuleConfig;
     datasource = new HttpTokenDataSource(config);
     vi.clearAllMocks();
   });

--- a/packages/signer/context-module/src/token/data/HttpTokenDataSource.ts
+++ b/packages/signer/context-module/src/token/data/HttpTokenDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import type { ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import type { ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import PACKAGE from "@root/package.json";
 
@@ -13,7 +13,8 @@ import { TokenDto } from "./TokenDto";
 @injectable()
 export class HttpTokenDataSource implements TokenDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
   ) {}
   public async getTokenInfosPayload({
     chainId,

--- a/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.test.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { Left, Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -19,7 +19,7 @@ describe("HttpTransactionCheckDataSource", () => {
       url: "web3checksUrl",
     },
     originToken: "originToken",
-  } as ContextModuleConfig;
+  } as ResolvedContextModuleConfig;
 
   beforeEach(() => {
     vi.resetAllMocks();

--- a/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -19,7 +19,8 @@ import {
 @injectable()
 export class HttpTransactionCheckDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
   ) {}
 
   public async getTransactionCheck({

--- a/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.test.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { Left, Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -22,7 +22,7 @@ describe("HttpTypedDataCheckDataSource", () => {
       url: "web3checksUrl",
     },
     originToken: "originToken",
-  } as ContextModuleConfig;
+  } as ResolvedContextModuleConfig;
 
   beforeEach(() => {
     vi.resetAllMocks();

--- a/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -20,7 +20,8 @@ import {
 @injectable()
 export class HttpTypedDataCheckDataSource implements TypedDataCheckDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
   ) {}
 
   public async getTypedDataCheck({

--- a/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.test.ts
+++ b/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { Left, Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -22,7 +22,7 @@ const config = {
     url: "https://nft.api.live.ledger.com",
   },
   originToken: "originToken",
-} as ContextModuleConfig;
+} as ResolvedContextModuleConfig;
 describe("HttpTrustedNameDataSource", () => {
   let datasource: TrustedNameDataSource;
 

--- a/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.ts
+++ b/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import type { ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import type { ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -21,7 +21,8 @@ import { TrustedNameDto } from "./TrustedNameDto";
 @injectable()
 export class HttpTrustedNameDataSource implements TrustedNameDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
   ) {}
 
   public async getDomainNamePayload({

--- a/packages/signer/context-module/src/trusted-name/di/trustedNameModuleFactory.ts
+++ b/packages/signer/context-module/src/trusted-name/di/trustedNameModuleFactory.ts
@@ -1,12 +1,14 @@
 import { ContainerModule } from "inversify";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { HttpTrustedNameDataSource } from "@/trusted-name/data/HttpTrustedNameDataSource";
 import { trustedNameTypes } from "@/trusted-name/di/trustedNameTypes";
 import { TrustedNameContextFieldLoader } from "@/trusted-name/domain/TrustedNameContextFieldLoader";
 import { TrustedNameContextLoader } from "@/trusted-name/domain/TrustedNameContextLoader";
 
-export const trustedNameModuleFactory = (config?: ContextModuleConfig) =>
+export const trustedNameModuleFactory = (
+  config?: ResolvedContextModuleConfig,
+) =>
   new ContainerModule(({ bind }) => {
     if (config?.customTrustedNameDataSource) {
       bind(trustedNameTypes.TrustedNameDataSource).toConstantValue(

--- a/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.test.ts
+++ b/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ResolvedContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -52,7 +52,7 @@ const config = {
     mode: "prod",
   },
   originToken: "originToken",
-} as ContextModuleConfig;
+} as ResolvedContextModuleConfig;
 describe("HttpTypedDataDataSource", () => {
   let datasource: TypedDataDataSource;
 

--- a/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.ts
+++ b/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.ts
@@ -5,7 +5,7 @@ import { Either, Left, Right } from "purify-ts";
 import { configTypes } from "@/config/di/configTypes";
 import type {
   ContextModuleCalMode,
-  ContextModuleConfig,
+  ResolvedContextModuleConfig,
 } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
@@ -42,7 +42,8 @@ import {
 @injectable()
 export class HttpTypedDataDataSource implements TypedDataDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ResolvedContextModuleConfig,
   ) {}
 
   public async getTypedDataFilters({


### PR DESCRIPTION
### 📝 Description

Refactors the config handling in the context module:

- Introduces a `ResolvedContextModuleConfig` type that makes optional fields (e.g. `reporter`) required after defaults are applied.
- Adds a `resolveConfig` function in `ContextModuleBuilder` that builds the full resolved config from `DEFAULT_CONFIG`, filling in defaults for optional fields.
- Simplifies the `ContextModuleBuilder` constructor by removing manual deep-spreading of `DEFAULT_CONFIG` sub-objects. The builder now stores a `ContextModuleConfig` (with optional fields) and defers resolution to `build()` time.
- The `originToken` field is folded into `this.config` directly, removing the separate field.
- All internal services and data sources use `ResolvedContextModuleConfig` to guarantee required fields are present.

No public API changes — this is an internal refactoring of config initialization.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Internal refactoring of config resolution pattern

### ✅ Checklist

- [x] **Covered by automatic tests** — existing tests updated with new type, no behavior change
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date** — no public API change
- [x] **Impact of the changes:**
  - Added `ResolvedContextModuleConfig` type and `resolveConfig` function
  - Updated all internal services and tests to use `ResolvedContextModuleConfig`
  - Simplified builder constructor (defaults applied at build time)