### PR TITLE
🐛 (context-module) [NO-ISSUE]: Classify account-ownership errors by numeric .status

### DIFF
--- a/.changeset/shiny-geese-invent.md
+++ b/.changeset/shiny-geese-invent.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/context-module": patch
+---
+
+Classify account-ownership errors by numeric `.status`, so consumer-intercepted errors are handled the same as vanilla `AxiosError`.

--- a/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.test.ts
+++ b/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.test.ts
@@ -30,6 +30,12 @@ function makeAxiosError(
   return err;
 }
 
+function makeInterceptedError(status: number, message: string): Error {
+  const err = new Error(message);
+  (err as unknown as { status: number }).status = status;
+  return err;
+}
+
 describe("HttpAccountOwnershipDataSource", () => {
   const config: ContextModuleServiceConfig = {
     metadataServiceDomain: {
@@ -274,6 +280,95 @@ describe("HttpAccountOwnershipDataSource", () => {
           ),
         ),
       );
+    });
+
+    // Consumers may install a global axios interceptor that replaces
+    // AxiosError with a custom class, preserving the HTTP status on
+    // `.status` and dropping `.response`. The datasource must still
+    // classify these.
+    describe("intercepted error shape (numeric .status on the error)", () => {
+      it.each([400, 401, 403, 404, 422, 429])(
+        "should classify HTTP %s on .status as verification_failed and forward message",
+        async (status) => {
+          const backendMessage =
+            "Address ByteVector(...) is not associated with the given public key ByteVector(...)";
+          vi.spyOn(axios, "request").mockRejectedValue(
+            makeInterceptedError(status, backendMessage),
+          );
+
+          const result = await new HttpAccountOwnershipDataSource(
+            config,
+          ).getDescriptor(baseParams);
+
+          const err = result.extract() as AccountOwnershipError;
+          expect(err.kind).toBe("verification_failed");
+          expect(err.message).toBe(backendMessage);
+        },
+      );
+
+      it.each([500, 502, 503, 504])(
+        "should classify HTTP %s on .status as service_unavailable with status prefix",
+        async (status) => {
+          vi.spyOn(axios, "request").mockRejectedValue(
+            makeInterceptedError(status, "down"),
+          );
+
+          const result = await new HttpAccountOwnershipDataSource(
+            config,
+          ).getDescriptor(baseParams);
+
+          const err = result.extract() as AccountOwnershipError;
+          expect(err.kind).toBe("service_unavailable");
+          expect(err.message).toContain(`backend ${status}`);
+          expect(err.message).toContain("down");
+        },
+      );
+
+      it("should ignore non-numeric .status and fall through to service_unavailable fallback", async () => {
+        const err = new Error("bad");
+        (err as unknown as { status: string }).status = "422";
+        vi.spyOn(axios, "request").mockRejectedValue(err);
+
+        const result = await new HttpAccountOwnershipDataSource(
+          config,
+        ).getDescriptor(baseParams);
+
+        expect(result).toEqual(
+          Left(
+            new AccountOwnershipError(
+              "service_unavailable",
+              "[ContextModule] HttpAccountOwnershipDataSource: Failed to fetch account ownership descriptor",
+            ),
+          ),
+        );
+      });
+
+      it("should forward .message from plain object errors (not Error instances)", async () => {
+        vi.spyOn(axios, "request").mockRejectedValue({
+          status: 422,
+          message: "plain object message",
+        });
+
+        const result = await new HttpAccountOwnershipDataSource(
+          config,
+        ).getDescriptor(baseParams);
+
+        const err = result.extract() as AccountOwnershipError;
+        expect(err.kind).toBe("verification_failed");
+        expect(err.message).toBe("plain object message");
+      });
+
+      it("should use an 'Unknown error' fallback when the object has no usable message", async () => {
+        vi.spyOn(axios, "request").mockRejectedValue({ status: 422 });
+
+        const result = await new HttpAccountOwnershipDataSource(
+          config,
+        ).getDescriptor(baseParams);
+
+        const err = result.extract() as AccountOwnershipError;
+        expect(err.kind).toBe("verification_failed");
+        expect(err.message).toBe("Unknown error");
+      });
     });
 
     it("should use correct metadata service URL from config", async () => {

--- a/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.ts
+++ b/packages/signer/context-module/src/account-ownership/data/HttpAccountOwnershipDataSource.ts
@@ -80,7 +80,16 @@ export class HttpAccountOwnershipDataSource
    * Classifies a caught request error into an {@link AccountOwnershipError}:
    * HTTP 4xx responses carry the backend's `message` verbatim and are marked
    * as `verification_failed`; everything else (network failure, 5xx,
-   * non-axios errors) is marked as `service_unavailable`.
+   * unrecognized errors) is marked as `service_unavailable`.
+   *
+   * Two shapes are recognized:
+   * - Vanilla {@link AxiosError} with `.response` (standalone axios usage).
+   * - Any error carrying a numeric `.status` field. Consumers may install a
+   *   global axios interceptor that replaces {@link AxiosError} with a
+   *   custom class, typically stripping `.response` but preserving the HTTP
+   *   status on a top-level `.status` field. The duck-typed branch keeps
+   *   classification correct on those paths without coupling to any
+   *   host-specific class.
    */
   private classifyError(error: unknown): AccountOwnershipError {
     if (axios.isAxiosError(error) && error.response) {
@@ -89,21 +98,56 @@ export class HttpAccountOwnershipDataSource
         error.response.data,
         error.message,
       );
+      return this.classifyFromStatus(status, backendMessage);
+    }
 
-      if (status >= 400 && status < 500) {
-        return new AccountOwnershipError("verification_failed", backendMessage);
-      }
-
-      return new AccountOwnershipError(
-        "service_unavailable",
-        `[ContextModule] HttpAccountOwnershipDataSource: backend ${status}: ${backendMessage}`,
-      );
+    if (this.hasNumericStatus(error)) {
+      const status = error.status;
+      const message = this.extractErrorMessage(error);
+      return this.classifyFromStatus(status, message);
     }
 
     return new AccountOwnershipError(
       "service_unavailable",
       "[ContextModule] HttpAccountOwnershipDataSource: Failed to fetch account ownership descriptor",
     );
+  }
+
+  private classifyFromStatus(
+    status: number,
+    message: string,
+  ): AccountOwnershipError {
+    if (status >= 400 && status < 500) {
+      return new AccountOwnershipError("verification_failed", message);
+    }
+    return new AccountOwnershipError(
+      "service_unavailable",
+      `[ContextModule] HttpAccountOwnershipDataSource: backend ${status}: ${message}`,
+    );
+  }
+
+  private hasNumericStatus(value: unknown): value is { status: number } {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      "status" in value &&
+      typeof (value as { status: unknown }).status === "number"
+    );
+  }
+
+  private extractErrorMessage(value: unknown): string {
+    if (
+      typeof value === "object" &&
+      value !== null &&
+      "message" in value &&
+      typeof (value as { message: unknown }).message === "string"
+    ) {
+      return (value as { message: string }).message;
+    }
+    if (typeof value === "string") {
+      return value;
+    }
+    return "Unknown error";
   }
 
   private extractBackendMessage(data: unknown, fallback: string): string {


### PR DESCRIPTION
### 📝 Description

Fixes a case where `HttpAccountOwnershipDataSource` misclassified backend 4xx responses as transient service failures when running inside a consumer (such as Ledger Live) that installs a global axios interceptor to normalize HTTP errors into its own error shape.

### ❓ Context

 The datasource previously inspected `AxiosError.response.status` to decide between `verification_failed` (4xx) and `service_unavailable`  (5xx / network). 
 
 That works for standalone axios usage, but breaks  whenever the consumer has replaced axios' native error with a custom class before our `catch` block sees it.  
 
 In practice, a consumer-side interceptor typically:  
 
 - removes `.response` from the caught object,  
 - drops the `isAxiosError` marker,  
 - but **preserves the HTTP status as a top-level `.status` field** on the new error.  
 
 Since `axios.isAxiosError(error) && error.response` evaluated to `false`, the classifier fell through to the generic "unknown error"  branch. As a result, a real 422 from the trusted metadata service (backend refused the public key ↔ address mapping) surfaced as a  transient `TrustedMetadataServiceError` instead of the terminal `AddressVerificationFailedError` introduced in #1434. This masked a  security-relevant distinction: "backend says no" and "backend is down" were reported to the consumer as the same thing.

- **JIRA or GitHub link**: [NO-ISSUE]

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [x] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [x] **Impact of the changes:** none, consumer part is still under construction, the package is not yet released

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
