### PR TITLE
👽️ (context-concordium) [NO-ISSUE]: Split trusted metadata service errors in verifyAddress

### DIFF
--- a/.changeset/blue-carrots-stick.md
+++ b/.changeset/blue-carrots-stick.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-concordium": minor
+---
+
+`verifyAddress` now distinguishes between `AddressVerificationFailedError` (backend actively refused the pubkey → address mapping) and `TrustedMetadataServiceError` (backend unreachable / 5xx). The backend's reason is forwarded into `error.message`.

--- a/.changeset/whole-yaks-allow.md
+++ b/.changeset/whole-yaks-allow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/context-module": minor
+---
+
+Split trusted metadata service errors for account ownership into `verification_failed` (HTTP 4xx) vs `service_unavailable` (network / 5xx / malformed), exposed via the new `AccountOwnershipError` class. Backend error message is now forwarded verbatim instead of swallowed.

--- a/packages/signer/context-module/src/account-ownership/data/AccountOwnershipError.ts
+++ b/packages/signer/context-module/src/account-ownership/data/AccountOwnershipError.ts
@@ -1,0 +1,24 @@
+/**
+ * Classification for errors returned by the trusted metadata service when
+ * fetching an account-ownership descriptor.
+ *
+ * - `verification_failed`: the service was reached and actively refused the
+ *   pubkey → address mapping (HTTP 4xx). Treat as a terminal, non-retryable
+ *   verification failure.
+ * - `service_unavailable`: the service could not answer (network failure,
+ *   HTTP 5xx, malformed response). Treat as transient; fallback UI may be
+ *   appropriate.
+ */
+export type AccountOwnershipErrorKind =
+  | "verification_failed"
+  | "service_unavailable";
+
+export class AccountOwnershipError extends Error {
+  readonly kind: AccountOwnershipErrorKind;
+
+  constructor(kind: AccountOwnershipErrorKind, message: string) {
+    super(message);
+    this.name = "AccountOwnershipError";
+    this.kind = kind;
+  }
+}

--- a/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.test.ts
+++ b/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.test.ts
@@ -1,6 +1,7 @@
-import axios from "axios";
+import axios, { AxiosError, type AxiosResponse } from "axios";
 import { Left, Right } from "purify-ts";
 
+import { AccountOwnershipError } from "@/account-ownership/data/AccountOwnershipError";
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import {
   LEDGER_CLIENT_VERSION_HEADER,
@@ -11,6 +12,23 @@ import PACKAGE from "@root/package.json";
 import { HttpAccountOwnershipDataSource } from "./HttpAccountOwnershipDataSource";
 
 vi.mock("axios");
+
+function makeAxiosError(
+  status: number,
+  data: unknown,
+  message = "Request failed",
+): AxiosError {
+  const err = new AxiosError(message);
+  err.message = message;
+  err.response = {
+    status,
+    data,
+    statusText: "",
+    headers: {},
+    config: {} as never,
+  } as AxiosResponse;
+  return err;
+}
 
 describe("HttpAccountOwnershipDataSource", () => {
   const config: ContextModuleServiceConfig = {
@@ -26,30 +44,31 @@ describe("HttpAccountOwnershipDataSource", () => {
     keyUsage: "trusted_name",
   };
 
+  const baseParams = {
+    publicKey: "abcdef1234567890",
+    address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
+    challenge: "0xabcdef",
+    network: "mainnet" as const,
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(axios, "isAxiosError").mockImplementation(
+      (value: unknown): value is AxiosError => value instanceof AxiosError,
+    );
   });
 
   describe("getDescriptor", () => {
     it("should return descriptor on successful request", async () => {
-      // GIVEN
-      const params = {
-        publicKey: "abcdef1234567890",
-        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
-        challenge: "0xabcdef",
-        network: "mainnet" as const,
-      };
       vi.spyOn(axios, "request").mockResolvedValue({
         status: 200,
         data: validDto,
       });
 
-      // WHEN
       const result = await new HttpAccountOwnershipDataSource(
         config,
-      ).getDescriptor(params);
+      ).getDescriptor(baseParams);
 
-      // THEN
       expect(axios.request).toHaveBeenCalledWith({
         method: "GET",
         url: "https://nft.api.live.ledger-test.com/v2/concordium/owner/abcdef1234567890/3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
@@ -62,32 +81,20 @@ describe("HttpAccountOwnershipDataSource", () => {
           [LEDGER_ORIGIN_TOKEN_HEADER]: "test-origin-token",
         },
       });
-      expect(result).toEqual(
-        Right({
-          signedDescriptor: "signed-descriptor-data",
-          keyId: "domain_metadata_key",
-          keyUsage: "trusted_name",
-        }),
-      );
+      expect(result).toEqual(Right(validDto));
     });
 
     it("should pass testnet network parameter", async () => {
-      // GIVEN
-      const params = {
-        publicKey: "abcdef1234567890",
-        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
-        challenge: "0xabcdef",
-        network: "testnet" as const,
-      };
       vi.spyOn(axios, "request").mockResolvedValue({
         status: 200,
         data: validDto,
       });
 
-      // WHEN
-      await new HttpAccountOwnershipDataSource(config).getDescriptor(params);
+      await new HttpAccountOwnershipDataSource(config).getDescriptor({
+        ...baseParams,
+        network: "testnet",
+      });
 
-      // THEN
       expect(axios.request).toHaveBeenCalledWith(
         expect.objectContaining({
           params: {
@@ -98,178 +105,171 @@ describe("HttpAccountOwnershipDataSource", () => {
       );
     });
 
-    it("should return error when response data is empty", async () => {
-      // GIVEN
-      const params = {
-        publicKey: "abcdef1234567890",
-        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
-        challenge: "0xabcdef",
-        network: "mainnet" as const,
-      };
+    it("should classify empty response as service_unavailable", async () => {
       vi.spyOn(axios, "request").mockResolvedValue({
         status: 200,
         data: null,
       });
 
-      // WHEN
       const result = await new HttpAccountOwnershipDataSource(
         config,
-      ).getDescriptor(params);
+      ).getDescriptor(baseParams);
 
-      // THEN
-      expect(result).toEqual(
-        Left(
-          new Error(
-            "[ContextModule] HttpAccountOwnershipDataSource: unexpected empty response",
-          ),
-        ),
-      );
+      expect(result.isLeft()).toBe(true);
+      const err = result.extract() as AccountOwnershipError;
+      expect(err).toBeInstanceOf(AccountOwnershipError);
+      expect(err.kind).toBe("service_unavailable");
+      expect(err.message).toContain("unexpected empty response");
     });
 
-    it("should return error when signedDescriptor is missing", async () => {
-      // GIVEN
-      const params = {
-        publicKey: "abcdef1234567890",
-        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
-        challenge: "0xabcdef",
-        network: "mainnet" as const,
-      };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: {
-          keyId: "domain_metadata_key",
-          keyUsage: "trusted_name",
-        },
-      });
+    it.each([
+      ["signedDescriptor missing", { keyId: "k", keyUsage: "u" }],
+      ["keyId missing", { signedDescriptor: "s", keyUsage: "u" }],
+      ["keyUsage missing", { signedDescriptor: "s", keyId: "k" }],
+      [
+        "wrong field type",
+        { signedDescriptor: "s", keyId: 123, keyUsage: "u" },
+      ],
+    ])(
+      "should classify malformed response (%s) as service_unavailable",
+      async (_label, data) => {
+        vi.spyOn(axios, "request").mockResolvedValue({ status: 200, data });
 
-      // WHEN
+        const result = await new HttpAccountOwnershipDataSource(
+          config,
+        ).getDescriptor(baseParams);
+
+        expect(result.isLeft()).toBe(true);
+        const err = result.extract() as AccountOwnershipError;
+        expect(err).toBeInstanceOf(AccountOwnershipError);
+        expect(err.kind).toBe("service_unavailable");
+        expect(err.message).toContain("invalid response format");
+      },
+    );
+
+    it("should classify 422 with { message } body as verification_failed and forward backend message", async () => {
+      const backendMessage =
+        "Address ByteVector(32 bytes, 0xa63c) is not associated with the given public key ByteVector(32 bytes, 0x9dc1) on the network Testnet";
+      vi.spyOn(axios, "request").mockRejectedValue(
+        makeAxiosError(422, { message: backendMessage }),
+      );
+
       const result = await new HttpAccountOwnershipDataSource(
         config,
-      ).getDescriptor(params);
+      ).getDescriptor(baseParams);
 
-      // THEN
-      expect(result).toEqual(
-        Left(
-          new Error(
-            "[ContextModule] HttpAccountOwnershipDataSource: invalid response format",
-          ),
-        ),
-      );
+      expect(result.isLeft()).toBe(true);
+      const err = result.extract() as AccountOwnershipError;
+      expect(err).toBeInstanceOf(AccountOwnershipError);
+      expect(err.kind).toBe("verification_failed");
+      expect(err.message).toBe(backendMessage);
     });
 
-    it("should return error when keyId is missing", async () => {
-      // GIVEN
-      const params = {
-        publicKey: "abcdef1234567890",
-        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
-        challenge: "0xabcdef",
-        network: "mainnet" as const,
-      };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: {
-          signedDescriptor: "signed-descriptor-data",
-          keyUsage: "trusted_name",
-        },
-      });
+    it.each([400, 401, 403, 404, 429])(
+      "should classify HTTP %s as verification_failed",
+      async (status) => {
+        vi.spyOn(axios, "request").mockRejectedValue(
+          makeAxiosError(status, { message: "refused" }),
+        );
 
-      // WHEN
+        const result = await new HttpAccountOwnershipDataSource(
+          config,
+        ).getDescriptor(baseParams);
+
+        const err = result.extract() as AccountOwnershipError;
+        expect(err.kind).toBe("verification_failed");
+        expect(err.message).toBe("refused");
+      },
+    );
+
+    it("should classify 500 as service_unavailable with status prefix", async () => {
+      vi.spyOn(axios, "request").mockRejectedValue(
+        makeAxiosError(500, { message: "internal error" }),
+      );
+
       const result = await new HttpAccountOwnershipDataSource(
         config,
-      ).getDescriptor(params);
+      ).getDescriptor(baseParams);
 
-      // THEN
-      expect(result).toEqual(
-        Left(
-          new Error(
-            "[ContextModule] HttpAccountOwnershipDataSource: invalid response format",
-          ),
-        ),
-      );
+      const err = result.extract() as AccountOwnershipError;
+      expect(err.kind).toBe("service_unavailable");
+      expect(err.message).toContain("backend 500");
+      expect(err.message).toContain("internal error");
     });
 
-    it("should return error when keyUsage is missing", async () => {
-      // GIVEN
-      const params = {
-        publicKey: "abcdef1234567890",
-        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
-        challenge: "0xabcdef",
-        network: "mainnet" as const,
-      };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: {
-          signedDescriptor: "signed-descriptor-data",
-          keyId: "domain_metadata_key",
-        },
-      });
+    it.each([502, 503, 504])(
+      "should classify HTTP %s as service_unavailable",
+      async (status) => {
+        vi.spyOn(axios, "request").mockRejectedValue(
+          makeAxiosError(status, { message: "down" }),
+        );
 
-      // WHEN
+        const result = await new HttpAccountOwnershipDataSource(
+          config,
+        ).getDescriptor(baseParams);
+
+        const err = result.extract() as AccountOwnershipError;
+        expect(err.kind).toBe("service_unavailable");
+      },
+    );
+
+    it("should accept string body and forward it as message on 4xx", async () => {
+      vi.spyOn(axios, "request").mockRejectedValue(
+        makeAxiosError(422, "plain text reason"),
+      );
+
       const result = await new HttpAccountOwnershipDataSource(
         config,
-      ).getDescriptor(params);
+      ).getDescriptor(baseParams);
 
-      // THEN
-      expect(result).toEqual(
-        Left(
-          new Error(
-            "[ContextModule] HttpAccountOwnershipDataSource: invalid response format",
-          ),
-        ),
-      );
+      const err = result.extract() as AccountOwnershipError;
+      expect(err.kind).toBe("verification_failed");
+      expect(err.message).toBe("plain text reason");
     });
 
-    it("should return error when field has wrong type", async () => {
-      // GIVEN
-      const params = {
-        publicKey: "abcdef1234567890",
-        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
-        challenge: "0xabcdef",
-        network: "mainnet" as const,
-      };
-      vi.spyOn(axios, "request").mockResolvedValue({
-        status: 200,
-        data: {
-          signedDescriptor: "signed-descriptor-data",
-          keyId: 123,
-          keyUsage: "trusted_name",
-        },
-      });
+    it("should fall back to axios error message when body has no message", async () => {
+      vi.spyOn(axios, "request").mockRejectedValue(
+        makeAxiosError(422, {}, "Request failed with status code 422"),
+      );
 
-      // WHEN
       const result = await new HttpAccountOwnershipDataSource(
         config,
-      ).getDescriptor(params);
+      ).getDescriptor(baseParams);
 
-      // THEN
-      expect(result).toEqual(
-        Left(
-          new Error(
-            "[ContextModule] HttpAccountOwnershipDataSource: invalid response format",
-          ),
-        ),
-      );
+      const err = result.extract() as AccountOwnershipError;
+      expect(err.kind).toBe("verification_failed");
+      expect(err.message).toBe("Request failed with status code 422");
     });
 
-    it("should return error when axios request fails", async () => {
-      // GIVEN
-      const params = {
-        publicKey: "abcdef1234567890",
-        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
-        challenge: "0xabcdef",
-        network: "mainnet" as const,
-      };
-      vi.spyOn(axios, "request").mockRejectedValue(new Error("Network error"));
+    it("should fall back to axios error message when body message is empty", async () => {
+      vi.spyOn(axios, "request").mockRejectedValue(
+        makeAxiosError(
+          422,
+          { message: "" },
+          "Request failed with status code 422",
+        ),
+      );
 
-      // WHEN
       const result = await new HttpAccountOwnershipDataSource(
         config,
-      ).getDescriptor(params);
+      ).getDescriptor(baseParams);
 
-      // THEN
+      const err = result.extract() as AccountOwnershipError;
+      expect(err.kind).toBe("verification_failed");
+      expect(err.message).toBe("Request failed with status code 422");
+    });
+
+    it("should classify non-axios / network errors as service_unavailable", async () => {
+      vi.spyOn(axios, "request").mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const result = await new HttpAccountOwnershipDataSource(
+        config,
+      ).getDescriptor(baseParams);
+
       expect(result).toEqual(
         Left(
-          new Error(
+          new AccountOwnershipError(
+            "service_unavailable",
             "[ContextModule] HttpAccountOwnershipDataSource: Failed to fetch account ownership descriptor",
           ),
         ),
@@ -277,30 +277,21 @@ describe("HttpAccountOwnershipDataSource", () => {
     });
 
     it("should use correct metadata service URL from config", async () => {
-      // GIVEN
       const customConfig: ContextModuleServiceConfig = {
         metadataServiceDomain: {
           url: "https://custom-metadata.example.com",
         },
         originToken: "custom-token",
       } as ContextModuleServiceConfig;
-      const params = {
-        publicKey: "abcdef1234567890",
-        address: "3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",
-        challenge: "0xabcdef",
-        network: "mainnet" as const,
-      };
       vi.spyOn(axios, "request").mockResolvedValue({
         status: 200,
         data: validDto,
       });
 
-      // WHEN
       await new HttpAccountOwnershipDataSource(customConfig).getDescriptor(
-        params,
+        baseParams,
       );
 
-      // THEN
       expect(axios.request).toHaveBeenCalledWith(
         expect.objectContaining({
           url: "https://custom-metadata.example.com/v2/concordium/owner/abcdef1234567890/3kFkntk2H5FGMzeR3GjQKPhdZK9LShKdPHsj2fiGKCdmDXj2WB",

--- a/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.ts
+++ b/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.ts
@@ -7,6 +7,7 @@ import {
   type AccountOwnershipDescriptor,
   type GetAccountOwnershipParams,
 } from "@/account-ownership/data/AccountOwnershipDataSource";
+import { AccountOwnershipError } from "@/account-ownership/data/AccountOwnershipError";
 import { type AccountOwnershipDto } from "@/account-ownership/data/dto/AccountOwnershipDto";
 import { configTypes } from "@/config/di/configTypes";
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
@@ -49,7 +50,8 @@ export class HttpAccountOwnershipDataSource
 
       if (!response.data) {
         return Left(
-          new Error(
+          new AccountOwnershipError(
+            "service_unavailable",
             "[ContextModule] HttpAccountOwnershipDataSource: unexpected empty response",
           ),
         );
@@ -57,7 +59,8 @@ export class HttpAccountOwnershipDataSource
 
       if (!this.isAccountOwnershipDto(response.data)) {
         return Left(
-          new Error(
+          new AccountOwnershipError(
+            "service_unavailable",
             "[ContextModule] HttpAccountOwnershipDataSource: invalid response format",
           ),
         );
@@ -68,13 +71,55 @@ export class HttpAccountOwnershipDataSource
         keyId: response.data.keyId,
         keyUsage: response.data.keyUsage,
       });
-    } catch (_error) {
-      return Left(
-        new Error(
-          "[ContextModule] HttpAccountOwnershipDataSource: Failed to fetch account ownership descriptor",
-        ),
+    } catch (error) {
+      return Left(this.classifyError(error));
+    }
+  }
+
+  /**
+   * Classifies a caught request error into an {@link AccountOwnershipError}:
+   * HTTP 4xx responses carry the backend's `message` verbatim and are marked
+   * as `verification_failed`; everything else (network failure, 5xx,
+   * non-axios errors) is marked as `service_unavailable`.
+   */
+  private classifyError(error: unknown): AccountOwnershipError {
+    if (axios.isAxiosError(error) && error.response) {
+      const status = error.response.status;
+      const backendMessage = this.extractBackendMessage(
+        error.response.data,
+        error.message,
+      );
+
+      if (status >= 400 && status < 500) {
+        return new AccountOwnershipError("verification_failed", backendMessage);
+      }
+
+      return new AccountOwnershipError(
+        "service_unavailable",
+        `[ContextModule] HttpAccountOwnershipDataSource: backend ${status}: ${backendMessage}`,
       );
     }
+
+    return new AccountOwnershipError(
+      "service_unavailable",
+      "[ContextModule] HttpAccountOwnershipDataSource: Failed to fetch account ownership descriptor",
+    );
+  }
+
+  private extractBackendMessage(data: unknown, fallback: string): string {
+    if (typeof data === "string" && data.length > 0) {
+      return data;
+    }
+    if (
+      typeof data === "object" &&
+      data !== null &&
+      "message" in data &&
+      typeof (data as { message: unknown }).message === "string" &&
+      (data as { message: string }).message.length > 0
+    ) {
+      return (data as { message: string }).message;
+    }
+    return fallback;
   }
 
   private isAccountOwnershipDto(value: unknown): value is AccountOwnershipDto {

--- a/packages/signer/context-module/src/index.ts
+++ b/packages/signer/context-module/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./account-ownership/data/AccountOwnershipDataSource";
+export * from "./account-ownership/data/AccountOwnershipError";
 export * from "./account-ownership/data/HttpAccountOwnershipDataSource";
 export * from "./account-ownership/domain/AccountOwnershipContextLoader";
 export * from "./calldata/data/CalldataDescriptorDataSource";

--- a/packages/signer/signer-concordium/README.md
+++ b/packages/signer/signer-concordium/README.md
@@ -250,6 +250,13 @@ type Signature = Uint8Array; // 64-byte Ed25519 signature
 
 Securely verify a Concordium account address on the Ledger device using the trusted backend pattern. The signer fetches a signed account ownership descriptor from the trusted metadata service, loads it onto the device via the PKI infrastructure, then triggers address verification. The device validates the descriptor's signature chain, derives the public key from the given path, and displays the address for user confirmation only if the key matches.
 
+The flow can fail in two distinct ways at the metadata-service boundary. Both are surfaced via `DeviceActionStatus.Error` and must be discriminated by the stable `errorCode` string on the emitted error:
+
+- **`errorCode: "address_verification_failed"`** — the trusted metadata service was reached and actively refused the pubkey → address mapping (HTTP 4xx, typically 422). The backend's `message` is forwarded verbatim in `error.message`. Treat as a terminal, non-retryable verification failure.
+- **`errorCode: "trusted_metadata_service_error"`** — the trusted metadata service could not answer (network failure, HTTP 5xx, malformed response). Treat as transient; a retry or a cached-address fallback may be appropriate.
+
+Device-originated errors (`"6985"` user rejected, `"5515"` locked device, `"6b0c"` trusted name mismatch) are surfaced the same way.
+
 ```typescript
 const { observable, cancel } = signerConcordium.verifyAddress(
   derivationPath,

--- a/packages/signer/signer-concordium/src/internal/app-binder/command/utils/AddressVerificationFailedError.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/command/utils/AddressVerificationFailedError.ts
@@ -1,0 +1,21 @@
+import { DeviceExchangeError } from "@ledgerhq/device-management-kit";
+
+import { ConcordiumErrorCodes } from "@internal/app-binder/command/utils/ConcordiumApplicationErrors";
+
+/**
+ * Raised when the trusted metadata service was reached but actively refused
+ * the pubkey → address mapping (HTTP 4xx). This is a terminal, non-retryable
+ * verification failure: the backend has looked up the mapping and does not
+ * recognize it. Distinguished from {@link TrustedMetadataServiceError}, which
+ * signals a transient service-side issue (network failure, 5xx, malformed
+ * response).
+ */
+export class AddressVerificationFailedError extends DeviceExchangeError<ConcordiumErrorCodes> {
+  constructor(message?: string) {
+    super({
+      tag: "AddressVerificationFailedError",
+      message: message ?? "Address verification failed",
+      errorCode: ConcordiumErrorCodes.ADDRESS_VERIFICATION_FAILED,
+    });
+  }
+}

--- a/packages/signer/signer-concordium/src/internal/app-binder/command/utils/ConcordiumApplicationErrors.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/command/utils/ConcordiumApplicationErrors.ts
@@ -14,6 +14,7 @@ export enum ConcordiumErrorCodes {
   TRUSTED_NAME_MISMATCH = "6b0c",
   UNSUPPORTED_TRANSACTION_TYPE = "unsupported_transaction_type",
   TRUSTED_METADATA_SERVICE_ERROR = "trusted_metadata_service_error",
+  ADDRESS_VERIFICATION_FAILED = "address_verification_failed",
 }
 
 export const CONCORDIUM_APP_ERRORS: CommandErrors<ConcordiumErrorCodes> = {
@@ -27,6 +28,9 @@ export const CONCORDIUM_APP_ERRORS: CommandErrors<ConcordiumErrorCodes> = {
   unsupported_transaction_type: { message: "Unsupported transaction type" },
   trusted_metadata_service_error: {
     message: "Trusted metadata service error",
+  },
+  address_verification_failed: {
+    message: "Address verification failed",
   },
 };
 

--- a/packages/signer/signer-concordium/src/internal/app-binder/task/VerifyAddressTask.test.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/task/VerifyAddressTask.test.ts
@@ -1,4 +1,5 @@
 import {
+  AccountOwnershipError,
   type ClearSignContext,
   ClearSignContextType,
   type ContextModule,
@@ -13,6 +14,7 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { vi } from "vitest";
 
+import { AddressVerificationFailedError } from "@internal/app-binder/command/utils/AddressVerificationFailedError";
 import {
   ConcordiumAppCommandError,
   ConcordiumErrorCodes,
@@ -41,11 +43,11 @@ function makeSuccessContext(withCertificate = true): ClearSignContext[] {
   ];
 }
 
-function makeErrorContext(message: string): ClearSignContext[] {
+function makeErrorContext(error: Error): ClearSignContext[] {
   return [
     {
       type: ClearSignContextType.ERROR,
-      error: new Error(message),
+      error,
     },
   ];
 }
@@ -176,13 +178,13 @@ describe("VerifyAddressTask", () => {
       expect(sendCommandMock).toHaveBeenCalledTimes(2);
     });
 
-    it("should fail with TrustedMetadataServiceError when context module returns error context", async () => {
+    it("should fail with TrustedMetadataServiceError when context loader returns a plain Error (service_unavailable)", async () => {
       mockSendCommandSequence(
         CommandResultFactory({ data: { publicKey: PUBLIC_KEY } }),
         CommandResultFactory({ data: { challenge: CHALLENGE } }),
       );
       vi.spyOn(contextModuleMock, "getContexts").mockResolvedValue(
-        makeErrorContext("Backend unavailable"),
+        makeErrorContext(new Error("Backend unavailable")),
       );
 
       const result = await createTask().run();
@@ -193,6 +195,56 @@ describe("VerifyAddressTask", () => {
         expect(result.error).toHaveProperty(
           "errorCode",
           ConcordiumErrorCodes.TRUSTED_METADATA_SERVICE_ERROR,
+        );
+      }
+    });
+
+    it("should fail with TrustedMetadataServiceError when AccountOwnershipError kind is service_unavailable", async () => {
+      mockSendCommandSequence(
+        CommandResultFactory({ data: { publicKey: PUBLIC_KEY } }),
+        CommandResultFactory({ data: { challenge: CHALLENGE } }),
+      );
+      vi.spyOn(contextModuleMock, "getContexts").mockResolvedValue(
+        makeErrorContext(
+          new AccountOwnershipError("service_unavailable", "backend 503"),
+        ),
+      );
+
+      const result = await createTask().run();
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(TrustedMetadataServiceError);
+        expect((result.error as TrustedMetadataServiceError).message).toBe(
+          "backend 503",
+        );
+      }
+    });
+
+    it("should fail with AddressVerificationFailedError when AccountOwnershipError kind is verification_failed", async () => {
+      const backendMessage =
+        "Address ByteVector(32 bytes, 0xa63c) is not associated with the given public key ByteVector(32 bytes, 0x9dc1) on the network Testnet";
+      mockSendCommandSequence(
+        CommandResultFactory({ data: { publicKey: PUBLIC_KEY } }),
+        CommandResultFactory({ data: { challenge: CHALLENGE } }),
+      );
+      vi.spyOn(contextModuleMock, "getContexts").mockResolvedValue(
+        makeErrorContext(
+          new AccountOwnershipError("verification_failed", backendMessage),
+        ),
+      );
+
+      const result = await createTask().run();
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(AddressVerificationFailedError);
+        expect(result.error).toHaveProperty(
+          "errorCode",
+          ConcordiumErrorCodes.ADDRESS_VERIFICATION_FAILED,
+        );
+        expect((result.error as AddressVerificationFailedError).message).toBe(
+          backendMessage,
         );
       }
     });

--- a/packages/signer/signer-concordium/src/internal/app-binder/task/VerifyAddressTask.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/task/VerifyAddressTask.ts
@@ -1,4 +1,5 @@
 import {
+  AccountOwnershipError,
   type AccountOwnershipNetwork,
   type ClearSignContextSuccess,
   ClearSignContextType,
@@ -20,6 +21,7 @@ import { type VerifyAddressErrorCodes } from "@api/app-binder/VerifyAddressDevic
 import { GetChallengeCommand } from "@internal/app-binder/command/GetChallengeCommand";
 import { GetPublicKeyCommand } from "@internal/app-binder/command/GetPublicKeyCommand";
 import { SetTrustedNameCommand } from "@internal/app-binder/command/SetTrustedNameCommand";
+import { AddressVerificationFailedError } from "@internal/app-binder/command/utils/AddressVerificationFailedError";
 import { TrustedMetadataServiceError } from "@internal/app-binder/command/utils/TrustedMetadataServiceError";
 import { VerifyAddressCommand } from "@internal/app-binder/command/VerifyAddressCommand";
 
@@ -113,8 +115,17 @@ export class VerifyAddressTask {
         (c) => c.type === ClearSignContextType.ERROR,
       );
       if (errorCtx && "error" in errorCtx) {
+        const err = errorCtx.error;
+        if (
+          err instanceof AccountOwnershipError &&
+          err.kind === "verification_failed"
+        ) {
+          return CommandResultFactory({
+            error: new AddressVerificationFailedError(err.message),
+          });
+        }
         return CommandResultFactory({
-          error: new TrustedMetadataServiceError(errorCtx.error.message),
+          error: new TrustedMetadataServiceError(err.message),
         });
       }
       return CommandResultFactory({


### PR DESCRIPTION
### 📝 Description

Splits the single `TrustedMetadataServiceError` previously emitted by `verifyAddress` into two semantically distinct errors, and forwards the backend's error message through the stack instead of swallowing it.

### ❓ Context

Today, any failure at the trusted metadata service boundary collapses into `TrustedMetadataServiceError` (errorCode `trusted_metadata_service_error`), regardless of whether the backend:

- was unreachable / timed out / returned 5xx (transient infra issue), or
- was reached and **actively refused** the pubkey → address mapping (HTTP 4xx, typically 422 with a body such as `"Address ByteVector(32 bytes, 0x…) is not associated with the given public key ByteVector(32 bytes, 0x…) on the network Testnet"`).

Those two cases are semantically opposite:

- transient failures should let consumers show a graceful fallback (e.g. the address-with-warning UI in Ledger Wallet's Concordium Receive flow), and are candidates for retry;
- an explicit 4xx refusal is a **terminal, non-retryable verification failure** — the backend has looked at the mapping and does not recognize it. Hiding this behind a "service unavailable" banner is misleading at best and security-relevant at worst.

On top of that, the caught error's body message was dropped at the datasource layer, so even if a consumer wanted to show *why* the backend refused, the information was gone.

- **JIRA or GitHub link**: [NO-ISSUE]

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [x] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [x] **Impact of the changes:** currently - none. packages are not yet released and the consumers are not yet wired up

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
