### PR TITLE
🐛 (signer-eth) [NO-ISSUE]: Fix duplicate proxy info send in EIP-712 flow

### DIFF
--- a/.changeset/long-flies-try.md
+++ b/.changeset/long-flies-try.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": patch
+---
+
+Fix duplicate PROXY_INFO send in EIP-712 typed data signing that caused a challenge mismatch error on the device

--- a/packages/signer/signer-eth/src/internal/app-binder/task/ProvideEIP712ContextTask.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/ProvideEIP712ContextTask.test.ts
@@ -1088,7 +1088,7 @@ describe("ProvideEIP712ContextTask", () => {
     );
   });
 
-  it("Provide proxy", async () => {
+  it("Provide proxy from clearSignContext when not in additionalContexts", async () => {
     // GIVEN
     const proxy: ClearSignContextSuccess<ClearSignContextType.PROXY_INFO> = {
       type: ClearSignContextType.PROXY_INFO,
@@ -1126,6 +1126,61 @@ describe("ProvideEIP712ContextTask", () => {
     expect(apiMock.sendCommand).toHaveBeenCalledWith(
       new ProvideProxyInfoCommand({
         data: hexaStringToBuffer("0x0003010203")!,
+        isFirstChunk: true,
+      }),
+    );
+  });
+
+  it("Skip duplicate proxy from clearSignContext when already in additionalContexts", async () => {
+    // GIVEN
+    const proxy: ClearSignContextSuccess<ClearSignContextType.PROXY_INFO> = {
+      type: ClearSignContextType.PROXY_INFO,
+      payload: "0x010203",
+    };
+    const additionalProxy: ClearSignContextSuccess<ClearSignContextType.PROXY_INFO> =
+      {
+        type: ClearSignContextType.PROXY_INFO,
+        payload: "0xaabbcc",
+      };
+    const clearSignContext: TypedDataClearSignContextSuccess = {
+      ...TEST_CLEAR_SIGN_CONTEXT,
+      proxy,
+    };
+    const args: ProvideEIP712ContextTaskArgs = {
+      deviceModelId: DeviceModelId.STAX,
+      derivationPath: "44'/60'/0'/0/0",
+      types: TEST_TYPES,
+      domain: TEST_DOMAIN_VALUES,
+      message: TEST_MESSAGE_VALUES,
+      clearSignContext: Just(clearSignContext),
+      calldatasPreContexts: {},
+      calldatasPostContexts: {},
+      additionalContexts: [additionalProxy],
+      loggerFactory: mockLoggerFactory,
+    };
+
+    // WHEN
+    apiMock.sendCommand.mockResolvedValue(
+      CommandResultFactory({ data: { tokenIndex: 4 } }),
+    );
+    await new ProvideEIP712ContextTask(
+      apiMock,
+      contextModuleMock,
+      args,
+      provideContextFactoryMock,
+    ).run();
+
+    // THEN — the clearSignContext proxy (0x010203) should NOT be sent
+    expect(apiMock.sendCommand).not.toHaveBeenCalledWith(
+      new ProvideProxyInfoCommand({
+        data: hexaStringToBuffer("0x0003010203")!,
+        isFirstChunk: true,
+      }),
+    );
+    // — the additionalContexts proxy (0xaabbcc) should have been sent
+    expect(apiMock.sendCommand).toHaveBeenCalledWith(
+      new ProvideProxyInfoCommand({
+        data: hexaStringToBuffer("0x0003aabbcc")!,
         isFirstChunk: true,
       }),
     );

--- a/packages/signer/signer-eth/src/internal/app-binder/task/ProvideEIP712ContextTask.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/ProvideEIP712ContextTask.ts
@@ -137,11 +137,15 @@ export class ProvideEIP712ContextTask {
       await this.provideContext(context);
     }
 
-    // Send proxy descriptor first if required
+    // Send proxy descriptor from clear sign context only if not already
+    // provided via additionalContexts (which uses a fresh challenge).
+    const alreadyProvidedProxy = this.args.additionalContexts.some(
+      (c) => c.type === ClearSignContextType.PROXY_INFO,
+    );
     const proxyContext:
       | ClearSignContextSuccess<ClearSignContextType.PROXY_INFO>
       | undefined = this.args.clearSignContext.extract()?.proxy;
-    if (proxyContext !== undefined) {
+    if (proxyContext !== undefined && !alreadyProvidedProxy) {
       await this.provideContext(proxyContext);
     }
 


### PR DESCRIPTION
### 📝 Description

In the EIP-712 typed data signing flow, the proxy info context was sent to the device **twice**:
1. Once via `additionalContexts` (gated signing flow) — with a valid challenge
2. Once via `clearSignContext.extract()?.proxy` (typed data filters flow) — with a stale challenge

The second send caused a **challenge mismatch error** on the device because it had already rolled to a new challenge after processing the first proxy info.

Both proxy contexts resolve the same verifying contract, so the second send was redundant. This PR removes the duplicate proxy provide block from `ProvideEIP712ContextTask.run()`.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [ ] **Documentation is up-to-date** — No documentation changes needed
- [x] **Impact of the changes:**
  - Removes duplicate `PROVIDE_PROXY_INFO` APDU in EIP-712 typed data signing when gated signing with proxy is active
  - Fixes challenge mismatch error on the device

Made with [Cursor](https://cursor.com)