### PR TITLE
✨ (context-module) [LIVE-26528]: Add account ownership context loader for concordium address verification

### DIFF
--- a/.changeset/nasty-ideas-turn.md
+++ b/.changeset/nasty-ideas-turn.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/context-module": minor
+"@ledgerhq/device-signer-kit-ethereum": minor
+---
+
+Add AccountOwnership context loader for Concordium on-device address verification via trusted metadata service

--- a/packages/signer/context-module/src/DefaultContextModule.ts
+++ b/packages/signer/context-module/src/DefaultContextModule.ts
@@ -1,6 +1,7 @@
 import { type Container } from "inversify";
 import { Left } from "purify-ts";
 
+import { accountOwnershipTypes } from "@/account-ownership/di/accountOwnershipTypes";
 import { calldataTypes } from "@/calldata/di/calldataTypes";
 import { dynamicNetworkTypes } from "@/dynamic-network/di/dynamicNetworkTypes";
 import { type BlindSigningReportParams } from "@/reporter/data/BlindSigningReporterDatasource";
@@ -79,6 +80,9 @@ export class DefaultContextModule implements ContextModule {
 
   private _getDefaultLoaders(): ContextLoader<unknown>[] {
     return [
+      this._container.get<ContextLoader>(
+        accountOwnershipTypes.AccountOwnershipContextLoader,
+      ),
       this._container.get<ContextLoader>(
         externalPluginTypes.ExternalPluginContextLoader,
       ),

--- a/packages/signer/context-module/src/account-ownership/data/AccountOwnershipDataSource.ts
+++ b/packages/signer/context-module/src/account-ownership/data/AccountOwnershipDataSource.ts
@@ -1,0 +1,22 @@
+import { type Either } from "purify-ts";
+
+export type AccountOwnershipNetwork = "mainnet" | "testnet";
+
+export type GetAccountOwnershipParams = {
+  publicKey: string;
+  address: string;
+  challenge: string;
+  network: AccountOwnershipNetwork;
+};
+
+export type AccountOwnershipDescriptor = {
+  signedDescriptor: string;
+  keyId: string;
+  keyUsage: string;
+};
+
+export interface AccountOwnershipDataSource {
+  getDescriptor(
+    params: GetAccountOwnershipParams,
+  ): Promise<Either<Error, AccountOwnershipDescriptor>>;
+}

--- a/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.test.ts
+++ b/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.test.ts
@@ -1,0 +1,314 @@
+import axios from "axios";
+import { Left, Right } from "purify-ts";
+
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
+import {
+  LEDGER_CLIENT_VERSION_HEADER,
+  LEDGER_ORIGIN_TOKEN_HEADER,
+} from "@/shared/constant/HttpHeaders";
+import PACKAGE from "@root/package.json";
+
+import { HttpAccountOwnershipDataSource } from "./HttpAccountOwnershipDataSource";
+
+vi.mock("axios");
+
+describe("HttpAccountOwnershipDataSource", () => {
+  const config: ContextModuleServiceConfig = {
+    metadataServiceDomain: {
+      url: "https://nft.api.live.ledger-test.com",
+    },
+    originToken: "test-origin-token",
+  } as ContextModuleServiceConfig;
+
+  const validDto = {
+    signedDescriptor: "signed-descriptor-data",
+    keyId: "domain_metadata_key",
+    keyUsage: "trusted_name",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getDescriptor", () => {
+    it("should return descriptor on successful request", async () => {
+      // GIVEN
+      const params = {
+        publicKey: "abcdef1234567890",
+        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
+        challenge: "0xabcdef",
+        network: "mainnet" as const,
+      };
+      vi.spyOn(axios, "request").mockResolvedValue({
+        status: 200,
+        data: validDto,
+      });
+
+      // WHEN
+      const result = await new HttpAccountOwnershipDataSource(
+        config,
+      ).getDescriptor(params);
+
+      // THEN
+      expect(axios.request).toHaveBeenCalledWith({
+        method: "GET",
+        url: "https://nft.api.live.ledger-test.com/v2/concordium/owner/abcdef1234567890/3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
+        params: {
+          challenge: "0xabcdef",
+          network: "mainnet",
+        },
+        headers: {
+          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+          [LEDGER_ORIGIN_TOKEN_HEADER]: "test-origin-token",
+        },
+      });
+      expect(result).toEqual(
+        Right({
+          signedDescriptor: "signed-descriptor-data",
+          keyId: "domain_metadata_key",
+          keyUsage: "trusted_name",
+        }),
+      );
+    });
+
+    it("should pass testnet network parameter", async () => {
+      // GIVEN
+      const params = {
+        publicKey: "abcdef1234567890",
+        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
+        challenge: "0xabcdef",
+        network: "testnet" as const,
+      };
+      vi.spyOn(axios, "request").mockResolvedValue({
+        status: 200,
+        data: validDto,
+      });
+
+      // WHEN
+      await new HttpAccountOwnershipDataSource(config).getDescriptor(params);
+
+      // THEN
+      expect(axios.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: {
+            challenge: "0xabcdef",
+            network: "testnet",
+          },
+        }),
+      );
+    });
+
+    it("should return error when response data is empty", async () => {
+      // GIVEN
+      const params = {
+        publicKey: "abcdef1234567890",
+        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
+        challenge: "0xabcdef",
+        network: "mainnet" as const,
+      };
+      vi.spyOn(axios, "request").mockResolvedValue({
+        status: 200,
+        data: null,
+      });
+
+      // WHEN
+      const result = await new HttpAccountOwnershipDataSource(
+        config,
+      ).getDescriptor(params);
+
+      // THEN
+      expect(result).toEqual(
+        Left(
+          new Error(
+            "[ContextModule] HttpAccountOwnershipDataSource: unexpected empty response",
+          ),
+        ),
+      );
+    });
+
+    it("should return error when signedDescriptor is missing", async () => {
+      // GIVEN
+      const params = {
+        publicKey: "abcdef1234567890",
+        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
+        challenge: "0xabcdef",
+        network: "mainnet" as const,
+      };
+      vi.spyOn(axios, "request").mockResolvedValue({
+        status: 200,
+        data: {
+          keyId: "domain_metadata_key",
+          keyUsage: "trusted_name",
+        },
+      });
+
+      // WHEN
+      const result = await new HttpAccountOwnershipDataSource(
+        config,
+      ).getDescriptor(params);
+
+      // THEN
+      expect(result).toEqual(
+        Left(
+          new Error(
+            "[ContextModule] HttpAccountOwnershipDataSource: invalid response format",
+          ),
+        ),
+      );
+    });
+
+    it("should return error when keyId is missing", async () => {
+      // GIVEN
+      const params = {
+        publicKey: "abcdef1234567890",
+        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
+        challenge: "0xabcdef",
+        network: "mainnet" as const,
+      };
+      vi.spyOn(axios, "request").mockResolvedValue({
+        status: 200,
+        data: {
+          signedDescriptor: "signed-descriptor-data",
+          keyUsage: "trusted_name",
+        },
+      });
+
+      // WHEN
+      const result = await new HttpAccountOwnershipDataSource(
+        config,
+      ).getDescriptor(params);
+
+      // THEN
+      expect(result).toEqual(
+        Left(
+          new Error(
+            "[ContextModule] HttpAccountOwnershipDataSource: invalid response format",
+          ),
+        ),
+      );
+    });
+
+    it("should return error when keyUsage is missing", async () => {
+      // GIVEN
+      const params = {
+        publicKey: "abcdef1234567890",
+        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
+        challenge: "0xabcdef",
+        network: "mainnet" as const,
+      };
+      vi.spyOn(axios, "request").mockResolvedValue({
+        status: 200,
+        data: {
+          signedDescriptor: "signed-descriptor-data",
+          keyId: "domain_metadata_key",
+        },
+      });
+
+      // WHEN
+      const result = await new HttpAccountOwnershipDataSource(
+        config,
+      ).getDescriptor(params);
+
+      // THEN
+      expect(result).toEqual(
+        Left(
+          new Error(
+            "[ContextModule] HttpAccountOwnershipDataSource: invalid response format",
+          ),
+        ),
+      );
+    });
+
+    it("should return error when field has wrong type", async () => {
+      // GIVEN
+      const params = {
+        publicKey: "abcdef1234567890",
+        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
+        challenge: "0xabcdef",
+        network: "mainnet" as const,
+      };
+      vi.spyOn(axios, "request").mockResolvedValue({
+        status: 200,
+        data: {
+          signedDescriptor: "signed-descriptor-data",
+          keyId: 123,
+          keyUsage: "trusted_name",
+        },
+      });
+
+      // WHEN
+      const result = await new HttpAccountOwnershipDataSource(
+        config,
+      ).getDescriptor(params);
+
+      // THEN
+      expect(result).toEqual(
+        Left(
+          new Error(
+            "[ContextModule] HttpAccountOwnershipDataSource: invalid response format",
+          ),
+        ),
+      );
+    });
+
+    it("should return error when axios request fails", async () => {
+      // GIVEN
+      const params = {
+        publicKey: "abcdef1234567890",
+        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
+        challenge: "0xabcdef",
+        network: "mainnet" as const,
+      };
+      vi.spyOn(axios, "request").mockRejectedValue(new Error("Network error"));
+
+      // WHEN
+      const result = await new HttpAccountOwnershipDataSource(
+        config,
+      ).getDescriptor(params);
+
+      // THEN
+      expect(result).toEqual(
+        Left(
+          new Error(
+            "[ContextModule] HttpAccountOwnershipDataSource: Failed to fetch account ownership descriptor",
+          ),
+        ),
+      );
+    });
+
+    it("should use correct metadata service URL from config", async () => {
+      // GIVEN
+      const customConfig: ContextModuleServiceConfig = {
+        metadataServiceDomain: {
+          url: "https://custom-metadata.example.com",
+        },
+        originToken: "custom-token",
+      } as ContextModuleServiceConfig;
+      const params = {
+        publicKey: "abcdef1234567890",
+        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
+        challenge: "0xabcdef",
+        network: "mainnet" as const,
+      };
+      vi.spyOn(axios, "request").mockResolvedValue({
+        status: 200,
+        data: validDto,
+      });
+
+      // WHEN
+      await new HttpAccountOwnershipDataSource(customConfig).getDescriptor(
+        params,
+      );
+
+      // THEN
+      expect(axios.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://custom-metadata.example.com/v2/concordium/owner/abcdef1234567890/3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
+          headers: expect.objectContaining({
+            [LEDGER_ORIGIN_TOKEN_HEADER]: "custom-token",
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.ts
+++ b/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.ts
@@ -1,0 +1,92 @@
+import axios from "axios";
+import { inject, injectable } from "inversify";
+import { type Either, Left, Right } from "purify-ts";
+
+import {
+  type AccountOwnershipDataSource,
+  type AccountOwnershipDescriptor,
+  type GetAccountOwnershipParams,
+} from "@/account-ownership/data/AccountOwnershipDataSource";
+import { type AccountOwnershipDto } from "@/account-ownership/data/dto/AccountOwnershipDto";
+import { configTypes } from "@/config/di/configTypes";
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
+import {
+  LEDGER_CLIENT_VERSION_HEADER,
+  LEDGER_ORIGIN_TOKEN_HEADER,
+} from "@/shared/constant/HttpHeaders";
+import PACKAGE from "@root/package.json";
+
+@injectable()
+export class HttpAccountOwnershipDataSource
+  implements AccountOwnershipDataSource
+{
+  constructor(
+    @inject(configTypes.Config)
+    private readonly config: ContextModuleServiceConfig,
+  ) {}
+
+  async getDescriptor({
+    publicKey,
+    address,
+    challenge,
+    network,
+  }: GetAccountOwnershipParams): Promise<
+    Either<Error, AccountOwnershipDescriptor>
+  > {
+    try {
+      const response = await axios.request<AccountOwnershipDto>({
+        method: "GET",
+        url: `${this.config.metadataServiceDomain.url}/v2/concordium/owner/${publicKey}/${address}`,
+        params: {
+          challenge,
+          network,
+        },
+        headers: {
+          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+          [LEDGER_ORIGIN_TOKEN_HEADER]: this.config.originToken,
+        },
+      });
+
+      if (!response.data) {
+        return Left(
+          new Error(
+            "[ContextModule] HttpAccountOwnershipDataSource: unexpected empty response",
+          ),
+        );
+      }
+
+      if (!this.isAccountOwnershipDto(response.data)) {
+        return Left(
+          new Error(
+            "[ContextModule] HttpAccountOwnershipDataSource: invalid response format",
+          ),
+        );
+      }
+
+      return Right({
+        signedDescriptor: response.data.signedDescriptor,
+        keyId: response.data.keyId,
+        keyUsage: response.data.keyUsage,
+      });
+    } catch (_error) {
+      return Left(
+        new Error(
+          "[ContextModule] HttpAccountOwnershipDataSource: Failed to fetch account ownership descriptor",
+        ),
+      );
+    }
+  }
+
+  private isAccountOwnershipDto(value: unknown): value is AccountOwnershipDto {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      "signedDescriptor" in value &&
+      "keyId" in value &&
+      "keyUsage" in value &&
+      typeof value.signedDescriptor === "string" &&
+      typeof value.keyId === "string" &&
+      typeof value.keyUsage === "string"
+    );
+  }
+}

--- a/packages/signer/context-module/src/account-ownership/data/dto/AccountOwnershipDto.ts
+++ b/packages/signer/context-module/src/account-ownership/data/dto/AccountOwnershipDto.ts
@@ -1,0 +1,5 @@
+export type AccountOwnershipDto = {
+  signedDescriptor: string;
+  keyId: string;
+  keyUsage: string;
+};

--- a/packages/signer/context-module/src/account-ownership/di/accountOwnershipModuleFactory.ts
+++ b/packages/signer/context-module/src/account-ownership/di/accountOwnershipModuleFactory.ts
@@ -1,0 +1,16 @@
+import { ContainerModule } from "inversify";
+
+import { HttpAccountOwnershipDataSource } from "@/account-ownership/data/HttpAccountOwnershipDataSource";
+import { AccountOwnershipContextLoader } from "@/account-ownership/domain/AccountOwnershipContextLoader";
+
+import { accountOwnershipTypes } from "./accountOwnershipTypes";
+
+export const accountOwnershipModuleFactory = () =>
+  new ContainerModule(({ bind }) => {
+    bind(accountOwnershipTypes.AccountOwnershipDataSource).to(
+      HttpAccountOwnershipDataSource,
+    );
+    bind(accountOwnershipTypes.AccountOwnershipContextLoader).to(
+      AccountOwnershipContextLoader,
+    );
+  });

--- a/packages/signer/context-module/src/account-ownership/di/accountOwnershipTypes.ts
+++ b/packages/signer/context-module/src/account-ownership/di/accountOwnershipTypes.ts
@@ -1,0 +1,4 @@
+export const accountOwnershipTypes = {
+  AccountOwnershipDataSource: Symbol.for("AccountOwnershipDataSource"),
+  AccountOwnershipContextLoader: Symbol.for("AccountOwnershipContextLoader"),
+};

--- a/packages/signer/context-module/src/account-ownership/domain/AccountOwnershipContextLoader.test.ts
+++ b/packages/signer/context-module/src/account-ownership/domain/AccountOwnershipContextLoader.test.ts
@@ -1,0 +1,278 @@
+import { DeviceModelId } from "@ledgerhq/device-management-kit";
+import { Left, Right } from "purify-ts";
+
+import type {
+  AccountOwnershipDataSource,
+  AccountOwnershipDescriptor,
+} from "@/account-ownership/data/AccountOwnershipDataSource";
+import {
+  type AccountOwnershipContextInput,
+  AccountOwnershipContextLoader,
+} from "@/account-ownership/domain/AccountOwnershipContextLoader";
+import { type PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
+import { type PkiCertificate } from "@/pki/model/PkiCertificate";
+import {
+  type ClearSignContextSuccess,
+  ClearSignContextType,
+} from "@/shared/model/ClearSignContext";
+
+describe("AccountOwnershipContextLoader", () => {
+  const mockDataSource: AccountOwnershipDataSource = {
+    getDescriptor: vi.fn(),
+  };
+  const mockPkiCertificateLoader: PkiCertificateLoader = {
+    loadCertificate: vi.fn(),
+  };
+  const loader = new AccountOwnershipContextLoader(
+    mockDataSource,
+    mockPkiCertificateLoader,
+  );
+
+  const mockCertificate: PkiCertificate = {
+    keyUsageNumber: 4,
+    payload: new Uint8Array([1, 2, 3]),
+  };
+
+  const mockDescriptor: AccountOwnershipDescriptor = {
+    signedDescriptor: "account-ownership-descriptor-payload",
+    keyId: "domain_metadata_key",
+    keyUsage: "trusted_name",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(mockPkiCertificateLoader, "loadCertificate").mockResolvedValue(
+      mockCertificate,
+    );
+  });
+
+  describe("canHandle", () => {
+    const validInput: AccountOwnershipContextInput = {
+      publicKey: "abcdef1234567890",
+      address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
+      network: "mainnet",
+      deviceModelId: DeviceModelId.FLEX,
+      challenge: "0xabcdef",
+    };
+
+    it("should return true for valid input with ACCOUNT_OWNERSHIP type", () => {
+      expect(
+        loader.canHandle(validInput, [ClearSignContextType.ACCOUNT_OWNERSHIP]),
+      ).toBe(true);
+    });
+
+    it("should return false when expected types include unsupported types", () => {
+      expect(loader.canHandle(validInput, [ClearSignContextType.TOKEN])).toBe(
+        false,
+      );
+      expect(
+        loader.canHandle(validInput, [ClearSignContextType.TRUSTED_NAME]),
+      ).toBe(false);
+    });
+
+    it("should return true when expected types include ACCOUNT_OWNERSHIP among others", () => {
+      expect(
+        loader.canHandle(validInput, [
+          ClearSignContextType.ACCOUNT_OWNERSHIP,
+          ClearSignContextType.TOKEN,
+        ]),
+      ).toBe(true);
+    });
+
+    it.each([
+      [null, "null input"],
+      [undefined, "undefined input"],
+      [{}, "empty object"],
+      ["string", "string input"],
+      [123, "number input"],
+    ])("should return false for %s", (input, _description) => {
+      expect(
+        loader.canHandle(input, [ClearSignContextType.ACCOUNT_OWNERSHIP]),
+      ).toBe(false);
+    });
+
+    it.each([
+      [{ ...validInput, publicKey: undefined }, "missing publicKey"],
+      [{ ...validInput, address: undefined }, "missing address"],
+      [{ ...validInput, network: undefined }, "missing network"],
+      [{ ...validInput, deviceModelId: undefined }, "missing deviceModelId"],
+      [{ ...validInput, challenge: undefined }, "missing challenge"],
+    ])("should return false for %s", (input, _description) => {
+      expect(
+        loader.canHandle(input, [ClearSignContextType.ACCOUNT_OWNERSHIP]),
+      ).toBe(false);
+    });
+
+    it.each([
+      [{ ...validInput, publicKey: "" }, "empty publicKey"],
+      [{ ...validInput, address: "" }, "empty address"],
+      [{ ...validInput, challenge: "" }, "empty challenge"],
+    ])("should return false for %s", (input, _description) => {
+      expect(
+        loader.canHandle(input, [ClearSignContextType.ACCOUNT_OWNERSHIP]),
+      ).toBe(false);
+    });
+
+    it("should return false for invalid network value", () => {
+      expect(
+        loader.canHandle({ ...validInput, network: "devnet" }, [
+          ClearSignContextType.ACCOUNT_OWNERSHIP,
+        ]),
+      ).toBe(false);
+    });
+
+    it("should return true for testnet network", () => {
+      expect(
+        loader.canHandle({ ...validInput, network: "testnet" }, [
+          ClearSignContextType.ACCOUNT_OWNERSHIP,
+        ]),
+      ).toBe(true);
+    });
+
+    it("should return true for different device models", () => {
+      for (const deviceModelId of [
+        DeviceModelId.NANO_S,
+        DeviceModelId.NANO_SP,
+        DeviceModelId.NANO_X,
+        DeviceModelId.STAX,
+        DeviceModelId.FLEX,
+      ]) {
+        expect(
+          loader.canHandle({ ...validInput, deviceModelId }, [
+            ClearSignContextType.ACCOUNT_OWNERSHIP,
+          ]),
+        ).toBe(true);
+      }
+    });
+  });
+
+  describe("load", () => {
+    const input: AccountOwnershipContextInput = {
+      publicKey: "abcdef1234567890",
+      address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
+      network: "mainnet",
+      deviceModelId: DeviceModelId.FLEX,
+      challenge: "0xabcdef",
+    };
+
+    it("should return ACCOUNT_OWNERSHIP context with certificate", async () => {
+      // GIVEN
+      vi.spyOn(mockDataSource, "getDescriptor").mockResolvedValue(
+        Right(mockDescriptor),
+      );
+
+      // WHEN
+      const result = await loader.load(input);
+
+      // THEN
+      expect(mockDataSource.getDescriptor).toHaveBeenCalledWith({
+        publicKey: "abcdef1234567890",
+        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
+        challenge: "0xabcdef",
+        network: "mainnet",
+      });
+      expect(mockPkiCertificateLoader.loadCertificate).toHaveBeenCalledWith({
+        keyId: "domain_metadata_key",
+        keyUsage: "trusted_name",
+        targetDevice: DeviceModelId.FLEX,
+      });
+      expect(result).toEqual([
+        {
+          type: ClearSignContextType.ACCOUNT_OWNERSHIP,
+          payload: "account-ownership-descriptor-payload",
+          certificate: mockCertificate,
+        },
+      ]);
+    });
+
+    it("should return ACCOUNT_OWNERSHIP context without certificate when loadCertificate returns undefined", async () => {
+      // GIVEN
+      vi.spyOn(mockDataSource, "getDescriptor").mockResolvedValue(
+        Right(mockDescriptor),
+      );
+      vi.spyOn(mockPkiCertificateLoader, "loadCertificate").mockResolvedValue(
+        undefined,
+      );
+
+      // WHEN
+      const result = await loader.load(input);
+
+      // THEN
+      expect(result).toEqual([
+        {
+          type: ClearSignContextType.ACCOUNT_OWNERSHIP,
+          payload: "account-ownership-descriptor-payload",
+          certificate: undefined,
+        },
+      ]);
+    });
+
+    it("should return ERROR context when data source returns Left", async () => {
+      // GIVEN
+      const error = new Error("Failed to get descriptor");
+      vi.spyOn(mockDataSource, "getDescriptor").mockResolvedValue(Left(error));
+
+      // WHEN
+      const result = await loader.load(input);
+
+      // THEN
+      expect(result).toEqual([
+        {
+          type: ClearSignContextType.ERROR,
+          error,
+        },
+      ]);
+      expect(mockPkiCertificateLoader.loadCertificate).not.toHaveBeenCalled();
+    });
+
+    it("should pass correct device model to certificate loader", async () => {
+      // GIVEN
+      const inputNanoX = { ...input, deviceModelId: DeviceModelId.NANO_X };
+      vi.spyOn(mockDataSource, "getDescriptor").mockResolvedValue(
+        Right(mockDescriptor),
+      );
+
+      // WHEN
+      await loader.load(inputNanoX);
+
+      // THEN
+      expect(mockPkiCertificateLoader.loadCertificate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetDevice: DeviceModelId.NANO_X,
+        }),
+      );
+    });
+
+    it("should pass testnet network to data source", async () => {
+      // GIVEN
+      const inputTestnet = { ...input, network: "testnet" as const };
+      vi.spyOn(mockDataSource, "getDescriptor").mockResolvedValue(
+        Right(mockDescriptor),
+      );
+
+      // WHEN
+      await loader.load(inputTestnet);
+
+      // THEN
+      expect(mockDataSource.getDescriptor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          network: "testnet",
+        }),
+      );
+    });
+
+    it("should handle long descriptor payloads", async () => {
+      // GIVEN
+      const longPayload = "a".repeat(1000);
+      vi.spyOn(mockDataSource, "getDescriptor").mockResolvedValue(
+        Right({ ...mockDescriptor, signedDescriptor: longPayload }),
+      );
+
+      // WHEN
+      const result = await loader.load(input);
+
+      // THEN
+      expect((result[0] as ClearSignContextSuccess).payload).toBe(longPayload);
+    });
+  });
+});

--- a/packages/signer/context-module/src/account-ownership/domain/AccountOwnershipContextLoader.ts
+++ b/packages/signer/context-module/src/account-ownership/domain/AccountOwnershipContextLoader.ts
@@ -1,0 +1,99 @@
+import { type DeviceModelId } from "@ledgerhq/device-management-kit";
+import { inject, injectable } from "inversify";
+
+import type {
+  AccountOwnershipDataSource,
+  AccountOwnershipNetwork,
+} from "@/account-ownership/data/AccountOwnershipDataSource";
+import { accountOwnershipTypes } from "@/account-ownership/di/accountOwnershipTypes";
+import { pkiTypes } from "@/pki/di/pkiTypes";
+import { type PkiCertificateLoader } from "@/pki/domain/PkiCertificateLoader";
+import { type ContextLoader } from "@/shared/domain/ContextLoader";
+import {
+  type ClearSignContext,
+  ClearSignContextType,
+} from "@/shared/model/ClearSignContext";
+
+export type AccountOwnershipContextInput = {
+  publicKey: string;
+  address: string;
+  network: AccountOwnershipNetwork;
+  deviceModelId: DeviceModelId;
+  challenge: string;
+};
+
+const SUPPORTED_TYPES: ClearSignContextType[] = [
+  ClearSignContextType.ACCOUNT_OWNERSHIP,
+];
+
+@injectable()
+export class AccountOwnershipContextLoader
+  implements ContextLoader<AccountOwnershipContextInput>
+{
+  constructor(
+    @inject(accountOwnershipTypes.AccountOwnershipDataSource)
+    private readonly _dataSource: AccountOwnershipDataSource,
+    @inject(pkiTypes.PkiCertificateLoader)
+    private readonly _certificateLoader: PkiCertificateLoader,
+  ) {}
+
+  canHandle(
+    input: unknown,
+    expectedTypes: ClearSignContextType[],
+  ): input is AccountOwnershipContextInput {
+    return (
+      SUPPORTED_TYPES.every((type) => expectedTypes.includes(type)) &&
+      typeof input === "object" &&
+      input !== null &&
+      "publicKey" in input &&
+      typeof input.publicKey === "string" &&
+      input.publicKey.length > 0 &&
+      "address" in input &&
+      typeof input.address === "string" &&
+      input.address.length > 0 &&
+      "network" in input &&
+      (input.network === "mainnet" || input.network === "testnet") &&
+      "deviceModelId" in input &&
+      input.deviceModelId !== undefined &&
+      "challenge" in input &&
+      typeof input.challenge === "string" &&
+      input.challenge.length > 0
+    );
+  }
+
+  async load({
+    publicKey,
+    address,
+    network,
+    deviceModelId,
+    challenge,
+  }: AccountOwnershipContextInput): Promise<ClearSignContext[]> {
+    const descriptor = await this._dataSource.getDescriptor({
+      publicKey,
+      address,
+      challenge,
+      network,
+    });
+
+    return descriptor.caseOf({
+      Left: (error): Promise<ClearSignContext[]> =>
+        Promise.resolve([
+          {
+            type: ClearSignContextType.ERROR,
+            error,
+          },
+        ]),
+      Right: async (result): Promise<ClearSignContext[]> => [
+        {
+          type: ClearSignContextType.ACCOUNT_OWNERSHIP,
+          payload: result.signedDescriptor,
+          certificate: await this._certificateLoader.loadCertificate({
+            keyId: result.keyId,
+            keyUsage: result.keyUsage,
+            targetDevice: deviceModelId,
+          }),
+        },
+      ],
+    });
+  }
+}

--- a/packages/signer/context-module/src/di.ts
+++ b/packages/signer/context-module/src/di.ts
@@ -1,6 +1,7 @@
 import { type LoggerPublisherService } from "@ledgerhq/device-management-kit";
 import { Container } from "inversify";
 
+import { accountOwnershipModuleFactory } from "@/account-ownership/di/accountOwnershipModuleFactory";
 import { calldataModuleFactory } from "@/calldata/di/calldataModuleFactory";
 import { configModuleFactory } from "@/config/di/configModuleFactory";
 import { configTypes } from "@/config/di/configTypes";
@@ -40,6 +41,7 @@ export const makeContainer = ({ config }: MakeContainerArgs) => {
 
   container.loadSync(
     configModuleFactory(config),
+    accountOwnershipModuleFactory(),
     externalPluginModuleFactory(),
     dynamicNetworkModuleFactory(),
     nftModuleFactory(),

--- a/packages/signer/context-module/src/index.ts
+++ b/packages/signer/context-module/src/index.ts
@@ -1,3 +1,6 @@
+export * from "./account-ownership/data/AccountOwnershipDataSource";
+export * from "./account-ownership/data/HttpAccountOwnershipDataSource";
+export * from "./account-ownership/domain/AccountOwnershipContextLoader";
 export * from "./calldata/data/CalldataDescriptorDataSource";
 export * from "./calldata/data/HttpCalldataDescriptorDataSource";
 export * from "./calldata/domain/CalldataContextLoader";

--- a/packages/signer/context-module/src/shared/model/ClearSignContext.ts
+++ b/packages/signer/context-module/src/shared/model/ClearSignContext.ts
@@ -19,6 +19,7 @@ export enum ClearSignContextType {
   SAFE = "safe",
   SIGNER = "signer",
   GATED_SIGNING = "gatedSigning",
+  ACCOUNT_OWNERSHIP = "accountOwnership",
 }
 
 export enum ClearSignContextReferenceType {

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BuildBaseContexts.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BuildBaseContexts.ts
@@ -200,6 +200,7 @@ export class BuildBaseContexts {
       case ClearSignContextType.ENUM:
       case ClearSignContextType.SAFE:
       case ClearSignContextType.SIGNER:
+      case ClearSignContextType.ACCOUNT_OWNERSHIP:
         return false;
       default: {
         const uncoveredType: never = type;
@@ -228,6 +229,7 @@ export class BuildBaseContexts {
       case ClearSignContextType.EXTERNAL_PLUGIN:
       case ClearSignContextType.SAFE:
       case ClearSignContextType.SIGNER:
+      case ClearSignContextType.ACCOUNT_OWNERSHIP:
         return false;
       default: {
         const uncoveredType: never = type;
@@ -291,6 +293,7 @@ export class BuildBaseContexts {
       /* not used here */
       case ClearSignContextType.SAFE:
       case ClearSignContextType.SIGNER:
+      case ClearSignContextType.ACCOUNT_OWNERSHIP:
         return 90;
 
       default: {

--- a/packages/signer/signer-eth/src/internal/app-binder/task/BuildSubcontextsTask.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/BuildSubcontextsTask.ts
@@ -55,6 +55,7 @@ export class BuildSubcontextsTask {
       case ClearSignContextType.SAFE:
       case ClearSignContextType.SIGNER:
       case ClearSignContextType.GATED_SIGNING:
+      case ClearSignContextType.ACCOUNT_OWNERSHIP:
         return {
           subcontextCallbacks: [],
         };

--- a/packages/signer/signer-eth/src/internal/app-binder/task/ProvideContextTask.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/ProvideContextTask.ts
@@ -218,6 +218,12 @@ export class ProvideContextTask {
               isFirstChunk: args.isFirstChunk,
             }),
         }).run();
+      case ClearSignContextType.ACCOUNT_OWNERSHIP:
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            `The context type [${type}] is not supported by the Ethereum signer`,
+          ),
+        });
       default: {
         const uncoveredType: never = type;
         return CommandResultFactory({

--- a/packages/signer/signer-eth/src/internal/app-binder/task/ProvideEIP712ContextTask.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/ProvideEIP712ContextTask.ts
@@ -393,6 +393,7 @@ export class ProvideEIP712ContextTask {
       case ClearSignContextType.TRANSACTION_FIELD_DESCRIPTION:
       case ClearSignContextType.SAFE:
       case ClearSignContextType.SIGNER:
+      case ClearSignContextType.ACCOUNT_OWNERSHIP:
         throw new Error(
           `Context type ${type} not supported in EIP712 messages`,
         );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Implements the context module layer for the Concordium verify-address flow ([ADR 001](https://ledgerhq.atlassian.net/wiki/spaces/BI/pages/6717210681/Concordium+-+ADR+001+Verify+address+on+device)). Adds a new `ACCOUNT_OWNERSHIP` context type and a loader that queries the trusted metadata service (GET `/v2/concordium/owner/{pubkey}/{address}`) for signed account ownership descriptors, along with PKI certificate loading for device-side verification. This follows the same architecture as the existing Safe module and lays the groundwork for the `signer-concordium`'s verifyAddress implementation in a follow-up PR.

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [LIVE-26528](https://ledgerhq.atlassian.net/browse/LIVE-26528)

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [x] **Impact of the changes:** The ACCOUNT_OWNERSHIP enum addition required mechanical updates to all exhaustive ClearSignContextType switches in signer-eth (ProvideContextTask, BuildBaseContexts, BuildSubcontextsTask, ProvideEIP712ContextTask) — no behavioral change, just adding pass-through/unsupported cases.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[LIVE-26528]: https://ledgerhq.atlassian.net/browse/LIVE-26528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ