### PR TITLE
🐛 (node-hid) [NO-ISSUE]: Filter Ledger devices to the APDU HID interface

### DIFF
--- a/.changeset/orange-icons-pump.md
+++ b/.changeset/orange-icons-pump.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-transport-kit-node-hid": patch
+---
+
+Filter Ledger HID devices to the APDU interface on macOS and Windows to prevent stalls when multiple HID interfaces are exposed

--- a/packages/transport/node-hid/src/api/transport/NodeHidTransport.test.ts
+++ b/packages/transport/node-hid/src/api/transport/NodeHidTransport.test.ts
@@ -88,6 +88,13 @@ const flushPromises = async () => {
   return new Promise(timers.setImmediate);
 };
 
+const setProcessPlatform = (platform: NodeJS.Platform) => {
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true,
+  });
+};
+
 /**
  * Helper to create a USB device event object matching the usb module's Device type
  */
@@ -115,6 +122,7 @@ const emitUsbDetachEvent = (vendorId: number, productId: number) => {
 };
 
 describe("NodeHidTransport", () => {
+  const originalPlatform = process.platform;
   let transport: NodeHidTransport;
   let apduReceiverServiceFactoryStub: ApduReceiverServiceFactory;
   let apduSenderServiceFactoryStub: ApduSenderServiceFactory;
@@ -195,6 +203,7 @@ describe("NodeHidTransport", () => {
   });
 
   afterEach(() => {
+    setProcessPlatform(originalPlatform);
     vi.restoreAllMocks();
     vi.clearAllMocks();
     vi.useRealTimers();
@@ -327,6 +336,68 @@ describe("NodeHidTransport", () => {
           },
         );
       }));
+
+    it("should ignore non-APDU ledger interfaces on darwin", async () => {
+      setProcessPlatform("darwin");
+
+      const genericInterface = nodeHidDeviceStubBuilder({
+        path: "/dev/hidraw0",
+        interface: 2,
+        usagePage: 0xf1d0,
+      });
+      const apduInterface = nodeHidDeviceStubBuilder({
+        path: "/dev/hidraw1",
+        interface: 0,
+        usagePage: 0xffa0,
+      });
+
+      mockDevicesAsync.mockResolvedValueOnce([genericInterface, apduInterface]);
+      mockDevicesAsync.mockResolvedValue([genericInterface, apduInterface]);
+
+      const discoveredDevices = await lastValueFrom(
+        transport.startDiscovering().pipe(toArray()),
+      );
+
+      expect(discoveredDevices).toHaveLength(1);
+      expect(
+        (
+          discoveredDevices[0] as TransportDiscoveredDevice & {
+            hidDevice: NodeHIDDevice;
+          }
+        ).hidDevice.path,
+      ).toBe("/dev/hidraw1");
+    });
+
+    it("should ignore non-APDU ledger interfaces on win32", async () => {
+      setProcessPlatform("win32");
+
+      const genericInterface = nodeHidDeviceStubBuilder({
+        path: "\\\\?\\hid#vid_2c97&pid_0001&mi_01#generic",
+        interface: 2,
+        usagePage: 0xf1d0,
+      });
+      const apduInterface = nodeHidDeviceStubBuilder({
+        path: "\\\\?\\hid#vid_2c97&pid_0001&mi_00#apdu",
+        interface: 0,
+        usagePage: 0xffa0,
+      });
+
+      mockDevicesAsync.mockResolvedValueOnce([genericInterface, apduInterface]);
+      mockDevicesAsync.mockResolvedValue([genericInterface, apduInterface]);
+
+      const discoveredDevices = await lastValueFrom(
+        transport.startDiscovering().pipe(toArray()),
+      );
+
+      expect(discoveredDevices).toHaveLength(1);
+      expect(
+        (
+          discoveredDevices[0] as TransportDiscoveredDevice & {
+            hidDevice: NodeHIDDevice;
+          }
+        ).hidDevice.path,
+      ).toBe("\\\\?\\hid#vid_2c97&pid_0001&mi_00#apdu");
+    });
 
     it("should throw DeviceNotRecognizedError if the device is not recognized", () =>
       new Promise<void>((resolve, reject) => {

--- a/packages/transport/node-hid/src/api/transport/NodeHidTransport.ts
+++ b/packages/transport/node-hid/src/api/transport/NodeHidTransport.ts
@@ -47,6 +47,21 @@ import {
 type NodeHIDAPI = typeof NodeHIDAPI;
 const NodeHIDAPI = { devicesAsync, HIDAsync } as const;
 
+// HID usage page used by Ledger devices for the APDU channel on macOS and Windows.
+const LEDGER_APDU_USAGE_PAGE = 0xffa0;
+
+const isLedgerApduInterface = (hidDevice: NodeHIDDevice) => {
+  if (hidDevice.vendorId !== LEDGER_VENDOR_ID) {
+    return false;
+  }
+
+  if (process.platform === "darwin" || process.platform === "win32") {
+    return hidDevice.usagePage === LEDGER_APDU_USAGE_PAGE;
+  }
+
+  return true;
+};
+
 type PromptDeviceAccessError =
   | NoAccessibleDeviceError
   | NodeHidTransportNotSupportedError;
@@ -136,9 +151,7 @@ export class NodeHidTransport implements Transport {
       try {
         const allDevices = await hidApi.devicesAsync();
 
-        const ledgerDevices = allDevices.filter(
-          (hidDevice) => hidDevice.vendorId === LEDGER_VENDOR_ID,
-        );
+        const ledgerDevices = allDevices.filter(isLedgerApduInterface);
 
         // Remove duplicates from same device with different interfaces by keeping only one device per vendorId:productId combination
         const uniqueDevices = Array.from(
@@ -251,9 +264,7 @@ export class NodeHidTransport implements Transport {
         try {
           const allDevices = await hidApi.devicesAsync();
 
-          hidDevices = allDevices.filter(
-            (d) => d.vendorId === LEDGER_VENDOR_ID,
-          );
+          hidDevices = allDevices.filter(isLedgerApduInterface);
           await this.updateTransportDiscoveredDevices();
         } catch (error) {
           const deviceError = new NoAccessibleDeviceError(error);


### PR DESCRIPTION
### 📝 Description

> PR based on #1377 by @danielnordh, reformatted with signed commits and changeset for CI compliance. Thanks @danielnordh!

Filter Node HID Ledger devices to the APDU HID interface (`usagePage === 0xffa0`) on macOS and Windows, aligning behavior with legacy LedgerJS.

On macOS and Windows, some Ledger devices expose multiple HID interfaces. The transport previously filtered only by `vendorId`, which could cause APDU communication to stall (observed on Ledger Nano X with firmware 2.6.1 and Ethereum app 1.21.3). Applying the same APDU-interface filter used by legacy LedgerJS restores correct behavior.

Changes:
- Add an `isLedgerApduInterface` predicate filtering Ledger HID devices to `usagePage === 0xffa0` on `darwin` and `win32`
- Apply the filter consistently across both device-discovery paths in `NodeHidTransport`
- Add regression tests covering duplicate Ledger HID interfaces on both `darwin` and `win32`

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Original PR**: #1377

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date** — no doc changes needed
- [x] **Impact of the changes:**
  - Node HID device discovery now filters by APDU usage page on macOS/Windows
  - Prevents stalls when multiple HID interfaces are exposed by a Ledger device