### PR TITLE
✨ (context-module) [NO-ISSUE]: Mirror BlindSigningEventDto optional fields in BlindSigningReportParams

### DIFF
--- a/.changeset/giant-dragons-call.md
+++ b/.changeset/giant-dragons-call.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/context-module": minor
+---
+
+Add optional platform, appVersion, platformOS, platformVersion, liveAppContext and sessionId fields to BlindSigningReportParams to mirror BlindSigningEventDto, allowing consumers with a custom blind signing reporter to forward them end-to-end

--- a/packages/signer/context-module/src/reporter/data/BlindSigningReporterDatasource.ts
+++ b/packages/signer/context-module/src/reporter/data/BlindSigningReporterDatasource.ts
@@ -2,6 +2,7 @@ import { type Either } from "purify-ts";
 
 import {
   type BlindSigningMethod,
+  type BlindSigningPlatform,
   type BlindSignReason,
   type ClearSigningType,
 } from "@/reporter/model/BlindSigningEvent";
@@ -23,6 +24,12 @@ export type BlindSigningReportParams = {
   signerAppVersion: string;
   deviceVersion: string | null;
   ethContext: BlindSigningReportEthContext | null;
+  platform?: BlindSigningPlatform;
+  appVersion?: string;
+  platformOS?: string;
+  platformVersion?: string;
+  liveAppContext?: string | null;
+  sessionId?: string | null;
 };
 
 export interface BlindSigningReporterDatasource {

--- a/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.test.ts
+++ b/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.test.ts
@@ -6,6 +6,7 @@ import { type BlindSigningReportParams } from "@/reporter/data/BlindSigningRepor
 import { HttpBlindSigningReporterDatasource } from "@/reporter/data/HttpBlindSigningReporterDatasource";
 import {
   BlindSigningMethod,
+  BlindSigningPlatform,
   BlindSignReason,
   ClearSigningType,
 } from "@/reporter/model/BlindSigningEvent";
@@ -128,6 +129,31 @@ describe("HttpBlindSigningReporterDatasource", () => {
       expect(axios.request).toHaveBeenCalledWith(
         expect.objectContaining({
           data: { ...params, source: config.appSource },
+        }),
+      );
+    });
+
+    it("should forward optional DTO fields when provided", async () => {
+      // GIVEN
+      vi.spyOn(axios, "request").mockResolvedValueOnce({ data: {} });
+      const paramsWithOptionalFields: BlindSigningReportParams = {
+        ...params,
+        platform: BlindSigningPlatform.DESKTOP,
+        appVersion: "2.80.0",
+        platformOS: "macOS",
+        platformVersion: "14.5",
+        liveAppContext: "swap",
+        sessionId: "session-123",
+      };
+
+      // WHEN
+      const dataSource = new HttpBlindSigningReporterDatasource(config);
+      await dataSource.report(paramsWithOptionalFields);
+
+      // THEN
+      expect(axios.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { ...paramsWithOptionalFields, source: config.appSource },
         }),
       );
     });


### PR DESCRIPTION
### 📝 Description

Aligns `BlindSigningReportParams` with the shape of `BlindSigningEventDto` by adding the six optional fields the HTTP payload already supports:

- `platform?: BlindSigningPlatform`
- `appVersion?: string`
- `platformOS?: string`
- `platformVersion?: string`
- `liveAppContext?: string | null`
- `sessionId?: string | null`

These fields flow through `ContextModule.report(...)` → `BlindSigningReporter.report(...)` → `BlindSigningReporterDatasource.report(...)`. Adding them to the public params type lets consumers that inject a custom reporter via `ContextModuleBuilder.setBlindSigningReporter(...)` provide and forward this contextual data end-to-end. The default `HttpBlindSigningReporterDatasource` already spreads `...params` into the request body, so no datasource code change was needed.

Backwards compatible: all new fields are optional.

### ❓ Context

- **JIRA or GitHub link**: NO-ISSUE
- **Feature**: Public API parity between `BlindSigningReportParams` and `BlindSigningEventDto` for custom reporter injection.

### ✅ Checklist

- [x] **Covered by automatic tests** — added `should forward optional DTO fields when provided` in `HttpBlindSigningReporterDatasource.test.ts`
- [x] **Changeset is provided** — minor bump for `@ledgerhq/context-module`
- [x] **Documentation is up-to-date** — type is self-documenting, no doc changes needed
- [x] **Impact of the changes:**
  - `BlindSigningReportParams` gains 6 optional fields (non-breaking)
  - `HttpBlindSigningReporterDatasource` automatically forwards them in the POST body
  - Consumers with a custom `BlindSigningReporter` can now receive these fields

Made with [Cursor](https://cursor.com)