### PR TITLE
🐛 (clear-signing-tester) [NO-ISSUE]: Skip pre-release OS versions in auto-resolution

### DIFF
--- a/apps/clear-signing-tester/src/infrastructure/services/AppVersionResolverService.ts
+++ b/apps/clear-signing-tester/src/infrastructure/services/AppVersionResolverService.ts
@@ -136,10 +136,29 @@ export class AppVersionResolverService implements AppVersionResolver {
 
   private getAvailableOsVersions(devicePath: string): string[] {
     try {
-      return readdirSync(devicePath).filter((name) => {
+      const allVersions = readdirSync(devicePath).filter((name) => {
         const fullPath = join(devicePath, name);
         return statSync(fullPath).isDirectory();
       });
+
+      const stableVersions = allVersions.filter(
+        (v) => semver.valid(v) && semver.prerelease(v) === null,
+      );
+
+      if (stableVersions.length > 0) {
+        const skipped = allVersions.length - stableVersions.length;
+        if (skipped > 0) {
+          this.logger.debug(
+            `Filtered out ${skipped} pre-release OS version(s) from auto-resolution`,
+          );
+        }
+        return stableVersions;
+      }
+
+      this.logger.warn(
+        "No stable OS versions found, falling back to all versions including pre-releases",
+      );
+      return allVersions;
     } catch (error) {
       this.logger.error(`Failed to read device directory: ${devicePath}`, {
         data: { error },


### PR DESCRIPTION
## Summary

- Filter out pre-release OS versions (e.g. `1.6.0-rc1`, `1.4.0-rc3`) from the `AppVersionResolverService` auto-resolution, so the latest **stable** OS is selected by default
- Prevents automatic selection of coin-apps requiring SDK api_levels not yet supported by the bundled Speculos in `ledger-app-dev-tools:latest`
- Falls back to pre-releases only if no stable versions exist at all
- Explicitly requested versions via `--os-version` are unaffected

## Context

The `coin-apps` repository contains both stable and pre-release OS directories (e.g. `flex/1.6.0-rc1/`). The auto-resolver was picking `1.6.0-rc1` (api_level 26) over the stable `1.5.1` (api_level 25), causing Speculos to fail with `invalid SDK api_level: 26` since the bundled Speculos only supports up to api_level 25.

## Test plan

- [x] Verified auto-resolution now picks `flex/1.5.1` instead of `flex/1.6.0-rc1`
- [x] Verified Speculos starts successfully with the resolved version
- [ ] Explicit `--os-version 1.6.0-rc1` still works when intentionally requested


Made with [Cursor](https://cursor.com)