### PR TITLE
🎨 (context-module) [NO-ISSUE]: Refactor ContextModuleConfig to restrict public API surface

### DIFF
--- a/.changeset/lovely-aliens-report.md
+++ b/.changeset/lovely-aliens-report.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/context-module": minor
+---
+
+Refactor ContextModuleConfig to only expose necessary configuration types publicly, keeping internal types like loader config private since they are not intended for external consumers

--- a/packages/signer/context-module/src/ContextModuleBuilder.test.ts
+++ b/packages/signer/context-module/src/ContextModuleBuilder.test.ts
@@ -1,14 +1,16 @@
 import { type LoggerPublisherService } from "@ledgerhq/device-management-kit";
-import { type Container } from "inversify";
 
 import { configTypes } from "./config/di/configTypes";
 import { type ContextModuleConstructorArgs } from "./config/model/ContextModuleBuildArgs";
 import {
   type ContextModuleCalConfig,
-  type ContextModuleConfig,
   type ContextModuleDatasourceConfig,
   type ContextModuleMetadataServiceConfig,
+  type ContextModuleServiceConfig,
 } from "./config/model/ContextModuleConfig";
+import { HttpProxyDataSource } from "./proxy/data/HttpProxyDataSource";
+import { HttpSafeProxyDataSource } from "./proxy/data/HttpSafeProxyDataSource";
+import { proxyTypes } from "./proxy/di/proxyTypes";
 import { type ContextLoader } from "./shared/domain/ContextLoader";
 import { HttpTrustedNameDataSource } from "./trusted-name/data/HttpTrustedNameDataSource";
 import { type TrustedNameDataSource } from "./trusted-name/data/TrustedNameDataSource";
@@ -86,10 +88,9 @@ describe("ContextModuleBuilder", () => {
       .setCalConfig(defaultCalConfig)
       .setWeb3ChecksConfig(defaultWeb3ChecksConfig)
       .build();
-    // @ts-expect-error _container is private
-    const config = (res["_container"] as Container).get<ContextModuleConfig>(
-      configTypes.Config,
-    );
+    const config = (res as DefaultContextModule)[
+      "_container"
+    ].get<ContextModuleServiceConfig>(configTypes.Config);
 
     expect(res).toBeInstanceOf(DefaultContextModule);
     expect(config.cal).toEqual(defaultCalConfig);
@@ -114,7 +115,7 @@ describe("ContextModuleBuilder", () => {
         .build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ContextModuleServiceConfig>(configTypes.Config);
 
       expect(res).toBeInstanceOf(DefaultContextModule);
       expect(config.metadataServiceDomain).toEqual(customMetadataConfig);
@@ -131,7 +132,7 @@ describe("ContextModuleBuilder", () => {
         .build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ContextModuleServiceConfig>(configTypes.Config);
 
       expect(config.metadataServiceDomain.url).toBe(customMetadataConfig.url);
       expect(config.metadataServiceDomain.url).not.toBe(
@@ -152,7 +153,7 @@ describe("ContextModuleBuilder", () => {
       const res = contextModuleBuilder.setCalConfig(customCalConfig).build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ContextModuleServiceConfig>(configTypes.Config);
 
       expect(res).toBeInstanceOf(DefaultContextModule);
       expect(config.cal).toEqual(customCalConfig);
@@ -169,7 +170,7 @@ describe("ContextModuleBuilder", () => {
       const res = contextModuleBuilder.setCalConfig(customCalConfig).build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ContextModuleServiceConfig>(configTypes.Config);
 
       expect(config.cal.url).toBe(customCalConfig.url);
       expect(config.cal.mode).toBe(customCalConfig.mode);
@@ -192,7 +193,7 @@ describe("ContextModuleBuilder", () => {
         .build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ContextModuleServiceConfig>(configTypes.Config);
 
       expect(res).toBeInstanceOf(DefaultContextModule);
       expect(config.web3checks).toEqual(customWeb3ChecksConfig);
@@ -209,7 +210,7 @@ describe("ContextModuleBuilder", () => {
         .build();
       const config = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<ContextModuleServiceConfig>(configTypes.Config);
 
       expect(config.web3checks.url).toBe(customWeb3ChecksConfig.url);
       expect(config.web3checks.url).not.toBe(
@@ -219,7 +220,7 @@ describe("ContextModuleBuilder", () => {
   });
 
   describe("setDatasourceConfig", () => {
-    it("should set the datasource configuration with safe proxy", () => {
+    it("should bind HttpSafeProxyDataSource when proxy is 'safe'", () => {
       const contextModuleBuilder = new ContextModuleBuilder(defaultBuilderArgs);
       const customDatasourceConfig: ContextModuleDatasourceConfig = {
         proxy: "safe",
@@ -228,16 +229,14 @@ describe("ContextModuleBuilder", () => {
       const res = contextModuleBuilder
         .setDatasourceConfig(customDatasourceConfig)
         .build();
-      const config = (res as DefaultContextModule)[
-        "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      // @ts-expect-error _container is private
+      const proxyDataSource = res["_container"].get(proxyTypes.ProxyDataSource);
 
       expect(res).toBeInstanceOf(DefaultContextModule);
-      expect(config.datasource).toEqual(customDatasourceConfig);
-      expect(config.datasource?.proxy).toBe("safe");
+      expect(proxyDataSource).toBeInstanceOf(HttpSafeProxyDataSource);
     });
 
-    it("should set the datasource configuration with default proxy", () => {
+    it("should bind HttpProxyDataSource when proxy is 'default'", () => {
       const contextModuleBuilder = new ContextModuleBuilder(defaultBuilderArgs);
       const customDatasourceConfig: ContextModuleDatasourceConfig = {
         proxy: "default",
@@ -246,46 +245,25 @@ describe("ContextModuleBuilder", () => {
       const res = contextModuleBuilder
         .setDatasourceConfig(customDatasourceConfig)
         .build();
-      const config = (res as DefaultContextModule)[
-        "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      // @ts-expect-error _container is private
+      const proxyDataSource = res["_container"].get(proxyTypes.ProxyDataSource);
 
       expect(res).toBeInstanceOf(DefaultContextModule);
-      expect(config.datasource).toEqual(customDatasourceConfig);
-      expect(config.datasource?.proxy).toBe("default");
+      expect(proxyDataSource).toBeInstanceOf(HttpProxyDataSource);
     });
 
-    it("should override the default datasource configuration", () => {
-      const contextModuleBuilder = new ContextModuleBuilder(defaultBuilderArgs);
-      const customDatasourceConfig: ContextModuleDatasourceConfig = {
-        proxy: "safe",
-      };
-
-      const res = contextModuleBuilder
-        .setDatasourceConfig(customDatasourceConfig)
-        .build();
-      const config = (res as DefaultContextModule)[
-        "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
-
-      expect(config.datasource?.proxy).toBe("safe");
-      expect(config.datasource).not.toBeUndefined();
-    });
-
-    it("should set an empty datasource configuration", () => {
+    it("should bind HttpProxyDataSource when datasource config is empty", () => {
       const contextModuleBuilder = new ContextModuleBuilder(defaultBuilderArgs);
       const customDatasourceConfig: ContextModuleDatasourceConfig = {};
 
       const res = contextModuleBuilder
         .setDatasourceConfig(customDatasourceConfig)
         .build();
-      const config = (res as DefaultContextModule)[
-        "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      // @ts-expect-error _container is private
+      const proxyDataSource = res["_container"].get(proxyTypes.ProxyDataSource);
 
       expect(res).toBeInstanceOf(DefaultContextModule);
-      expect(config.datasource).toEqual(customDatasourceConfig);
-      expect(config.datasource?.proxy).toBeUndefined();
+      expect(proxyDataSource).toBeInstanceOf(HttpProxyDataSource);
     });
   });
 
@@ -296,22 +274,20 @@ describe("ContextModuleBuilder", () => {
       });
 
       const res = contextModuleBuilder.build();
-      const config = (res as DefaultContextModule)[
-        "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      const loggerFactory = (res as DefaultContextModule)["_container"].get<
+        (tag: string) => LoggerPublisherService
+      >(configTypes.ContextModuleLoggerFactory);
 
       expect(res).toBeInstanceOf(DefaultContextModule);
-      expect(config.loggerFactory).toBeDefined();
+      expect(loggerFactory).toBeDefined();
 
-      // Verify the default logger has empty implementations
-      const logger = config.loggerFactory("test");
+      const logger = loggerFactory("test");
       expect(logger.debug).toBeDefined();
       expect(logger.info).toBeDefined();
       expect(logger.warn).toBeDefined();
       expect(logger.error).toBeDefined();
       expect(logger.subscribers).toEqual([]);
 
-      // Verify the empty logger functions don't throw
       expect(() => logger.debug("test")).not.toThrow();
       expect(() => logger.info("test")).not.toThrow();
       expect(() => logger.warn("test")).not.toThrow();
@@ -327,12 +303,14 @@ describe("ContextModuleBuilder", () => {
       });
 
       const res = contextModuleBuilder.build();
-      const config = (res as DefaultContextModule)[
+      const boundLoggerFactory = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<(tag: string) => LoggerPublisherService>(
+        configTypes.ContextModuleLoggerFactory,
+      );
 
       expect(res).toBeInstanceOf(DefaultContextModule);
-      expect(config.loggerFactory).toBe(loggerFactory);
+      expect(boundLoggerFactory).toBe(loggerFactory);
     });
 
     it("should set the loggerFactory via setLoggerFactory", () => {
@@ -341,12 +319,14 @@ describe("ContextModuleBuilder", () => {
       const contextModuleBuilder = new ContextModuleBuilder(defaultBuilderArgs);
 
       const res = contextModuleBuilder.setLoggerFactory(loggerFactory).build();
-      const config = (res as DefaultContextModule)[
+      const boundLoggerFactory = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<(tag: string) => LoggerPublisherService>(
+        configTypes.ContextModuleLoggerFactory,
+      );
 
       expect(res).toBeInstanceOf(DefaultContextModule);
-      expect(config.loggerFactory).toBe(loggerFactory);
+      expect(boundLoggerFactory).toBe(loggerFactory);
     });
 
     it("should override constructor loggerFactory with setLoggerFactory", () => {
@@ -363,34 +343,39 @@ describe("ContextModuleBuilder", () => {
       const res = contextModuleBuilder
         .setLoggerFactory(overrideLoggerFactory)
         .build();
-      const config = (res as DefaultContextModule)[
+      const boundLoggerFactory = (res as DefaultContextModule)[
         "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
+      ].get<(tag: string) => LoggerPublisherService>(
+        configTypes.ContextModuleLoggerFactory,
+      );
 
-      expect(config.loggerFactory).toBe(overrideLoggerFactory);
-      expect(config.loggerFactory).not.toBe(constructorLoggerFactory);
+      expect(boundLoggerFactory).toBe(overrideLoggerFactory);
+      expect(boundLoggerFactory).not.toBe(constructorLoggerFactory);
+    });
+  });
+
+  describe("instance isolation", () => {
+    it("should not share customLoaders arrays between builder instances", () => {
+      const builder1 = new ContextModuleBuilder(defaultBuilderArgs);
+      const builder2 = new ContextModuleBuilder(defaultBuilderArgs);
+      const customLoader: ContextLoader = {
+        load: vi.fn(),
+        canHandle: vi.fn() as unknown as ContextLoader["canHandle"],
+      };
+
+      builder1.addLoader(customLoader);
+
+      const res1 = builder1.removeDefaultLoaders().build();
+      const res2 = builder2.removeDefaultLoaders().build();
+
+      // @ts-expect-error _loaders is private
+      expect(res1["_loaders"]).toHaveLength(1);
+      // @ts-expect-error _loaders is private
+      expect(res2["_loaders"]).toHaveLength(0);
     });
   });
 
   describe("setTrustedNameDataSource", () => {
-    it("should set a custom trusted name data source", () => {
-      const contextModuleBuilder = new ContextModuleBuilder(defaultBuilderArgs);
-      const customDataSource: TrustedNameDataSource = {
-        getDomainNamePayload: vi.fn(),
-        getTrustedNamePayload: vi.fn(),
-      };
-
-      const res = contextModuleBuilder
-        .setTrustedNameDataSource(customDataSource)
-        .build();
-      const config = (res as DefaultContextModule)[
-        "_container"
-      ].get<ContextModuleConfig>(configTypes.Config);
-
-      expect(res).toBeInstanceOf(DefaultContextModule);
-      expect(config.customTrustedNameDataSource).toBe(customDataSource);
-    });
-
     it("should inject the custom data source into the container", () => {
       const contextModuleBuilder = new ContextModuleBuilder(defaultBuilderArgs);
       const customDataSource: TrustedNameDataSource = {

--- a/packages/signer/context-module/src/ContextModuleBuilder.ts
+++ b/packages/signer/context-module/src/ContextModuleBuilder.ts
@@ -8,8 +8,10 @@ import {
   type ContextModuleCalConfig,
   type ContextModuleConfig,
   type ContextModuleDatasourceConfig,
+  type ContextModuleLoaderConfig,
   type ContextModuleMetadataServiceConfig,
   type ContextModuleReporterConfig,
+  type ContextModuleServiceConfig,
   type ContextModuleWeb3ChecksConfig,
 } from "./config/model/ContextModuleConfig";
 import { type BlindSigningReporter } from "./reporter/domain/BlindSigningReporter";
@@ -25,49 +27,58 @@ const DEFAULT_WEB3_CHECKS_URL = "https://web3checks-backend.api.ledger.com/v3";
 const DEFAULT_METADATA_SERVICE_DOMAIN = "https://nft.api.live.ledger.com";
 const DEFAULT_REPORTER_URL = "https://blind-signing-reporting.api.ledger.com";
 
-export const DEFAULT_CONFIG = {
-  cal: {
+/**
+ * Default configuration for the context module
+ *
+ * @note This configuration is frozen to prevent modifications after construction
+ * and can be used by external packages to get a default configuration.
+ */
+export const DEFAULT_CONFIG: Readonly<ContextModuleConfig> = Object.freeze({
+  cal: Object.freeze({
     url: DEFAULT_CAL_URL,
     mode: "prod",
     branch: "main",
-  } as ContextModuleCalConfig,
-  web3checks: {
+  }),
+  web3checks: Object.freeze({
     url: DEFAULT_WEB3_CHECKS_URL,
-  },
-  metadataServiceDomain: {
+  }),
+  metadataServiceDomain: Object.freeze({
     url: DEFAULT_METADATA_SERVICE_DOMAIN,
-  },
+  }),
+  reporter: Object.freeze({
+    url: DEFAULT_REPORTER_URL,
+  }),
+  datasource: Object.freeze({ proxy: "default" }),
+});
+
+/**
+ * Default loader configuration for the context module
+ *
+ * @note This configuration is internal and will be the default configuration for the context module.
+ */
+const DEFAULT_LOADER_CONFIG: ContextModuleLoaderConfig = {
   defaultLoaders: true,
-  customLoaders: [],
   defaultFieldLoaders: true,
+  customLoaders: [],
   customFieldLoaders: [],
   customTypedDataLoader: undefined,
   customSolanaLoader: undefined,
-  reporter: {
-    url: DEFAULT_REPORTER_URL,
-  },
-  loggerFactory: noopLoggerFactory,
+  customBlindSigningReporter: undefined,
+  customTrustedNameDataSource: undefined,
 };
 
 export class ContextModuleBuilder {
-  private config: ContextModuleConfig;
-  private originToken?: string;
+  private config: ContextModuleServiceConfig & ContextModuleLoaderConfig;
 
   constructor({ originToken, loggerFactory }: ContextModuleConstructorArgs) {
-    this.originToken = originToken;
-
     this.config = {
       ...DEFAULT_CONFIG,
-      cal: { ...DEFAULT_CONFIG.cal },
-      web3checks: { ...DEFAULT_CONFIG.web3checks },
-      metadataServiceDomain: { ...DEFAULT_CONFIG.metadataServiceDomain },
-      reporter: { ...DEFAULT_CONFIG.reporter },
-      customLoaders: [...DEFAULT_CONFIG.customLoaders],
-      customFieldLoaders: [...DEFAULT_CONFIG.customFieldLoaders],
-    };
-    if (loggerFactory) {
-      this.config.loggerFactory = loggerFactory;
-    }
+      ...DEFAULT_LOADER_CONFIG,
+      customLoaders: [],
+      customFieldLoaders: [],
+      originToken: originToken ?? "",
+      loggerFactory: loggerFactory ?? noopLoggerFactory,
+    } as ContextModuleServiceConfig & ContextModuleLoaderConfig;
   }
 
   /**
@@ -209,7 +220,6 @@ export class ContextModuleBuilder {
    * @returns the context module
    */
   build(): ContextModule {
-    const config = { ...this.config, originToken: this.originToken };
-    return new DefaultContextModule(config);
+    return new DefaultContextModule(this.config);
   }
 }

--- a/packages/signer/context-module/src/DefaultContextModule.test.ts
+++ b/packages/signer/context-module/src/DefaultContextModule.test.ts
@@ -1,4 +1,7 @@
-import { type ContextModuleConfig } from "./config/model/ContextModuleConfig";
+import {
+  type ContextModuleLoaderConfig,
+  type ContextModuleServiceConfig,
+} from "./config/model/ContextModuleConfig";
 import { type ContextFieldLoader } from "./shared/domain/ContextFieldLoader";
 import { type ContextLoader } from "./shared/domain/ContextLoader";
 import {
@@ -35,7 +38,8 @@ const fieldLoaderStubBuilder = (): ContextFieldLoader => {
 
 describe("DefaultContextModule", () => {
   const typedDataLoader: TypedDataContextLoader = { load: vi.fn() };
-  const defaultContextModuleConfig: ContextModuleConfig = {
+  const defaultContextModuleConfig: ContextModuleServiceConfig &
+    ContextModuleLoaderConfig = {
     customLoaders: [],
     defaultLoaders: false,
     defaultFieldLoaders: false,
@@ -51,6 +55,12 @@ describe("DefaultContextModule", () => {
     },
     metadataServiceDomain: {
       url: "https://metadata.com",
+    },
+    reporter: {
+      url: "https://reporter.com",
+    },
+    datasource: {
+      proxy: "default",
     },
     originToken: "originToken",
     loggerFactory: mockLoggerFactory,

--- a/packages/signer/context-module/src/DefaultContextModule.ts
+++ b/packages/signer/context-module/src/DefaultContextModule.ts
@@ -10,7 +10,10 @@ import type { TypedDataClearSignContext } from "@/shared/model/TypedDataClearSig
 import type { TypedDataContext } from "@/shared/model/TypedDataContext";
 import { trustedNameTypes } from "@/trusted-name/di/trustedNameTypes";
 
-import { type ContextModuleConfig } from "./config/model/ContextModuleConfig";
+import {
+  type ContextModuleLoaderConfig,
+  type ContextModuleServiceConfig,
+} from "./config/model/ContextModuleConfig";
 import { externalPluginTypes } from "./external-plugin/di/externalPluginTypes";
 import { gatedSigningTypes } from "./gated-signing/di/gatedSigningTypes";
 import { nftTypes } from "./nft/di/nftTypes";
@@ -41,7 +44,7 @@ export class DefaultContextModule implements ContextModule {
   private _fieldLoaders: ContextFieldLoader<unknown>[];
   private _blindSigningReporter: BlindSigningReporter;
 
-  constructor(args: ContextModuleConfig) {
+  constructor(args: ContextModuleServiceConfig & ContextModuleLoaderConfig) {
     this._container = makeContainer({ config: args });
 
     this._loaders = args.defaultLoaders ? this._getDefaultLoaders() : [];

--- a/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.test.ts
+++ b/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.test.ts
@@ -7,7 +7,7 @@ import type {
   CalldataFieldV1,
   CalldataTransactionInfoV1,
 } from "@/calldata/data/dto/CalldataDto";
-import type { ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import type { ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { type CalldataDescriptorDataSource } from "@/index";
 import { type PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
 import { type PkiCertificate } from "@/pki/model/PkiCertificate";
@@ -27,7 +27,7 @@ const config = {
     branch: "main",
   },
   originToken: "originToken",
-} as ContextModuleConfig;
+} as ContextModuleServiceConfig;
 
 describe("HttpCalldataDescriptorDataSource", () => {
   let datasource: CalldataDescriptorDataSource;

--- a/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.ts
+++ b/packages/signer/context-module/src/calldata/data/HttpCalldataDescriptorDataSource.ts
@@ -5,7 +5,7 @@ import { Either, Left, Right } from "purify-ts";
 import { configTypes } from "@/config/di/configTypes";
 import {
   type ContextModuleCalMode,
-  type ContextModuleConfig,
+  type ContextModuleServiceConfig,
 } from "@/config/model/ContextModuleConfig";
 import { pkiTypes } from "@/pki/di/pkiTypes";
 import { type PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
@@ -55,7 +55,8 @@ export class HttpCalldataDescriptorDataSource
   implements CalldataDescriptorDataSource
 {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
     @inject(pkiTypes.PkiCertificateLoader)
     private readonly _certificateLoader: PkiCertificateLoader,
     private readonly endpoint: string,

--- a/packages/signer/context-module/src/config/di/configModuleFactory.ts
+++ b/packages/signer/context-module/src/config/di/configModuleFactory.ts
@@ -1,10 +1,12 @@
 import { ContainerModule } from "inversify";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 
 import { configTypes } from "./configTypes";
 
-export const configModuleFactory = (config: ContextModuleConfig) =>
+export const configModuleFactory = (config: ContextModuleServiceConfig) =>
   new ContainerModule(({ bind }) => {
-    bind<ContextModuleConfig>(configTypes.Config).toConstantValue(config);
+    bind<ContextModuleServiceConfig>(configTypes.Config).toConstantValue(
+      config,
+    );
   });

--- a/packages/signer/context-module/src/config/model/ContextModuleConfig.ts
+++ b/packages/signer/context-module/src/config/model/ContextModuleConfig.ts
@@ -36,16 +36,22 @@ export type ContextModuleConfig = {
   cal: ContextModuleCalConfig;
   web3checks: ContextModuleWeb3ChecksConfig;
   metadataServiceDomain: ContextModuleMetadataServiceConfig;
+  reporter: ContextModuleReporterConfig;
+  datasource: ContextModuleDatasourceConfig;
+};
+
+export type ContextModuleServiceConfig = ContextModuleConfig & {
+  originToken: string;
+  loggerFactory: (tag: string) => LoggerPublisherService;
+};
+
+export type ContextModuleLoaderConfig = {
   defaultLoaders: boolean;
   defaultFieldLoaders: boolean;
   customFieldLoaders: ContextFieldLoader[];
   customLoaders: ContextLoader[];
-  loggerFactory: (tag: string) => LoggerPublisherService;
   customTypedDataLoader?: TypedDataContextLoader;
   customSolanaLoader?: SolanaContextLoader;
   customBlindSigningReporter?: BlindSigningReporter;
   customTrustedNameDataSource?: TrustedNameDataSource;
-  originToken?: string;
-  datasource?: ContextModuleDatasourceConfig;
-  reporter?: ContextModuleReporterConfig;
 };

--- a/packages/signer/context-module/src/di.ts
+++ b/packages/signer/context-module/src/di.ts
@@ -4,7 +4,10 @@ import { Container } from "inversify";
 import { calldataModuleFactory } from "@/calldata/di/calldataModuleFactory";
 import { configModuleFactory } from "@/config/di/configModuleFactory";
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import {
+  type ContextModuleLoaderConfig,
+  type ContextModuleServiceConfig,
+} from "@/config/model/ContextModuleConfig";
 import { dynamicNetworkModuleFactory } from "@/dynamic-network/di/dynamicNetworkModuleFactory";
 import { externalPluginModuleFactory } from "@/external-plugin/di/externalPluginModuleFactory";
 import { gatedSigningModuleFactory } from "@/gated-signing/di/gatedSigningModuleFactory";
@@ -23,7 +26,7 @@ import { typedDataModuleFactory } from "@/typed-data/di/typedDataModuleFactory";
 import { uniswapModuleFactory } from "@/uniswap/di/uniswapModuleFactory";
 
 type MakeContainerArgs = {
-  config: ContextModuleConfig;
+  config: ContextModuleServiceConfig & ContextModuleLoaderConfig;
 };
 
 export const makeContainer = ({ config }: MakeContainerArgs) => {
@@ -40,12 +43,12 @@ export const makeContainer = ({ config }: MakeContainerArgs) => {
     externalPluginModuleFactory(),
     dynamicNetworkModuleFactory(),
     nftModuleFactory(),
-    proxyModuleFactory(config),
+    proxyModuleFactory(config.datasource),
     safeModuleFactory(),
     gatedSigningModuleFactory(),
     tokenModuleFactory(),
     calldataModuleFactory(),
-    trustedNameModuleFactory(config),
+    trustedNameModuleFactory(config.customTrustedNameDataSource),
     typedDataModuleFactory(),
     nanoPkiModuleFactory(),
     uniswapModuleFactory(),

--- a/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.test.ts
+++ b/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.test.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { Left, Right } from "purify-ts";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 
 import { HttpDynamicNetworkDataSource } from "./HttpDynamicNetworkDataSource";
 
@@ -10,13 +10,13 @@ vi.mock("axios");
 
 describe("HttpNetworkDataSource", () => {
   let datasource: HttpDynamicNetworkDataSource;
-  const mockConfig: ContextModuleConfig = {
+  const mockConfig: ContextModuleServiceConfig = {
     cal: {
       url: "https://crypto-assets-service.api.ledger.com",
       mode: "prod",
       branch: "main",
     },
-  } as ContextModuleConfig;
+  } as ContextModuleServiceConfig;
 
   const mockNetworkResponse = {
     data: [

--- a/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.ts
+++ b/packages/signer/context-module/src/dynamic-network/data/HttpDynamicNetworkDataSource.ts
@@ -4,7 +4,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   type DynamicNetworkConfiguration,
   type DynamicNetworkDescriptor,
@@ -28,7 +28,8 @@ const LOWERCASE_KEY_TO_DEVICE_MODEL_ID: Record<string, DeviceModelId> = {
 @injectable()
 export class HttpDynamicNetworkDataSource implements DynamicNetworkDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
   ) {}
 
   async getDynamicNetworkConfiguration(

--- a/packages/signer/context-module/src/dynamic-network/domain/DynamicNetworkContextLoader.test.ts
+++ b/packages/signer/context-module/src/dynamic-network/domain/DynamicNetworkContextLoader.test.ts
@@ -1,7 +1,7 @@
 import { DeviceModelId } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { type DynamicNetworkDataSource } from "@/dynamic-network/data/DynamicNetworkDataSource";
 import {
   type DynamicNetworkContextInput,
@@ -36,7 +36,7 @@ describe("DynamicNetworkContextLoader", () => {
       mode: "prod",
       branch: "main",
     },
-  } as ContextModuleConfig;
+  } as ContextModuleServiceConfig;
 
   const mockCertificateLoader: PkiCertificateLoader = {
     loadCertificate: vi.fn(),

--- a/packages/signer/context-module/src/dynamic-network/domain/DynamicNetworkContextLoader.ts
+++ b/packages/signer/context-module/src/dynamic-network/domain/DynamicNetworkContextLoader.ts
@@ -5,7 +5,7 @@ import {
 import { inject, injectable } from "inversify";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { type DynamicNetworkDataSource } from "@/dynamic-network/data/DynamicNetworkDataSource";
 import { dynamicNetworkTypes } from "@/dynamic-network/di/dynamicNetworkTypes";
 import { pkiTypes } from "@/pki/di/pkiTypes";
@@ -37,7 +37,7 @@ export class DynamicNetworkContextLoader
   implements ContextLoader<DynamicNetworkContextInput>
 {
   private readonly _networkDataSource: DynamicNetworkDataSource;
-  private readonly _config: ContextModuleConfig;
+  private readonly _config: ContextModuleServiceConfig;
   private readonly _certificateLoader: PkiCertificateLoader;
   private logger: LoggerPublisherService;
 
@@ -45,7 +45,7 @@ export class DynamicNetworkContextLoader
     @inject(dynamicNetworkTypes.DynamicNetworkDataSource)
     networkDataSource: DynamicNetworkDataSource,
     @inject(configTypes.Config)
-    config: ContextModuleConfig,
+    config: ContextModuleServiceConfig,
     @inject(pkiTypes.PkiCertificateLoader)
     certificateLoader: PkiCertificateLoader,
     @inject(configTypes.ContextModuleLoggerFactory)

--- a/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.test.ts
+++ b/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.test.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import ABI from "@/external-plugin/__tests__/abi.json";
 import {
   type Abis,
@@ -30,7 +30,7 @@ const config = {
     url: "https://crypto-assets-service.api.ledger.com/v1",
   },
   originToken: "originToken",
-} as ContextModuleConfig;
+} as ContextModuleServiceConfig;
 
 describe("HttpExternalPuginDataSource", () => {
   let datasource: ExternalPluginDataSource;

--- a/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.ts
+++ b/packages/signer/context-module/src/external-plugin/data/HttpExternalPluginDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import type { ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import type { ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { DAppDto } from "@/external-plugin/data/DAppDto";
 import {
   ExternalPluginDataSource,
@@ -20,7 +20,8 @@ import PACKAGE from "@root/package.json";
 @injectable()
 export class HttpExternalPluginDataSource implements ExternalPluginDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
   ) {}
 
   async getDappInfos({

--- a/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.test.ts
+++ b/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { Left, Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { HttpGatedDescriptorDataSource } from "@/gated-signing/data/HttpGatedDescriptorDataSource";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
@@ -12,14 +12,14 @@ import PACKAGE from "@root/package.json";
 vi.mock("axios");
 
 describe("HttpGatedDescriptorDataSource", () => {
-  const config: ContextModuleConfig = {
+  const config: ContextModuleServiceConfig = {
     cal: {
       url: "https://crypto-assets-service.api.ledger.com/v1",
       branch: "next",
       mode: "prod",
     },
     originToken: "test-origin-token",
-  } as ContextModuleConfig;
+  } as ContextModuleServiceConfig;
 
   const contractAddress = "0x1111111254fb6c44bac0bed2854e76f90643097d";
   const selector = "0xa1251d75";
@@ -213,10 +213,10 @@ describe("HttpGatedDescriptorDataSource", () => {
     });
 
     it("should use config.cal.branch in ref param", async () => {
-      const configMain: ContextModuleConfig = {
+      const configMain: ContextModuleServiceConfig = {
         ...config,
         cal: { ...config.cal!, branch: "main" },
-      } as ContextModuleConfig;
+      } as ContextModuleServiceConfig;
       vi.spyOn(axios, "request").mockResolvedValue({
         status: 200,
         data: validGatedDappsResponse,

--- a/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.ts
+++ b/packages/signer/context-module/src/gated-signing/data/HttpGatedDescriptorDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -29,7 +29,8 @@ export class HttpGatedDescriptorDataSource
   implements GatedDescriptorDataSource
 {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
   ) {}
 
   async getGatedDescriptor({

--- a/packages/signer/context-module/src/index.ts
+++ b/packages/signer/context-module/src/index.ts
@@ -1,7 +1,16 @@
 export * from "./calldata/data/CalldataDescriptorDataSource";
 export * from "./calldata/data/HttpCalldataDescriptorDataSource";
 export * from "./calldata/domain/CalldataContextLoader";
-export * from "./config/model/ContextModuleConfig";
+export type {
+  ContextModuleCalBranch,
+  ContextModuleCalConfig,
+  ContextModuleCalMode,
+  ContextModuleConfig,
+  ContextModuleDatasourceConfig,
+  ContextModuleMetadataServiceConfig,
+  ContextModuleReporterConfig,
+  ContextModuleWeb3ChecksConfig,
+} from "./config/model/ContextModuleConfig";
 export * from "./ContextModule";
 export * from "./ContextModuleBuilder";
 export * from "./DefaultContextModule";

--- a/packages/signer/context-module/src/nft/data/HttpNftDataSource.test.ts
+++ b/packages/signer/context-module/src/nft/data/HttpNftDataSource.test.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -20,7 +20,7 @@ const config = {
     url: "https://nft.api.live.ledger.com",
   },
   originToken: "originToken",
-} as ContextModuleConfig;
+} as ContextModuleServiceConfig;
 describe("HttpNftDataSource", () => {
   let datasource: NftDataSource;
 

--- a/packages/signer/context-module/src/nft/data/HttpNftDataSource.ts
+++ b/packages/signer/context-module/src/nft/data/HttpNftDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   GetNftInformationsParams,
   GetSetPluginPayloadParams,
@@ -18,7 +18,8 @@ import PACKAGE from "@root/package.json";
 @injectable()
 export class HttpNftDataSource implements NftDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
   ) {}
 
   public async getSetPluginPayload({

--- a/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.test.ts
+++ b/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { Left, Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { HttpPkiCertificateDataSource } from "@/pki/data/HttpPkiCertificateDataSource";
 import { KeyUsage } from "@/pki/model/KeyUsage";
 import { type PkiCertificateInfo } from "@/pki/model/PkiCertificateInfo";
@@ -15,7 +15,7 @@ describe("HttpPkiCertificateDataSource", () => {
       mode: "test",
       branch: "main",
     },
-  } as ContextModuleConfig;
+  } as ContextModuleServiceConfig;
 
   describe("fetchCertificate", () => {
     it("should return certificate", async () => {

--- a/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.ts
+++ b/packages/signer/context-module/src/pki/data/HttpPkiCertificateDataSource.ts
@@ -6,7 +6,7 @@ import { Either, Left, Right } from "purify-ts";
 import { configTypes } from "@/config/di/configTypes";
 import type {
   ContextModuleCalMode,
-  ContextModuleConfig,
+  ContextModuleServiceConfig,
 } from "@/config/model/ContextModuleConfig";
 import { PkiCertificate } from "@/pki/model/PkiCertificate";
 import { PkiCertificateInfo } from "@/pki/model/PkiCertificateInfo";
@@ -25,7 +25,8 @@ import {
 @injectable()
 export class HttpPkiCertificateDataSource implements PkiCertificateDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
   ) {}
 
   async fetchCertificate(

--- a/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.test.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.test.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { KeyId } from "@/pki/model/KeyId";
 import { KeyUsage } from "@/pki/model/KeyUsage";
 import {
@@ -20,7 +20,7 @@ const config = {
     url: "https://metadata.api.live.ledger.com",
   },
   originToken: "test-origin-token",
-} as ContextModuleConfig;
+} as ContextModuleServiceConfig;
 
 describe("HttpProxyDataSource", () => {
   let datasource: ProxyDataSource;

--- a/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpProxyDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { KeyId } from "@/pki/model/KeyId";
 import { KeyUsage } from "@/pki/model/KeyUsage";
 import {
@@ -22,7 +22,8 @@ import {
 @injectable()
 export class HttpProxyDataSource implements ProxyDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
   ) {}
 
   async getProxyImplementationAddress({

--- a/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.test.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.test.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -18,7 +18,7 @@ const config = {
     url: "https://metadata.api.live.ledger.com",
   },
   originToken: "test-origin-token",
-} as ContextModuleConfig;
+} as ContextModuleServiceConfig;
 
 describe("HttpSafeProxyDataSource", () => {
   let datasource: ProxyDataSource;

--- a/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.ts
+++ b/packages/signer/context-module/src/proxy/data/HttpSafeProxyDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -20,7 +20,8 @@ import {
 @injectable()
 export class HttpSafeProxyDataSource implements ProxyDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
   ) {}
 
   async getProxyImplementationAddress({

--- a/packages/signer/context-module/src/proxy/di/proxyModuleFactory.test.ts
+++ b/packages/signer/context-module/src/proxy/di/proxyModuleFactory.test.ts
@@ -1,7 +1,7 @@
 import { Container } from "inversify";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { pkiTypes } from "@/pki/di/pkiTypes";
 import { type PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
 import { HttpProxyDataSource } from "@/proxy/data/HttpProxyDataSource";
@@ -13,12 +13,12 @@ import { proxyTypes } from "./proxyTypes";
 
 describe("proxyModuleFactory", () => {
   let container: Container;
-  const mockConfig: ContextModuleConfig = {
+  const mockConfig: ContextModuleServiceConfig = {
     metadataServiceDomain: {
       url: "https://metadata.api.live.ledger.com",
     },
     originToken: "test-origin-token",
-  } as ContextModuleConfig;
+  } as ContextModuleServiceConfig;
 
   const mockPkiCertificateLoader: PkiCertificateLoader = {
     loadCertificate: vi.fn(),
@@ -26,15 +26,13 @@ describe("proxyModuleFactory", () => {
 
   beforeEach(() => {
     container = new Container();
-    // Bind the config that the datasources depend on
     container.bind(configTypes.Config).toConstantValue(mockConfig);
-    // Bind the PKI certificate loader that ProxyContextFieldLoader depends on
     container
       .bind(pkiTypes.PkiCertificateLoader)
       .toConstantValue(mockPkiCertificateLoader);
   });
 
-  describe("when config is undefined", () => {
+  describe("when datasource config is undefined", () => {
     it("should bind HttpProxyDataSource as the default ProxyDataSource", () => {
       const module = proxyModuleFactory();
       container.load(module);
@@ -54,15 +52,9 @@ describe("proxyModuleFactory", () => {
     });
   });
 
-  describe("when config.datasource.proxy is 'safe'", () => {
+  describe("when datasource.proxy is 'safe'", () => {
     it("should bind HttpSafeProxyDataSource as the ProxyDataSource", () => {
-      const config: ContextModuleConfig = {
-        datasource: {
-          proxy: "safe",
-        },
-      } as ContextModuleConfig;
-
-      const module = proxyModuleFactory(config);
+      const module = proxyModuleFactory({ proxy: "safe" });
       container.load(module);
 
       const proxyDataSource = container.get(proxyTypes.ProxyDataSource);
@@ -70,13 +62,7 @@ describe("proxyModuleFactory", () => {
     });
 
     it("should bind ProxyContextFieldLoader", () => {
-      const config: ContextModuleConfig = {
-        datasource: {
-          proxy: "safe",
-        },
-      } as ContextModuleConfig;
-
-      const module = proxyModuleFactory(config);
+      const module = proxyModuleFactory({ proxy: "safe" });
       container.load(module);
 
       const proxyContextFieldLoader = container.get(
@@ -86,15 +72,9 @@ describe("proxyModuleFactory", () => {
     });
   });
 
-  describe("when config.datasource.proxy is 'default'", () => {
+  describe("when datasource.proxy is 'default'", () => {
     it("should bind HttpProxyDataSource as the ProxyDataSource", () => {
-      const config: ContextModuleConfig = {
-        datasource: {
-          proxy: "default",
-        },
-      } as ContextModuleConfig;
-
-      const module = proxyModuleFactory(config);
+      const module = proxyModuleFactory({ proxy: "default" });
       container.load(module);
 
       const proxyDataSource = container.get(proxyTypes.ProxyDataSource);
@@ -102,11 +82,9 @@ describe("proxyModuleFactory", () => {
     });
   });
 
-  describe("when config.datasource is undefined", () => {
+  describe("when datasource has no proxy set", () => {
     it("should bind HttpProxyDataSource as the default ProxyDataSource", () => {
-      const config: ContextModuleConfig = {} as ContextModuleConfig;
-
-      const module = proxyModuleFactory(config);
+      const module = proxyModuleFactory({});
       container.load(module);
 
       const proxyDataSource = container.get(proxyTypes.ProxyDataSource);
@@ -114,15 +92,11 @@ describe("proxyModuleFactory", () => {
     });
   });
 
-  describe("when config.datasource.proxy is an unexpected value", () => {
+  describe("when datasource.proxy is an unexpected value", () => {
     it("should bind HttpProxyDataSource as the default ProxyDataSource", () => {
-      const config: ContextModuleConfig = {
-        datasource: {
-          proxy: "unknown" as unknown as "safe" | "default",
-        },
-      } as ContextModuleConfig;
-
-      const module = proxyModuleFactory(config);
+      const module = proxyModuleFactory({
+        proxy: "unknown" as unknown as "safe" | "default",
+      });
       container.load(module);
 
       const proxyDataSource = container.get(proxyTypes.ProxyDataSource);

--- a/packages/signer/context-module/src/proxy/di/proxyModuleFactory.ts
+++ b/packages/signer/context-module/src/proxy/di/proxyModuleFactory.ts
@@ -1,14 +1,16 @@
 import { ContainerModule } from "inversify";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleDatasourceConfig } from "@/config/model/ContextModuleConfig";
 import { HttpProxyDataSource } from "@/proxy/data/HttpProxyDataSource";
 import { HttpSafeProxyDataSource } from "@/proxy/data/HttpSafeProxyDataSource";
 import { proxyTypes } from "@/proxy/di/proxyTypes";
 import { ProxyContextFieldLoader } from "@/proxy/domain/ProxyContextFieldLoader";
 
-export const proxyModuleFactory = (config?: ContextModuleConfig) =>
+export const proxyModuleFactory = (
+  datasource?: ContextModuleDatasourceConfig,
+) =>
   new ContainerModule(({ bind }) => {
-    if (config?.datasource?.proxy === "safe") {
+    if (datasource?.proxy === "safe") {
       bind(proxyTypes.ProxyDataSource).to(HttpSafeProxyDataSource);
     } else {
       bind(proxyTypes.ProxyDataSource).to(HttpProxyDataSource);

--- a/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.test.ts
+++ b/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { Left, Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { type BlindSigningReportParams } from "@/reporter/data/BlindSigningReporterDatasource";
 import { HttpBlindSigningReporterDatasource } from "@/reporter/data/HttpBlindSigningReporterDatasource";
 import {
@@ -24,7 +24,7 @@ describe("HttpBlindSigningReporterDatasource", () => {
       url: "https://reporter.test",
     },
     originToken: "originToken",
-  } as ContextModuleConfig;
+  } as ContextModuleServiceConfig;
 
   const params: BlindSigningReportParams = {
     signatureId: "a3f8Kb-1738850400000",

--- a/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
+++ b/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { type Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -20,14 +20,15 @@ export class HttpBlindSigningReporterDatasource
   implements BlindSigningReporterDatasource
 {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
   ) {}
 
   async report(params: BlindSigningReportParams): Promise<Either<Error, void>> {
     try {
       await axios.request({
         method: "POST",
-        url: `${this.config.reporter!.url}/v1/blind-signing-events`,
+        url: `${this.config.reporter.url}/v1/blind-signing-events`,
         data: params,
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,

--- a/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.test.ts
+++ b/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.test.ts
@@ -2,7 +2,7 @@ import { type HexaString } from "@ledgerhq/device-management-kit";
 import axios from "axios";
 import { Left, Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { HttpSafeAccountDataSource } from "@/safe/data/HttpSafeAccountDataSource";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
@@ -13,12 +13,12 @@ import PACKAGE from "@root/package.json";
 vi.mock("axios");
 
 describe("HttpSafeAccountDataSource", () => {
-  const config: ContextModuleConfig = {
+  const config: ContextModuleServiceConfig = {
     metadataServiceDomain: {
       url: "https://metadata.ledger.com",
     },
     originToken: "test-origin-token",
-  } as ContextModuleConfig;
+  } as ContextModuleServiceConfig;
 
   const validSafeAccountDto = {
     accountDescriptor: {
@@ -604,12 +604,12 @@ describe("HttpSafeAccountDataSource", () => {
 
     it("should use correct origin token from config", async () => {
       // GIVEN
-      const customConfig: ContextModuleConfig = {
+      const customConfig: ContextModuleServiceConfig = {
         metadataServiceDomain: {
           url: "https://metadata.ledger.com",
         },
         originToken: "custom-origin-token",
-      } as ContextModuleConfig;
+      } as ContextModuleServiceConfig;
       const params = {
         safeContractAddress: validsafeContractAddress,
         chainId: 1,
@@ -635,12 +635,12 @@ describe("HttpSafeAccountDataSource", () => {
 
     it("should use correct metadata service URL from config", async () => {
       // GIVEN
-      const customConfig: ContextModuleConfig = {
+      const customConfig: ContextModuleServiceConfig = {
         metadataServiceDomain: {
           url: "https://custom-metadata.example.com",
         },
         originToken: "test-token",
-      } as ContextModuleConfig;
+      } as ContextModuleServiceConfig;
       const params = {
         safeContractAddress: validsafeContractAddress,
         chainId: 1,

--- a/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.ts
+++ b/packages/signer/context-module/src/safe/data/HttpSafeAccountDataSource.ts
@@ -3,7 +3,7 @@ import { inject } from "inversify";
 import { type Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -19,7 +19,8 @@ import {
 
 export class HttpSafeAccountDataSource implements SafeAccountDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
   ) {}
 
   async getDescriptors({

--- a/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.test.ts
+++ b/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.test.ts
@@ -6,7 +6,7 @@ import {
 import axios from "axios";
 import { Left } from "purify-ts";
 
-import type { ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import type { ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import { HttpSolanaOwnerInfoDataSource } from "@/solana/data/HttpSolanaOwnerInfoDataSource";
 import type { SolanaTransactionContext } from "@/solana/domain/solanaContextTypes";
@@ -26,7 +26,7 @@ describe("HttpSolanaOwnerInfoDataSource", () => {
   const config = {
     metadataServiceDomain: { url: "https://some.doma.in" },
     originToken: "mock-origin-token",
-  } as ContextModuleConfig;
+  } as ContextModuleServiceConfig;
 
   const signedDescriptorHex = stringToHex("mock-descriptor");
   const responseData = {

--- a/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.ts
+++ b/packages/signer/context-module/src/solana/data/HttpSolanaOwnerInfoDataSource.ts
@@ -4,7 +4,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import type { ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import type { ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -23,7 +23,8 @@ import {
 @injectable()
 export class HttpSolanaOwnerInfoDataSource implements SolanaDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
   ) {
     if (!this.config.originToken) {
       throw new Error(

--- a/packages/signer/context-module/src/solana/domain/DefaultSolanaContextLoader.test.ts
+++ b/packages/signer/context-module/src/solana/domain/DefaultSolanaContextLoader.test.ts
@@ -6,7 +6,7 @@ import { DeviceModelId } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import type { PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
 import { KeyUsage } from "@/pki/model/KeyUsage";
 import { SolanaContextTypes } from "@/shared/model/SolanaContextTypes";
@@ -59,7 +59,7 @@ describe("SolanaTokenContextLoader", () => {
   });
 
   const makeLoader = (mode?: string) => {
-    const config = { cal: { mode } } as unknown as ContextModuleConfig;
+    const config = { cal: { mode } } as unknown as ContextModuleServiceConfig;
     return new SolanaTokenContextLoader(
       mockDataSource,
       config,

--- a/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.test.ts
+++ b/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.test.ts
@@ -4,7 +4,7 @@ import axios from "axios";
 import { Left, Right } from "purify-ts";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import PACKAGE from "@root/package.json";
 
@@ -27,13 +27,13 @@ const mockLoggerFactory = () => ({
 describe("HttpSolanaLifiDataSource", () => {
   let datasource: SolanaLifiDataSource;
   const templateId = "tpl-123";
-  const config: ContextModuleConfig = {
+  const config: ContextModuleServiceConfig = {
     cal: {
       url: "https://crypto-assets-service.api.ledger.com/v1",
       mode: "prod",
       branch: "main",
     },
-  } as ContextModuleConfig;
+  } as ContextModuleServiceConfig;
 
   beforeAll(() => {
     datasource = new HttpSolanaLifiDataSource(config, mockLoggerFactory);

--- a/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.ts
+++ b/packages/signer/context-module/src/solanaLifi/data/HttpSolanaLifiDataSource.ts
@@ -4,7 +4,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import PACKAGE from "@root/package.json";
 
@@ -19,7 +19,8 @@ export class HttpSolanaLifiDataSource implements SolanaLifiDataSource {
   private logger: LoggerPublisherService;
 
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
     @inject(configTypes.ContextModuleLoggerFactory)
     loggerFactory: (tag: string) => LoggerPublisherService,
   ) {

--- a/packages/signer/context-module/src/solanaLifi/domain/SolanaLifiContextLoader.test.ts
+++ b/packages/signer/context-module/src/solanaLifi/domain/SolanaLifiContextLoader.test.ts
@@ -5,7 +5,7 @@
 import { Left, Right } from "purify-ts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { type PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
 import {
   SolanaContextTypes,
@@ -39,7 +39,7 @@ const mockConfig = {
     mode: "test",
     branch: "main",
   },
-} as ContextModuleConfig;
+} as ContextModuleServiceConfig;
 
 describe("SolanaLifiContextLoader", () => {
   let mockDataSource: SolanaLifiDataSource;

--- a/packages/signer/context-module/src/solanaLifi/domain/SolanaLifiContextLoader.ts
+++ b/packages/signer/context-module/src/solanaLifi/domain/SolanaLifiContextLoader.ts
@@ -2,7 +2,7 @@ import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { pkiTypes } from "@/pki/di/pkiTypes";
 import { type PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
 import { KeyId } from "@/pki/model/KeyId";
@@ -38,7 +38,7 @@ export class SolanaLifiContextLoader
     @inject(lifiTypes.SolanaLifiDataSource)
     private readonly dataSource: SolanaLifiDataSource,
     @inject(configTypes.Config)
-    private readonly config: ContextModuleConfig,
+    private readonly config: ContextModuleServiceConfig,
     @inject(pkiTypes.PkiCertificateLoader)
     private readonly _certificateLoader: PkiCertificateLoader,
     @inject(configTypes.ContextModuleLoggerFactory)

--- a/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.test.ts
+++ b/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.test.ts
@@ -4,7 +4,7 @@ import axios from "axios";
 import { Left, Right } from "purify-ts";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import PACKAGE from "@root/package.json";
 
@@ -19,13 +19,13 @@ vi.mock("axios");
 describe("HttpSolanaTokenDataSource", () => {
   let datasource: SolanaTokenDataSource;
   const tokenInternalId = "sol:usdc";
-  const config: ContextModuleConfig = {
+  const config: ContextModuleServiceConfig = {
     cal: {
       url: "https://crypto-assets-service.api.ledger.com/v1",
       mode: "prod",
       branch: "main",
     },
-  } as ContextModuleConfig;
+  } as ContextModuleServiceConfig;
 
   const errorMessage = (id: string) =>
     `[ContextModule] HttpSolanaTokenDataSource: no token metadata for id ${id}`;

--- a/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.ts
+++ b/packages/signer/context-module/src/solanaToken/data/HttpSolanaTokenDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import PACKAGE from "@root/package.json";
 
@@ -16,7 +16,8 @@ import {
 @injectable()
 export class HttpSolanaTokenDataSource implements SolanaTokenDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
   ) {}
   public async getTokenInfosPayload({
     tokenInternalId,

--- a/packages/signer/context-module/src/solanaToken/domain/SolanaTokenContextLoader.test.ts
+++ b/packages/signer/context-module/src/solanaToken/domain/SolanaTokenContextLoader.test.ts
@@ -6,7 +6,7 @@ import { DeviceModelId } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import type { PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
 import { KeyUsage } from "@/pki/model/KeyUsage";
 import { SolanaContextTypes } from "@/shared/model/SolanaContextTypes";
@@ -61,7 +61,7 @@ describe("SolanaTokenContextLoader", () => {
   });
 
   const makeLoader = (mode?: string) => {
-    const config = { cal: { mode } } as unknown as ContextModuleConfig;
+    const config = { cal: { mode } } as unknown as ContextModuleServiceConfig;
     return new SolanaTokenContextLoader(
       mockDataSource,
       config,

--- a/packages/signer/context-module/src/solanaToken/domain/SolanaTokenContextLoader.ts
+++ b/packages/signer/context-module/src/solanaToken/domain/SolanaTokenContextLoader.ts
@@ -2,7 +2,7 @@ import { LoggerPublisherService } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { pkiTypes } from "@/pki/di/pkiTypes";
 import { type PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
 import { KeyUsage } from "@/pki/model/KeyUsage";
@@ -34,7 +34,8 @@ export class SolanaTokenContextLoader
   constructor(
     @inject(solanaTokenTypes.SolanaTokenDataSource)
     private readonly dataSource: SolanaTokenDataSource,
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
     @inject(pkiTypes.PkiCertificateLoader)
     private readonly _certificateLoader: PkiCertificateLoader,
     @inject(configTypes.ContextModuleLoggerFactory)

--- a/packages/signer/context-module/src/token/data/HttpTokenDataSource.test.ts
+++ b/packages/signer/context-module/src/token/data/HttpTokenDataSource.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { Left } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import { HttpTokenDataSource } from "@/token/data/HttpTokenDataSource";
 import { type TokenDataSource } from "@/token/data/TokenDataSource";
@@ -20,7 +20,7 @@ describe("HttpTokenDataSource", () => {
         mode: "prod",
         branch: "main",
       },
-    } as ContextModuleConfig;
+    } as ContextModuleServiceConfig;
     datasource = new HttpTokenDataSource(config);
     vi.clearAllMocks();
   });

--- a/packages/signer/context-module/src/token/data/HttpTokenDataSource.ts
+++ b/packages/signer/context-module/src/token/data/HttpTokenDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import type { ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import type { ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { LEDGER_CLIENT_VERSION_HEADER } from "@/shared/constant/HttpHeaders";
 import PACKAGE from "@root/package.json";
 
@@ -13,7 +13,8 @@ import { TokenDto } from "./TokenDto";
 @injectable()
 export class HttpTokenDataSource implements TokenDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
   ) {}
   public async getTokenInfosPayload({
     chainId,

--- a/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.test.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { Left, Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -19,7 +19,7 @@ describe("HttpTransactionCheckDataSource", () => {
       url: "web3checksUrl",
     },
     originToken: "originToken",
-  } as ContextModuleConfig;
+  } as ContextModuleServiceConfig;
 
   beforeEach(() => {
     vi.resetAllMocks();

--- a/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTransactionCheckDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -19,7 +19,8 @@ import {
 @injectable()
 export class HttpTransactionCheckDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
   ) {}
 
   public async getTransactionCheck({

--- a/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.test.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { Left, Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -22,7 +22,7 @@ describe("HttpTypedDataCheckDataSource", () => {
       url: "web3checksUrl",
     },
     originToken: "originToken",
-  } as ContextModuleConfig;
+  } as ContextModuleServiceConfig;
 
   beforeEach(() => {
     vi.resetAllMocks();

--- a/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.ts
+++ b/packages/signer/context-module/src/transaction-check/data/HttpTypedDataCheckDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -20,7 +20,8 @@ import {
 @injectable()
 export class HttpTypedDataCheckDataSource implements TypedDataCheckDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
   ) {}
 
   public async getTypedDataCheck({

--- a/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.test.ts
+++ b/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { Left, Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -22,7 +22,7 @@ const config = {
     url: "https://nft.api.live.ledger.com",
   },
   originToken: "originToken",
-} as ContextModuleConfig;
+} as ContextModuleServiceConfig;
 describe("HttpTrustedNameDataSource", () => {
   let datasource: TrustedNameDataSource;
 

--- a/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.ts
+++ b/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { Either, Left, Right } from "purify-ts";
 
 import { configTypes } from "@/config/di/configTypes";
-import type { ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import type { ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -21,7 +21,8 @@ import { TrustedNameDto } from "./TrustedNameDto";
 @injectable()
 export class HttpTrustedNameDataSource implements TrustedNameDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
   ) {}
 
   public async getDomainNamePayload({

--- a/packages/signer/context-module/src/trusted-name/di/trustedNameModuleFactory.ts
+++ b/packages/signer/context-module/src/trusted-name/di/trustedNameModuleFactory.ts
@@ -1,16 +1,18 @@
 import { ContainerModule } from "inversify";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
 import { HttpTrustedNameDataSource } from "@/trusted-name/data/HttpTrustedNameDataSource";
+import { type TrustedNameDataSource } from "@/trusted-name/data/TrustedNameDataSource";
 import { trustedNameTypes } from "@/trusted-name/di/trustedNameTypes";
 import { TrustedNameContextFieldLoader } from "@/trusted-name/domain/TrustedNameContextFieldLoader";
 import { TrustedNameContextLoader } from "@/trusted-name/domain/TrustedNameContextLoader";
 
-export const trustedNameModuleFactory = (config?: ContextModuleConfig) =>
+export const trustedNameModuleFactory = (
+  customTrustedNameDataSource?: TrustedNameDataSource,
+) =>
   new ContainerModule(({ bind }) => {
-    if (config?.customTrustedNameDataSource) {
+    if (customTrustedNameDataSource) {
       bind(trustedNameTypes.TrustedNameDataSource).toConstantValue(
-        config.customTrustedNameDataSource,
+        customTrustedNameDataSource,
       );
     } else {
       bind(trustedNameTypes.TrustedNameDataSource).to(

--- a/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.test.ts
+++ b/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { Right } from "purify-ts";
 
-import { type ContextModuleConfig } from "@/config/model/ContextModuleConfig";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
   LEDGER_ORIGIN_TOKEN_HEADER,
@@ -52,7 +52,7 @@ const config = {
     mode: "prod",
   },
   originToken: "originToken",
-} as ContextModuleConfig;
+} as ContextModuleServiceConfig;
 describe("HttpTypedDataDataSource", () => {
   let datasource: TypedDataDataSource;
 

--- a/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.ts
+++ b/packages/signer/context-module/src/typed-data/data/HttpTypedDataDataSource.ts
@@ -5,7 +5,7 @@ import { Either, Left, Right } from "purify-ts";
 import { configTypes } from "@/config/di/configTypes";
 import type {
   ContextModuleCalMode,
-  ContextModuleConfig,
+  ContextModuleServiceConfig,
 } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
@@ -42,7 +42,8 @@ import {
 @injectable()
 export class HttpTypedDataDataSource implements TypedDataDataSource {
   constructor(
-    @inject(configTypes.Config) private readonly config: ContextModuleConfig,
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
   ) {}
 
   public async getTypedDataFilters({


### PR DESCRIPTION
### 📝 Description

Refactor `ContextModuleConfig` into separate, focused types to improve separation of concerns and restrict the public API surface:

- **`ContextModuleConfig`**: Only contains service URL configurations (cal, web3checks, metadataServiceDomain, reporter, datasource) — this is the type exposed publicly.
- **`ContextModuleServiceConfig`**: Extends `ContextModuleConfig` with runtime dependencies (`originToken`, `loggerFactory`) — internal only.
- **`ContextModuleLoaderConfig`**: Contains loader-related configuration (custom loaders, field loaders, etc.) — internal only.

Additional improvements:
- Default config objects are now frozen with `Object.freeze()` to prevent accidental mutations.
- Module factories (`proxyModuleFactory`, `trustedNameModuleFactory`) now receive specific config slices instead of the full config object.
- Public exports in `index.ts` are now explicitly listed to avoid leaking internal types.
- All HTTP data sources now depend on `ContextModuleServiceConfig` instead of the monolithic `ContextModuleConfig`.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [ ] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - Internal types (`ContextModuleLoaderConfig`) are no longer exported publicly
  - `ContextModuleConfig` type is narrower (only service URLs), which is a breaking type change for consumers who relied on the full type
  - Default config is now immutable (frozen)
  - All data sources and module factories use more precise config types

Made with [Cursor](https://cursor.com)