### PR TITLE
✨ (signer-eth) [DSDK-1017]: Add blind signing detection and reporting to sign device actions

### DIFF
--- a/.changeset/calm-ducks-love.md
+++ b/.changeset/calm-ducks-love.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/signer-utils": minor
+---
+
+Add generateSignatureId utility for blind signing reports

--- a/.changeset/dirty-weeks-fly.md
+++ b/.changeset/dirty-weeks-fly.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/context-module": minor
+---
+
+Add source configuration to ContextModuleBuilder for blind signing reports

--- a/.changeset/tidy-onions-flow.md
+++ b/.changeset/tidy-onions-flow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": minor
+---
+
+Add blind signing detection and reporting to sign transaction and sign typed data device actions

--- a/apps/sample/src/providers/SignerEthProvider/index.tsx
+++ b/apps/sample/src/providers/SignerEthProvider/index.tsx
@@ -62,6 +62,7 @@ export const SignerEthProvider: React.FC<PropsWithChildren> = ({
       .setWeb3ChecksConfig(web3ChecksConfig)
       .setMetadataServiceConfig(metadataServiceConfig)
       .setDatasourceConfig(datasourceConfig)
+      .setSource("device-management-kit-playground")
       .build();
     const newSigner = new SignerEthBuilder({
       dmk,

--- a/apps/sample/src/providers/SignerEthProvider/index.tsx
+++ b/apps/sample/src/providers/SignerEthProvider/index.tsx
@@ -62,7 +62,7 @@ export const SignerEthProvider: React.FC<PropsWithChildren> = ({
       .setWeb3ChecksConfig(web3ChecksConfig)
       .setMetadataServiceConfig(metadataServiceConfig)
       .setDatasourceConfig(datasourceConfig)
-      .setSource("device-management-kit-playground")
+      .setAppSource("device-management-kit-playground")
       .build();
     const newSigner = new SignerEthBuilder({
       dmk,

--- a/packages/signer/context-module/README.md
+++ b/packages/signer/context-module/README.md
@@ -74,6 +74,16 @@ const contextModule = new ContextModuleBuilder({
   .build();
 ```
 
+You can set a source identifier that will be included in blind signing reports. This helps distinguish which integration triggered a blind signing event. The default value is `"third-party"`.
+
+```ts
+const contextModule = new ContextModuleBuilder({
+  originToken: "origin-token", // replace with your origin token
+})
+  .setSource("my-app-name")
+  .build();
+```
+
 It is also possible to instantiate the context module without the default loaders.
 
 ```ts

--- a/packages/signer/context-module/README.md
+++ b/packages/signer/context-module/README.md
@@ -80,7 +80,7 @@ You can set a source identifier that will be included in blind signing reports. 
 const contextModule = new ContextModuleBuilder({
   originToken: "origin-token", // replace with your origin token
 })
-  .setSource("my-app-name")
+  .setAppSource("my-app-name")
   .build();
 ```
 

--- a/packages/signer/context-module/src/ContextModuleBuilder.ts
+++ b/packages/signer/context-module/src/ContextModuleBuilder.ts
@@ -25,7 +25,7 @@ import { DefaultContextModule } from "./DefaultContextModule";
 const DEFAULT_CAL_URL = "https://crypto-assets-service.api.ledger.com/v1";
 const DEFAULT_WEB3_CHECKS_URL = "https://web3checks-backend.api.ledger.com/v3";
 const DEFAULT_METADATA_SERVICE_DOMAIN = "https://nft.api.live.ledger.com";
-const DEFAULT_REPORTER_URL = "https://blind-signing-reporting.api.ledger.com";
+const DEFAULT_REPORTER_URL = "https://ingest.aws.stg.ldg-tech.com/ingest/v1";
 
 /**
  * Default configuration for the context module
@@ -49,6 +49,7 @@ export const DEFAULT_CONFIG: Readonly<ContextModuleConfig> = Object.freeze({
     url: DEFAULT_REPORTER_URL,
   }),
   datasource: Object.freeze({ proxy: "default" }),
+  source: "third-party",
 });
 
 /**
@@ -178,6 +179,17 @@ export class ContextModuleBuilder {
    */
   setReporterConfig(reporterConfig: ContextModuleReporterConfig) {
     this.config.reporter = reporterConfig;
+    return this;
+  }
+
+  /**
+   * Set the source identifier included in blind signing reports
+   *
+   * @param source
+   * @returns this
+   */
+  setSource(source: string) {
+    this.config.source = source;
     return this;
   }
 

--- a/packages/signer/context-module/src/ContextModuleBuilder.ts
+++ b/packages/signer/context-module/src/ContextModuleBuilder.ts
@@ -49,7 +49,7 @@ export const DEFAULT_CONFIG: Readonly<ContextModuleConfig> = Object.freeze({
     url: DEFAULT_REPORTER_URL,
   }),
   datasource: Object.freeze({ proxy: "default" }),
-  source: "third-party",
+  appSource: "third-party",
 });
 
 /**
@@ -183,13 +183,13 @@ export class ContextModuleBuilder {
   }
 
   /**
-   * Set the source identifier included in blind signing reports
+   * Set the app source identifier included in blind signing reports
    *
-   * @param source
+   * @param appSource
    * @returns this
    */
-  setSource(source: string) {
-    this.config.source = source;
+  setAppSource(appSource: string) {
+    this.config.appSource = appSource;
     return this;
   }
 

--- a/packages/signer/context-module/src/DefaultContextModule.test.ts
+++ b/packages/signer/context-module/src/DefaultContextModule.test.ts
@@ -62,6 +62,7 @@ describe("DefaultContextModule", () => {
     datasource: {
       proxy: "default",
     },
+    source: "third-party",
     originToken: "originToken",
     loggerFactory: mockLoggerFactory,
   };

--- a/packages/signer/context-module/src/DefaultContextModule.test.ts
+++ b/packages/signer/context-module/src/DefaultContextModule.test.ts
@@ -62,7 +62,7 @@ describe("DefaultContextModule", () => {
     datasource: {
       proxy: "default",
     },
-    source: "third-party",
+    appSource: "third-party",
     originToken: "originToken",
     loggerFactory: mockLoggerFactory,
   };

--- a/packages/signer/context-module/src/config/model/ContextModuleConfig.ts
+++ b/packages/signer/context-module/src/config/model/ContextModuleConfig.ts
@@ -38,6 +38,7 @@ export type ContextModuleConfig = {
   metadataServiceDomain: ContextModuleMetadataServiceConfig;
   reporter: ContextModuleReporterConfig;
   datasource: ContextModuleDatasourceConfig;
+  source: string;
 };
 
 export type ContextModuleServiceConfig = ContextModuleConfig & {

--- a/packages/signer/context-module/src/config/model/ContextModuleConfig.ts
+++ b/packages/signer/context-module/src/config/model/ContextModuleConfig.ts
@@ -38,7 +38,7 @@ export type ContextModuleConfig = {
   metadataServiceDomain: ContextModuleMetadataServiceConfig;
   reporter: ContextModuleReporterConfig;
   datasource: ContextModuleDatasourceConfig;
-  source: string;
+  appSource: string;
 };
 
 export type ContextModuleServiceConfig = ContextModuleConfig & {

--- a/packages/signer/context-module/src/reporter/data/BlindSigningReporterDatasource.ts
+++ b/packages/signer/context-module/src/reporter/data/BlindSigningReporterDatasource.ts
@@ -1,8 +1,29 @@
 import { type Either } from "purify-ts";
 
-import { type BlindSigningEventDto } from "./dto/BlindSigningEventDto";
+import {
+  type BlindSigningMethod,
+  type BlindSignReason,
+  type ClearSigningType,
+} from "@/reporter/model/BlindSigningEvent";
+import { type BlindSigningModelId } from "@/reporter/model/BlindSigningModelId";
 
-export type BlindSigningReportParams = BlindSigningEventDto;
+export type BlindSigningReportEthContext = {
+  clearSigningType: ClearSigningType;
+  partialContextErrors: number;
+};
+
+export type BlindSigningReportParams = {
+  signatureId: string;
+  signingMethod: BlindSigningMethod;
+  isBlindSign: boolean;
+  chainId: number | null;
+  targetAddress: string | null;
+  blindSignReason: BlindSignReason | null;
+  modelId: BlindSigningModelId;
+  signerAppVersion: string;
+  deviceVersion: string | null;
+  ethContext: BlindSigningReportEthContext | null;
+};
 
 export interface BlindSigningReporterDatasource {
   report(params: BlindSigningReportParams): Promise<Either<Error, void>>;

--- a/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.test.ts
+++ b/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.test.ts
@@ -24,12 +24,12 @@ describe("HttpBlindSigningReporterDatasource", () => {
       url: "https://reporter.test",
     },
     originToken: "originToken",
+    source: "third-party",
   } as ContextModuleServiceConfig;
 
   const params: BlindSigningReportParams = {
     signatureId: "a3f8Kb-1738850400000",
     signingMethod: BlindSigningMethod.ETH_SIGN_TRANSACTION,
-    source: "ledger_wallet",
     isBlindSign: true,
     chainId: 1,
     targetAddress: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
@@ -92,7 +92,7 @@ describe("HttpBlindSigningReporterDatasource", () => {
       expect(axios.request).toHaveBeenCalledWith(
         expect.objectContaining({
           method: "POST",
-          url: `${config.reporter!.url}/v1/blind-signing-events`,
+          url: `${config.reporter!.url}/blind-signing-events`,
         }),
       );
     });
@@ -116,7 +116,7 @@ describe("HttpBlindSigningReporterDatasource", () => {
       );
     });
 
-    it("should call axios with the event payload as data", async () => {
+    it("should call axios with the event payload and injected source as data", async () => {
       // GIVEN
       vi.spyOn(axios, "request").mockResolvedValueOnce({ data: {} });
 
@@ -127,7 +127,7 @@ describe("HttpBlindSigningReporterDatasource", () => {
       // THEN
       expect(axios.request).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: params,
+          data: { ...params, source: config.source },
         }),
       );
     });

--- a/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.test.ts
+++ b/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.test.ts
@@ -24,7 +24,7 @@ describe("HttpBlindSigningReporterDatasource", () => {
       url: "https://reporter.test",
     },
     originToken: "originToken",
-    source: "third-party",
+    appSource: "third-party",
   } as ContextModuleServiceConfig;
 
   const params: BlindSigningReportParams = {
@@ -127,7 +127,7 @@ describe("HttpBlindSigningReporterDatasource", () => {
       // THEN
       expect(axios.request).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: { ...params, source: config.source },
+          data: { ...params, source: config.appSource },
         }),
       );
     });

--- a/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
+++ b/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
@@ -28,8 +28,8 @@ export class HttpBlindSigningReporterDatasource
     try {
       await axios.request({
         method: "POST",
-        url: `${this.config.reporter.url}/v1/blind-signing-events`,
-        data: params,
+        url: `${this.config.reporter.url}/blind-signing-events`,
+        data: { ...params, source: this.config.source },
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
           [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,

--- a/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
+++ b/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
@@ -29,7 +29,7 @@ export class HttpBlindSigningReporterDatasource
       await axios.request({
         method: "POST",
         url: `${this.config.reporter.url}/blind-signing-events`,
-        data: { ...params, source: this.config.source },
+        data: { ...params, source: this.config.appSource },
         headers: {
           [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
           [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,

--- a/packages/signer/context-module/src/reporter/data/dto/BlindSigningEventDto.ts
+++ b/packages/signer/context-module/src/reporter/data/dto/BlindSigningEventDto.ts
@@ -15,10 +15,10 @@ export type BlindSigningEventDto = {
   signatureId: string;
   signingMethod: BlindSigningMethod;
   source: string;
-  isBlindSign?: boolean;
+  isBlindSign: boolean;
   chainId: number | null;
   targetAddress: string | null;
-  blindSignReason: BlindSignReason;
+  blindSignReason: BlindSignReason | null;
   modelId: BlindSigningModelId;
   signerAppVersion: string;
   deviceVersion: string | null;

--- a/packages/signer/context-module/src/reporter/domain/DefaultBlindSigningReporter.test.ts
+++ b/packages/signer/context-module/src/reporter/domain/DefaultBlindSigningReporter.test.ts
@@ -14,7 +14,6 @@ describe("DefaultBlindSigningReporter", () => {
   const params = {
     signatureId: "a3f8Kb-1738850400000",
     signingMethod: BlindSigningMethod.ETH_SIGN_TRANSACTION,
-    source: "ledger_wallet",
     isBlindSign: true,
     chainId: 1,
     targetAddress: "0xdAC17F958D2ee523a2206206994597C13D831ec7",

--- a/packages/signer/signer-eth/README.md
+++ b/packages/signer/signer-eth/README.md
@@ -414,7 +414,7 @@ observable.subscribe({
 When the status is DeviceActionStatus.Pending, the state will include an `intermediateValue` object that provides useful information for interaction. The intermediateValue contains:
 
 - `requiredUserInteraction`: Indicates what action is needed from the user
-- `step`: The current step in the device action flow, available for the 'signTransaction' and 'signTypedData' flow.
+- `step`: The current step in the device action flow, available for the 'signTransaction' and 'signTypedData' flow. Steps include context provisioning, signing, blind sign fallback, and blind signing detection (`DETECT_BLIND_SIGNING`).
 
 ```typescript
 const { requiredUserInteraction, step /* if available */ } = intermediateValue;

--- a/packages/signer/signer-eth/src/api/app-binder/SignTransactionDeviceActionTypes.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignTransactionDeviceActionTypes.ts
@@ -32,6 +32,7 @@ export enum SignTransactionDAStep {
   PROVIDE_CONTEXTS = "signer.eth.steps.provideContexts",
   SIGN_TRANSACTION = "signer.eth.steps.signTransaction",
   BLIND_SIGN_TRANSACTION_FALLBACK = "signer.eth.steps.blindSignTransactionFallback",
+  DETECT_BLIND_SIGNING = "signer.eth.steps.detectBlindSigning",
 }
 
 export type SignTransactionDAOutput = Signature;
@@ -82,6 +83,8 @@ export type SignTransactionDAInternalState = {
   readonly clearSigningType: ClearSigningType | null;
   readonly transactionType: TransactionType | null;
   readonly signature: Signature | null;
+  readonly isBlindSign: boolean | null;
+  readonly usedFallback: boolean;
 };
 
 export type SignTransactionDAReturnType = ExecuteDeviceActionReturnType<

--- a/packages/signer/signer-eth/src/api/app-binder/SignTransactionDeviceActionTypes.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignTransactionDeviceActionTypes.ts
@@ -81,6 +81,7 @@ export type SignTransactionDAInternalState = {
   readonly subset: TransactionSubset | null;
   readonly contexts: ContextWithSubContexts[];
   readonly clearSigningType: ClearSigningType | null;
+  readonly contextErrorCount: number;
   readonly transactionType: TransactionType | null;
   readonly signature: Signature | null;
   readonly isBlindSign: boolean | null;

--- a/packages/signer/signer-eth/src/api/app-binder/SignTypedDataDeviceActionTypes.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignTypedDataDeviceActionTypes.ts
@@ -28,6 +28,7 @@ export enum SignTypedDataDAStateStep {
   PROVIDE_GENERIC_CONTEXT = "signer.eth.steps.provideGenericContext",
   SIGN_TYPED_DATA = "signer.eth.steps.signTypedData",
   SIGN_TYPED_DATA_LEGACY = "signer.eth.steps.signTypedDataLegacy",
+  DETECT_BLIND_SIGNING = "signer.eth.steps.detectBlindSigning",
 }
 
 export type SignTypedDataDAOutput = Signature;
@@ -77,6 +78,8 @@ export type SignTypedDataDAInternalState = {
   readonly from: string | null;
   readonly typedDataContext: ProvideEIP712ContextTaskArgs | null;
   readonly signature: Signature | null;
+  readonly isBlindSign: boolean | null;
+  readonly usedFallback: boolean;
 };
 
 export type SignTypedDataDAReturnType = ExecuteDeviceActionReturnType<

--- a/packages/signer/signer-eth/src/api/app-binder/SignTypedDataDeviceActionTypes.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignTypedDataDeviceActionTypes.ts
@@ -12,7 +12,7 @@ import { type GetConfigCommandResponse } from "@api/app-binder/GetConfigCommandT
 import { type Signature } from "@api/model/Signature";
 import { type TypedData } from "@api/model/TypedData";
 import { type EthErrorCodes } from "@internal/app-binder/command/utils/ethAppErrors";
-import type { ProvideEIP712ContextTaskArgs } from "@internal/app-binder/task/ProvideEIP712ContextTask";
+import type { BuildEIP712ContextTaskResult } from "@internal/app-binder/task/BuildEIP712ContextTask";
 import { type TransactionMapperService } from "@internal/transaction/service/mapper/TransactionMapperService";
 import { type TransactionParserService } from "@internal/transaction/service/parser/TransactionParserService";
 import { type TypedDataParserService } from "@internal/typed-data/service/TypedDataParserService";
@@ -76,7 +76,7 @@ export type SignTypedDataDAInternalState = {
   readonly error: SignTypedDataDAError | null;
   readonly appConfig: GetConfigCommandResponse | null;
   readonly from: string | null;
-  readonly typedDataContext: ProvideEIP712ContextTaskArgs | null;
+  readonly typedDataContext: BuildEIP712ContextTaskResult | null;
   readonly signature: Signature | null;
   readonly isBlindSign: boolean | null;
   readonly usedFallback: boolean;

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.test.ts
@@ -17,7 +17,7 @@ import {
   UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
 import { Transaction } from "ethers";
-import { Just } from "purify-ts";
+import { Right } from "purify-ts";
 import { lastValueFrom, Observable } from "rxjs";
 
 import {
@@ -76,7 +76,9 @@ describe("SignTransactionDeviceAction", () => {
   const provideContextsMock = vi.fn();
   const signTransactionMock = vi.fn();
   const getAddressMock = vi.fn();
+  const detectBlindSigningMock = vi.fn();
   function extractDependenciesMock() {
+    detectBlindSigningMock.mockResolvedValue({ isBlindSign: false });
     return {
       getAppConfig: getAppConfigMock,
       web3CheckOptIn: web3CheckOptInMock,
@@ -85,10 +87,25 @@ describe("SignTransactionDeviceAction", () => {
       provideContexts: provideContextsMock,
       signTransaction: signTransactionMock,
       getAddress: getAddressMock,
+      detectBlindSigning: detectBlindSigningMock,
     };
   }
   const apiMock = makeDeviceActionInternalApiMock();
   const defaultOptions = {};
+
+  function setupDefaultDeviceMocks() {
+    apiMock.getDeviceSessionState.mockReturnValue({
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Ethereum", version: "1.15.0" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    });
+    apiMock.getDeviceModel.mockReturnValue({
+      id: DeviceModelId.FLEX,
+    } as unknown as TransportDeviceModel);
+  }
   const defaultTransaction: Uint8Array = hexaStringToBuffer(
     Transaction.from({
       chainId: 1n,
@@ -123,7 +140,7 @@ describe("SignTransactionDeviceAction", () => {
     web3ChecksEnabled: boolean,
     web3ChecksOptIn: boolean,
   ) {
-    apiMock.getDeviceSessionState.mockReturnValueOnce({
+    apiMock.getDeviceSessionState.mockReturnValue({
       sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
       deviceStatus: DeviceStatus.CONNECTED,
       installedApps: [],
@@ -131,7 +148,7 @@ describe("SignTransactionDeviceAction", () => {
       deviceModelId: DeviceModelId.FLEX,
       isSecureConnectionAllowed: false,
     });
-    apiMock.getDeviceModel.mockReturnValueOnce({
+    apiMock.getDeviceModel.mockReturnValue({
       id: DeviceModelId.FLEX,
     } as unknown as TransportDeviceModel);
     getAppConfigMock.mockResolvedValue(
@@ -188,7 +205,7 @@ describe("SignTransactionDeviceAction", () => {
           clearSignContexts: contexts,
           clearSigningType: ClearSigningType.EIP7730,
         });
-        provideContextsMock.mockResolvedValueOnce(Just(void 0));
+        provideContextsMock.mockResolvedValueOnce(Right(void 0));
         signTransactionMock.mockResolvedValueOnce(
           CommandResultFactory({
             data: {
@@ -366,7 +383,7 @@ describe("SignTransactionDeviceAction", () => {
           clearSignContextsOptional: [],
           clearSigningType: ClearSigningType.BASIC,
         });
-        provideContextsMock.mockResolvedValueOnce(Just(void 0));
+        provideContextsMock.mockResolvedValueOnce(Right(void 0));
         signTransactionMock.mockResolvedValueOnce(
           CommandResultFactory({
             data: {
@@ -482,6 +499,7 @@ describe("SignTransactionDeviceAction", () => {
   describe("Error cases", () => {
     beforeEach(() => {
       vi.resetAllMocks();
+      setupDefaultDeviceMocks();
     });
 
     it("should return an error if the open app throw an error", async () => {
@@ -612,6 +630,7 @@ describe("SignTransactionDeviceAction", () => {
         clearSignContextsOptional: [],
         clearSigningType: ClearSigningType.BASIC,
       });
+      provideContextsMock.mockResolvedValueOnce(Right(void 0));
       signTransactionMock.mockResolvedValueOnce(
         CommandResultFactory({
           data: {
@@ -698,7 +717,7 @@ describe("SignTransactionDeviceAction", () => {
         clearSignContextsOptional: [],
         clearSigningType: ClearSigningType.BASIC,
       });
-      provideContextsMock.mockResolvedValueOnce(Just(void 0));
+      provideContextsMock.mockResolvedValueOnce(Right(void 0));
       signTransactionMock.mockResolvedValueOnce(
         CommandResultFactory({
           error: new InvalidStatusWordError("Sign transaction failed"),
@@ -759,7 +778,7 @@ describe("SignTransactionDeviceAction", () => {
         clearSignContextsOptional: [],
         clearSigningType: ClearSigningType.EIP7730,
       });
-      provideContextsMock.mockResolvedValueOnce(Just(void 0));
+      provideContextsMock.mockResolvedValueOnce(Right(void 0));
       signTransactionMock.mockRejectedValueOnce(
         new Error("Sign transaction failed"),
       );
@@ -843,7 +862,7 @@ describe("SignTransactionDeviceAction", () => {
         clearSignContextsOptional: [],
         clearSigningType: ClearSigningType.BASIC,
       });
-      provideContextsMock.mockResolvedValueOnce(Just(void 0));
+      provideContextsMock.mockResolvedValueOnce(Right(void 0));
       signTransactionMock.mockResolvedValueOnce(
         CommandResultFactory({
           error: new InvalidStatusWordError("Sign transaction failed"),
@@ -896,7 +915,7 @@ describe("SignTransactionDeviceAction", () => {
         clearSignContextsOptional: [],
         clearSigningType: ClearSigningType.BASIC,
       });
-      provideContextsMock.mockResolvedValueOnce(Just(void 0));
+      provideContextsMock.mockResolvedValueOnce(Right(void 0));
       signTransactionMock.mockResolvedValueOnce(
         CommandResultFactory({
           error: new InvalidStatusWordError("Sign transaction failed"),
@@ -947,7 +966,7 @@ describe("SignTransactionDeviceAction", () => {
         clearSignContextsOptional: [],
         clearSigningType: ClearSigningType.BASIC,
       });
-      provideContextsMock.mockResolvedValueOnce(Just(void 0));
+      provideContextsMock.mockResolvedValueOnce(Right(void 0));
 
       // Create an error with the user refusal error code
       const userRefusalError = new InvalidStatusWordError(
@@ -1006,7 +1025,7 @@ describe("SignTransactionDeviceAction", () => {
         clearSignContextsOptional: [],
         clearSigningType: ClearSigningType.EIP7730,
       });
-      provideContextsMock.mockResolvedValueOnce(Just(void 0));
+      provideContextsMock.mockResolvedValueOnce(Right(void 0));
 
       // Create an error with a different error code (not user refusal)
       const otherError = new InvalidStatusWordError("Some other error");

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.test.ts
@@ -1087,5 +1087,76 @@ describe("SignTransactionDeviceAction", () => {
         }),
       );
     });
+
+    it("should pass contextTypes to blind signing detection when metadata-only contexts are present", async () => {
+      setupOpenAppDAMock();
+      setupAppConfig("1.15.0", false, false);
+
+      const subsetWithCalldata: TransactionSubset = {
+        ...defaultSubset,
+        data: "0x6a761202",
+      };
+      const metadataOnlyContexts: ContextWithSubContexts[] = [
+        {
+          context: {
+            type: ClearSignContextType.TRANSACTION_CHECK,
+            payload: "check-payload",
+          },
+          subcontextCallbacks: [],
+        },
+      ];
+
+      const deviceAction = new SignTransactionDeviceAction({
+        input: {
+          derivationPath: "44'/60'/0'/0/0",
+          transaction: defaultTransaction,
+          options: defaultOptions,
+          contextModule: contextModuleMock as unknown as ContextModule,
+          mapper: mapperMock,
+          parser: parserMock,
+        },
+      });
+      vi.spyOn(deviceAction, "extractDependencies").mockReturnValue(
+        extractDependenciesMock(),
+      );
+      parseTransactionMock.mockResolvedValueOnce({
+        subset: subsetWithCalldata,
+        type: TransactionType.EIP1559,
+      });
+      getAddressMock.mockResolvedValueOnce(
+        CommandResultFactory({
+          data: { address: defaultAddress },
+        }),
+      );
+      buildContextsMock.mockResolvedValueOnce({
+        clearSignContexts: metadataOnlyContexts,
+        clearSigningType: ClearSigningType.BASIC,
+      });
+      provideContextsMock.mockResolvedValueOnce(Right(void 0));
+      signTransactionMock.mockResolvedValueOnce(
+        CommandResultFactory({
+          data: {
+            v: 0x1c,
+            r: "0x8a540510e13b0f2b11a451275716d29e08caad07e89a1c84964782fb5e1ad788",
+            s: "0x64a0de235b270fbe81e8e40688f4a9f9ad9d283d690552c9331d7773ceafa513",
+          },
+        }),
+      );
+      observable = deviceAction._execute(apiMock).observable;
+
+      await lastValueFrom(observable);
+
+      expect(detectBlindSigningMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            input: expect.objectContaining({
+              hasContext: true,
+              contextTypes: [ClearSignContextType.TRANSACTION_CHECK],
+              type: "transaction",
+            }),
+          }),
+        }),
+      );
+    });
   });
 });

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.ts
@@ -3,6 +3,7 @@ import {
   type CommandResult,
   type DeviceActionStateMachine,
   DeviceModelId,
+  DeviceSessionStateType,
   type InternalApi,
   isSuccessCommandResult,
   OpenAppDeviceAction,
@@ -39,6 +40,11 @@ import {
 } from "@internal/app-binder/command/Web3CheckOptInCommand";
 import { APP_NAME } from "@internal/app-binder/constants";
 import { EthereumApplicationResolver } from "@internal/app-binder/EthereumApplicationResolver";
+import {
+  BlindSigningDetectionTask,
+  type BlindSigningDetectionTaskArgs,
+  type BlindSigningDetectionTaskResult,
+} from "@internal/app-binder/task/BlindSigningDetectionTask";
 import {
   BuildFullContextsTask,
   type BuildFullContextsTaskArgs,
@@ -85,6 +91,9 @@ export type MachineDependencies = {
       clearSigningType: ClearSigningType;
     };
   }) => Promise<CommandResult<Signature, EthErrorCodes>>;
+  readonly detectBlindSigning: (arg0: {
+    input: BlindSigningDetectionTaskArgs;
+  }) => Promise<BlindSigningDetectionTaskResult>;
 };
 
 export class SignTransactionDeviceAction extends XStateDeviceAction<
@@ -119,6 +128,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
       buildContexts,
       signTransaction,
       provideContexts,
+      detectBlindSigning,
     } = this.extractDependencies(internalApi);
 
     return setup({
@@ -138,6 +148,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
         buildContexts: fromPromise(buildContexts),
         provideContexts: fromPromise(provideContexts),
         signTransaction: fromPromise(signTransaction),
+        detectBlindSigning: fromPromise(detectBlindSigning),
       },
       guards: {
         noInternalError: ({ context }) => context._internalState.error === null,
@@ -160,6 +171,8 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
           !context._internalState.appConfig!.web3ChecksEnabled &&
           !context._internalState.appConfig!.web3ChecksOptIn,
         skipOpenApp: ({ context }) => !!context.input.options.skipOpenApp,
+        hasSignature: ({ context }) =>
+          context._internalState.signature !== null,
       },
       actions: {
         assignErrorFromEvent: assign({
@@ -188,6 +201,8 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
             clearSigningType: null,
             transactionType: null,
             signature: null,
+            isBlindSign: null,
+            usedFallback: false,
           },
         };
       },
@@ -465,15 +480,6 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
               step: SignTransactionDAStep.PROVIDE_CONTEXTS,
             },
           }),
-          exit: assign({
-            // remove the first context of the first transaction details as it has been consumed
-            _internalState: ({ context }) => {
-              return {
-                ...context._internalState,
-                contexts: context._internalState.contexts.slice(1),
-              };
-            },
-          }),
           invoke: {
             id: "provideContexts",
             src: "provideContexts",
@@ -536,12 +542,12 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
         },
         SignTransactionResultCheck: {
           always: [
-            { guard: "noInternalError", target: "Success" },
+            { guard: "noInternalError", target: "DetectBlindSigning" },
             {
               guard: "notRefusedByUser",
               target: "BlindSignTransactionFallback",
             },
-            { target: "Error" },
+            { target: "DetectBlindSigning" },
           ],
         },
         BlindSignTransactionFallback: {
@@ -550,6 +556,10 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
               requiredUserInteraction: UserInteractionRequired.None,
               step: SignTransactionDAStep.BLIND_SIGN_TRANSACTION_FALLBACK,
             },
+            _internalState: ({ context }) => ({
+              ...context._internalState,
+              usedFallback: true,
+            }),
           }),
           invoke: {
             id: "blindSignTransactionFallback",
@@ -581,16 +591,75 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
               ],
             },
             onError: {
-              target: "Error",
+              target: "DetectBlindSigning",
               actions: "assignErrorFromEvent",
             },
           },
         },
         BlindSignTransactionFallbackResultCheck: {
-          always: [
-            { guard: "noInternalError", target: "Success" },
-            { target: "Error" },
-          ],
+          always: "DetectBlindSigning",
+        },
+        DetectBlindSigning: {
+          entry: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTransactionDAStep.DETECT_BLIND_SIGNING,
+            },
+          }),
+          invoke: {
+            id: "detectBlindSigning",
+            src: "detectBlindSigning",
+            input: ({ context }) => {
+              const sessionState = internalApi.getDeviceSessionState();
+              const deviceVersion =
+                sessionState.sessionStateType !==
+                DeviceSessionStateType.Connected
+                  ? (sessionState.firmwareVersion?.os ?? null)
+                  : null;
+              const { subset, contexts, usedFallback } = context._internalState;
+              const hasCalldata = !!subset?.data && subset.data.length > 2;
+              return {
+                input: {
+                  type: "transaction" as const,
+                  hasContext: !hasCalldata || contexts.length > 0,
+                  usedFallback,
+                  chainId: subset?.chainId ?? null,
+                  targetAddress: subset?.to ?? null,
+                  deviceModelId: internalApi.getDeviceModel().id,
+                  signerAppVersion:
+                    context._internalState.appConfig?.version ?? "",
+                  deviceVersion,
+                },
+                contextModule: context.input.contextModule,
+                loggerFactory: this.getLoggerFactory(internalApi),
+              };
+            },
+            onDone: [
+              {
+                guard: "hasSignature",
+                target: "Success",
+                actions: assign({
+                  _internalState: ({ event, context }) => ({
+                    ...context._internalState,
+                    isBlindSign: event.output.isBlindSign,
+                  }),
+                }),
+              },
+              {
+                target: "Error",
+                actions: assign({
+                  _internalState: ({ event, context }) => ({
+                    ...context._internalState,
+                    isBlindSign: event.output.isBlindSign,
+                  }),
+                }),
+              },
+            ],
+            onError: [
+              { guard: "hasSignature", target: "Success" },
+              { target: "Error" },
+            ],
+          },
         },
         Success: {
           type: "final",
@@ -648,6 +717,10 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
         loggerFactory: this.getLoggerFactory(internalApi),
       }).run();
 
+    const detectBlindSigning = async (arg0: {
+      input: BlindSigningDetectionTaskArgs;
+    }) => new BlindSigningDetectionTask(arg0.input).run();
+
     return {
       getAddress,
       getAppConfig,
@@ -656,6 +729,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
       buildContexts,
       provideContexts,
       signTransaction,
+      detectBlindSigning,
     };
   }
 }

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.ts
@@ -622,6 +622,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
                 input: {
                   type: "transaction" as const,
                   hasContext: !hasCalldata || contexts.length > 0,
+                  contextTypes: contexts.map((c) => c.context.type),
                   usedFallback,
                   chainId: subset?.chainId ?? null,
                   targetAddress: subset?.to ?? null,

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.ts
@@ -199,6 +199,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
             subset: null,
             contexts: [],
             clearSigningType: null,
+            contextErrorCount: 0,
             transactionType: null,
             signature: null,
             isBlindSign: null,
@@ -463,6 +464,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
                     ...context._internalState,
                     contexts: event.output.clearSignContexts,
                     clearSigningType: event.output.clearSigningType,
+                    contextErrorCount: event.output.contextErrorCount,
                   }),
                 }),
               ],
@@ -616,7 +618,13 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
                 DeviceSessionStateType.Connected
                   ? (sessionState.firmwareVersion?.os ?? null)
                   : null;
-              const { subset, contexts, usedFallback } = context._internalState;
+              const {
+                subset,
+                contexts,
+                usedFallback,
+                clearSigningType,
+                contextErrorCount,
+              } = context._internalState;
               const hasCalldata = !!subset?.data && subset.data.length > 2;
               return {
                 input: {
@@ -630,6 +638,8 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
                   signerAppVersion:
                     context._internalState.appConfig?.version ?? "",
                   deviceVersion,
+                  clearSigningType,
+                  partialContextErrors: contextErrorCount,
                 },
                 contextModule: context.input.contextModule,
                 loggerFactory: this.getLoggerFactory(internalApi),

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.test.ts
@@ -6,6 +6,7 @@ import {
   DeviceModelId,
   DeviceSessionStateType,
   DeviceStatus,
+  type TransportDeviceModel,
   UnknownDAError,
   UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
@@ -133,7 +134,9 @@ describe("SignTypedDataDeviceAction", () => {
   const signTypedDataMock = vi.fn();
   const signTypedDataLegacyMock = vi.fn();
   const getAddressMock = vi.fn();
+  const detectBlindSigningMock = vi.fn();
   function extractDependenciesMock() {
+    detectBlindSigningMock.mockResolvedValue({ isBlindSign: false });
     return {
       getAddress: getAddressMock,
       getAppConfig: getAppConfigMock,
@@ -142,6 +145,7 @@ describe("SignTypedDataDeviceAction", () => {
       provideContext: provideContextMock,
       signTypedData: signTypedDataMock,
       signTypedDataLegacy: signTypedDataLegacyMock,
+      detectBlindSigning: detectBlindSigningMock,
     };
   }
 
@@ -163,7 +167,7 @@ describe("SignTypedDataDeviceAction", () => {
     web3ChecksEnabled: boolean,
     web3ChecksOptIn: boolean,
   ) {
-    apiMock.getDeviceSessionState.mockReturnValueOnce({
+    apiMock.getDeviceSessionState.mockReturnValue({
       sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
       deviceStatus: DeviceStatus.CONNECTED,
       installedApps: [],
@@ -171,6 +175,9 @@ describe("SignTypedDataDeviceAction", () => {
       deviceModelId: DeviceModelId.FLEX,
       isSecureConnectionAllowed: false,
     });
+    apiMock.getDeviceModel.mockReturnValue({
+      id: DeviceModelId.FLEX,
+    } as unknown as TransportDeviceModel);
     getAppConfigMock.mockResolvedValue(
       CommandResultFactory({
         data: createAppConfig(version, web3ChecksEnabled, web3ChecksOptIn),
@@ -180,6 +187,17 @@ describe("SignTypedDataDeviceAction", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    apiMock.getDeviceSessionState.mockReturnValue({
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Ethereum", version: "1.15.0" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: false,
+    });
+    apiMock.getDeviceModel.mockReturnValue({
+      id: DeviceModelId.FLEX,
+    } as unknown as TransportDeviceModel);
   });
 
   describe("Success case", () => {
@@ -272,6 +290,13 @@ describe("SignTypedDataDeviceAction", () => {
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.SignTypedData,
               step: SignTypedDataDAStateStep.SIGN_TYPED_DATA,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.DETECT_BLIND_SIGNING,
             },
             status: DeviceActionStatus.Pending,
           },
@@ -405,6 +430,13 @@ describe("SignTypedDataDeviceAction", () => {
             status: DeviceActionStatus.Pending,
           },
           {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.DETECT_BLIND_SIGNING,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
             output: {
               v: 0x1c,
               r: "0x8a540510e13b0f2b11a451275716d29e08caad07e89a1c84964782fb5e1ad788",
@@ -516,6 +548,13 @@ describe("SignTypedDataDeviceAction", () => {
             status: DeviceActionStatus.Pending,
           },
           {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.DETECT_BLIND_SIGNING,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
             output: {
               v: 0x1c,
               r: "0x8a540510e13b0f2b11a451275716d29e08caad07e89a1c84964782fb5e1ad788",
@@ -608,6 +647,13 @@ describe("SignTypedDataDeviceAction", () => {
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.SignTypedData,
               step: SignTypedDataDAStateStep.SIGN_TYPED_DATA_LEGACY,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.DETECT_BLIND_SIGNING,
             },
             status: DeviceActionStatus.Pending,
           },
@@ -816,6 +862,13 @@ describe("SignTypedDataDeviceAction", () => {
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.SignTypedData,
               step: SignTypedDataDAStateStep.SIGN_TYPED_DATA,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.DETECT_BLIND_SIGNING,
             },
             status: DeviceActionStatus.Pending,
           },
@@ -1069,6 +1122,13 @@ describe("SignTypedDataDeviceAction", () => {
             status: DeviceActionStatus.Pending,
           },
           {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.DETECT_BLIND_SIGNING,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
             output: {
               v: 0x1c,
               r: "0x8a540510e13b0f2b11a451275716d29e08caad07e89a1c84964782fb5e1ad788",
@@ -1185,6 +1245,13 @@ describe("SignTypedDataDeviceAction", () => {
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.SignTypedData,
               step: SignTypedDataDAStateStep.SIGN_TYPED_DATA_LEGACY,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.DETECT_BLIND_SIGNING,
             },
             status: DeviceActionStatus.Pending,
           },

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.ts
@@ -1,9 +1,10 @@
-import { type ContextModule } from "@ledgerhq/context-module";
+import type { ContextModule } from "@ledgerhq/context-module";
 import {
   ApplicationChecker,
   type CommandResult,
   type DeviceActionStateMachine,
   DeviceModelId,
+  DeviceSessionStateType,
   type InternalApi,
   isSuccessCommandResult,
   OpenAppDeviceAction,
@@ -40,6 +41,11 @@ import {
 } from "@internal/app-binder/command/Web3CheckOptInCommand";
 import { APP_NAME } from "@internal/app-binder/constants";
 import { EthereumApplicationResolver } from "@internal/app-binder/EthereumApplicationResolver";
+import {
+  BlindSigningDetectionTask,
+  type BlindSigningDetectionTaskArgs,
+  type BlindSigningDetectionTaskResult,
+} from "@internal/app-binder/task/BlindSigningDetectionTask";
 import { BuildEIP712ContextTask } from "@internal/app-binder/task/BuildEIP712ContextTask";
 import {
   ProvideEIP712ContextTask,
@@ -91,6 +97,9 @@ export type MachineDependencies = {
       data: TypedData;
     };
   }) => Promise<CommandResult<Signature, EthErrorCodes>>;
+  readonly detectBlindSigning: (arg0: {
+    input: BlindSigningDetectionTaskArgs;
+  }) => Promise<BlindSigningDetectionTaskResult>;
 };
 
 export class SignTypedDataDeviceAction extends XStateDeviceAction<
@@ -125,6 +134,7 @@ export class SignTypedDataDeviceAction extends XStateDeviceAction<
       provideContext,
       signTypedData,
       signTypedDataLegacy,
+      detectBlindSigning,
     } = this.extractDependencies(internalApi);
 
     return setup({
@@ -144,6 +154,7 @@ export class SignTypedDataDeviceAction extends XStateDeviceAction<
         provideContext: fromPromise(provideContext),
         signTypedData: fromPromise(signTypedData),
         signTypedDataLegacy: fromPromise(signTypedDataLegacy),
+        detectBlindSigning: fromPromise(detectBlindSigning),
       },
       guards: {
         noInternalError: ({ context }) => context._internalState.error === null,
@@ -166,6 +177,8 @@ export class SignTypedDataDeviceAction extends XStateDeviceAction<
           !context._internalState.appConfig!.web3ChecksEnabled &&
           !context._internalState.appConfig!.web3ChecksOptIn,
         skipOpenApp: ({ context }) => context.input.skipOpenApp,
+        hasSignature: ({ context }) =>
+          context._internalState.signature !== null,
       },
       actions: {
         assignErrorFromEvent: assign({
@@ -191,6 +204,8 @@ export class SignTypedDataDeviceAction extends XStateDeviceAction<
             from: null,
             typedDataContext: null,
             signature: null,
+            isBlindSign: null,
+            usedFallback: false,
           },
         };
       },
@@ -498,16 +513,16 @@ export class SignTypedDataDeviceAction extends XStateDeviceAction<
               ],
             },
             onError: {
-              target: "Error",
+              target: "DetectBlindSigning",
               actions: "assignErrorFromEvent",
             },
           },
         },
         SignTypedDataResultCheck: {
           always: [
-            { guard: "noInternalError", target: "Success" },
+            { guard: "noInternalError", target: "DetectBlindSigning" },
             { guard: "notRefusedByUser", target: "SignTypedDataLegacy" },
-            { target: "Error" },
+            { target: "DetectBlindSigning" },
           ],
         },
         SignTypedDataLegacy: {
@@ -516,6 +531,10 @@ export class SignTypedDataDeviceAction extends XStateDeviceAction<
               requiredUserInteraction: UserInteractionRequired.SignTypedData,
               step: SignTypedDataDAStateStep.SIGN_TYPED_DATA_LEGACY,
             },
+            _internalState: ({ context }) => ({
+              ...context._internalState,
+              usedFallback: true,
+            }),
           }),
           invoke: {
             id: "signTypedDataLegacy",
@@ -544,16 +563,76 @@ export class SignTypedDataDeviceAction extends XStateDeviceAction<
               ],
             },
             onError: {
-              target: "Error",
+              target: "DetectBlindSigning",
               actions: "assignErrorFromEvent",
             },
           },
         },
         SignTypedDataLegacyResultCheck: {
-          always: [
-            { guard: "noInternalError", target: "Success" },
-            { target: "Error" },
-          ],
+          always: "DetectBlindSigning",
+        },
+        DetectBlindSigning: {
+          entry: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.DETECT_BLIND_SIGNING,
+            },
+          }),
+          invoke: {
+            id: "detectBlindSigning",
+            src: "detectBlindSigning",
+            input: ({ context }) => {
+              const sessionState = internalApi.getDeviceSessionState();
+              const deviceVersion =
+                sessionState.sessionStateType !==
+                DeviceSessionStateType.Connected
+                  ? (sessionState.firmwareVersion?.os ?? null)
+                  : null;
+              return {
+                input: {
+                  type: "typedData" as const,
+                  hasContext:
+                    context._internalState.typedDataContext?.clearSignContext.isJust() ??
+                    false,
+                  usedFallback: context._internalState.usedFallback,
+                  chainId: context.input.data.domain.chainId ?? null,
+                  targetAddress:
+                    context.input.data.domain.verifyingContract ?? null,
+                  deviceModelId: internalApi.getDeviceModel().id,
+                  signerAppVersion:
+                    context._internalState.appConfig?.version ?? "",
+                  deviceVersion,
+                },
+                contextModule: context.input.contextModule,
+                loggerFactory: this.getLoggerFactory(internalApi),
+              };
+            },
+            onDone: [
+              {
+                guard: "hasSignature",
+                target: "Success",
+                actions: assign({
+                  _internalState: ({ event, context }) => ({
+                    ...context._internalState,
+                    isBlindSign: event.output.isBlindSign,
+                  }),
+                }),
+              },
+              {
+                target: "Error",
+                actions: assign({
+                  _internalState: ({ event, context }) => ({
+                    ...context._internalState,
+                    isBlindSign: event.output.isBlindSign,
+                  }),
+                }),
+              },
+            ],
+            onError: [
+              { guard: "hasSignature", target: "Success" },
+              { target: "Error" },
+            ],
+          },
         },
         Success: {
           type: "final",
@@ -641,6 +720,10 @@ export class SignTypedDataDeviceAction extends XStateDeviceAction<
         this.getLoggerFactory(internalApi),
       ).run();
 
+    const detectBlindSigning = async (arg0: {
+      input: BlindSigningDetectionTaskArgs;
+    }) => new BlindSigningDetectionTask(arg0.input).run();
+
     return {
       getAddress,
       getAppConfig,
@@ -649,6 +732,7 @@ export class SignTypedDataDeviceAction extends XStateDeviceAction<
       provideContext,
       signTypedData,
       signTypedDataLegacy,
+      detectBlindSigning,
     };
   }
 }

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.ts
@@ -46,7 +46,10 @@ import {
   type BlindSigningDetectionTaskArgs,
   type BlindSigningDetectionTaskResult,
 } from "@internal/app-binder/task/BlindSigningDetectionTask";
-import { BuildEIP712ContextTask } from "@internal/app-binder/task/BuildEIP712ContextTask";
+import {
+  BuildEIP712ContextTask,
+  type BuildEIP712ContextTaskResult,
+} from "@internal/app-binder/task/BuildEIP712ContextTask";
 import {
   ProvideEIP712ContextTask,
   type ProvideEIP712ContextTaskArgs,
@@ -79,7 +82,7 @@ export type MachineDependencies = {
       transactionParser: TransactionParserService;
       from: string;
     };
-  }) => Promise<ProvideEIP712ContextTaskArgs>;
+  }) => Promise<BuildEIP712ContextTaskResult>;
   readonly provideContext: (arg0: {
     input: {
       contextModule: ContextModule;
@@ -602,6 +605,12 @@ export class SignTypedDataDeviceAction extends XStateDeviceAction<
                   signerAppVersion:
                     context._internalState.appConfig?.version ?? "",
                   deviceVersion,
+                  clearSigningType:
+                    context._internalState.typedDataContext?.clearSigningType ??
+                    null,
+                  partialContextErrors:
+                    context._internalState.typedDataContext
+                      ?.contextErrorCount ?? 0,
                 },
                 contextModule: context.input.contextModule,
                 loggerFactory: this.getLoggerFactory(internalApi),

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BlindSigningDetectionTask.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BlindSigningDetectionTask.test.ts
@@ -1,4 +1,7 @@
-import { type ContextModule } from "@ledgerhq/context-module";
+import {
+  ClearSignContextType,
+  type ContextModule,
+} from "@ledgerhq/context-module";
 import { DeviceModelId } from "@ledgerhq/device-management-kit";
 
 import {
@@ -90,6 +93,67 @@ describe("computeIsBlindSign", () => {
         type: "typedData",
         hasContext: false,
         usedFallback: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("should return true when hasContext is true but only metadata-only context types are present", () => {
+    expect(
+      computeIsBlindSign({
+        ...baseInput,
+        hasContext: true,
+        usedFallback: false,
+        contextTypes: [ClearSignContextType.TRANSACTION_CHECK],
+      }),
+    ).toBe(true);
+  });
+
+  it("should return true when hasContext is true but only DYNAMIC_NETWORK and GATED_SIGNING context types are present", () => {
+    expect(
+      computeIsBlindSign({
+        ...baseInput,
+        hasContext: true,
+        usedFallback: false,
+        contextTypes: [
+          ClearSignContextType.DYNAMIC_NETWORK,
+          ClearSignContextType.GATED_SIGNING,
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("should return false when hasContext is true and real clear-signing context types are present alongside metadata", () => {
+    expect(
+      computeIsBlindSign({
+        ...baseInput,
+        hasContext: true,
+        usedFallback: false,
+        contextTypes: [
+          ClearSignContextType.TRANSACTION_CHECK,
+          ClearSignContextType.TRANSACTION_INFO,
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("should return false when hasContext is true with empty contextTypes (no calldata scenario)", () => {
+    expect(
+      computeIsBlindSign({
+        ...baseInput,
+        hasContext: true,
+        usedFallback: false,
+        contextTypes: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("should return true when hasContext is false even with contextTypes provided", () => {
+    expect(
+      computeIsBlindSign({
+        ...baseInput,
+        hasContext: false,
+        usedFallback: false,
+        contextTypes: [],
       }),
     ).toBe(true);
   });

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BlindSigningDetectionTask.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BlindSigningDetectionTask.test.ts
@@ -1,0 +1,247 @@
+import { type ContextModule } from "@ledgerhq/context-module";
+import { DeviceModelId } from "@ledgerhq/device-management-kit";
+
+import {
+  type BlindSigningDetectionInput,
+  BlindSigningDetectionTask,
+  type BlindSigningDetectionTaskArgs,
+  computeIsBlindSign,
+} from "./BlindSigningDetectionTask";
+
+vi.mock("@ledgerhq/signer-utils", () => ({
+  generateSignatureId: () => "aBcDeF-1700000000000",
+}));
+
+const mockLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  subscribers: [],
+};
+
+const mockLoggerFactory = (_tag: string) => mockLogger;
+
+const baseInput: BlindSigningDetectionInput = {
+  type: "transaction",
+  hasContext: false,
+  usedFallback: false,
+  chainId: 1,
+  targetAddress: "0xabc",
+  deviceModelId: DeviceModelId.FLEX,
+  signerAppVersion: "1.12.1",
+  deviceVersion: "2.2.3",
+};
+
+describe("computeIsBlindSign", () => {
+  it("should return false when hasContext is true and no fallback", () => {
+    expect(
+      computeIsBlindSign({
+        ...baseInput,
+        hasContext: true,
+        usedFallback: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("should return true when hasContext is false and no fallback", () => {
+    expect(
+      computeIsBlindSign({
+        ...baseInput,
+        hasContext: false,
+        usedFallback: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("should return true when usedFallback is true even with context", () => {
+    expect(
+      computeIsBlindSign({
+        ...baseInput,
+        hasContext: true,
+        usedFallback: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("should return true when usedFallback is true and no context", () => {
+    expect(
+      computeIsBlindSign({
+        ...baseInput,
+        hasContext: false,
+        usedFallback: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("should work for typedData type", () => {
+    expect(
+      computeIsBlindSign({
+        ...baseInput,
+        type: "typedData",
+        hasContext: true,
+        usedFallback: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      computeIsBlindSign({
+        ...baseInput,
+        type: "typedData",
+        hasContext: false,
+        usedFallback: false,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("BlindSigningDetectionTask", () => {
+  const mockContextModule = {
+    getContexts: vi.fn(),
+    getFieldContext: vi.fn(),
+    getTypedDataFilters: vi.fn(),
+    getSolanaContext: vi.fn(),
+    report: vi.fn(),
+  } as unknown as ContextModule;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should detect blind signing for transaction and report with mapped params", async () => {
+    const args: BlindSigningDetectionTaskArgs = {
+      input: {
+        ...baseInput,
+        hasContext: false,
+        usedFallback: false,
+      },
+      contextModule: mockContextModule,
+      loggerFactory: mockLoggerFactory,
+    };
+
+    const task = new BlindSigningDetectionTask(args);
+    const result = await task.run();
+
+    expect(result.isBlindSign).toBe(true);
+    expect(mockContextModule.report).toHaveBeenCalledWith({
+      signatureId: "aBcDeF-1700000000000",
+      signingMethod: "eth_signTransaction",
+      isBlindSign: true,
+      chainId: 1,
+      targetAddress: "0xabc",
+      blindSignReason: "no_clear_signing_context",
+      modelId: "flex",
+      signerAppVersion: "1.12.1",
+      deviceVersion: "2.2.3",
+      ethContext: null,
+    });
+  });
+
+  it("should detect non-blind signing for transaction and report", async () => {
+    const args: BlindSigningDetectionTaskArgs = {
+      input: {
+        ...baseInput,
+        hasContext: true,
+        usedFallback: false,
+      },
+      contextModule: mockContextModule,
+      loggerFactory: mockLoggerFactory,
+    };
+
+    const task = new BlindSigningDetectionTask(args);
+    const result = await task.run();
+
+    expect(result.isBlindSign).toBe(false);
+    expect(mockContextModule.report).toHaveBeenCalledWith(
+      expect.objectContaining({ isBlindSign: false, blindSignReason: null }),
+    );
+  });
+
+  it("should use device_rejected_context reason when usedFallback is true", async () => {
+    const args: BlindSigningDetectionTaskArgs = {
+      input: {
+        ...baseInput,
+        hasContext: true,
+        usedFallback: true,
+      },
+      contextModule: mockContextModule,
+      loggerFactory: mockLoggerFactory,
+    };
+
+    const task = new BlindSigningDetectionTask(args);
+    const result = await task.run();
+
+    expect(result.isBlindSign).toBe(true);
+    expect(mockContextModule.report).toHaveBeenCalledWith(
+      expect.objectContaining({
+        blindSignReason: "device_rejected_context",
+      }),
+    );
+  });
+
+  it("should detect blind signing for typed data", async () => {
+    const args: BlindSigningDetectionTaskArgs = {
+      input: {
+        ...baseInput,
+        type: "typedData",
+        hasContext: false,
+        usedFallback: true,
+      },
+      contextModule: mockContextModule,
+      loggerFactory: mockLoggerFactory,
+    };
+
+    const task = new BlindSigningDetectionTask(args);
+    const result = await task.run();
+
+    expect(result.isBlindSign).toBe(true);
+    expect(mockContextModule.report).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signingMethod: "eth_signTypedData",
+        blindSignReason: "device_rejected_context",
+      }),
+    );
+  });
+
+  it("should not fail if contextModule.report throws", async () => {
+    (mockContextModule.report as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Network error"),
+    );
+
+    const args: BlindSigningDetectionTaskArgs = {
+      input: {
+        ...baseInput,
+        hasContext: false,
+        usedFallback: false,
+      },
+      contextModule: mockContextModule,
+      loggerFactory: mockLoggerFactory,
+    };
+
+    const task = new BlindSigningDetectionTask(args);
+    const result = await task.run();
+
+    expect(result.isBlindSign).toBe(true);
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+
+  it("should map DeviceModelId to BlindSigningModelId correctly", async () => {
+    const args: BlindSigningDetectionTaskArgs = {
+      input: {
+        ...baseInput,
+        hasContext: false,
+        usedFallback: false,
+        deviceModelId: DeviceModelId.NANO_X,
+      },
+      contextModule: mockContextModule,
+      loggerFactory: mockLoggerFactory,
+    };
+
+    const task = new BlindSigningDetectionTask(args);
+    await task.run();
+
+    expect(mockContextModule.report).toHaveBeenCalledWith(
+      expect.objectContaining({ modelId: "nanoX" }),
+    );
+  });
+});

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BlindSigningDetectionTask.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BlindSigningDetectionTask.test.ts
@@ -8,7 +8,6 @@ import {
   type BlindSigningDetectionInput,
   BlindSigningDetectionTask,
   type BlindSigningDetectionTaskArgs,
-  computeIsBlindSign,
 } from "./BlindSigningDetectionTask";
 
 vi.mock("@ledgerhq/signer-utils", () => ({
@@ -35,129 +34,6 @@ const baseInput: BlindSigningDetectionInput = {
   signerAppVersion: "1.12.1",
   deviceVersion: "2.2.3",
 };
-
-describe("computeIsBlindSign", () => {
-  it("should return false when hasContext is true and no fallback", () => {
-    expect(
-      computeIsBlindSign({
-        ...baseInput,
-        hasContext: true,
-        usedFallback: false,
-      }),
-    ).toBe(false);
-  });
-
-  it("should return true when hasContext is false and no fallback", () => {
-    expect(
-      computeIsBlindSign({
-        ...baseInput,
-        hasContext: false,
-        usedFallback: false,
-      }),
-    ).toBe(true);
-  });
-
-  it("should return true when usedFallback is true even with context", () => {
-    expect(
-      computeIsBlindSign({
-        ...baseInput,
-        hasContext: true,
-        usedFallback: true,
-      }),
-    ).toBe(true);
-  });
-
-  it("should return true when usedFallback is true and no context", () => {
-    expect(
-      computeIsBlindSign({
-        ...baseInput,
-        hasContext: false,
-        usedFallback: true,
-      }),
-    ).toBe(true);
-  });
-
-  it("should work for typedData type", () => {
-    expect(
-      computeIsBlindSign({
-        ...baseInput,
-        type: "typedData",
-        hasContext: true,
-        usedFallback: false,
-      }),
-    ).toBe(false);
-
-    expect(
-      computeIsBlindSign({
-        ...baseInput,
-        type: "typedData",
-        hasContext: false,
-        usedFallback: false,
-      }),
-    ).toBe(true);
-  });
-
-  it("should return true when hasContext is true but only metadata-only context types are present", () => {
-    expect(
-      computeIsBlindSign({
-        ...baseInput,
-        hasContext: true,
-        usedFallback: false,
-        contextTypes: [ClearSignContextType.TRANSACTION_CHECK],
-      }),
-    ).toBe(true);
-  });
-
-  it("should return true when hasContext is true but only DYNAMIC_NETWORK and GATED_SIGNING context types are present", () => {
-    expect(
-      computeIsBlindSign({
-        ...baseInput,
-        hasContext: true,
-        usedFallback: false,
-        contextTypes: [
-          ClearSignContextType.DYNAMIC_NETWORK,
-          ClearSignContextType.GATED_SIGNING,
-        ],
-      }),
-    ).toBe(true);
-  });
-
-  it("should return false when hasContext is true and real clear-signing context types are present alongside metadata", () => {
-    expect(
-      computeIsBlindSign({
-        ...baseInput,
-        hasContext: true,
-        usedFallback: false,
-        contextTypes: [
-          ClearSignContextType.TRANSACTION_CHECK,
-          ClearSignContextType.TRANSACTION_INFO,
-        ],
-      }),
-    ).toBe(false);
-  });
-
-  it("should return false when hasContext is true with empty contextTypes (no calldata scenario)", () => {
-    expect(
-      computeIsBlindSign({
-        ...baseInput,
-        hasContext: true,
-        usedFallback: false,
-        contextTypes: [],
-      }),
-    ).toBe(false);
-  });
-
-  it("should return true when hasContext is false even with contextTypes provided", () => {
-    expect(
-      computeIsBlindSign({
-        ...baseInput,
-        hasContext: false,
-        usedFallback: false,
-        contextTypes: [],
-      }),
-    ).toBe(true);
-  });
-});
 
 describe("BlindSigningDetectionTask", () => {
   const mockContextModule = {
@@ -287,6 +163,102 @@ describe("BlindSigningDetectionTask", () => {
 
     expect(result.isBlindSign).toBe(true);
     expect(mockLogger.error).toHaveBeenCalled();
+  });
+
+  it("should return true when hasContext is true but only metadata-only context types are present", async () => {
+    const args: BlindSigningDetectionTaskArgs = {
+      input: {
+        ...baseInput,
+        hasContext: true,
+        usedFallback: false,
+        contextTypes: [ClearSignContextType.TRANSACTION_CHECK],
+      },
+      contextModule: mockContextModule,
+      loggerFactory: mockLoggerFactory,
+    };
+
+    const task = new BlindSigningDetectionTask(args);
+    const result = await task.run();
+
+    expect(result.isBlindSign).toBe(true);
+  });
+
+  it("should return true when hasContext is true but only DYNAMIC_NETWORK and GATED_SIGNING context types are present", async () => {
+    const args: BlindSigningDetectionTaskArgs = {
+      input: {
+        ...baseInput,
+        hasContext: true,
+        usedFallback: false,
+        contextTypes: [
+          ClearSignContextType.DYNAMIC_NETWORK,
+          ClearSignContextType.GATED_SIGNING,
+        ],
+      },
+      contextModule: mockContextModule,
+      loggerFactory: mockLoggerFactory,
+    };
+
+    const task = new BlindSigningDetectionTask(args);
+    const result = await task.run();
+
+    expect(result.isBlindSign).toBe(true);
+  });
+
+  it("should return false when hasContext is true and real clear-signing context types are present alongside metadata", async () => {
+    const args: BlindSigningDetectionTaskArgs = {
+      input: {
+        ...baseInput,
+        hasContext: true,
+        usedFallback: false,
+        contextTypes: [
+          ClearSignContextType.TRANSACTION_CHECK,
+          ClearSignContextType.TRANSACTION_INFO,
+        ],
+      },
+      contextModule: mockContextModule,
+      loggerFactory: mockLoggerFactory,
+    };
+
+    const task = new BlindSigningDetectionTask(args);
+    const result = await task.run();
+
+    expect(result.isBlindSign).toBe(false);
+  });
+
+  it("should return false when hasContext is true with empty contextTypes (no calldata scenario)", async () => {
+    const args: BlindSigningDetectionTaskArgs = {
+      input: {
+        ...baseInput,
+        hasContext: true,
+        usedFallback: false,
+        contextTypes: [],
+      },
+      contextModule: mockContextModule,
+      loggerFactory: mockLoggerFactory,
+    };
+
+    const task = new BlindSigningDetectionTask(args);
+    const result = await task.run();
+
+    expect(result.isBlindSign).toBe(false);
+  });
+
+  it("should return true when hasContext is false even with contextTypes provided", async () => {
+    const args: BlindSigningDetectionTaskArgs = {
+      input: {
+        ...baseInput,
+        hasContext: false,
+        usedFallback: false,
+        contextTypes: [],
+      },
+      contextModule: mockContextModule,
+      loggerFactory: mockLoggerFactory,
+    };
+
+    const task = new BlindSigningDetectionTask(args);
+    const result = await task.run();
+
+    expect(result.isBlindSign).toBe(true);
   });
 
   it("should map DeviceModelId to BlindSigningModelId correctly", async () => {

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BlindSigningDetectionTask.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BlindSigningDetectionTask.test.ts
@@ -4,6 +4,8 @@ import {
 } from "@ledgerhq/context-module";
 import { DeviceModelId } from "@ledgerhq/device-management-kit";
 
+import { ClearSigningType } from "@api/model/ClearSigningType";
+
 import {
   type BlindSigningDetectionInput,
   BlindSigningDetectionTask,
@@ -33,6 +35,8 @@ const baseInput: BlindSigningDetectionInput = {
   deviceModelId: DeviceModelId.FLEX,
   signerAppVersion: "1.12.1",
   deviceVersion: "2.2.3",
+  clearSigningType: null,
+  partialContextErrors: 0,
 };
 
 describe("BlindSigningDetectionTask", () => {
@@ -278,6 +282,55 @@ describe("BlindSigningDetectionTask", () => {
 
     expect(mockContextModule.report).toHaveBeenCalledWith(
       expect.objectContaining({ modelId: "nanoX" }),
+    );
+  });
+
+  it("should populate ethContext when clearSigningType is provided", async () => {
+    const args: BlindSigningDetectionTaskArgs = {
+      input: {
+        ...baseInput,
+        hasContext: true,
+        usedFallback: false,
+        clearSigningType: ClearSigningType.EIP7730,
+        partialContextErrors: 2,
+      },
+      contextModule: mockContextModule,
+      loggerFactory: mockLoggerFactory,
+    };
+
+    const task = new BlindSigningDetectionTask(args);
+    await task.run();
+
+    expect(mockContextModule.report).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ethContext: {
+          clearSigningType: "eip7730",
+          partialContextErrors: 2,
+        },
+      }),
+    );
+  });
+
+  it("should set ethContext to null when clearSigningType is null", async () => {
+    const args: BlindSigningDetectionTaskArgs = {
+      input: {
+        ...baseInput,
+        hasContext: true,
+        usedFallback: false,
+        clearSigningType: null,
+        partialContextErrors: 0,
+      },
+      contextModule: mockContextModule,
+      loggerFactory: mockLoggerFactory,
+    };
+
+    const task = new BlindSigningDetectionTask(args);
+    await task.run();
+
+    expect(mockContextModule.report).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ethContext: null,
+      }),
     );
   });
 });

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BlindSigningDetectionTask.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BlindSigningDetectionTask.ts
@@ -1,0 +1,101 @@
+import {
+  BlindSigningMethod,
+  type BlindSigningReportParams,
+  BlindSignReason,
+  type ContextModule,
+  mapDeviceModelId,
+} from "@ledgerhq/context-module";
+import {
+  type DeviceModelId,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+import { generateSignatureId } from "@ledgerhq/signer-utils";
+
+export type BlindSigningDetectionInput = {
+  type: "transaction" | "typedData";
+  hasContext: boolean;
+  usedFallback: boolean;
+  chainId: number | null;
+  targetAddress: string | null;
+  deviceModelId: DeviceModelId;
+  signerAppVersion: string;
+  deviceVersion: string | null;
+};
+
+export type BlindSigningDetectionTaskArgs = {
+  input: BlindSigningDetectionInput;
+  contextModule: ContextModule;
+  loggerFactory: (tag: string) => LoggerPublisherService;
+};
+
+export type BlindSigningDetectionTaskResult = {
+  isBlindSign: boolean;
+};
+
+export function computeIsBlindSign(input: BlindSigningDetectionInput): boolean {
+  if (input.usedFallback) {
+    return true;
+  }
+  return !input.hasContext;
+}
+
+function computeBlindSignReason(
+  input: BlindSigningDetectionInput,
+): BlindSignReason {
+  if (input.usedFallback) {
+    return BlindSignReason.DEVICE_REJECTED_CONTEXT;
+  }
+  return BlindSignReason.NO_CLEAR_SIGNING_CONTEXT;
+}
+
+function buildReportParams(
+  input: BlindSigningDetectionInput,
+  isBlindSign: boolean,
+): BlindSigningReportParams {
+  const signingMethod =
+    input.type === "transaction"
+      ? BlindSigningMethod.ETH_SIGN_TRANSACTION
+      : BlindSigningMethod.ETH_SIGN_TYPED_DATA;
+
+  return {
+    signatureId: generateSignatureId(),
+    signingMethod,
+    isBlindSign,
+    chainId: input.chainId,
+    targetAddress: input.targetAddress,
+    blindSignReason: isBlindSign ? computeBlindSignReason(input) : null,
+    modelId: mapDeviceModelId(input.deviceModelId),
+    signerAppVersion: input.signerAppVersion,
+    deviceVersion: input.deviceVersion,
+    ethContext: null,
+  };
+}
+
+export class BlindSigningDetectionTask {
+  private readonly _logger: LoggerPublisherService;
+
+  constructor(private readonly _args: BlindSigningDetectionTaskArgs) {
+    this._logger = _args.loggerFactory("BlindSigningDetectionTask");
+  }
+
+  async run(): Promise<BlindSigningDetectionTaskResult> {
+    const { input, contextModule } = this._args;
+
+    const isBlindSign = computeIsBlindSign(input);
+
+    this._logger.debug("[run] Blind signing detection result", {
+      data: { isBlindSign, type: input.type },
+    });
+
+    try {
+      const params = buildReportParams(input, isBlindSign);
+      await contextModule.report(params);
+    } catch (error) {
+      this._logger.error("[run] Failed to report blind signing event", {
+        data: { error },
+      });
+    }
+
+    return { isBlindSign };
+  }
+}

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BlindSigningDetectionTask.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BlindSigningDetectionTask.ts
@@ -2,6 +2,7 @@ import {
   BlindSigningMethod,
   type BlindSigningReportParams,
   BlindSignReason,
+  ClearSignContextType,
   type ContextModule,
   mapDeviceModelId,
 } from "@ledgerhq/context-module";
@@ -11,9 +12,17 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { generateSignatureId } from "@ledgerhq/signer-utils";
 
+const METADATA_ONLY_CONTEXT_TYPES = new Set<ClearSignContextType>([
+  ClearSignContextType.TRANSACTION_CHECK,
+  ClearSignContextType.DYNAMIC_NETWORK,
+  ClearSignContextType.DYNAMIC_NETWORK_ICON,
+  ClearSignContextType.GATED_SIGNING,
+]);
+
 export type BlindSigningDetectionInput = {
   type: "transaction" | "typedData";
   hasContext: boolean;
+  contextTypes?: ClearSignContextType[];
   usedFallback: boolean;
   chainId: number | null;
   targetAddress: string | null;
@@ -35,6 +44,14 @@ export type BlindSigningDetectionTaskResult = {
 export function computeIsBlindSign(input: BlindSigningDetectionInput): boolean {
   if (input.usedFallback) {
     return true;
+  }
+  if (input.contextTypes && input.hasContext && input.contextTypes.length > 0) {
+    const hasClearSignContexts = input.contextTypes.some(
+      (type) => !METADATA_ONLY_CONTEXT_TYPES.has(type),
+    );
+    if (!hasClearSignContexts) {
+      return true;
+    }
   }
   return !input.hasContext;
 }

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BlindSigningDetectionTask.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BlindSigningDetectionTask.ts
@@ -12,6 +12,8 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { generateSignatureId } from "@ledgerhq/signer-utils";
 
+import { type ClearSigningType } from "@api/model/ClearSigningType";
+
 const METADATA_ONLY_CONTEXT_TYPES = new Set<ClearSignContextType>([
   ClearSignContextType.TRANSACTION_CHECK,
   ClearSignContextType.DYNAMIC_NETWORK,
@@ -29,6 +31,8 @@ export type BlindSigningDetectionInput = {
   deviceModelId: DeviceModelId;
   signerAppVersion: string;
   deviceVersion: string | null;
+  clearSigningType: ClearSigningType | null;
+  partialContextErrors: number;
 };
 
 export type BlindSigningDetectionTaskArgs = {
@@ -84,7 +88,13 @@ function buildReportParams(
     modelId: mapDeviceModelId(input.deviceModelId),
     signerAppVersion: input.signerAppVersion,
     deviceVersion: input.deviceVersion,
-    ethContext: null,
+    ethContext:
+      input.clearSigningType !== null
+        ? {
+            clearSigningType: input.clearSigningType,
+            partialContextErrors: input.partialContextErrors,
+          }
+        : null,
   };
 }
 

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BlindSigningDetectionTask.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BlindSigningDetectionTask.ts
@@ -41,7 +41,7 @@ export type BlindSigningDetectionTaskResult = {
   isBlindSign: boolean;
 };
 
-export function computeIsBlindSign(input: BlindSigningDetectionInput): boolean {
+function computeIsBlindSign(input: BlindSigningDetectionInput): boolean {
   if (input.usedFallback) {
     return true;
   }

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BuildBaseContexts.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BuildBaseContexts.test.ts
@@ -97,6 +97,7 @@ describe("BuildBaseContexts", () => {
       clearSignContexts,
       clearSignContextsOptional,
       clearSigningType: ClearSigningType.BASIC,
+      contextErrorCount: 0,
     });
   });
 
@@ -157,6 +158,7 @@ describe("BuildBaseContexts", () => {
       ],
       clearSignContextsOptional: [clearSignContexts[2]],
       clearSigningType: ClearSigningType.EIP7730,
+      contextErrorCount: 0,
     });
   });
 
@@ -217,6 +219,7 @@ describe("BuildBaseContexts", () => {
       ],
       clearSignContextsOptional: [clearSignContexts[0]], // enum
       clearSigningType: ClearSigningType.EIP7730,
+      contextErrorCount: 0,
     });
   });
 
@@ -254,6 +257,7 @@ describe("BuildBaseContexts", () => {
       clearSignContexts,
       clearSignContextsOptional: [],
       clearSigningType: ClearSigningType.BASIC,
+      contextErrorCount: 0,
     });
   });
 
@@ -303,6 +307,7 @@ describe("BuildBaseContexts", () => {
       ],
       clearSignContextsOptional: [clearSignContexts[2]],
       clearSigningType: ClearSigningType.EIP7730,
+      contextErrorCount: 0,
     });
   });
 
@@ -338,6 +343,7 @@ describe("BuildBaseContexts", () => {
       clearSignContexts: [clearSignContexts[1], clearSignContexts[0]],
       clearSignContextsOptional,
       clearSigningType: ClearSigningType.EIP7730,
+      contextErrorCount: 0,
     });
   });
 
@@ -467,6 +473,7 @@ describe("BuildBaseContexts", () => {
       clearSignContexts: [clearSignContexts[1], clearSignContexts[3]],
       clearSignContextsOptional: [],
       clearSigningType: ClearSigningType.BASIC,
+      contextErrorCount: 2,
     });
   });
 
@@ -516,6 +523,7 @@ describe("BuildBaseContexts", () => {
       clearSignContexts: [clearSignContexts[1], clearSignContexts[3]],
       clearSignContextsOptional: [],
       clearSigningType: ClearSigningType.BASIC,
+      contextErrorCount: 0,
     });
   });
 
@@ -559,6 +567,7 @@ describe("BuildBaseContexts", () => {
       clearSignContexts: [clearSignContexts[1], clearSignContexts[3]],
       clearSignContextsOptional: [],
       clearSigningType: ClearSigningType.BASIC,
+      contextErrorCount: 0,
     });
   });
 
@@ -608,6 +617,7 @@ describe("BuildBaseContexts", () => {
       clearSignContexts: [clearSignContexts[1], clearSignContexts[3]],
       clearSignContextsOptional: [clearSignContexts[4]],
       clearSigningType: ClearSigningType.EIP7730,
+      contextErrorCount: 0,
     });
   });
 
@@ -653,6 +663,7 @@ describe("BuildBaseContexts", () => {
       clearSignContexts: [clearSignContexts[0]],
       clearSignContextsOptional: [],
       clearSigningType: ClearSigningType.BASIC,
+      contextErrorCount: 0,
     });
   });
 
@@ -698,6 +709,7 @@ describe("BuildBaseContexts", () => {
       clearSignContexts: [clearSignContexts[0]],
       clearSignContextsOptional: [],
       clearSigningType: ClearSigningType.BASIC,
+      contextErrorCount: 0,
     });
   });
 
@@ -740,6 +752,7 @@ describe("BuildBaseContexts", () => {
       clearSignContexts: [clearSignContexts[0]],
       clearSignContextsOptional: [],
       clearSigningType: ClearSigningType.BASIC,
+      contextErrorCount: 0,
     });
   });
 
@@ -779,6 +792,7 @@ describe("BuildBaseContexts", () => {
       clearSignContexts: [],
       clearSignContextsOptional: [],
       clearSigningType: ClearSigningType.BASIC,
+      contextErrorCount: 0,
     });
   });
 

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BuildBaseContexts.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BuildBaseContexts.ts
@@ -51,6 +51,7 @@ export type BuildBaseContextsResult = {
   readonly clearSignContexts: ClearSignContextSuccess[];
   readonly clearSignContextsOptional: ClearSignContextSuccess[];
   readonly clearSigningType: ClearSigningType;
+  readonly contextErrorCount: number;
 };
 
 export type BuildBaseContextsArgs = {
@@ -108,6 +109,9 @@ export class BuildBaseContexts {
       );
 
     // filter out the error contexts
+    const contextErrorCount = clearSignContexts.filter(
+      (context) => context.type === ClearSignContextType.ERROR,
+    ).length;
     const contextsSuccess: ClearSignContextSuccess[] = clearSignContexts.filter(
       (context) => context.type !== ClearSignContextType.ERROR,
     );
@@ -131,14 +135,15 @@ export class BuildBaseContexts {
       this._supportsGenericParser(deviceState, appConfig) &&
       this._hasValidTransactionInfo(contextsForSigning)
     ) {
-      return this._getERC7730Contexts(contextsForSigning);
+      return this._getERC7730Contexts(contextsForSigning, contextErrorCount);
     } else {
-      return this._getBasicContexts(contextsForSigning);
+      return this._getBasicContexts(contextsForSigning, contextErrorCount);
     }
   }
 
   private _getERC7730Contexts(
     contexts: ClearSignContextSuccess[],
+    contextErrorCount: number,
   ): BuildBaseContextsResult {
     const clearSignContexts: ClearSignContextSuccess[] = contexts
       .filter((context) => this._isContextNeededForERC7730ClearSigning(context))
@@ -153,11 +158,13 @@ export class BuildBaseContexts {
       clearSignContexts,
       clearSignContextsOptional,
       clearSigningType: ClearSigningType.EIP7730,
+      contextErrorCount,
     };
   }
 
   private _getBasicContexts(
     contexts: ClearSignContextSuccess[],
+    contextErrorCount: number,
   ): BuildBaseContextsResult {
     const clearSignContexts: ClearSignContextSuccess[] = contexts
       .filter((context) => this._isContextNeededForBasicClearSigning(context))
@@ -169,6 +176,7 @@ export class BuildBaseContexts {
       clearSignContexts,
       clearSignContextsOptional: [],
       clearSigningType: ClearSigningType.BASIC,
+      contextErrorCount,
     };
   }
 

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BuildEIP712ContextTask.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BuildEIP712ContextTask.test.ts
@@ -234,6 +234,8 @@ describe("BuildEIP712ContextTask", () => {
       calldatasPreContexts: {},
       calldatasPostContexts: {},
       loggerFactory: mockLoggerFactory,
+      clearSigningType: ClearSigningType.BASIC,
+      contextErrorCount: 0,
     });
   });
 
@@ -286,6 +288,8 @@ describe("BuildEIP712ContextTask", () => {
       calldatasPreContexts: {},
       calldatasPostContexts: {},
       loggerFactory: mockLoggerFactory,
+      clearSigningType: ClearSigningType.BASIC,
+      contextErrorCount: 0,
     });
   });
 
@@ -341,6 +345,8 @@ describe("BuildEIP712ContextTask", () => {
       calldatasPreContexts: {},
       calldatasPostContexts: {},
       loggerFactory: mockLoggerFactory,
+      clearSigningType: ClearSigningType.EIP7730,
+      contextErrorCount: 0,
     });
     expect(parserMock.parse).toHaveBeenCalledWith(TEST_DATA);
     expect(contextModuleMock.getTypedDataFilters).toHaveBeenCalledWith({
@@ -415,6 +421,8 @@ describe("BuildEIP712ContextTask", () => {
       calldatasPostContexts: {},
       additionalContexts: [txCheckContext],
       loggerFactory: mockLoggerFactory,
+      clearSigningType: ClearSigningType.EIP7730,
+      contextErrorCount: 0,
     });
   });
 
@@ -561,6 +569,8 @@ describe("BuildEIP712ContextTask", () => {
         0: [],
       },
       loggerFactory: mockLoggerFactory,
+      clearSigningType: ClearSigningType.EIP7730,
+      contextErrorCount: 0,
     });
   });
 

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BuildEIP712ContextTask.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BuildEIP712ContextTask.ts
@@ -34,6 +34,11 @@ import { type TypedDataParserService } from "@internal/typed-data/service/TypedD
 
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
+export type BuildEIP712ContextTaskResult = ProvideEIP712ContextTaskArgs & {
+  clearSigningType: ClearSigningType;
+  contextErrorCount: number;
+};
+
 export class BuildEIP712ContextTask {
   constructor(
     private readonly api: InternalApi,
@@ -52,7 +57,7 @@ export class BuildEIP712ContextTask {
     ) => new BuildFullContextsTask(internalApi, args),
   ) {}
 
-  async run(): Promise<ProvideEIP712ContextTaskArgs> {
+  async run(): Promise<BuildEIP712ContextTaskResult> {
     // Clear signing context
     // Parse the message types and values
     const parsed = this.parser.parse(this.data);
@@ -71,10 +76,8 @@ export class BuildEIP712ContextTask {
       challenge = challengeRes.data.challenge;
     }
 
-    const additionalContexts = await this.getAdditionalContexts(
-      deviceState,
-      challenge,
-    );
+    const { contexts: additionalContexts, contextErrorCount } =
+      await this.getAdditionalContexts(deviceState, challenge);
 
     // Get clear signing context, if any
     let clearSignContext: Maybe<TypedDataClearSignContextSuccess> = Nothing;
@@ -127,13 +130,22 @@ export class BuildEIP712ContextTask {
       deviceModelId: deviceState.deviceModelId,
       loggerFactory: this.loggerFactory,
     };
-    return provideTaskArgs;
+    return {
+      ...provideTaskArgs,
+      clearSigningType: clearSignContext.isJust()
+        ? ClearSigningType.EIP7730
+        : ClearSigningType.BASIC,
+      contextErrorCount,
+    };
   }
 
   private async getAdditionalContexts(
     deviceState: DeviceSessionState,
     challenge: string | undefined,
-  ): Promise<ClearSignContextSuccess[]> {
+  ): Promise<{
+    contexts: ClearSignContextSuccess[];
+    contextErrorCount: number;
+  }> {
     const supportsGatedSigning = new ApplicationChecker(
       deviceState,
       this.appConfig,
@@ -162,7 +174,7 @@ export class BuildEIP712ContextTask {
     }
 
     // Fetch the contexts
-    const contexts = await this.contextModule.getContexts(
+    const allContexts = await this.contextModule.getContexts(
       {
         deviceModelId: deviceState.deviceModelId,
         data: this.data,
@@ -173,10 +185,16 @@ export class BuildEIP712ContextTask {
       contextTypes,
     );
 
+    const contextErrorCount = allContexts.filter(
+      (context) => context.type === ClearSignContextType.ERROR,
+    ).length;
+
     // Filter valid contexts
-    return contexts.filter((context) =>
+    const contexts = allContexts.filter((context) =>
       contextTypes.includes(context.type),
     ) as ClearSignContextSuccess[];
+
+    return { contexts, contextErrorCount };
   }
 
   private getClearSignVersion(

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BuildFullContextsTask.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BuildFullContextsTask.test.ts
@@ -132,6 +132,7 @@ describe("BuildFullContextsTask", () => {
         clearSignContexts: [],
         clearSignContextsOptional: [],
         clearSigningType: ClearSigningType.BASIC,
+        contextErrorCount: 0,
       });
 
       const task = new BuildFullContextsTask(
@@ -159,6 +160,7 @@ describe("BuildFullContextsTask", () => {
       expect(result).toEqual({
         clearSignContexts: [],
         clearSigningType: ClearSigningType.BASIC,
+        contextErrorCount: 0,
       });
     });
 
@@ -180,6 +182,7 @@ describe("BuildFullContextsTask", () => {
           },
         ],
         clearSigningType: ClearSigningType.EIP7730,
+        contextErrorCount: 0,
       });
       buildSubContextTaskRunMock.mockReturnValue({
         subcontextCallbacks: [],
@@ -232,6 +235,7 @@ describe("BuildFullContextsTask", () => {
           },
         ],
         clearSigningType: ClearSigningType.EIP7730,
+        contextErrorCount: 0,
       });
     });
 
@@ -250,6 +254,7 @@ describe("BuildFullContextsTask", () => {
         ],
         clearSignContextsOptional: [],
         clearSigningType: ClearSigningType.EIP7730,
+        contextErrorCount: 0,
       });
       buildSubContextTaskRunMock.mockReturnValueOnce({
         subcontextCallbacks: [],
@@ -341,6 +346,7 @@ describe("BuildFullContextsTask", () => {
           },
         ],
         clearSigningType: ClearSigningType.EIP7730,
+        contextErrorCount: 0,
       });
       // nested context
       buildBaseContextsTaskRunMock.mockReturnValueOnce({
@@ -356,6 +362,7 @@ describe("BuildFullContextsTask", () => {
         ],
         clearSignContextsOptional: [],
         clearSigningType: ClearSigningType.EIP7730,
+        contextErrorCount: 0,
       });
       buildSubContextTaskRunMock.mockReturnValue({
         subcontextCallbacks: [],
@@ -396,6 +403,7 @@ describe("BuildFullContextsTask", () => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         clearSignContexts: expect.any(Array),
         clearSigningType: ClearSigningType.EIP7730,
+        contextErrorCount: 0,
       });
       expect(result.clearSignContexts[0]).toEqual({
         context: {

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BuildFullContextsTask.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BuildFullContextsTask.ts
@@ -34,6 +34,7 @@ import {
 export type BuildFullContextsTaskResult = {
   readonly clearSignContexts: ContextWithSubContexts[];
   readonly clearSigningType: ClearSigningType;
+  readonly contextErrorCount: number;
 };
 
 export type BuildFullContextsTaskArgs = {
@@ -79,8 +80,12 @@ export class BuildFullContextsTask {
     this._logger.debug("[run] Starting BuildFullContextsTask");
 
     // get the base contexts
-    const { clearSignContexts, clearSigningType, clearSignContextsOptional } =
-      await this._buildBaseContextsTaskFactory(this._api, this._args).run();
+    const {
+      clearSignContexts,
+      clearSigningType,
+      clearSignContextsOptional,
+      contextErrorCount,
+    } = await this._buildBaseContextsTaskFactory(this._api, this._args).run();
 
     this._logger.debug("[run] Base contexts built", {
       data: {
@@ -163,6 +168,7 @@ export class BuildFullContextsTask {
     return {
       clearSignContexts: contextWithNestedContexts,
       clearSigningType,
+      contextErrorCount,
     };
   }
 }

--- a/packages/signer/signer-utils/src/index.ts
+++ b/packages/signer/signer-utils/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./utils/CommandErrorHelper";
 export * from "./utils/DerivationPathUtils";
+export * from "./utils/SignatureIdUtils";

--- a/packages/signer/signer-utils/src/utils/SignatureIdUtils.test.ts
+++ b/packages/signer/signer-utils/src/utils/SignatureIdUtils.test.ts
@@ -1,0 +1,25 @@
+import { generateSignatureId } from "./SignatureIdUtils";
+
+describe("generateSignatureId", () => {
+  it("should return a string matching <6 alphanumeric chars>-<unix timestamp ms>", () => {
+    const id = generateSignatureId();
+    expect(id).toMatch(/^[A-Za-z0-9]{6}-\d+$/);
+  });
+
+  it("should embed a recent timestamp", () => {
+    const before = Date.now();
+    const id = generateSignatureId();
+    const after = Date.now();
+
+    const timestamp = Number(id.split("-")[1]);
+    expect(timestamp).toBeGreaterThanOrEqual(before);
+    expect(timestamp).toBeLessThanOrEqual(after);
+  });
+
+  it("should produce unique ids on successive calls", () => {
+    const ids = new Set(
+      Array.from({ length: 50 }, () => generateSignatureId()),
+    );
+    expect(ids.size).toBe(50);
+  });
+});

--- a/packages/signer/signer-utils/src/utils/SignatureIdUtils.ts
+++ b/packages/signer/signer-utils/src/utils/SignatureIdUtils.ts
@@ -1,0 +1,13 @@
+const ALPHANUMERIC_CHARS =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+const RANDOM_PART_LENGTH = 6;
+
+export function generateSignatureId(): string {
+  let random = "";
+  for (let i = 0; i < RANDOM_PART_LENGTH; i++) {
+    random += ALPHANUMERIC_CHARS.charAt(
+      Math.floor(Math.random() * ALPHANUMERIC_CHARS.length),
+    );
+  }
+  return `${random}-${Date.now()}`;
+}


### PR DESCRIPTION
### 📝 Description

Add blind signing detection and reporting to the Ethereum signer's `signTransaction` and `signTypedData` device actions. When a transaction falls back to blind signing (i.e., clear signing context could not be fully provided), the signer now detects this and reports it via the context module's blind signing reporter.

Key changes:
- **signer-utils**: New `generateSignatureId` utility for creating unique signature identifiers used in blind signing reports.
- **context-module**: Add `source` configuration to `ContextModuleConfig` and `setSource()` builder method, allowing integrators to identify their app in blind signing reports (defaults to `"third-party"`).
- **signer-eth**: New `BlindSigningDetectionTask` that checks whether a signing operation was blind-signed, and reports it. Integrated into both `SignTransactionDeviceAction` and `SignTypedDataDeviceAction` with a new `DETECT_BLIND_SIGNING` step.
- **sample app**: Sets the source to `"device-management-kit-playground"` on the context module builder.
- **Documentation**: Updated context-module and signer-eth READMEs to reflect the new API surface.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1017](https://ledgerhq.atlassian.net/browse/DSDK-1017)

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date**
- [ ] **Impact of the changes:**
  - New `BlindSigningDetectionTask` runs after signing in `signTransaction` and `signTypedData` flows
  - New `DETECT_BLIND_SIGNING` step emitted in device action intermediate values
  - New `source` field in `ContextModuleConfig` and `setSource()` on `ContextModuleBuilder`
  - New `generateSignatureId` export from `@ledgerhq/signer-utils`
  - Blind signing events are reported to the backend when detected

---

### 🧐 Checklist for the PR Reviewers

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.

Made with [Cursor](https://cursor.com)

[DSDK-1017]: https://ledgerhq.atlassian.net/browse/DSDK-1017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ