### PR TITLE
✨ (signer-zcash) [LIVE-28170]: Implement Zcash getAddress command and test coverage

### DIFF
--- a/.changeset/bright-moles-fetch.md
+++ b/.changeset/bright-moles-fetch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-zcash": patch
+---
+
+Add Vitest coverage for GetAddress (command, use case, binder, default signer), wire test scripts, harden GetAddressCommand parsing and Zcash app errors, remove unused GetAddress device-action placeholder. Sample app: use Zcash coin type 133' in default derivation paths.

--- a/apps/sample/src/components/SignerZcashView/index.tsx
+++ b/apps/sample/src/components/SignerZcashView/index.tsx
@@ -66,7 +66,7 @@ export const SignerZcashView: React.FC<{ sessionId: string }> = ({
           });
         },
         initialValues: {
-          derivationPath: "44'/0'/0'/0/0",
+          derivationPath: "44'/133'/0'/0/0",
           checkOnDevice: false,
           skipOpenApp: false,
         },
@@ -106,7 +106,7 @@ export const SignerZcashView: React.FC<{ sessionId: string }> = ({
           });
         },
         initialValues: {
-          derivationPath: "44'/0'/0'/0/0",
+          derivationPath: "44'/133'/0'/0/0",
           transaction: "",
           skipOpenApp: false,
         },
@@ -131,7 +131,7 @@ export const SignerZcashView: React.FC<{ sessionId: string }> = ({
           return signer.signMessage(derivationPath, message);
         },
         initialValues: {
-          derivationPath: "44'/0'/0'/0/0",
+          derivationPath: "44'/133'/0'/0/0",
           message: "Hello World",
         },
         deviceModelId,

--- a/packages/signer/signer-zcash/package.json
+++ b/packages/signer/signer-zcash/package.json
@@ -32,7 +32,10 @@
     "lint:fix": "pnpm lint --fix",
     "prettier": "prettier . --check",
     "prettier:fix": "prettier . --write",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@ledgerhq/signer-utils": "workspace:^",

--- a/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.test.ts
+++ b/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.test.ts
@@ -1,0 +1,29 @@
+import {
+  type DeviceManagementKit,
+  type DeviceSessionId,
+} from "@ledgerhq/device-management-kit";
+import { vi } from "vitest";
+
+import { DefaultSignerZcash } from "./DefaultSignerZcash";
+
+describe("DefaultSignerZcash", () => {
+  it("should be defined", () => {
+    const signer = new DefaultSignerZcash({
+      dmk: {} as DeviceManagementKit,
+      sessionId: {} as DeviceSessionId,
+    });
+    expect(signer).toBeDefined();
+  });
+
+  it("should call getAddress via device action", () => {
+    const dmk = {
+      executeDeviceAction: vi.fn(),
+    } as unknown as DeviceManagementKit;
+    const sessionId = {} as DeviceSessionId;
+    const signer = new DefaultSignerZcash({ dmk, sessionId });
+
+    signer.getAddress("44'/133'/0'/0/0", {});
+
+    expect(dmk.executeDeviceAction).toHaveBeenCalled();
+  });
+});

--- a/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.test.ts
@@ -1,0 +1,138 @@
+import {
+  DeviceActionStatus,
+  type DeviceManagementKit,
+  type DeviceSessionId,
+  type ExecuteDeviceActionReturnType,
+  SendCommandInAppDeviceAction,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+import { from } from "rxjs";
+import { vi } from "vitest";
+
+import {
+  type GetAddressDAError,
+  type GetAddressDAIntermediateValue,
+  type GetAddressDAOutput,
+} from "@api/app-binder/GetAddressDeviceActionTypes";
+import {
+  GetAddressCommand,
+  type GetAddressCommandArgs,
+  type GetAddressCommandResponse,
+} from "@internal/app-binder/command/GetAddressCommand";
+import type { ZcashErrorCodes } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+import { APP_NAME } from "@internal/app-binder/constants";
+import { ZcashAppBinder } from "@internal/app-binder/ZcashAppBinder";
+
+type ZcashGetAddressSendCommandAction = SendCommandInAppDeviceAction<
+  GetAddressCommandResponse,
+  GetAddressCommandArgs,
+  ZcashErrorCodes,
+  UserInteractionRequired.None | UserInteractionRequired.VerifyAddress
+>;
+
+type ExecuteDeviceActionCallArgs = {
+  sessionId: DeviceSessionId;
+  deviceAction: ZcashGetAddressSendCommandAction;
+};
+
+describe("ZcashAppBinder", () => {
+  it("should be defined", () => {
+    const binder = new ZcashAppBinder({} as DeviceManagementKit, "session-id");
+    expect(binder).toBeDefined();
+  });
+
+  describe("getAddress", () => {
+    it("should call dmk.executeDeviceAction with SendCommandInAppDeviceAction and return the result", () => {
+      const sessionId = "test-session-id";
+      const getAddressArgs = {
+        derivationPath: "44'/133'/0'/0/0",
+        checkOnDevice: false,
+        skipOpenApp: false,
+      };
+      const expectedResult: ExecuteDeviceActionReturnType<
+        GetAddressDAOutput,
+        GetAddressDAError,
+        GetAddressDAIntermediateValue
+      > = {
+        observable: from([
+          {
+            status: DeviceActionStatus.Completed as const,
+            output: {
+              publicKey: new Uint8Array([0x01, 0x02]),
+              address: "t1KstBMLLaGcEBGKFxeGqTGmtCNsDE79Ljd",
+              chainCode: new Uint8Array(32).fill(0xcd),
+            },
+          },
+        ]),
+        cancel: vi.fn(),
+      };
+      const executeDeviceActionMock = vi.fn().mockReturnValue(expectedResult);
+      const dmkMock = {
+        executeDeviceAction: executeDeviceActionMock,
+      } as unknown as DeviceManagementKit;
+      const binder = new ZcashAppBinder(dmkMock, sessionId);
+
+      const result = binder.getAddress(getAddressArgs);
+
+      expect(executeDeviceActionMock).toHaveBeenCalledTimes(1);
+      const args = executeDeviceActionMock.mock
+        .calls[0]![0] as ExecuteDeviceActionCallArgs;
+      expect(args.sessionId).toBe(sessionId);
+      expect(args.deviceAction).toBeInstanceOf(SendCommandInAppDeviceAction);
+      expect(args.deviceAction.input.command).toBeInstanceOf(GetAddressCommand);
+      expect(args.deviceAction.input.appName).toBe(APP_NAME);
+      expect(args.deviceAction.input.requiredUserInteraction).toBe(
+        UserInteractionRequired.None,
+      );
+      expect(args.deviceAction.input.skipOpenApp).toBe(false);
+      expect(result).toBe(expectedResult);
+    });
+
+    it("when checkOnDevice is true: UserInteractionRequired.VerifyAddress", () => {
+      const executeDeviceActionMock = vi.fn().mockReturnValue({
+        observable: from([]),
+        cancel: vi.fn(),
+      });
+      const dmkMock = {
+        executeDeviceAction: executeDeviceActionMock,
+      } as unknown as DeviceManagementKit;
+      const binder = new ZcashAppBinder(dmkMock, "sessionId");
+
+      binder.getAddress({
+        derivationPath: "44'/133'/0'/0/0",
+        checkOnDevice: true,
+        skipOpenApp: false,
+      });
+
+      const args = executeDeviceActionMock.mock
+        .calls[0]![0] as ExecuteDeviceActionCallArgs;
+      expect(args.deviceAction.input.requiredUserInteraction).toBe(
+        UserInteractionRequired.VerifyAddress,
+      );
+    });
+
+    it("when checkOnDevice is false: UserInteractionRequired.None", () => {
+      const executeDeviceActionMock = vi.fn().mockReturnValue({
+        observable: from([]),
+        cancel: vi.fn(),
+      });
+      const dmkMock = {
+        executeDeviceAction: executeDeviceActionMock,
+      } as unknown as DeviceManagementKit;
+      const binder = new ZcashAppBinder(dmkMock, "sessionId");
+
+      binder.getAddress({
+        derivationPath: "44'/133'/0'/0/0",
+        checkOnDevice: false,
+        skipOpenApp: true,
+      });
+
+      const args = executeDeviceActionMock.mock
+        .calls[0]![0] as ExecuteDeviceActionCallArgs;
+      expect(args.deviceAction.input.requiredUserInteraction).toBe(
+        UserInteractionRequired.None,
+      );
+      expect(args.deviceAction.input.skipOpenApp).toBe(true);
+    });
+  });
+});

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetAddressCommand.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetAddressCommand.test.ts
@@ -1,0 +1,339 @@
+import {
+  ApduResponse,
+  type InvalidStatusWordError,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { GetAddressCommand } from "@internal/app-binder/command/GetAddressCommand";
+import { type ZcashAppCommandError } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+// Standard Zcash BIP44 path: m/44'/133'/0'/0/0
+// Path elements (BE u32): 0x8000002C, 0x80000085, 0x80000000, 0x00000000, 0x00000000
+const GET_ADDRESS_APDU_NO_DISPLAY = Uint8Array.from([
+  0xe0, // CLA
+  0x40, // INS (GET_WALLET_PUBLIC_KEY)
+  0x00, // P1 (no display)
+  0x00, // P2
+  0x15, // Data length: 1 (path len) + 5*4 (path elements) = 21
+  0x05, // Number of path elements
+  0x80,
+  0x00,
+  0x00,
+  0x2c, // 44'
+  0x80,
+  0x00,
+  0x00,
+  0x85, // 133'
+  0x80,
+  0x00,
+  0x00,
+  0x00, // 0'
+  0x00,
+  0x00,
+  0x00,
+  0x00, // 0
+  0x00,
+  0x00,
+  0x00,
+  0x00, // 0
+]);
+
+const GET_ADDRESS_APDU_WITH_DISPLAY = Uint8Array.from([
+  0xe0, // CLA
+  0x40, // INS
+  0x01, // P1 (display on device)
+  0x00, // P2
+  0x15, // Data length: 21
+  0x05,
+  0x80,
+  0x00,
+  0x00,
+  0x2c,
+  0x80,
+  0x00,
+  0x00,
+  0x85,
+  0x80,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+]);
+
+// m/44'/133'/1'/0/5
+const GET_ADDRESS_APDU_CUSTOM_PATH = Uint8Array.from([
+  0xe0, // CLA
+  0x40, // INS
+  0x00, // P1 (no display)
+  0x00, // P2
+  0x15, // Data length: 21
+  0x05,
+  0x80,
+  0x00,
+  0x00,
+  0x2c, // 44'
+  0x80,
+  0x00,
+  0x00,
+  0x85, // 133'
+  0x80,
+  0x00,
+  0x00,
+  0x01, // 1'
+  0x00,
+  0x00,
+  0x00,
+  0x00, // 0
+  0x00,
+  0x00,
+  0x00,
+  0x05, // 5
+]);
+
+function buildSuccessResponse(
+  publicKey: Uint8Array,
+  address: string,
+  chainCode: Uint8Array,
+): ApduResponse {
+  const addressBytes = new TextEncoder().encode(address);
+  const data = new Uint8Array(
+    1 + publicKey.length + 1 + addressBytes.length + chainCode.length,
+  );
+  let offset = 0;
+
+  data[offset++] = publicKey.length;
+  data.set(publicKey, offset);
+  offset += publicKey.length;
+
+  data[offset++] = addressBytes.length;
+  data.set(addressBytes, offset);
+  offset += addressBytes.length;
+
+  data.set(chainCode, offset);
+
+  return new ApduResponse({
+    statusCode: new Uint8Array([0x90, 0x00]),
+    data,
+  });
+}
+
+describe("GetAddressCommand", () => {
+  const defaultArgs = {
+    derivationPath: "44'/133'/0'/0/0",
+    checkOnDevice: false,
+  };
+
+  describe("name", () => {
+    it("should be 'GetAddress'", () => {
+      const command = new GetAddressCommand(defaultArgs);
+      expect(command.name).toBe("GetAddress");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("should return correct APDU with checkOnDevice false", () => {
+      const command = new GetAddressCommand(defaultArgs);
+      const apdu = command.getApdu();
+      expect(apdu.getRawApdu()).toStrictEqual(GET_ADDRESS_APDU_NO_DISPLAY);
+    });
+
+    it("should return correct APDU with checkOnDevice true", () => {
+      const command = new GetAddressCommand({
+        ...defaultArgs,
+        checkOnDevice: true,
+      });
+      const apdu = command.getApdu();
+      expect(apdu.getRawApdu()).toStrictEqual(GET_ADDRESS_APDU_WITH_DISPLAY);
+    });
+
+    it("should return correct APDU with a custom derivation path", () => {
+      const command = new GetAddressCommand({
+        derivationPath: "44'/133'/1'/0/5",
+        checkOnDevice: false,
+      });
+      const apdu = command.getApdu();
+      expect(apdu.getRawApdu()).toStrictEqual(GET_ADDRESS_APDU_CUSTOM_PATH);
+    });
+  });
+
+  describe("parseResponse", () => {
+    const publicKey = new Uint8Array(65).fill(0xab);
+    const address = "t1KstBMLLaGcEBGKFxeGqTGmtCNsDE79Ljd";
+    const chainCode = new Uint8Array(32).fill(0xcd);
+
+    it("should return publicKey, address, and chainCode on success", () => {
+      const command = new GetAddressCommand(defaultArgs);
+      const response = buildSuccessResponse(publicKey, address, chainCode);
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data.publicKey).toStrictEqual(publicKey);
+        expect(result.data.address).toBe(address);
+        expect(result.data.chainCode).toStrictEqual(chainCode);
+      }
+    });
+
+    it("should return ZcashAppCommandError when user denies", () => {
+      const command = new GetAddressCommand(defaultArgs);
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x69, 0x85]),
+        data: new Uint8Array(0),
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as ZcashAppCommandError;
+        expect(err.errorCode).toBe("6985");
+      }
+    });
+
+    it("should return ZcashAppCommandError for incorrect data", () => {
+      const command = new GetAddressCommand(defaultArgs);
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x6a, 0x80]),
+        data: new Uint8Array(0),
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as ZcashAppCommandError;
+        expect(err.errorCode).toBe("6a80");
+      }
+    });
+
+    it("should return InvalidStatusWordError when response data is empty", () => {
+      const command = new GetAddressCommand(defaultArgs);
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: new Uint8Array(0),
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidStatusWordError;
+        expect((err.originalError as { message: string }).message).toBe(
+          "Public key length is missing",
+        );
+      }
+    });
+
+    it("should return InvalidStatusWordError when public key data is truncated", () => {
+      const command = new GetAddressCommand(defaultArgs);
+      const data = new Uint8Array([0x41, 0x01, 0x02]);
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data,
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidStatusWordError;
+        expect((err.originalError as { message: string }).message).toBe(
+          "Public key is missing",
+        );
+      }
+    });
+
+    it("should return InvalidStatusWordError when address length is missing", () => {
+      const command = new GetAddressCommand(defaultArgs);
+      const data = new Uint8Array(1 + 65);
+      data[0] = 65;
+      data.fill(0xab, 1, 66);
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data,
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidStatusWordError;
+        expect((err.originalError as { message: string }).message).toBe(
+          "Address length is missing",
+        );
+      }
+    });
+
+    it("should return InvalidStatusWordError when address data is truncated", () => {
+      const command = new GetAddressCommand(defaultArgs);
+      const data = new Uint8Array(1 + 65 + 1 + 5);
+      data[0] = 65;
+      data.fill(0xab, 1, 66);
+      data[66] = 35;
+      data.fill(0x61, 67, 72);
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data,
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidStatusWordError;
+        expect((err.originalError as { message: string }).message).toBe(
+          "Address is missing",
+        );
+      }
+    });
+
+    it("should return InvalidStatusWordError when chain code is missing", () => {
+      const command = new GetAddressCommand(defaultArgs);
+      const addrBytes = new TextEncoder().encode(address);
+      const data = new Uint8Array(1 + 65 + 1 + addrBytes.length + 10);
+      let offset = 0;
+      data[offset++] = 65;
+      data.fill(0xab, offset, offset + 65);
+      offset += 65;
+      data[offset++] = addrBytes.length;
+      data.set(addrBytes, offset);
+      offset += addrBytes.length;
+      data.fill(0xcd, offset, offset + 10);
+
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: data.slice(0, offset + 10),
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidStatusWordError;
+        expect((err.originalError as { message: string }).message).toBe(
+          "Chain code is missing",
+        );
+      }
+    });
+
+    it("should handle unknown non-success status code via GlobalCommandErrorHandler", () => {
+      const command = new GetAddressCommand(defaultArgs);
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x55, 0x15]),
+        data: new Uint8Array(0),
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+    });
+  });
+});

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetAddressCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetAddressCommand.ts
@@ -1,11 +1,27 @@
 import {
   type Apdu,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  ApduParser,
   type ApduResponse,
   type Command,
   type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
 } from "@ledgerhq/device-management-kit";
+import {
+  CommandErrorHelper,
+  DerivationPathUtils,
+} from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
 
-import { type ZcashErrorCodes } from "./utils/zcashApplicationErrors";
+import {
+  ZCASH_APP_ERRORS,
+  ZcashAppCommandErrorFactory,
+  type ZcashErrorCodes,
+} from "./utils/zcashApplicationErrors";
+
+const CHAIN_CODE_LENGTH = 32;
 
 export type GetAddressCommandArgs = {
   readonly derivationPath: string;
@@ -14,7 +30,8 @@ export type GetAddressCommandArgs = {
 
 export type GetAddressCommandResponse = {
   readonly publicKey: Uint8Array;
-  readonly chainCode?: Uint8Array;
+  readonly address: string;
+  readonly chainCode: Uint8Array;
 };
 
 export class GetAddressCommand
@@ -25,25 +42,104 @@ export class GetAddressCommand
 
   private readonly args: GetAddressCommandArgs;
 
+  private readonly errorHelper = new CommandErrorHelper<
+    GetAddressCommandResponse,
+    ZcashErrorCodes
+  >(ZCASH_APP_ERRORS, ZcashAppCommandErrorFactory);
+
   constructor(args: GetAddressCommandArgs) {
     this.args = args;
   }
 
   getApdu(): Apdu {
-    // TODO: Implement APDU construction based on your blockchain's protocol
-    // Example structure:
-    // const builder = new ApduBuilder({ cla: 0xe0, ins: 0x02, p1: 0x00, p2: 0x00 });
-    // Add derivation path and other data to builder
-    // return builder.build();
-    console.log(this.args);
-    throw new Error("GetAddressCommand.getApdu() not implemented");
+    const getAddressArgs: ApduBuilderArgs = {
+      cla: 0xe0,
+      ins: 0x40,
+      p1: this.args.checkOnDevice ? 0x01 : 0x00,
+      p2: 0x00,
+    };
+
+    const builder = new ApduBuilder(getAddressArgs);
+
+    const path = DerivationPathUtils.splitPath(this.args.derivationPath);
+    builder.add8BitUIntToData(path.length);
+    path.forEach((element) => {
+      builder.add32BitUIntToData(element);
+    });
+
+    return builder.build();
   }
 
   parseResponse(
-    _apduResponse: ApduResponse,
+    apduResponse: ApduResponse,
   ): CommandResult<GetAddressCommandResponse, ZcashErrorCodes> {
-    // TODO: Implement response parsing based on your blockchain's protocol
-    // return CommandResultFactory({ data: { ... } });
-    throw new Error("GetAddressCommand.parseResponse() not implemented");
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      const parser = new ApduParser(apduResponse);
+
+      const publicKeyLength = parser.extract8BitUInt();
+      if (publicKeyLength === undefined) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Public key length is missing"),
+        });
+      }
+
+      if (parser.testMinimalLength(publicKeyLength) === false) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Public key is missing"),
+        });
+      }
+
+      const publicKey = parser.extractFieldByLength(publicKeyLength);
+      if (publicKey === undefined) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Unable to extract public key"),
+        });
+      }
+
+      const addressLength = parser.extract8BitUInt();
+      if (addressLength === undefined) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Address length is missing"),
+        });
+      }
+
+      if (parser.testMinimalLength(addressLength) === false) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Address is missing"),
+        });
+      }
+
+      const addressBytes = parser.extractFieldByLength(addressLength);
+      if (addressBytes === undefined) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Unable to extract address"),
+        });
+      }
+
+      const address = parser.encodeToString(addressBytes);
+
+      if (parser.testMinimalLength(CHAIN_CODE_LENGTH) === false) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Chain code is missing"),
+        });
+      }
+
+      const chainCode = parser.extractFieldByLength(CHAIN_CODE_LENGTH);
+      if (chainCode === undefined) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Unable to extract chain code"),
+        });
+      }
+
+      return CommandResultFactory({
+        data: {
+          publicKey,
+          address,
+          chainCode,
+        },
+      });
+    });
   }
 }

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/utils/zcashApplicationErrors.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/utils/zcashApplicationErrors.ts
@@ -1,5 +1,36 @@
-export enum ZcashErrorCodes {}
-// Define your error codes here
-// Example:
-// INVALID_DERIVATION_PATH = 0x6a80,
-// TRANSACTION_PARSING_ERROR = 0x6a81,
+import {
+  type CommandErrorArgs,
+  type CommandErrors,
+  DeviceExchangeError,
+} from "@ledgerhq/device-management-kit";
+
+export type ZcashErrorCodes =
+  | "6400"
+  | "6700"
+  | "6985"
+  | "6a80"
+  | "6b00"
+  | "6d00"
+  | "6e00"
+  | "6f00";
+
+export const ZCASH_APP_ERRORS: CommandErrors<ZcashErrorCodes> = {
+  "6400": { message: "Execution error" },
+  "6700": { message: "Wrong APDU length" },
+  "6985": { message: "Denied by user" },
+  "6a80": { message: "Incorrect data" },
+  "6b00": { message: "Wrong P1/P2" },
+  "6d00": { message: "INS not supported" },
+  "6e00": { message: "CLA not supported" },
+  "6f00": { message: "Technical problem" },
+};
+
+export class ZcashAppCommandError extends DeviceExchangeError<ZcashErrorCodes> {
+  constructor(args: CommandErrorArgs<ZcashErrorCodes>) {
+    super({ tag: "ZcashAppCommandError", ...args });
+  }
+}
+
+export const ZcashAppCommandErrorFactory = (
+  args: CommandErrorArgs<ZcashErrorCodes>,
+) => new ZcashAppCommandError(args);

--- a/packages/signer/signer-zcash/src/internal/app-binder/device-action/GetAddress/GetAddressDeviceAction.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/device-action/GetAddress/GetAddressDeviceAction.ts
@@ -1,3 +1,0 @@
-// TODO: Implement GetAddressDeviceAction if needed
-// This is a placeholder - you may not need a custom device action for getAddress
-// if SendCommandInAppDeviceAction is sufficient

--- a/packages/signer/signer-zcash/src/internal/use-cases/address/GetAddressUseCase.test.ts
+++ b/packages/signer/signer-zcash/src/internal/use-cases/address/GetAddressUseCase.test.ts
@@ -1,0 +1,76 @@
+import {
+  DeviceActionStatus,
+  type ExecuteDeviceActionReturnType,
+} from "@ledgerhq/device-management-kit";
+import { from } from "rxjs";
+import { vi } from "vitest";
+
+import {
+  type GetAddressDAError,
+  type GetAddressDAIntermediateValue,
+  type GetAddressDAOutput,
+} from "@api/app-binder/GetAddressDeviceActionTypes";
+import { type ZcashAppBinder } from "@internal/app-binder/ZcashAppBinder";
+
+import { GetAddressUseCase } from "./GetAddressUseCase";
+
+describe("GetAddressUseCase", () => {
+  it("should call getAddress on appBinder with default options", () => {
+    const derivationPath = "44'/133'/0'/0/0";
+    const getAddressMock = vi.fn();
+    const appBinder = {
+      getAddress: getAddressMock,
+    } as unknown as ZcashAppBinder;
+    const expectedResult: ExecuteDeviceActionReturnType<
+      GetAddressDAOutput,
+      GetAddressDAError,
+      GetAddressDAIntermediateValue
+    > = {
+      observable: from([
+        {
+          status: DeviceActionStatus.Completed as const,
+          output: {
+            publicKey: new Uint8Array([0x01]),
+            address: "t1Test",
+            chainCode: new Uint8Array(32),
+          },
+        },
+      ]),
+      cancel: vi.fn(),
+    };
+    getAddressMock.mockReturnValue(expectedResult);
+
+    const useCase = new GetAddressUseCase(appBinder);
+    const result = useCase.execute(derivationPath);
+
+    expect(getAddressMock).toHaveBeenCalledWith({
+      derivationPath,
+      checkOnDevice: false,
+      skipOpenApp: false,
+    });
+    expect(result).toBe(expectedResult);
+  });
+
+  it("should forward checkOnDevice and skipOpenApp from options", () => {
+    const derivationPath = "44'/133'/1'/0/5";
+    const getAddressMock = vi.fn().mockReturnValue({
+      observable: from([]),
+      cancel: vi.fn(),
+    });
+    const appBinder = {
+      getAddress: getAddressMock,
+    } as unknown as ZcashAppBinder;
+
+    const useCase = new GetAddressUseCase(appBinder);
+    useCase.execute(derivationPath, {
+      checkOnDevice: true,
+      skipOpenApp: true,
+    });
+
+    expect(getAddressMock).toHaveBeenCalledWith({
+      derivationPath,
+      checkOnDevice: true,
+      skipOpenApp: true,
+    });
+  });
+});

--- a/packages/signer/signer-zcash/src/internal/use-cases/address/di/addressModule.test.ts
+++ b/packages/signer/signer-zcash/src/internal/use-cases/address/di/addressModule.test.ts
@@ -1,0 +1,24 @@
+import { Container } from "inversify";
+
+import { addressModuleFactory } from "./addressModule";
+import { addressTypes } from "./addressTypes";
+
+describe("addressModuleFactory", () => {
+  describe("Default", () => {
+    let container: Container;
+    let mod: ReturnType<typeof addressModuleFactory>;
+    beforeEach(() => {
+      mod = addressModuleFactory();
+      container = new Container();
+      container.loadSync(mod);
+    });
+
+    it("should return the address module", () => {
+      expect(mod).toBeDefined();
+    });
+
+    it("should bind GetAddressUseCase", () => {
+      expect(container.isBound(addressTypes.GetAddressUseCase)).toBeTruthy();
+    });
+  });
+});

--- a/packages/signer/signer-zcash/vitest.config.mjs
+++ b/packages/signer/signer-zcash/vitest.config.mjs
@@ -9,6 +9,7 @@ export default defineConfig({
   ...baseConfig,
   test: {
     ...baseConfig.test,
+    include: ["src/**/*.test.ts"],
     setupFiles: ["./vitest.setup.mjs"],
     coverage: {
       reporter: ["lcov", "text"],

--- a/packages/signer/signer-zcash/vitest.config.mjs
+++ b/packages/signer/signer-zcash/vitest.config.mjs
@@ -1,19 +1,32 @@
 import baseConfig from "@ledgerhq/vitest-config-dmk";
 import { defineConfig } from "vitest/config";
 import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   ...baseConfig,
   test: {
     ...baseConfig.test,
-    include: ["src/**/*.test.ts"],
     setupFiles: ["./vitest.setup.mjs"],
+    coverage: {
+      reporter: ["lcov", "text"],
+      provider: "istanbul",
+      include: ["src/**/*.ts"],
+      exclude: [
+        "src/**/*.stub.ts",
+        "src/index.ts",
+        "src/api/index.ts",
+        "src/**/__test-utils__/*",
+      ],
+    },
   },
   resolve: {
     alias: {
+      "@root": path.resolve(__dirname),
       "@api": path.resolve(__dirname, "src/api"),
       "@internal": path.resolve(__dirname, "src/internal"),
-      "@root": path.resolve(__dirname, "."),
     },
   },
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->
### 📝 Description

This PR aligns Zcash getAddress behavior with the rest of the signer stack: tighter GetAddressCommand parsing, clearer Zcash app error handling, and Vitest coverage for the command, use case, app binder, default signer, and address DI module. It removes the unused GetAddress device-action placeholder. The sample app default derivation paths use Zcash coin type 133'.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-28170](https://ledgerhq.atlassian.net/browse/LIVE-28170) <!-- adjust URL if your org uses another base -->

- **Feature**: Zcash signer getAddress implementation and tests

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [ ] **Documentation is up-to-date** <!-- tick if you did not need doc updates -->
- [x] **Impact of the changes:**
  - `@ledgerhq/device-signer-kit-zcash`: getAddress command/error handling; tests; removal of unused device-action file.
  - `apps/sample`: default Zcash derivation uses coin type 133'.


### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[LIVE-28170]: https://ledgerhq.atlassian.net/browse/LIVE-28170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ