### PR TITLE
✨ (os-update) [DSDK-1095]: Add backup app storage task

### DIFF
--- a/.changeset/curly-webs-lead.md
+++ b/.changeset/curly-webs-lead.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": minor
+---
+
+Add backup app storage task

--- a/apps/sample/src/components/CommandsView/index.tsx
+++ b/apps/sample/src/components/CommandsView/index.tsx
@@ -1,9 +1,16 @@
 import React, { useMemo } from "react";
 import {
+  BackupStorageCommand,
+  type BackupStorageCommandErrorCodes,
+  type BackupStorageCommandResponse,
   BatteryStatusType,
   CloseAppCommand,
   GetAppAndVersionCommand,
   type GetAppAndVersionResponse,
+  GetAppStorageInfoCommand,
+  type GetAppStorageInfoCommandArgs,
+  type GetAppStorageInfoCommandErrorCodes,
+  type GetAppStorageInfoCommandResponse,
   type GetBatteryStatusArgs,
   GetBatteryStatusCommand,
   type GetBatteryStatusResponse,
@@ -115,6 +122,38 @@ export const CommandsView: React.FC<{ sessionId: string }> = ({
           statusType: BatteryStatusType.BATTERY_CURRENT,
         },
       } satisfies CommandProps<GetBatteryStatusArgs, GetBatteryStatusResponse>,
+      {
+        title: "Get app storage info",
+        description: "Get the app storage info of the device",
+        sendCommand: ({ appName }) => {
+          const command = new GetAppStorageInfoCommand({ appName });
+          return dmk.sendCommand({
+            sessionId: selectedSessionId,
+            command,
+          });
+        },
+        initialValues: { appName: "" },
+      } satisfies CommandProps<
+        GetAppStorageInfoCommandArgs,
+        GetAppStorageInfoCommandResponse,
+        GetAppStorageInfoCommandErrorCodes
+      >,
+      {
+        title: "Backup app storage",
+        description: "Backup the app storage of the device",
+        sendCommand: () => {
+          const command = new BackupStorageCommand();
+          return dmk.sendCommand({
+            sessionId: selectedSessionId,
+            command,
+          });
+        },
+        initialValues: undefined,
+      } satisfies CommandProps<
+        void,
+        BackupStorageCommandResponse,
+        BackupStorageCommandErrorCodes
+      >,
     ],
     [selectedSessionId, dmk],
   );

--- a/packages/device-management-kit/src/api/command/os/BackupStorageCommand.test.ts
+++ b/packages/device-management-kit/src/api/command/os/BackupStorageCommand.test.ts
@@ -1,0 +1,119 @@
+import { isSuccessCommandResult } from "@api/command/model/CommandResult";
+import { BackupStorageCommand } from "@api/command/os/BackupStorageCommand";
+import { ApduResponse } from "@api/device-session/ApduResponse";
+
+describe("BackupStorageCommand", () => {
+  describe("Name", () => {
+    it("name should be 'BackupStorage'", () => {
+      // ARRANGE
+      const command = new BackupStorageCommand();
+
+      // ACT
+      const name = command.name;
+
+      // ASSERT
+      expect(name).toBe("BackupStorage");
+    });
+  });
+
+  describe("Command", () => {
+    it("should return the correct APDU for backing up app storage", () => {
+      // ARRANGE
+      const expectedApdu = Uint8Array.from([0xe0, 0x6b, 0x00, 0x00, 0x00]);
+
+      // ACT
+      const apdu = new BackupStorageCommand().getApdu();
+
+      // ASSERT
+      expect(apdu.getRawApdu()).toEqual(expectedApdu);
+    });
+  });
+
+  describe("Success response", () => {
+    it("should return the app storage data chunk as a hex string", () => {
+      // ARRANGE
+      const statusCode = Uint8Array.from([0x90, 0x00]);
+      const response = new ApduResponse({
+        statusCode,
+        data: Uint8Array.from([0xab, 0xcd, 0xef, 0x01, 0x23]),
+      });
+
+      // ACT
+      const result = new BackupStorageCommand().parseResponse(response);
+
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      expect(result).toEqual({
+        data: {
+          chunkData: Uint8Array.from([0xab, 0xcd, 0xef, 0x01, 0x23]),
+          chunkSize: 5,
+        },
+        status: "SUCCESS",
+      });
+    });
+  });
+
+  describe("Error response", () => {
+    it.each([
+      {
+        description: "get info was not called first",
+        statusCode: [0x51, 0x23],
+        expectedMessage: "Invalid context. Get info must be called.",
+      },
+      {
+        description: "AES key generation fails",
+        statusCode: [0x54, 0x19],
+        expectedMessage: "Failed to generate AES key.",
+      },
+      {
+        description: "crypto operation fails",
+        statusCode: [0x54, 0x1a],
+        expectedMessage: "Internal error, crypto operation failed.",
+      },
+      {
+        description: "AES CMAC computation fails",
+        statusCode: [0x54, 0x1b],
+        expectedMessage: "Internal error, failed to compute AES CMAC.",
+      },
+      {
+        description: "encryption of backup fails",
+        statusCode: [0x54, 0x1c],
+        expectedMessage: "Failed to encrypt the app storage backup.",
+      },
+      {
+        description: "device is in recovery mode",
+        statusCode: [0x62, 0x2f],
+        expectedMessage: "Invalid device state, recovery mode.",
+      },
+      {
+        description: "backup was already performed",
+        statusCode: [0x66, 0x42],
+        expectedMessage: "Invalid backup state, backup already performed.",
+      },
+      {
+        description:
+          "error code is not specific to BackupStorageCommand (global error)",
+        statusCode: [0x55, 0x15],
+        expectedMessage: "Device is locked.",
+      },
+    ])(
+      "should return error when $description",
+      ({ statusCode, expectedMessage }) => {
+        // ARRANGE
+        const response = new ApduResponse({
+          statusCode: Uint8Array.from(statusCode),
+          data: new Uint8Array([]),
+        });
+
+        // ACT
+        const result = new BackupStorageCommand().parseResponse(response);
+
+        // ASSERT
+        expect(isSuccessCommandResult(result)).toBe(false);
+        expect((result as unknown as { error: Error }).error.message).toBe(
+          expectedMessage,
+        );
+      },
+    );
+  });
+});

--- a/packages/device-management-kit/src/api/command/os/BackupStorageCommand.ts
+++ b/packages/device-management-kit/src/api/command/os/BackupStorageCommand.ts
@@ -1,0 +1,109 @@
+import { type Apdu } from "@api/apdu/model/Apdu";
+import { ApduBuilder } from "@api/apdu/utils/ApduBuilder";
+import { ApduParser } from "@api/apdu/utils/ApduParser";
+import { type Command } from "@api/command/Command";
+import { InvalidStatusWordError } from "@api/command/Errors";
+import {
+  type CommandResult,
+  CommandResultFactory,
+} from "@api/command/model/CommandResult";
+import {
+  type CommandErrors,
+  isCommandErrorCode,
+} from "@api/command/utils/CommandErrors";
+import { CommandUtils } from "@api/command/utils/CommandUtils";
+import { GlobalCommandErrorHandler } from "@api/command/utils/GlobalCommandError";
+import { type ApduResponse } from "@api/device-session/ApduResponse";
+import { type CommandErrorArgs, DeviceExchangeError } from "@api/Error";
+
+export type BackupStorageCommandResponse = {
+  chunkData: Uint8Array;
+  chunkSize: number;
+};
+
+export type BackupStorageCommandErrorCodes =
+  | "5123"
+  | "5419"
+  | "541a"
+  | "541b"
+  | "541c"
+  | "622f"
+  | "6642";
+
+export const BACKUP_STORAGE_ERRORS: CommandErrors<BackupStorageCommandErrorCodes> =
+  {
+    "5123": { message: "Invalid context. Get info must be called." },
+    "5419": { message: "Failed to generate AES key." },
+    "541a": { message: "Internal error, crypto operation failed." },
+    "541b": { message: "Internal error, failed to compute AES CMAC." },
+    "541c": { message: "Failed to encrypt the app storage backup." },
+    "622f": { message: "Invalid device state, recovery mode." },
+    "6642": { message: "Invalid backup state, backup already performed." },
+  };
+
+export class BackupStorageCommandError extends DeviceExchangeError<BackupStorageCommandErrorCodes> {
+  constructor(args: CommandErrorArgs<BackupStorageCommandErrorCodes>) {
+    super({ tag: "BackupStorageCommandError", ...args });
+  }
+}
+
+export type BackupStorageCommandResult = CommandResult<
+  BackupStorageCommandResponse,
+  BackupStorageCommandErrorCodes
+>;
+
+export class BackupStorageCommand
+  implements
+    Command<BackupStorageCommandResponse, void, BackupStorageCommandErrorCodes>
+{
+  readonly name = "BackupStorage";
+
+  private readonly header = {
+    cla: 0xe0,
+    ins: 0x6b,
+    p1: 0x00,
+    p2: 0x00,
+  };
+
+  getApdu(): Apdu {
+    return new ApduBuilder(this.header).build();
+  }
+
+  parseResponse(apduResponse: ApduResponse): BackupStorageCommandResult {
+    const parser = new ApduParser(apduResponse);
+
+    if (!CommandUtils.isSuccessResponse(apduResponse)) {
+      const errorCode = parser.encodeToHexaString(apduResponse.statusCode);
+      if (isCommandErrorCode(errorCode, BACKUP_STORAGE_ERRORS)) {
+        return CommandResultFactory({
+          error: new BackupStorageCommandError({
+            ...BACKUP_STORAGE_ERRORS[errorCode],
+            errorCode,
+          }),
+        });
+      }
+      return CommandResultFactory({
+        error: GlobalCommandErrorHandler.handle(apduResponse),
+      });
+    }
+
+    const appStorageDataChunk = parser.extractFieldByLength(
+      parser.getUnparsedRemainingLength(),
+    );
+
+    if (appStorageDataChunk === undefined) {
+      return CommandResultFactory({
+        error: new InvalidStatusWordError(
+          "Failed to extract app storage data chunk",
+        ),
+      });
+    }
+
+    return CommandResultFactory({
+      data: {
+        chunkData: appStorageDataChunk,
+        chunkSize: appStorageDataChunk.length,
+      },
+    });
+  }
+}

--- a/packages/device-management-kit/src/api/command/os/GetAppStorageInfoCommand.test.ts
+++ b/packages/device-management-kit/src/api/command/os/GetAppStorageInfoCommand.test.ts
@@ -1,0 +1,193 @@
+import { InvalidStatusWordError } from "@api/command/Errors";
+import { isSuccessCommandResult } from "@api/command/model/CommandResult";
+import { GetAppStorageInfoCommand } from "@api/command/os/GetAppStorageInfoCommand";
+import { ApduResponse } from "@api/device-session/ApduResponse";
+
+describe("GetAppStorageInfoCommand", () => {
+  describe("Name", () => {
+    it("name should be 'GetAppStorageInfo'", () => {
+      // ARRANGE
+      const command = new GetAppStorageInfoCommand({ appName: "MyApp" });
+
+      // ACT
+      const name = command.name;
+
+      // ASSERT
+      expect(name).toBe("GetAppStorageInfo");
+    });
+  });
+
+  describe("Command", () => {
+    it("should return the correct APDU for getting the app storage info", () => {
+      // ARRANGE
+      const expectedApdu = Uint8Array.from([
+        0xe0, 0x6a, 0x00, 0x00, 0x05, 0x4d, 0x79, 0x41, 0x70, 0x70,
+      ]);
+
+      // ACT
+      const apdu = new GetAppStorageInfoCommand({ appName: "MyApp" }).getApdu();
+
+      // ASSERT
+      expect(apdu.getRawApdu()).toEqual(expectedApdu);
+    });
+  });
+
+  describe("Success response", () => {
+    it("should return correct app storage info when app storage size is not 0", () => {
+      // ARRANGE
+      const statusCode = Uint8Array.from([0x90, 0x00]);
+      const response = new ApduResponse({
+        statusCode,
+        data: Uint8Array.from([
+          // appStorageSize (32-bit BE) = 1
+          0x00, 0x00, 0x00, 0x01,
+          // appStorageVersion (32-bit BE) = 1
+          0x00, 0x00, 0x00, 0x01,
+          // appStorageProperties (16-bit BE) = 0x0003 (bits 0 and 1 set)
+          0x00, 0x03,
+          // appStorageHash (32 bytes)
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+        ]),
+      });
+
+      // ACT
+      const result = new GetAppStorageInfoCommand({
+        appName: "MyApp",
+      }).parseResponse(response);
+
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      expect(result).toEqual({
+        data: {
+          storageSize: 1,
+          storageVersion: "1",
+          hasSettings: true,
+          hasData: true,
+          storageHash:
+            "0000000000000000000000000000000000000000000000000000000000000001",
+        },
+        status: "SUCCESS",
+      });
+    });
+
+    it("should return correct app storage info when app storage size is 0", () => {
+      // ARRANGE
+      const statusCode = Uint8Array.from([0x90, 0x00]);
+      const response = new ApduResponse({
+        statusCode,
+        data: Uint8Array.from([
+          // appStorageSize (32-bit BE) = 0
+          0x00, 0x00, 0x00, 0x00,
+        ]),
+      });
+
+      // ACT
+      const result = new GetAppStorageInfoCommand({
+        appName: "MyApp",
+      }).parseResponse(response);
+
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      expect(result).toEqual({
+        data: {
+          storageSize: 0,
+          storageVersion: "",
+          hasSettings: false,
+          hasData: false,
+          storageHash: "",
+        },
+        status: "SUCCESS",
+      });
+    });
+  });
+
+  describe("Error response", () => {
+    it.each([
+      {
+        description: "application is not found",
+        statusCode: [0x51, 0x23],
+        expectedMessage: "Application not found.",
+      },
+      {
+        description: "device is in recovery mode",
+        statusCode: [0x66, 0x2f],
+        expectedMessage: "Device is in recovery mode.",
+      },
+      {
+        description: "application name length is invalid",
+        statusCode: [0x67, 0x0a],
+        expectedMessage: "Invalid application name length, two chars minimum.",
+      },
+      {
+        description:
+          "error code is not specific to GetAppStorageInfoCommand (global error)",
+        statusCode: [0x55, 0x15],
+        expectedMessage: "Device is locked.",
+      },
+    ])(
+      "should return error when $description",
+      ({ statusCode, expectedMessage }) => {
+        // ARRANGE
+        const response = new ApduResponse({
+          statusCode: Uint8Array.from(statusCode),
+          data: new Uint8Array([]),
+        });
+
+        // ACT
+        const result = new GetAppStorageInfoCommand({
+          appName: "MyApp",
+        }).parseResponse(response);
+
+        // ASSERT
+        expect(isSuccessCommandResult(result)).toBe(false);
+        expect((result as unknown as { error: Error }).error.message).toBe(
+          expectedMessage,
+        );
+      },
+    );
+
+    it.each([
+      {
+        description: "app storage size extraction fails",
+        data: new Uint8Array([]),
+        expectedOriginalMessage: "Failed to extract app storage size",
+      },
+      {
+        description: "app storage version extraction fails",
+        data: Uint8Array.from([0x00, 0x00, 0x00, 0x01]),
+        expectedOriginalMessage: "Failed to extract app storage version",
+      },
+      {
+        description: "app storage properties extraction fails",
+        data: Uint8Array.from([0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01]),
+        expectedOriginalMessage: "Failed to extract app storage properties",
+      },
+    ])(
+      "should return error when $description",
+      ({ data, expectedOriginalMessage }) => {
+        // ARRANGE
+        const response = new ApduResponse({
+          statusCode: Uint8Array.from([0x90, 0x00]),
+          data,
+        });
+
+        // ACT
+        const result = new GetAppStorageInfoCommand({
+          appName: "MyApp",
+        }).parseResponse(response);
+
+        // ASSERT
+        expect(isSuccessCommandResult(result)).toBe(false);
+        expect(
+          (result as unknown as { error: InvalidStatusWordError }).error,
+        ).toBeInstanceOf(InvalidStatusWordError);
+        expect(
+          (result as unknown as { error: InvalidStatusWordError }).error
+            .originalError?.message,
+        ).toBe(expectedOriginalMessage);
+      },
+    );
+  });
+});

--- a/packages/device-management-kit/src/api/command/os/GetAppStorageInfoCommand.ts
+++ b/packages/device-management-kit/src/api/command/os/GetAppStorageInfoCommand.ts
@@ -1,0 +1,141 @@
+import { type Apdu } from "@api/apdu/model/Apdu";
+import { ApduBuilder } from "@api/apdu/utils/ApduBuilder";
+import { ApduParser } from "@api/apdu/utils/ApduParser";
+import { type Command } from "@api/command/Command";
+import { InvalidStatusWordError } from "@api/command/Errors";
+import {
+  type CommandResult,
+  CommandResultFactory,
+} from "@api/command/model/CommandResult";
+import { isCommandErrorCode } from "@api/command/utils/CommandErrors";
+import { type CommandErrors } from "@api/command/utils/CommandErrors";
+import { CommandUtils } from "@api/command/utils/CommandUtils";
+import { GlobalCommandErrorHandler } from "@api/command/utils/GlobalCommandError";
+import { type ApduResponse } from "@api/device-session/ApduResponse";
+import { type CommandErrorArgs, DeviceExchangeError } from "@api/Error";
+
+export type GetAppStorageInfoCommandArgs = {
+  appName: string;
+};
+
+export type GetAppStorageInfoCommandResponse = {
+  storageSize: number;
+  storageVersion: string;
+  hasSettings: boolean;
+  hasData: boolean;
+  storageHash: string;
+};
+
+export type GetAppStorageInfoCommandErrorCodes = "5123" | "662f" | "670a";
+
+export const GET_APP_STORAGE_INFO_ERRORS: CommandErrors<GetAppStorageInfoCommandErrorCodes> =
+  {
+    "5123": { message: "Application not found." },
+    "662f": { message: "Device is in recovery mode." },
+    "670a": { message: "Invalid application name length, two chars minimum." },
+  };
+
+export class GetAppStorageInfoCommandError extends DeviceExchangeError<GetAppStorageInfoCommandErrorCodes> {
+  constructor(args: CommandErrorArgs<GetAppStorageInfoCommandErrorCodes>) {
+    super({ tag: "GetAppStorageInfoCommandError", ...args });
+  }
+}
+
+export type GetAppStorageInfoCommandResult = CommandResult<
+  GetAppStorageInfoCommandResponse,
+  GetAppStorageInfoCommandErrorCodes
+>;
+
+export class GetAppStorageInfoCommand
+  implements
+    Command<
+      GetAppStorageInfoCommandResponse,
+      GetAppStorageInfoCommandArgs,
+      GetAppStorageInfoCommandErrorCodes
+    >
+{
+  readonly name = "GetAppStorageInfo";
+
+  private readonly header = {
+    cla: 0xe0,
+    ins: 0x6a,
+    p1: 0x00,
+    p2: 0x00,
+  };
+
+  constructor(private readonly args: GetAppStorageInfoCommandArgs) {}
+
+  getApdu(): Apdu {
+    const { appName } = this.args;
+    return new ApduBuilder(this.header).addAsciiStringToData(appName).build();
+  }
+
+  parseResponse(apduResponse: ApduResponse): GetAppStorageInfoCommandResult {
+    const parser = new ApduParser(apduResponse);
+    if (!CommandUtils.isSuccessResponse(apduResponse)) {
+      const errorCode = parser.encodeToHexaString(apduResponse.statusCode);
+      if (isCommandErrorCode(errorCode, GET_APP_STORAGE_INFO_ERRORS)) {
+        return CommandResultFactory({
+          error: new GetAppStorageInfoCommandError({
+            ...GET_APP_STORAGE_INFO_ERRORS[errorCode],
+            errorCode,
+          }),
+        });
+      }
+      return CommandResultFactory({
+        error: GlobalCommandErrorHandler.handle(apduResponse),
+      });
+    }
+
+    const appStorageSize = parser.extract32BitUInt();
+    if (appStorageSize === undefined) {
+      return CommandResultFactory({
+        error: new InvalidStatusWordError("Failed to extract app storage size"),
+      });
+    }
+
+    let appStorageVersion = "";
+    let hasAppStorageSettings = false;
+    let hasAppStorageData = false;
+    let hash = "";
+
+    if (appStorageSize !== 0) {
+      const appStorageVersionNumber = parser.extract32BitUInt();
+      if (appStorageVersionNumber === undefined) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            "Failed to extract app storage version",
+          ),
+        });
+      }
+      appStorageVersion = appStorageVersionNumber.toString(16);
+      /**
+       * The properties byte is a bitfield with the following structure:
+       * - Bit 0: hasSettings
+       * - Bit 1: hasData
+       */
+      const appStorageProperties = parser.extract16BitUInt();
+      if (appStorageProperties === undefined) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            "Failed to extract app storage properties",
+          ),
+        });
+      }
+
+      hasAppStorageSettings = (appStorageProperties & 1) === 1;
+      hasAppStorageData = (appStorageProperties & 2) === 2;
+      hash = parser.encodeToHexaString(parser.extractFieldByLength(0x20));
+    }
+
+    return CommandResultFactory({
+      data: {
+        storageSize: appStorageSize,
+        storageVersion: appStorageVersion,
+        hasSettings: hasAppStorageSettings,
+        hasData: hasAppStorageData,
+        storageHash: hash,
+      },
+    });
+  }
+}

--- a/packages/device-management-kit/src/api/device-action/task/BackupAppStorageTask.test.ts
+++ b/packages/device-management-kit/src/api/device-action/task/BackupAppStorageTask.test.ts
@@ -1,0 +1,140 @@
+import { BackupStorageCommandError } from "@api/command/os/BackupStorageCommand";
+import { GetAppStorageInfoCommandError } from "@api/command/os/GetAppStorageInfoCommand";
+import { type InternalApi } from "@api/device-action/DeviceAction";
+import {
+  BackupAppStorageTask,
+  type BackupAppStorageTaskResponse,
+} from "@api/device-action/task/BackupAppStorageTask";
+import { CommandResultFactory, isSuccessCommandResult } from "@api/index";
+import { type LoggerPublisherService } from "@api/logger-publisher/service/LoggerPublisherService";
+
+describe("BackupAppStorageTask", () => {
+  let api: InternalApi;
+  let logger: LoggerPublisherService;
+  const sendCommand = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api = {
+      sendCommand,
+    } as unknown as InternalApi;
+    logger = {
+      debug: vi.fn(),
+    } as unknown as LoggerPublisherService;
+  });
+
+  describe("Success", () => {
+    it("should backup app storage data successfully", async () => {
+      // ARRANGE
+      const task = new BackupAppStorageTask(
+        {
+          appName: "MyApp",
+        },
+        api,
+        logger,
+      );
+
+      sendCommand
+        .mockResolvedValueOnce(
+          CommandResultFactory({ data: { storageSize: 15 } }),
+        )
+        .mockResolvedValueOnce(
+          CommandResultFactory({
+            data: {
+              chunkData: new Uint8Array([0x01, 0x23, 0x45, 0x67, 0x89]),
+              chunkSize: 5,
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          CommandResultFactory({
+            data: {
+              chunkData: new Uint8Array([0x0a, 0x0b, 0x0c, 0x0d, 0x0e]),
+              chunkSize: 5,
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          CommandResultFactory({
+            data: {
+              chunkData: new Uint8Array([0x0f, 0x10, 0x11, 0x12, 0x13]),
+              chunkSize: 5,
+            },
+          }),
+        );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      expect(
+        (result as { data: BackupAppStorageTaskResponse }).data.appStorageData,
+      ).toBe("0x01234567890a0b0c0d0e0f10111213");
+    });
+  });
+
+  describe("Error", () => {
+    it("should return error when getting app storage info fails", async () => {
+      // ARRANGE
+      const task = new BackupAppStorageTask(
+        {
+          appName: "MyApp",
+        },
+        api,
+        logger,
+      );
+
+      sendCommand.mockResolvedValueOnce(
+        CommandResultFactory({
+          error: new GetAppStorageInfoCommandError({
+            message: "Application not found.",
+            errorCode: "5123",
+          }),
+        }),
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(result.status).toBe("ERROR");
+    });
+
+    it("should return error when backing up app storage data fails", async () => {
+      // ARRANGE
+      const task = new BackupAppStorageTask(
+        {
+          appName: "MyApp",
+        },
+        api,
+        logger,
+      );
+
+      sendCommand
+        .mockResolvedValueOnce(
+          CommandResultFactory({ data: { storageSize: 100 } }),
+        )
+        .mockResolvedValueOnce(
+          CommandResultFactory({
+            error: new BackupStorageCommandError({
+              message: "Failed to backup app storage data.",
+              errorCode: "541c",
+            }),
+          }),
+        );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      expect(
+        (result as { error: BackupStorageCommandError }).error,
+      ).toBeInstanceOf(BackupStorageCommandError);
+      expect(
+        (result as { error: BackupStorageCommandError }).error.message,
+      ).toBe("Failed to backup app storage data.");
+    });
+  });
+});

--- a/packages/device-management-kit/src/api/device-action/task/BackupAppStorageTask.ts
+++ b/packages/device-management-kit/src/api/device-action/task/BackupAppStorageTask.ts
@@ -1,0 +1,97 @@
+import {
+  type CommandResult,
+  CommandResultFactory,
+  isSuccessCommandResult,
+} from "@api/command/model/CommandResult";
+import {
+  BackupStorageCommand,
+  type BackupStorageCommandErrorCodes,
+} from "@api/command/os/BackupStorageCommand";
+import {
+  GetAppStorageInfoCommand,
+  type GetAppStorageInfoCommandErrorCodes,
+} from "@api/command/os/GetAppStorageInfoCommand";
+import { type InternalApi } from "@api/device-action/DeviceAction";
+import { type LoggerPublisherService } from "@api/logger-publisher/service/LoggerPublisherService";
+import { bufferToHexaString, type HexaString } from "@api/utils/HexaString";
+
+type BackupAppStorageTaskArgs = {
+  appName: string;
+};
+
+export type BackupAppStorageTaskResponse = {
+  appStorageData: HexaString;
+};
+
+export type BackupAppStorageTaskErrorCodes =
+  | GetAppStorageInfoCommandErrorCodes
+  | BackupStorageCommandErrorCodes;
+
+export class BackupAppStorageTask {
+  constructor(
+    private readonly args: BackupAppStorageTaskArgs,
+    private readonly api: InternalApi,
+    private readonly logger: LoggerPublisherService,
+  ) {}
+
+  public async run(): Promise<
+    CommandResult<BackupAppStorageTaskResponse, BackupAppStorageTaskErrorCodes>
+  > {
+    this.logger.debug("[run] Starting BackupAppStorageTask", {
+      data: {
+        appName: this.args.appName,
+      },
+    });
+
+    const { appName } = this.args;
+
+    const getAppStorageInfo = await this.api.sendCommand(
+      new GetAppStorageInfoCommand({
+        appName,
+      }),
+    );
+
+    if (!isSuccessCommandResult(getAppStorageInfo)) {
+      this.logger.debug("[run] Failed to get app storage info", {
+        data: { error: getAppStorageInfo.error },
+      });
+      return getAppStorageInfo;
+    }
+
+    const { storageSize } = getAppStorageInfo.data;
+    let offset = 0;
+    let appStorageDataBytes = new Uint8Array(0);
+
+    while (offset < storageSize) {
+      const backupStorage = await this.api.sendCommand(
+        new BackupStorageCommand(),
+      );
+      if (!isSuccessCommandResult(backupStorage)) {
+        this.logger.debug("[run] Failed to backup app storage", {
+          data: { error: backupStorage.error },
+        });
+        return backupStorage;
+      }
+
+      const { chunkData, chunkSize } = backupStorage.data;
+      appStorageDataBytes = Uint8Array.from([
+        ...appStorageDataBytes,
+        ...chunkData,
+      ]);
+      offset += chunkSize;
+    }
+
+    const appStorageData = bufferToHexaString(appStorageDataBytes);
+    this.logger.debug("[run] App storage data backed up successfully", {
+      data: {
+        appStorageData,
+      },
+    });
+
+    return CommandResultFactory({
+      data: {
+        appStorageData,
+      },
+    });
+  }
+}

--- a/packages/device-management-kit/src/api/index.ts
+++ b/packages/device-management-kit/src/api/index.ts
@@ -17,11 +17,24 @@ export {
   CommandResultStatus,
   isSuccessCommandResult,
 } from "@api/command/model/CommandResult";
+export {
+  BackupStorageCommand,
+  type BackupStorageCommandErrorCodes,
+  type BackupStorageCommandResponse,
+  type BackupStorageCommandResult,
+} from "@api/command/os/BackupStorageCommand";
 export { CloseAppCommand } from "@api/command/os/CloseAppCommand";
 export {
   GetAppAndVersionCommand,
   type GetAppAndVersionResponse,
 } from "@api/command/os/GetAppAndVersionCommand";
+export {
+  GetAppStorageInfoCommand,
+  type GetAppStorageInfoCommandArgs,
+  type GetAppStorageInfoCommandErrorCodes,
+  type GetAppStorageInfoCommandResponse,
+  type GetAppStorageInfoCommandResult,
+} from "@api/command/os/GetAppStorageInfoCommand";
 export {
   GetBackgroundImageSizeCommand,
   GetBackgroundImageSizeCommandError,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add the `BackupAppStorageTask` which enables backing up encrypted app storage data from a Ledger device. This is part of the OS update flow where app data must be preserved before a firmware upgrade (see the [OS update backup study](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6898450536/OS+Update+migration+to+DMK+Backup+Step)): 

The implementation introduces two new APDU commands and a task that orchestrates them:

- **`GetAppStorageInfoCommand`** (`0xE0 0x6A`) — Queries the device for app storage metadata (size, version, settings/data flags, hash) given an app name.
- **`BackupStorageCommand`** (`0xE0 0x6B`) — Reads encrypted app storage data one chunk at a time.
- **`BackupAppStorageTask`** — Orchestrates the full backup: first retrieves storage info to determine total size, then iteratively reads chunks until all data is collected, returning the concatenated result as a hex string.

Both commands include comprehensive error handling with typed error codes covering invalid context, crypto failures, recovery mode, and invalid backup state scenarios.

The commands are also available in the sample app for manual testing.*

**Result:**

https://github.com/user-attachments/assets/6eff762b-c71d-4aa2-a721-bafb2e93817f

*You will need to install `Boilerplate` app (`v2.2.0-dev`) from Ledger Wallet app, in **developer mode**, with custom provider set to `16`, with a `Ledger Flex` and OS version at `1.5.1`. This app has been created by OS team for test purposes, with a fake storage of 1044 bytes. 

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1095](https://ledgerhq.atlassian.net/browse/DSDK-1095)

- **Feature**: Backup app storage task for the OS update flow

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** — Unit tests for both commands and the task
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - New `GetAppStorageInfoCommand` for querying app storage metadata
  - New `BackupStorageCommand` for reading encrypted storage chunks
  - New `BackupAppStorageTask` orchestrating the backup flow
  - New error types: `GetAppStorageInfoCommandError`, `BackupStorageCommandError`, `BackupAppStorageTaskErrorCodes`
  - New model types: `AppStorageInfo`, `AppStorageChunkData`, `AppStorageData`
  - Sample app integration for manual testing

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[DSDK-1095]: https://ledgerhq.atlassian.net/browse/DSDK-1095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ