### PR TITLE
♻️ (device-management-kit) [NO-ISSUE]: Remove battery-specific command result errors

### DIFF
--- a/.changeset/green-beds-jump.md
+++ b/.changeset/green-beds-jump.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Remove battery-specific command result errors and use `InvalidResponseFormatError` for battery response parsing failures.

--- a/packages/device-management-kit/src/api/command/Errors.ts
+++ b/packages/device-management-kit/src/api/command/Errors.ts
@@ -9,33 +9,6 @@ export class InvalidStatusWordError implements DmkError {
   }
 }
 
-export class InvalidBatteryStatusTypeError implements DmkError {
-  readonly _tag = "InvalidBatteryStatusTypeError";
-  readonly originalError: Error;
-
-  constructor(message?: string) {
-    this.originalError = new Error(message ?? "Invalid battery status type.");
-  }
-}
-
-export class InvalidBatteryDataError implements DmkError {
-  readonly _tag = "InvalidBatteryDataError";
-  readonly originalError: Error;
-
-  constructor(message?: string) {
-    this.originalError = new Error(message ?? "Invalid battery data.");
-  }
-}
-
-export class InvalidBatteryFlagsError implements DmkError {
-  readonly _tag = "InvalidBatteryFlagsError";
-  readonly originalError: Error;
-
-  constructor(message?: string) {
-    this.originalError = new Error(message ?? "Invalid battery flags.");
-  }
-}
-
 export class InvalidResponseFormatError implements DmkError {
   readonly _tag = "InvalidResponseFormatError";
   readonly originalError: Error;

--- a/packages/device-management-kit/src/api/command/model/CommandResult.ts
+++ b/packages/device-management-kit/src/api/command/model/CommandResult.ts
@@ -1,6 +1,4 @@
 import {
-  type InvalidBatteryDataError,
-  type InvalidBatteryStatusTypeError,
   type InvalidGetFirmwareMetadataResponseError,
   type InvalidResponseFormatError,
   type InvalidStatusWordError,
@@ -22,8 +20,6 @@ export type CommandSuccessResult<Data> = {
 export type CommandErrorResult<SpecificErrorCodes = void> = {
   error:
     | DeviceExchangeError<SpecificErrorCodes | GlobalCommandErrorStatusCode>
-    | InvalidBatteryDataError
-    | InvalidBatteryStatusTypeError
     | InvalidResponseFormatError
     | InvalidStatusWordError
     | InvalidGetFirmwareMetadataResponseError
@@ -43,8 +39,6 @@ export function CommandResultFactory<Data, SpecificErrorCodes = void>({
       data?: undefined;
       error:
         | DeviceExchangeError<SpecificErrorCodes>
-        | InvalidBatteryDataError
-        | InvalidBatteryStatusTypeError
         | InvalidResponseFormatError
         | InvalidStatusWordError
         | InvalidGetFirmwareMetadataResponseError

--- a/packages/device-management-kit/src/api/command/os/GetBatteryStatusCommand.test.ts
+++ b/packages/device-management-kit/src/api/command/os/GetBatteryStatusCommand.test.ts
@@ -3,6 +3,7 @@ import {
   CommandResultFactory,
   isSuccessCommandResult,
 } from "@api/command/model/CommandResult";
+import { GlobalCommandErrorHandler } from "@api/command/utils/GlobalCommandError";
 import { ApduResponse } from "@api/device-session/ApduResponse";
 
 import {
@@ -33,6 +34,7 @@ const TEMPERATURE_RESPONSE_HEX = Uint8Array.from([0x10, 0x90, 0x00]);
 const FLAGS_RESPONSE_HEX = Uint8Array.from([
   0x00, 0x00, 0x00, 0x0f, 0x90, 0x00,
 ]);
+const EMPTY_SUCCESS_RESPONSE_HEX = Uint8Array.from([0x90, 0x00]);
 const FAILED_RESPONSE_HEX = Uint8Array.from([0x67, 0x00]);
 
 describe("GetBatteryStatus", () => {
@@ -138,7 +140,7 @@ describe("GetBatteryStatus", () => {
         }),
       );
     });
-    it("should return InvalidResponseFormatError when expected battery data is missing", () => {
+    it("should return a handled command error when the status word is not successful", () => {
       const FAILED_RESPONSE = new ApduResponse({
         statusCode: FAILED_RESPONSE_HEX.slice(-2),
         data: FAILED_RESPONSE_HEX.slice(0, -2),
@@ -147,6 +149,21 @@ describe("GetBatteryStatus", () => {
         statusType: BatteryStatusType.BATTERY_PERCENTAGE,
       });
       const result = command.parseResponse(FAILED_RESPONSE);
+      expect(result).toStrictEqual(
+        CommandResultFactory({
+          error: GlobalCommandErrorHandler.handle(FAILED_RESPONSE),
+        }),
+      );
+    });
+    it("should return InvalidResponseFormatError when expected battery data is missing", () => {
+      const EMPTY_SUCCESS_RESPONSE = new ApduResponse({
+        statusCode: EMPTY_SUCCESS_RESPONSE_HEX.slice(-2),
+        data: EMPTY_SUCCESS_RESPONSE_HEX.slice(0, -2),
+      });
+      const command = new GetBatteryStatusCommand({
+        statusType: BatteryStatusType.BATTERY_PERCENTAGE,
+      });
+      const result = command.parseResponse(EMPTY_SUCCESS_RESPONSE);
       expect(result).toStrictEqual(
         CommandResultFactory({
           error: new InvalidResponseFormatError(

--- a/packages/device-management-kit/src/api/command/os/GetBatteryStatusCommand.test.ts
+++ b/packages/device-management-kit/src/api/command/os/GetBatteryStatusCommand.test.ts
@@ -29,10 +29,18 @@ const GET_BATTERY_STATUS_APDU_FLAGS = Uint8Array.from([
 ]);
 
 const PERCENTAGE_RESPONSE_HEX = Uint8Array.from([0x37, 0x90, 0x00]);
+const PERCENTAGE_OVERFLOW_RESPONSE_HEX = Uint8Array.from([0x65, 0x90, 0x00]);
 const VOLTAGE_RESPONSE_HEX = Uint8Array.from([0x0f, 0xff, 0x90, 0x00]);
 const TEMPERATURE_RESPONSE_HEX = Uint8Array.from([0x10, 0x90, 0x00]);
+const CURRENT_RESPONSE_HEX = Uint8Array.from([0xff, 0x90, 0x00]);
 const FLAGS_RESPONSE_HEX = Uint8Array.from([
   0x00, 0x00, 0x00, 0x0f, 0x90, 0x00,
+]);
+const QI_FLAGS_RESPONSE_HEX = Uint8Array.from([
+  0x00, 0x00, 0x00, 0x01, 0x90, 0x00,
+]);
+const NONE_FLAGS_RESPONSE_HEX = Uint8Array.from([
+  0x00, 0x00, 0x00, 0x00, 0x90, 0x00,
 ]);
 const EMPTY_SUCCESS_RESPONSE_HEX = Uint8Array.from([0x90, 0x00]);
 const FAILED_RESPONSE_HEX = Uint8Array.from([0x67, 0x00]);
@@ -98,6 +106,17 @@ describe("GetBatteryStatus", () => {
       const parsed = command.parseResponse(PERCENTAGE_RESPONSE);
       expect(parsed).toStrictEqual(CommandResultFactory({ data: 55 }));
     });
+    it("should return -1 when battery percentage is above 100", () => {
+      const PERCENTAGE_OVERFLOW_RESPONSE = new ApduResponse({
+        statusCode: PERCENTAGE_OVERFLOW_RESPONSE_HEX.slice(-2),
+        data: PERCENTAGE_OVERFLOW_RESPONSE_HEX.slice(0, -2),
+      });
+      const command = new GetBatteryStatusCommand({
+        statusType: BatteryStatusType.BATTERY_PERCENTAGE,
+      });
+      const parsed = command.parseResponse(PERCENTAGE_OVERFLOW_RESPONSE);
+      expect(parsed).toStrictEqual(CommandResultFactory({ data: -1 }));
+    });
     it("should parse the response when querying voltage", () => {
       const VOLTAGE_RESPONSE = new ApduResponse({
         statusCode: VOLTAGE_RESPONSE_HEX.slice(-2),
@@ -120,6 +139,17 @@ describe("GetBatteryStatus", () => {
       const parsed = command.parseResponse(TEMPERATURE_RESPONSE);
       expect(parsed).toStrictEqual(CommandResultFactory({ data: 16 }));
     });
+    it("should parse the response when querying current", () => {
+      const CURRENT_RESPONSE = new ApduResponse({
+        statusCode: CURRENT_RESPONSE_HEX.slice(-2),
+        data: CURRENT_RESPONSE_HEX.slice(0, -2),
+      });
+      const command = new GetBatteryStatusCommand({
+        statusType: BatteryStatusType.BATTERY_CURRENT,
+      });
+      const parsed = command.parseResponse(CURRENT_RESPONSE);
+      expect(parsed).toStrictEqual(CommandResultFactory({ data: -1 }));
+    });
     it("should parse the response when querying flags", () => {
       const FLAGS_RESPONSE = new ApduResponse({
         statusCode: FLAGS_RESPONSE_HEX.slice(-2),
@@ -133,6 +163,46 @@ describe("GetBatteryStatus", () => {
         CommandResultFactory({
           data: {
             charging: ChargingMode.USB,
+            issueCharging: false,
+            issueTemperature: false,
+            issueBattery: false,
+          },
+        }),
+      );
+    });
+    it("should parse the response when querying flags with Qi charging", () => {
+      const QI_FLAGS_RESPONSE = new ApduResponse({
+        statusCode: QI_FLAGS_RESPONSE_HEX.slice(-2),
+        data: QI_FLAGS_RESPONSE_HEX.slice(0, -2),
+      });
+      const command = new GetBatteryStatusCommand({
+        statusType: BatteryStatusType.BATTERY_FLAGS,
+      });
+      const parsed = command.parseResponse(QI_FLAGS_RESPONSE);
+      expect(parsed).toStrictEqual(
+        CommandResultFactory({
+          data: {
+            charging: ChargingMode.QI,
+            issueCharging: false,
+            issueTemperature: false,
+            issueBattery: false,
+          },
+        }),
+      );
+    });
+    it("should parse the response when querying flags with no charging", () => {
+      const NONE_FLAGS_RESPONSE = new ApduResponse({
+        statusCode: NONE_FLAGS_RESPONSE_HEX.slice(-2),
+        data: NONE_FLAGS_RESPONSE_HEX.slice(0, -2),
+      });
+      const command = new GetBatteryStatusCommand({
+        statusType: BatteryStatusType.BATTERY_FLAGS,
+      });
+      const parsed = command.parseResponse(NONE_FLAGS_RESPONSE);
+      expect(parsed).toStrictEqual(
+        CommandResultFactory({
+          data: {
+            charging: ChargingMode.NONE,
             issueCharging: false,
             issueTemperature: false,
             issueBattery: false,
@@ -168,6 +238,74 @@ describe("GetBatteryStatus", () => {
         CommandResultFactory({
           error: new InvalidResponseFormatError(
             "getBatteryStatus: missing battery percentage in response",
+          ),
+        }),
+      );
+    });
+    it("should return InvalidResponseFormatError when voltage data is missing", () => {
+      const EMPTY_SUCCESS_RESPONSE = new ApduResponse({
+        statusCode: EMPTY_SUCCESS_RESPONSE_HEX.slice(-2),
+        data: EMPTY_SUCCESS_RESPONSE_HEX.slice(0, -2),
+      });
+      const command = new GetBatteryStatusCommand({
+        statusType: BatteryStatusType.BATTERY_VOLTAGE,
+      });
+      const result = command.parseResponse(EMPTY_SUCCESS_RESPONSE);
+      expect(result).toStrictEqual(
+        CommandResultFactory({
+          error: new InvalidResponseFormatError(
+            "getBatteryStatus: missing battery voltage in response",
+          ),
+        }),
+      );
+    });
+    it("should return InvalidResponseFormatError when temperature data is missing", () => {
+      const EMPTY_SUCCESS_RESPONSE = new ApduResponse({
+        statusCode: EMPTY_SUCCESS_RESPONSE_HEX.slice(-2),
+        data: EMPTY_SUCCESS_RESPONSE_HEX.slice(0, -2),
+      });
+      const command = new GetBatteryStatusCommand({
+        statusType: BatteryStatusType.BATTERY_TEMPERATURE,
+      });
+      const result = command.parseResponse(EMPTY_SUCCESS_RESPONSE);
+      expect(result).toStrictEqual(
+        CommandResultFactory({
+          error: new InvalidResponseFormatError(
+            "getBatteryStatus: missing battery temperature in response",
+          ),
+        }),
+      );
+    });
+    it("should return InvalidResponseFormatError when current data is missing", () => {
+      const EMPTY_SUCCESS_RESPONSE = new ApduResponse({
+        statusCode: EMPTY_SUCCESS_RESPONSE_HEX.slice(-2),
+        data: EMPTY_SUCCESS_RESPONSE_HEX.slice(0, -2),
+      });
+      const command = new GetBatteryStatusCommand({
+        statusType: BatteryStatusType.BATTERY_CURRENT,
+      });
+      const result = command.parseResponse(EMPTY_SUCCESS_RESPONSE);
+      expect(result).toStrictEqual(
+        CommandResultFactory({
+          error: new InvalidResponseFormatError(
+            "getBatteryStatus: missing battery current in response",
+          ),
+        }),
+      );
+    });
+    it("should return InvalidResponseFormatError when flags data is missing", () => {
+      const EMPTY_SUCCESS_RESPONSE = new ApduResponse({
+        statusCode: EMPTY_SUCCESS_RESPONSE_HEX.slice(-2),
+        data: EMPTY_SUCCESS_RESPONSE_HEX.slice(0, -2),
+      });
+      const command = new GetBatteryStatusCommand({
+        statusType: BatteryStatusType.BATTERY_FLAGS,
+      });
+      const result = command.parseResponse(EMPTY_SUCCESS_RESPONSE);
+      expect(result).toStrictEqual(
+        CommandResultFactory({
+          error: new InvalidResponseFormatError(
+            "getBatteryStatus: missing battery flags in response",
           ),
         }),
       );

--- a/packages/device-management-kit/src/api/command/os/GetBatteryStatusCommand.test.ts
+++ b/packages/device-management-kit/src/api/command/os/GetBatteryStatusCommand.test.ts
@@ -1,3 +1,4 @@
+import { InvalidResponseFormatError } from "@api/command/Errors";
 import {
   CommandResultFactory,
   isSuccessCommandResult,
@@ -137,7 +138,7 @@ describe("GetBatteryStatus", () => {
         }),
       );
     });
-    it("should return an error if the response returned unsupported format", () => {
+    it("should return InvalidResponseFormatError when expected battery data is missing", () => {
       const FAILED_RESPONSE = new ApduResponse({
         statusCode: FAILED_RESPONSE_HEX.slice(-2),
         data: FAILED_RESPONSE_HEX.slice(0, -2),
@@ -146,7 +147,31 @@ describe("GetBatteryStatus", () => {
         statusType: BatteryStatusType.BATTERY_PERCENTAGE,
       });
       const result = command.parseResponse(FAILED_RESPONSE);
+      expect(result).toStrictEqual(
+        CommandResultFactory({
+          error: new InvalidResponseFormatError(
+            "getBatteryStatus: missing battery percentage in response",
+          ),
+        }),
+      );
+    });
+    it("should return InvalidResponseFormatError when status type is unsupported", () => {
+      const PERCENTAGE_RESPONSE = new ApduResponse({
+        statusCode: PERCENTAGE_RESPONSE_HEX.slice(-2),
+        data: PERCENTAGE_RESPONSE_HEX.slice(0, -2),
+      });
+      const command = new GetBatteryStatusCommand({
+        statusType: 0xff as BatteryStatusType,
+      });
+      const result = command.parseResponse(PERCENTAGE_RESPONSE);
       expect(isSuccessCommandResult(result)).toBeFalsy();
+      expect(result).toStrictEqual(
+        CommandResultFactory({
+          error: new InvalidResponseFormatError(
+            "getBatteryStatus: unsupported battery status type",
+          ),
+        }),
+      );
     });
   });
 });

--- a/packages/device-management-kit/src/api/command/os/GetBatteryStatusCommand.ts
+++ b/packages/device-management-kit/src/api/command/os/GetBatteryStatusCommand.ts
@@ -2,10 +2,7 @@ import { type Apdu } from "@api/apdu/model/Apdu";
 import { ApduBuilder, type ApduBuilderArgs } from "@api/apdu/utils/ApduBuilder";
 import { ApduParser } from "@api/apdu/utils/ApduParser";
 import { type Command } from "@api/command/Command";
-import {
-  InvalidBatteryDataError,
-  InvalidBatteryStatusTypeError,
-} from "@api/command/Errors";
+import { InvalidResponseFormatError } from "@api/command/Errors";
 import {
   type CommandResult,
   CommandResultFactory,
@@ -103,14 +100,18 @@ export class GetBatteryStatusCommand
     apduResponse: ApduResponse,
   ): CommandResult<GetBatteryStatusResponse> {
     const parser = new ApduParser(apduResponse);
+    const invalidResponseFormat = (message: string) =>
+      CommandResultFactory<GetBatteryStatusResponse>({
+        error: new InvalidResponseFormatError(message),
+      });
 
     switch (this.args.statusType) {
       case BatteryStatusType.BATTERY_PERCENTAGE: {
         const percentage = parser.extract8BitUInt();
         if (percentage === undefined) {
-          return CommandResultFactory({
-            error: new InvalidBatteryDataError("Cannot parse APDU response"),
-          });
+          return invalidResponseFormat(
+            "getBatteryStatus: missing battery percentage in response",
+          );
         }
         return CommandResultFactory({
           data: percentage > 100 ? -1 : percentage,
@@ -119,9 +120,9 @@ export class GetBatteryStatusCommand
       case BatteryStatusType.BATTERY_VOLTAGE: {
         const data = parser.extract16BitUInt();
         if (data === undefined) {
-          return CommandResultFactory({
-            error: new InvalidBatteryDataError("Cannot parse APDU response"),
-          });
+          return invalidResponseFormat(
+            "getBatteryStatus: missing battery voltage in response",
+          );
         }
         return CommandResultFactory({
           data,
@@ -131,9 +132,11 @@ export class GetBatteryStatusCommand
       case BatteryStatusType.BATTERY_CURRENT: {
         const data = parser.extract8BitUInt();
         if (data === undefined) {
-          return CommandResultFactory({
-            error: new InvalidBatteryDataError("Cannot parse APDU response"),
-          });
+          return invalidResponseFormat(
+            this.args.statusType === BatteryStatusType.BATTERY_TEMPERATURE
+              ? "getBatteryStatus: missing battery temperature in response"
+              : "getBatteryStatus: missing battery current in response",
+          );
         }
         return CommandResultFactory({
           data: (data << 24) >> 24,
@@ -142,9 +145,9 @@ export class GetBatteryStatusCommand
       case BatteryStatusType.BATTERY_FLAGS: {
         const flags = parser.extract32BitUInt();
         if (flags === undefined) {
-          return CommandResultFactory({
-            error: new InvalidBatteryDataError("Cannot parse APDU response"),
-          });
+          return invalidResponseFormat(
+            "getBatteryStatus: missing battery flags in response",
+          );
         }
         const chargingUSB = !!(flags & FlagMasks.USB_POWERED);
         const chargingQi = !chargingUSB && !!(flags & FlagMasks.CHARGING);
@@ -162,11 +165,9 @@ export class GetBatteryStatusCommand
         });
       }
       default:
-        return CommandResultFactory({
-          error: new InvalidBatteryStatusTypeError(
-            "One or some case(s) not covered",
-          ),
-        });
+        return invalidResponseFormat(
+          "getBatteryStatus: unsupported battery status type",
+        );
     }
   }
 }

--- a/packages/device-management-kit/src/api/command/os/GetBatteryStatusCommand.ts
+++ b/packages/device-management-kit/src/api/command/os/GetBatteryStatusCommand.ts
@@ -7,6 +7,8 @@ import {
   type CommandResult,
   CommandResultFactory,
 } from "@api/command/model/CommandResult";
+import { CommandUtils } from "@api/command/utils/CommandUtils";
+import { GlobalCommandErrorHandler } from "@api/command/utils/GlobalCommandError";
 import { type ApduResponse } from "@api/device-session/ApduResponse";
 
 /**
@@ -99,6 +101,11 @@ export class GetBatteryStatusCommand
   parseResponse(
     apduResponse: ApduResponse,
   ): CommandResult<GetBatteryStatusResponse> {
+    if (!CommandUtils.isSuccessResponse(apduResponse)) {
+      return CommandResultFactory({
+        error: GlobalCommandErrorHandler.handle(apduResponse),
+      });
+    }
     const parser = new ApduParser(apduResponse);
     const invalidResponseFormat = (message: string) =>
       CommandResultFactory<GetBatteryStatusResponse>({


### PR DESCRIPTION
### 📝 Description

This PR removes battery-specific parsing errors from the central `CommandResult` surface in DMK.

`GetBatteryStatusCommand` now guards on the APDU status word before parsing and returns `GlobalCommandErrorHandler` results for non-success status words. For successful responses, battery parsing failures are mapped to `InvalidResponseFormatError` with command-specific messages, so `CommandResult` and `CommandResultFactory` no longer need to know about battery-only error classes.

This is intentionally scoped to the battery command only. While doing this cleanup, I found a broader architectural issue: some non-command workflows still use `CommandResult` as a generic result type.
Follow-up tech debt issue: #1442.

The battery command test suite was also extended to full coverage.

### ❓ Context

- **JIRA or GitHub link**: `[NO-ISSUE]`
- **Feature**: Simplify battery command result errors

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - remove `InvalidBatteryDataError` and `InvalidBatteryStatusTypeError` from the central `CommandResult` typing
  - guard `GetBatteryStatusCommand` payload parsing with status-word validation so non-success responses use global command handling
  - switch successful battery parsing failures to `InvalidResponseFormatError` with contextual messages
  - bring `GetBatteryStatusCommand` to full test coverage
  - keep firmware metadata cleanup out of scope until task-level result typing is addressed