### PR TITLE
♻️ (dmk) [NO-ISSUE]: Extract a generic result base DmkResult from CommandResult

### DIFF
--- a/.changeset/full-frogs-allow.md
+++ b/.changeset/full-frogs-allow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": patch
+---
+
+Align Ethereum device action error typing with the DMK task result error contract.

--- a/.changeset/salty-pumas-rush.md
+++ b/.changeset/salty-pumas-rush.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-zcash": patch
+---
+
+Align Zcash app binder task typing with the DMK task result error contract.

--- a/.changeset/slow-owls-flow.md
+++ b/.changeset/slow-owls-flow.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Introduce `DmkResult` as a generic base result abstraction and move task-specific firmware metadata errors out of `CommandResult`.
+
+Code that constructs `CommandResultFactory` with `InvalidGetFirmwareMetadataResponseError` will now fail at the type level. Non-command flows should use `DmkResultFactory` instead.

--- a/packages/config/eslint/index.js
+++ b/packages/config/eslint/index.js
@@ -134,6 +134,24 @@ export default [
       ],
     },
   },
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    ignores: ["**/*.test.ts", "**/*.test.tsx", "**/command/**"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "warn",
+        {
+          paths: [
+            {
+              name: "@ledgerhq/device-management-kit",
+              importNames: ["CommandResultFactory"],
+              message: "Use DmkResultFactory outside the command layer.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 
   {
     files: ["**/*.tsx"],

--- a/packages/device-management-kit/eslint.config.mjs
+++ b/packages/device-management-kit/eslint.config.mjs
@@ -10,4 +10,31 @@ export default [
       },
     },
   },
+  {
+    files: ["src/**/*.ts"],
+    ignores: [
+      "src/**/*.test.ts",
+      "src/api/command/**/*.ts",
+      "src/api/index.ts",
+    ],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@api/command/model/CommandResult",
+              importNames: ["CommandResultFactory"],
+              message: "Use DmkResultFactory outside the command layer.",
+            },
+            {
+              name: "@ledgerhq/device-management-kit",
+              importNames: ["CommandResultFactory"],
+              message: "Use DmkResultFactory outside the command layer.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];

--- a/packages/device-management-kit/eslint.config.mjs
+++ b/packages/device-management-kit/eslint.config.mjs
@@ -28,6 +28,11 @@ export default [
               message: "Use DmkResultFactory outside the command layer.",
             },
             {
+              name: "@api/index",
+              importNames: ["CommandResultFactory"],
+              message: "Use DmkResultFactory outside the command layer.",
+            },
+            {
               name: "@ledgerhq/device-management-kit",
               importNames: ["CommandResultFactory"],
               message: "Use DmkResultFactory outside the command layer.",

--- a/packages/device-management-kit/src/api/command/Errors.ts
+++ b/packages/device-management-kit/src/api/command/Errors.ts
@@ -17,14 +17,3 @@ export class InvalidResponseFormatError implements DmkError {
     this.originalError = new Error(message ?? "Invalid response format.");
   }
 }
-
-export class InvalidGetFirmwareMetadataResponseError implements DmkError {
-  readonly _tag = "InvalidGetFirmwareMetadataResponseError";
-  readonly originalError: Error;
-
-  constructor(message?: string) {
-    this.originalError = new Error(
-      message ?? "Invalid Firmware Metadata response error.",
-    );
-  }
-}

--- a/packages/device-management-kit/src/api/command/model/CommandResult.ts
+++ b/packages/device-management-kit/src/api/command/model/CommandResult.ts
@@ -1,34 +1,38 @@
-import {
-  type InvalidGetFirmwareMetadataResponseError,
-  type InvalidResponseFormatError,
-  type InvalidStatusWordError,
+import type {
+  InvalidResponseFormatError,
+  InvalidStatusWordError,
 } from "@api/command/Errors";
-import { type GlobalCommandErrorStatusCode } from "@api/command/utils/GlobalCommandError";
-import {
-  type DeviceExchangeError,
-  type UnknownDeviceExchangeError,
+import type { GlobalCommandErrorStatusCode } from "@api/command/utils/GlobalCommandError";
+import type {
+  DeviceExchangeError,
+  UnknownDeviceExchangeError,
 } from "@api/Error";
+import type {
+  DmkErrorResult,
+  DmkResult,
+  DmkSuccessResult,
+} from "@api/model/DmkResult";
+import {
+  DmkResultFactory,
+  DmkResultStatus,
+  isSuccessDmkResult,
+} from "@api/model/DmkResult";
 
-export enum CommandResultStatus {
-  Error = "ERROR",
-  Success = "SUCCESS",
-}
-export type CommandSuccessResult<Data> = {
-  status: CommandResultStatus.Success;
-  data: Data;
-};
-export type CommandErrorResult<SpecificErrorCodes = void> = {
-  error:
-    | DeviceExchangeError<SpecificErrorCodes | GlobalCommandErrorStatusCode>
-    | InvalidResponseFormatError
-    | InvalidStatusWordError
-    | InvalidGetFirmwareMetadataResponseError
-    | UnknownDeviceExchangeError;
-  status: CommandResultStatus.Error;
-};
-export type CommandResult<Data, SpecificErrorCodes = void> =
-  | CommandSuccessResult<Data>
-  | CommandErrorResult<SpecificErrorCodes>;
+export { DmkResultStatus as CommandResultStatus };
+type CommandError<SpecificErrorCodes = void> =
+  | DeviceExchangeError<SpecificErrorCodes | GlobalCommandErrorStatusCode>
+  | InvalidResponseFormatError
+  | InvalidStatusWordError
+  | UnknownDeviceExchangeError;
+
+export type CommandSuccessResult<Data> = DmkSuccessResult<Data>;
+export type CommandErrorResult<SpecificErrorCodes = void> = DmkErrorResult<
+  CommandError<SpecificErrorCodes>
+>;
+export type CommandResult<Data, SpecificErrorCodes = void> = DmkResult<
+  Data,
+  CommandError<SpecificErrorCodes>
+>;
 
 export function CommandResultFactory<Data, SpecificErrorCodes = void>({
   data,
@@ -37,27 +41,21 @@ export function CommandResultFactory<Data, SpecificErrorCodes = void>({
   | { data: Data; error?: undefined }
   | {
       data?: undefined;
-      error:
-        | DeviceExchangeError<SpecificErrorCodes>
-        | InvalidResponseFormatError
-        | InvalidStatusWordError
-        | InvalidGetFirmwareMetadataResponseError
-        | UnknownDeviceExchangeError;
+      error: CommandError<SpecificErrorCodes>;
     }): CommandResult<Data, SpecificErrorCodes> {
-  if (error) {
-    return {
-      status: CommandResultStatus.Error,
+  if (error !== undefined) {
+    return DmkResultFactory({
       error,
-    };
+    });
   }
-  return {
-    status: CommandResultStatus.Success,
+
+  return DmkResultFactory({
     data,
-  };
+  });
 }
 
 export function isSuccessCommandResult<Data, StatusCode>(
   result: CommandResult<Data, StatusCode>,
 ): result is CommandSuccessResult<Data> {
-  return result.status === CommandResultStatus.Success;
+  return isSuccessDmkResult(result);
 }

--- a/packages/device-management-kit/src/api/device-action/os/CallTaskInAppDeviceAction/CallTaskInAppDeviceAction.test.ts
+++ b/packages/device-management-kit/src/api/device-action/os/CallTaskInAppDeviceAction/CallTaskInAppDeviceAction.test.ts
@@ -16,6 +16,7 @@ import { UserInteractionRequired } from "@api/device-action/model/UserInteractio
 import { UnknownDAError } from "@api/device-action/os/Errors";
 import { OpenAppDeviceAction } from "@api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction";
 import { openAppDAStateStep } from "@api/device-action/os/OpenAppDeviceAction/types";
+import { DmkResultFactory } from "@api/model/DmkResult";
 import { type Command } from "@api/types";
 import { UnknownDeviceExchangeError } from "@root/src";
 
@@ -174,7 +175,7 @@ describe("CallTaskInAppDeviceAction", () => {
         setupOpenAppDAMock();
 
         callMyTask.mockResolvedValue(
-          CommandResultFactory({
+          DmkResultFactory({
             error: new UnknownDeviceExchangeError("Mocked error"),
           }),
         );
@@ -239,7 +240,7 @@ describe("CallTaskInAppDeviceAction", () => {
         setupOpenAppDAMock();
 
         callMyTask.mockResolvedValue(
-          CommandResultFactory({ data: mockedCommandResponse }),
+          DmkResultFactory({ data: mockedCommandResponse }),
         );
 
         const deviceAction = new CallTaskInAppDeviceAction({
@@ -300,7 +301,7 @@ describe("CallTaskInAppDeviceAction", () => {
         setupOpenAppDAMock();
 
         callMyTask.mockResolvedValue(
-          CommandResultFactory({ data: mockedCommandResponse }),
+          DmkResultFactory({ data: mockedCommandResponse }),
         );
 
         const deviceAction = new CallTaskInAppDeviceAction({
@@ -374,7 +375,7 @@ class TestCommand implements Command<MyCommandResponse, MyCommandParams> {
 
 type MyCommandCallTaskDAState = DeviceActionState<
   CallTaskInAppDAOutput<MyCommandResponse>,
-  CallTaskInAppDAError<UnknownDAError>,
+  CallTaskInAppDAError<UnknownDAError | UnknownDeviceExchangeError>,
   CallTaskInAppDAIntermediateValue<
     UserInteractionRequired.None | UserInteractionRequired.VerifyAddress
   >

--- a/packages/device-management-kit/src/api/device-action/os/CallTaskInAppDeviceAction/CallTaskInAppDeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/os/CallTaskInAppDeviceAction/CallTaskInAppDeviceAction.ts
@@ -1,10 +1,6 @@
 import { Left, Right } from "purify-ts";
 import { assign, fromPromise, setup } from "xstate";
 
-import {
-  type CommandResult,
-  isSuccessCommandResult,
-} from "@api/command/model/CommandResult";
 import { type InternalApi } from "@api/device-action/DeviceAction";
 import { UserInteractionRequired } from "@api/device-action/model/UserInteractionRequired";
 import { UnknownDAError } from "@api/device-action/os/Errors";
@@ -14,6 +10,7 @@ import {
   type DeviceActionStateMachine,
   XStateDeviceAction,
 } from "@api/device-action/xstate-utils/XStateDeviceAction";
+import { type DmkResult, isSuccessDmkResult } from "@api/model/DmkResult";
 
 import {
   type CallTaskInAppDAError,
@@ -22,6 +19,7 @@ import {
   type CallTaskInAppDAInternalState,
   type CallTaskInAppDAOutput,
   callTaskInAppDAStateStep,
+  type CallTaskInAppTaskError,
 } from "./CallTaskInAppDeviceActionTypes";
 
 /**
@@ -32,7 +30,7 @@ import {
  * ```ts
  * input: {
  *  appName: string;
- *  task: (internalApi: InternalApi) => Promise<CommandResult<TaskResponse, TaskErrorCodes>>;
+ *  task: (internalApi: InternalApi) => Promise<DmkResult<TaskResponse, TaskError>>;
  *  requiredUserInteraction: UserInteraction;
  * }
  * ```
@@ -52,30 +50,30 @@ import {
  */
 export class CallTaskInAppDeviceAction<
   TaskResponse,
-  TaskErrorCodes,
-  UserInteraction extends UserInteractionRequired,
+  TaskError = void,
+  UserInteraction extends UserInteractionRequired = UserInteractionRequired,
 > extends XStateDeviceAction<
   CallTaskInAppDAOutput<TaskResponse>,
-  CallTaskInAppDAInput<TaskResponse, TaskErrorCodes, UserInteraction>,
-  CallTaskInAppDAError<TaskErrorCodes>,
+  CallTaskInAppDAInput<TaskResponse, TaskError, UserInteraction>,
+  CallTaskInAppDAError<TaskError>,
   CallTaskInAppDAIntermediateValue<UserInteraction>,
-  CallTaskInAppDAInternalState<TaskResponse, TaskErrorCodes>
+  CallTaskInAppDAInternalState<TaskResponse, TaskError>
 > {
   makeStateMachine(
     internalAPI: InternalApi,
   ): DeviceActionStateMachine<
     CallTaskInAppDAOutput<TaskResponse>,
-    CallTaskInAppDAInput<TaskResponse, TaskErrorCodes, UserInteraction>,
-    CallTaskInAppDAError<TaskErrorCodes>,
+    CallTaskInAppDAInput<TaskResponse, TaskError, UserInteraction>,
+    CallTaskInAppDAError<TaskError>,
     CallTaskInAppDAIntermediateValue<UserInteraction>,
-    CallTaskInAppDAInternalState<TaskResponse, TaskErrorCodes>
+    CallTaskInAppDAInternalState<TaskResponse, TaskError>
   > {
     type types = StateMachineTypes<
       CallTaskInAppDAOutput<TaskResponse>,
-      CallTaskInAppDAInput<TaskResponse, TaskErrorCodes, UserInteraction>,
-      CallTaskInAppDAError<TaskErrorCodes>,
+      CallTaskInAppDAInput<TaskResponse, TaskError, UserInteraction>,
+      CallTaskInAppDAError<TaskError>,
       CallTaskInAppDAIntermediateValue<UserInteraction>,
-      CallTaskInAppDAInternalState<TaskResponse, TaskErrorCodes>
+      CallTaskInAppDAInternalState<TaskResponse, TaskError>
     >;
 
     const { callTask } = this.extractDependencies(internalAPI);
@@ -149,7 +147,7 @@ export class CallTaskInAppDeviceAction<
               actions: assign({
                 _internalState: (_) => {
                   return _.event.output.caseOf<
-                    CallTaskInAppDAInternalState<TaskResponse, TaskErrorCodes>
+                    CallTaskInAppDAInternalState<TaskResponse, TaskError>
                   >({
                     Right: () => _.context._internalState,
                     Left: (error) => ({
@@ -194,7 +192,7 @@ export class CallTaskInAppDeviceAction<
               actions: [
                 assign({
                   _internalState: ({ event, context }) => {
-                    if (isSuccessCommandResult(event.output)) {
+                    if (isSuccessDmkResult(event.output)) {
                       return {
                         ...context._internalState,
                         taskResponse: event.output.data,
@@ -245,8 +243,10 @@ export class CallTaskInAppDeviceAction<
       callTask: (_: {
         input: (
           internalApi: InternalApi,
-        ) => Promise<CommandResult<TaskResponse, TaskErrorCodes>>;
-      }): Promise<CommandResult<TaskResponse, TaskErrorCodes>> =>
+        ) => Promise<
+          DmkResult<TaskResponse, CallTaskInAppTaskError<TaskError>>
+        >;
+      }): Promise<DmkResult<TaskResponse, CallTaskInAppTaskError<TaskError>>> =>
         _.input(internalApi),
     };
   }

--- a/packages/device-management-kit/src/api/device-action/os/CallTaskInAppDeviceAction/CallTaskInAppDeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/os/CallTaskInAppDeviceAction/CallTaskInAppDeviceAction.ts
@@ -52,8 +52,8 @@ import {
  */
 export class CallTaskInAppDeviceAction<
   TaskResponse,
-  TaskError extends DmkError = DmkError,
-  UserInteraction extends UserInteractionRequired = UserInteractionRequired,
+  TaskError extends DmkError,
+  UserInteraction extends UserInteractionRequired,
 > extends XStateDeviceAction<
   CallTaskInAppDAOutput<TaskResponse>,
   CallTaskInAppDAInput<TaskResponse, TaskError, UserInteraction>,

--- a/packages/device-management-kit/src/api/device-action/os/CallTaskInAppDeviceAction/CallTaskInAppDeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/os/CallTaskInAppDeviceAction/CallTaskInAppDeviceAction.ts
@@ -10,6 +10,7 @@ import {
   type DeviceActionStateMachine,
   XStateDeviceAction,
 } from "@api/device-action/xstate-utils/XStateDeviceAction";
+import { type DmkError } from "@api/Error";
 import { type DmkResult, isSuccessDmkResult } from "@api/model/DmkResult";
 
 import {
@@ -19,7 +20,6 @@ import {
   type CallTaskInAppDAInternalState,
   type CallTaskInAppDAOutput,
   callTaskInAppDAStateStep,
-  type CallTaskInAppTaskError,
 } from "./CallTaskInAppDeviceActionTypes";
 
 /**
@@ -30,7 +30,9 @@ import {
  * ```ts
  * input: {
  *  appName: string;
- *  task: (internalApi: InternalApi) => Promise<DmkResult<TaskResponse, TaskError>>;
+ *  task: (
+ *    internalApi: InternalApi,
+ *  ) => Promise<DmkResult<TaskResponse, TaskError>>;
  *  requiredUserInteraction: UserInteraction;
  * }
  * ```
@@ -50,7 +52,7 @@ import {
  */
 export class CallTaskInAppDeviceAction<
   TaskResponse,
-  TaskError = void,
+  TaskError extends DmkError = DmkError,
   UserInteraction extends UserInteractionRequired = UserInteractionRequired,
 > extends XStateDeviceAction<
   CallTaskInAppDAOutput<TaskResponse>,
@@ -243,11 +245,8 @@ export class CallTaskInAppDeviceAction<
       callTask: (_: {
         input: (
           internalApi: InternalApi,
-        ) => Promise<
-          DmkResult<TaskResponse, CallTaskInAppTaskError<TaskError>>
-        >;
-      }): Promise<DmkResult<TaskResponse, CallTaskInAppTaskError<TaskError>>> =>
-        _.input(internalApi),
+        ) => Promise<DmkResult<TaskResponse, TaskError>>;
+      }): Promise<DmkResult<TaskResponse, TaskError>> => _.input(internalApi),
     };
   }
 }

--- a/packages/device-management-kit/src/api/device-action/os/CallTaskInAppDeviceAction/CallTaskInAppDeviceActionTypes.ts
+++ b/packages/device-management-kit/src/api/device-action/os/CallTaskInAppDeviceAction/CallTaskInAppDeviceActionTypes.ts
@@ -1,4 +1,3 @@
-import { type CommandErrorResult } from "@api/command/model/CommandResult";
 import { type InternalApi } from "@api/device-action/DeviceAction";
 import { type UserInteractionRequired } from "@api/device-action/model/UserInteractionRequired";
 import {
@@ -18,28 +17,22 @@ export type CallTaskInAppDAStateStep =
 
 export type CallTaskInAppDAOutput<TaskResponse> = TaskResponse;
 
-export type CallTaskInAppTaskError<TaskError = void> = [TaskError] extends [
-  string | void,
-]
-  ? CommandErrorResult<TaskError>["error"]
-  : Extract<TaskError, DmkError>;
-
 export type CallTaskInAppDAInput<
   TaskResponse,
-  TaskError = void,
+  TaskError extends DmkError = DmkError,
   UserInteraction = UserInteractionRequired,
 > = {
   readonly task: (
     internalApi: InternalApi,
-  ) => Promise<DmkResult<TaskResponse, CallTaskInAppTaskError<TaskError>>>;
+  ) => Promise<DmkResult<TaskResponse, TaskError>>;
   readonly appName: string;
   readonly skipOpenApp: boolean;
   readonly requiredUserInteraction: UserInteraction;
 };
 
-export type CallTaskInAppDAError<TaskError = void> =
+export type CallTaskInAppDAError<TaskError extends DmkError = DmkError> =
   | OpenAppDAError
-  | CallTaskInAppTaskError<TaskError>;
+  | TaskError;
 
 export type CallTaskInAppDARequiredInteraction = UserInteractionRequired.None;
 
@@ -52,7 +45,10 @@ export type CallTaskInAppDAIntermediateValue<UserInteraction> =
     }
   | OpenAppDAIntermediateValue;
 
-export type CallTaskInAppDAInternalState<TaskResponse, TaskError = void> = {
+export type CallTaskInAppDAInternalState<
+  TaskResponse,
+  TaskError extends DmkError = DmkError,
+> = {
   readonly taskResponse: TaskResponse | null;
   readonly error: CallTaskInAppDAError<TaskError> | null;
 };

--- a/packages/device-management-kit/src/api/device-action/os/CallTaskInAppDeviceAction/CallTaskInAppDeviceActionTypes.ts
+++ b/packages/device-management-kit/src/api/device-action/os/CallTaskInAppDeviceAction/CallTaskInAppDeviceActionTypes.ts
@@ -19,8 +19,8 @@ export type CallTaskInAppDAOutput<TaskResponse> = TaskResponse;
 
 export type CallTaskInAppDAInput<
   TaskResponse,
-  TaskError extends DmkError = DmkError,
-  UserInteraction = UserInteractionRequired,
+  TaskError extends DmkError,
+  UserInteraction,
 > = {
   readonly task: (
     internalApi: InternalApi,

--- a/packages/device-management-kit/src/api/device-action/os/CallTaskInAppDeviceAction/CallTaskInAppDeviceActionTypes.ts
+++ b/packages/device-management-kit/src/api/device-action/os/CallTaskInAppDeviceAction/CallTaskInAppDeviceActionTypes.ts
@@ -1,13 +1,12 @@
-import {
-  type CommandErrorResult,
-  type CommandResult,
-} from "@api/command/model/CommandResult";
+import { type CommandErrorResult } from "@api/command/model/CommandResult";
 import { type InternalApi } from "@api/device-action/DeviceAction";
 import { type UserInteractionRequired } from "@api/device-action/model/UserInteractionRequired";
 import {
   type OpenAppDAError,
   type OpenAppDAIntermediateValue,
 } from "@api/device-action/os/OpenAppDeviceAction/types";
+import { type DmkError } from "@api/Error";
+import { type DmkResult } from "@api/model/DmkResult";
 
 export const callTaskInAppDAStateStep = Object.freeze({
   OPEN_APP: "os.callTaskInApp.steps.openApp",
@@ -19,22 +18,28 @@ export type CallTaskInAppDAStateStep =
 
 export type CallTaskInAppDAOutput<TaskResponse> = TaskResponse;
 
+export type CallTaskInAppTaskError<TaskError = void> = [TaskError] extends [
+  string | void,
+]
+  ? CommandErrorResult<TaskError>["error"]
+  : Extract<TaskError, DmkError>;
+
 export type CallTaskInAppDAInput<
   TaskResponse,
-  TaskErrorCodes,
-  UserInteraction,
+  TaskError = void,
+  UserInteraction = UserInteractionRequired,
 > = {
   readonly task: (
     internalApi: InternalApi,
-  ) => Promise<CommandResult<TaskResponse, TaskErrorCodes>>;
+  ) => Promise<DmkResult<TaskResponse, CallTaskInAppTaskError<TaskError>>>;
   readonly appName: string;
   readonly skipOpenApp: boolean;
   readonly requiredUserInteraction: UserInteraction;
 };
 
-export type CallTaskInAppDAError<TaskErrorCodes = void> =
+export type CallTaskInAppDAError<TaskError = void> =
   | OpenAppDAError
-  | CommandErrorResult<TaskErrorCodes>["error"];
+  | CallTaskInAppTaskError<TaskError>;
 
 export type CallTaskInAppDARequiredInteraction = UserInteractionRequired.None;
 
@@ -47,7 +52,7 @@ export type CallTaskInAppDAIntermediateValue<UserInteraction> =
     }
   | OpenAppDAIntermediateValue;
 
-export type CallTaskInAppDAInternalState<TaskResponse, TaskErrorCodes> = {
+export type CallTaskInAppDAInternalState<TaskResponse, TaskError = void> = {
   readonly taskResponse: TaskResponse | null;
-  readonly error: CallTaskInAppDAError<TaskErrorCodes> | null;
+  readonly error: CallTaskInAppDAError<TaskError> | null;
 };

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceMetadata/GetDeviceMetadataDeviceAction.test.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceMetadata/GetDeviceMetadataDeviceAction.test.ts
@@ -1,6 +1,5 @@
 import { concat, of, throwError } from "rxjs";
 
-import { CommandResultFactory } from "@api/command/model/CommandResult";
 import { DeviceStatus } from "@api/device/DeviceStatus";
 import { BTC_APP } from "@api/device-action/__test-utils__/data";
 import { makeDeviceActionInternalApiMock } from "@api/device-action/__test-utils__/makeInternalApi";
@@ -22,6 +21,7 @@ import {
 } from "@api/device-session/DeviceSessionState";
 import { DeviceSessionStateType } from "@api/device-session/DeviceSessionState";
 import { UnknownDeviceExchangeError } from "@api/Error";
+import { DmkResultFactory } from "@api/model/DmkResult";
 import {
   type SecureChannelEventPayload,
   SecureChannelEventType,
@@ -133,7 +133,7 @@ describe("GetDeviceMetadataDeviceAction", () => {
 
         getDeviceMetadataMock.mockResolvedValueOnce(null);
         getFirmwareMetadataMock.mockResolvedValueOnce(
-          CommandResultFactory({
+          DmkResultFactory({
             data: {
               deviceVersion: DEVICE_VERSION,
               firmware: FIRMWARE,
@@ -144,7 +144,7 @@ describe("GetDeviceMetadataDeviceAction", () => {
           }),
         );
         getApplicationsMetadataMock.mockResolvedValueOnce(
-          CommandResultFactory({
+          DmkResultFactory({
             data: {
               applications: APPS,
               applicationsUpdates: APPS_UPDATE,
@@ -244,7 +244,7 @@ describe("GetDeviceMetadataDeviceAction", () => {
         });
 
         getFirmwareMetadataMock.mockResolvedValueOnce(
-          CommandResultFactory({
+          DmkResultFactory({
             data: {
               deviceVersion: DEVICE_VERSION,
               firmware: FIRMWARE,
@@ -255,7 +255,7 @@ describe("GetDeviceMetadataDeviceAction", () => {
           }),
         );
         getApplicationsMetadataMock.mockResolvedValueOnce(
-          CommandResultFactory({
+          DmkResultFactory({
             data: {
               applications: APPS,
               applicationsUpdates: APPS_UPDATE,
@@ -347,7 +347,7 @@ describe("GetDeviceMetadataDeviceAction", () => {
 
         getDeviceMetadataMock.mockResolvedValueOnce(null);
         getFirmwareMetadataMock.mockResolvedValueOnce(
-          CommandResultFactory({
+          DmkResultFactory({
             data: {
               deviceVersion: DEVICE_VERSION,
               firmware: FIRMWARE,
@@ -382,7 +382,7 @@ describe("GetDeviceMetadataDeviceAction", () => {
           ),
         );
         getApplicationsMetadataMock.mockResolvedValueOnce(
-          CommandResultFactory({
+          DmkResultFactory({
             data: {
               applications: APPS,
               applicationsUpdates: APPS_UPDATE,
@@ -619,7 +619,7 @@ describe("GetDeviceMetadataDeviceAction", () => {
 
         getDeviceMetadataMock.mockResolvedValueOnce(null);
         getFirmwareMetadataMock.mockResolvedValueOnce(
-          CommandResultFactory({
+          DmkResultFactory({
             error: new UnknownDeviceExchangeError("GetFirmwareMetadata failed"),
           }),
         );
@@ -683,7 +683,7 @@ describe("GetDeviceMetadataDeviceAction", () => {
 
         getDeviceMetadataMock.mockResolvedValueOnce(null);
         getFirmwareMetadataMock.mockResolvedValueOnce(
-          CommandResultFactory({
+          DmkResultFactory({
             data: {
               deviceVersion: DEVICE_VERSION,
               firmware: FIRMWARE,
@@ -769,7 +769,7 @@ describe("GetDeviceMetadataDeviceAction", () => {
 
         getDeviceMetadataMock.mockResolvedValueOnce(null);
         getFirmwareMetadataMock.mockResolvedValueOnce(
-          CommandResultFactory({
+          DmkResultFactory({
             data: {
               deviceVersion: DEVICE_VERSION,
               firmware: FIRMWARE,
@@ -780,7 +780,7 @@ describe("GetDeviceMetadataDeviceAction", () => {
           }),
         );
         getApplicationsMetadataMock.mockResolvedValueOnce(
-          CommandResultFactory({
+          DmkResultFactory({
             error: new UnknownDeviceExchangeError(
               "GetApplicationsMetadata failed",
             ),
@@ -871,7 +871,7 @@ describe("GetDeviceMetadataDeviceAction", () => {
 
         getDeviceMetadataMock.mockResolvedValueOnce(null);
         getFirmwareMetadataMock.mockResolvedValueOnce(
-          CommandResultFactory({
+          DmkResultFactory({
             data: {
               deviceVersion: DEVICE_VERSION,
               firmware: FIRMWARE,

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceMetadata/GetDeviceMetadataDeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceMetadata/GetDeviceMetadataDeviceAction.ts
@@ -2,7 +2,6 @@ import { Left, Right } from "purify-ts";
 import { type Observable } from "rxjs";
 import { assign, fromObservable, fromPromise, setup } from "xstate";
 
-import { isSuccessCommandResult } from "@api/command/model/CommandResult";
 import { type InternalApi } from "@api/device-action/DeviceAction";
 import { UserInteractionRequired } from "@api/device-action/model/UserInteractionRequired";
 import { DEFAULT_UNLOCK_TIMEOUT_MS } from "@api/device-action/os/Const";
@@ -30,6 +29,7 @@ import {
   type FirmwareVersion,
   type InstalledLanguagePackage,
 } from "@api/device-session/DeviceSessionState";
+import { isSuccessDmkResult } from "@api/model/DmkResult";
 import { installedAppResultGuard } from "@api/secure-channel/device-action/ListInstalledApps/types";
 import { ConnectToSecureChannelTask } from "@api/secure-channel/task/ConnectToSecureChannelTask";
 import { SecureChannelEventType } from "@api/secure-channel/task/types";
@@ -315,7 +315,7 @@ export class GetDeviceMetadataDeviceAction extends XStateDeviceAction<
               target: "GetFirmwareMetadataResultCheck",
               actions: assign({
                 _internalState: (_) => {
-                  if (isSuccessCommandResult(_.event.output)) {
+                  if (isSuccessDmkResult(_.event.output)) {
                     const deviceState = internalApi.getDeviceSessionState();
                     if (
                       deviceState.sessionStateType !==
@@ -537,7 +537,7 @@ export class GetDeviceMetadataDeviceAction extends XStateDeviceAction<
               target: "GetApplicationsMetadataResultCheck",
               actions: assign({
                 _internalState: (_) => {
-                  if (isSuccessCommandResult(_.event.output)) {
+                  if (isSuccessDmkResult(_.event.output)) {
                     const deviceState = internalApi.getDeviceSessionState();
                     if (
                       deviceState.sessionStateType !==

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceMetadata/types.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceMetadata/types.ts
@@ -11,7 +11,7 @@ import {
   type ListAppsDARequiredInteraction,
   type ListAppsDAStateStep,
 } from "@api/device-action/os/ListApps/types";
-import { type GetApplicationsMetadataTaskError } from "@api/device-action/task/GetApplicationsMetadataTask";
+import { type GetApplicationsMetadataTaskError } from "@api/device-action/task/Errors";
 import { type GetFirmwareMetadataTaskError } from "@api/device-action/task/GetFirmwareMetadataTask";
 import {
   type Catalog,

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceMetadata/types.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceMetadata/types.ts
@@ -1,4 +1,3 @@
-import { type CommandErrorResult } from "@api/command/model/CommandResult";
 import { type DeviceActionState } from "@api/device-action/model/DeviceActionState";
 import { type GetDeviceStatusDAStateStep } from "@api/device-action/os/GetDeviceStatus/types";
 import {
@@ -12,6 +11,8 @@ import {
   type ListAppsDARequiredInteraction,
   type ListAppsDAStateStep,
 } from "@api/device-action/os/ListApps/types";
+import { type GetApplicationsMetadataTaskError } from "@api/device-action/task/GetApplicationsMetadataTask";
+import { type GetFirmwareMetadataTaskError } from "@api/device-action/task/GetFirmwareMetadataTask";
 import {
   type Catalog,
   type CustomImage,
@@ -59,7 +60,8 @@ export type GetDeviceMetadataDAError =
   | ListAppsDAError
   | ListInstalledAppsDAError
   | SecureChannelDAErrors
-  | CommandErrorResult["error"];
+  | GetApplicationsMetadataTaskError
+  | GetFirmwareMetadataTaskError;
 
 export type GetDeviceMetadataDARequiredInteraction =
   | GoToDashboardDARequiredInteraction

--- a/packages/device-management-kit/src/api/device-action/task/BackupAppStorageTask.test.ts
+++ b/packages/device-management-kit/src/api/device-action/task/BackupAppStorageTask.test.ts
@@ -5,7 +5,11 @@ import {
   BackupAppStorageTask,
   type BackupAppStorageTaskResponse,
 } from "@api/device-action/task/BackupAppStorageTask";
-import { CommandResultFactory, isSuccessCommandResult } from "@api/index";
+import {
+  CommandResultFactory,
+  DmkResultFactory,
+  isSuccessDmkResult,
+} from "@api/index";
 import { type LoggerPublisherService } from "@api/logger-publisher/service/LoggerPublisherService";
 
 describe("BackupAppStorageTask", () => {
@@ -67,7 +71,7 @@ describe("BackupAppStorageTask", () => {
       const result = await task.run();
 
       // ASSERT
-      expect(isSuccessCommandResult(result)).toBe(true);
+      expect(isSuccessDmkResult(result)).toBe(true);
       expect(
         (result as { data: BackupAppStorageTaskResponse }).data.appStorageData,
       ).toBe("0x01234567890a0b0c0d0e0f10111213");
@@ -98,7 +102,14 @@ describe("BackupAppStorageTask", () => {
       const result = await task.run();
 
       // ASSERT
-      expect(result.status).toBe("ERROR");
+      expect(result).toStrictEqual(
+        DmkResultFactory({
+          error: new GetAppStorageInfoCommandError({
+            message: "Application not found.",
+            errorCode: "5123",
+          }),
+        }),
+      );
     });
 
     it("should return error when backing up app storage data fails", async () => {
@@ -128,7 +139,7 @@ describe("BackupAppStorageTask", () => {
       const result = await task.run();
 
       // ASSERT
-      expect(isSuccessCommandResult(result)).toBe(false);
+      expect(isSuccessDmkResult(result)).toBe(false);
       expect(
         (result as { error: BackupStorageCommandError }).error,
       ).toBeInstanceOf(BackupStorageCommandError);

--- a/packages/device-management-kit/src/api/device-action/task/BackupAppStorageTask.ts
+++ b/packages/device-management-kit/src/api/device-action/task/BackupAppStorageTask.ts
@@ -1,6 +1,5 @@
 import {
-  type CommandResult,
-  CommandResultFactory,
+  type CommandErrorResult,
   isSuccessCommandResult,
 } from "@api/command/model/CommandResult";
 import {
@@ -13,6 +12,7 @@ import {
 } from "@api/command/os/GetAppStorageInfoCommand";
 import { type InternalApi } from "@api/device-action/DeviceAction";
 import { type LoggerPublisherService } from "@api/logger-publisher/service/LoggerPublisherService";
+import { type DmkResult, DmkResultFactory } from "@api/model/DmkResult";
 import { bufferToHexaString, type HexaString } from "@api/utils/HexaString";
 
 export type BackupAppStorageTaskArgs = {
@@ -27,6 +27,10 @@ export type BackupAppStorageTaskErrorCodes =
   | GetAppStorageInfoCommandErrorCodes
   | BackupStorageCommandErrorCodes;
 
+export type BackupAppStorageTaskError =
+  | CommandErrorResult<GetAppStorageInfoCommandErrorCodes>["error"]
+  | CommandErrorResult<BackupStorageCommandErrorCodes>["error"];
+
 export class BackupAppStorageTask {
   constructor(
     private readonly args: BackupAppStorageTaskArgs,
@@ -35,7 +39,7 @@ export class BackupAppStorageTask {
   ) {}
 
   public async run(): Promise<
-    CommandResult<BackupAppStorageTaskResponse, BackupAppStorageTaskErrorCodes>
+    DmkResult<BackupAppStorageTaskResponse, BackupAppStorageTaskError>
   > {
     this.logger.debug("[run] Starting BackupAppStorageTask", {
       data: {
@@ -55,7 +59,9 @@ export class BackupAppStorageTask {
       this.logger.debug("[run] Failed to get app storage info", {
         data: { error: getAppStorageInfo.error },
       });
-      return getAppStorageInfo;
+      return DmkResultFactory({
+        error: getAppStorageInfo.error,
+      });
     }
 
     const { storageSize } = getAppStorageInfo.data;
@@ -70,7 +76,9 @@ export class BackupAppStorageTask {
         this.logger.debug("[run] Failed to backup app storage", {
           data: { error: backupStorage.error },
         });
-        return backupStorage;
+        return DmkResultFactory({
+          error: backupStorage.error,
+        });
       }
 
       const { chunkData, chunkSize } = backupStorage.data;
@@ -88,7 +96,7 @@ export class BackupAppStorageTask {
       },
     });
 
-    return CommandResultFactory({
+    return DmkResultFactory({
       data: {
         appStorageData,
       },

--- a/packages/device-management-kit/src/api/device-action/task/Errors.ts
+++ b/packages/device-management-kit/src/api/device-action/task/Errors.ts
@@ -1,0 +1,23 @@
+import { type DmkError } from "@api/Error";
+
+export class InvalidGetFirmwareMetadataResponseError implements DmkError {
+  readonly _tag = "InvalidGetFirmwareMetadataResponseError";
+  readonly originalError: Error;
+
+  constructor(message?: string) {
+    this.originalError = new Error(
+      message ?? "Invalid Firmware Metadata response error.",
+    );
+  }
+}
+
+export class GetApplicationsMetadataTaskError implements DmkError {
+  readonly _tag = "GetApplicationsMetadataTaskError";
+  readonly originalError: Error;
+
+  constructor(message?: string) {
+    this.originalError = new Error(
+      message ?? "Failed to get applications metadata.",
+    );
+  }
+}

--- a/packages/device-management-kit/src/api/device-action/task/GetApplicationsMetadataTask.test.ts
+++ b/packages/device-management-kit/src/api/device-action/task/GetApplicationsMetadataTask.test.ts
@@ -1,13 +1,14 @@
 import { EitherAsync } from "purify-ts";
 
-import { InvalidStatusWordError } from "@api/command/Errors";
 import { CommandResultFactory } from "@api/command/model/CommandResult";
 import {
   BTC_APP_METADATA,
   ETH_APP_METADATA,
 } from "@api/device-action/__test-utils__/data";
 import { makeDeviceActionInternalApiMock } from "@api/device-action/__test-utils__/makeInternalApi";
+import { GetApplicationsMetadataTaskError } from "@api/device-action/task/Errors";
 import { type FirmwareVersion } from "@api/device-session/DeviceSessionState";
+import { DmkResultFactory } from "@api/model/DmkResult";
 import { type DeviceVersion } from "@internal/manager-api/model/Device";
 import { type FinalFirmware } from "@internal/manager-api/model/Firmware";
 import { type LanguagePackage } from "@internal/manager-api/model/Language";
@@ -86,7 +87,7 @@ describe("GetApplicationsMetadataTask", () => {
 
     // THEN
     expect(result).toStrictEqual(
-      CommandResultFactory({
+      DmkResultFactory({
         data: {
           applications: APPS,
           applicationsUpdates: [],
@@ -113,7 +114,7 @@ describe("GetApplicationsMetadataTask", () => {
 
     // THEN
     expect(result).toStrictEqual(
-      CommandResultFactory({
+      DmkResultFactory({
         data: {
           applications: APPS,
           applicationsUpdates: [],
@@ -143,7 +144,7 @@ describe("GetApplicationsMetadataTask", () => {
 
     // THEN
     expect(result).toStrictEqual(
-      CommandResultFactory({
+      DmkResultFactory({
         data: {
           applications: [app],
           applicationsUpdates: [BTC_APP_METADATA],
@@ -167,7 +168,7 @@ describe("GetApplicationsMetadataTask", () => {
 
     // THEN
     expect(result).toStrictEqual(
-      CommandResultFactory({
+      DmkResultFactory({
         data: {
           applications: APPS,
           applicationsUpdates: [],
@@ -194,8 +195,10 @@ describe("GetApplicationsMetadataTask", () => {
 
     // THEN
     expect(result).toStrictEqual(
-      CommandResultFactory({
-        error: new InvalidStatusWordError("Cannot get the application catalog"),
+      DmkResultFactory({
+        error: new GetApplicationsMetadataTaskError(
+          "Cannot get the application catalog",
+        ),
       }),
     );
   });
@@ -213,8 +216,10 @@ describe("GetApplicationsMetadataTask", () => {
 
     // THEN
     expect(result).toStrictEqual(
-      CommandResultFactory({
-        error: new InvalidStatusWordError("Cannot get the application catalog"),
+      DmkResultFactory({
+        error: new GetApplicationsMetadataTaskError(
+          "Cannot get the application catalog",
+        ),
       }),
     );
   });
@@ -232,8 +237,10 @@ describe("GetApplicationsMetadataTask", () => {
 
     // THEN
     expect(result).toStrictEqual(
-      CommandResultFactory({
-        error: new InvalidStatusWordError("Cannot get the languages catalog"),
+      DmkResultFactory({
+        error: new GetApplicationsMetadataTaskError(
+          "Cannot get the languages catalog",
+        ),
       }),
     );
   });

--- a/packages/device-management-kit/src/api/device-action/task/GetApplicationsMetadataTask.ts
+++ b/packages/device-management-kit/src/api/device-action/task/GetApplicationsMetadataTask.ts
@@ -1,21 +1,20 @@
 import { gt } from "semver";
 
-import { InvalidStatusWordError } from "@api/command/Errors";
-import {
-  type CommandResult,
-  CommandResultFactory,
-  isSuccessCommandResult,
-} from "@api/command/model/CommandResult";
+import { isSuccessCommandResult } from "@api/command/model/CommandResult";
 import { ListLanguagePackCommand } from "@api/command/os/ListLanguagePackCommand";
 import type { InternalApi } from "@api/device-action/DeviceAction";
+import { GetApplicationsMetadataTaskError } from "@api/device-action/task/Errors";
 import {
   type Catalog,
   type FirmwareVersion,
   type InstalledLanguagePackage,
 } from "@api/device-session/DeviceSessionState";
+import { type DmkResult, DmkResultFactory } from "@api/model/DmkResult";
 import { type Application } from "@internal/manager-api/model/Application";
 import { type DeviceVersion } from "@internal/manager-api/model/Device";
 import { type FinalFirmware } from "@internal/manager-api/model/Firmware";
+
+export { GetApplicationsMetadataTaskError } from "@api/device-action/task/Errors";
 
 export type InstalledApp = {
   hash: string;
@@ -30,12 +29,17 @@ export type GetApplicationsMetadataTaskArgs = {
   installedApps: InstalledApp[];
 };
 
-export type GetApplicationsMetadataTaskResult = CommandResult<{
+export type GetApplicationsMetadataTaskResponse = {
   applications: Application[];
   applicationsUpdates: Application[];
   installedLanguages: InstalledLanguagePackage[];
   catalog: Catalog;
-}>;
+};
+
+export type GetApplicationsMetadataTaskResult = DmkResult<
+  GetApplicationsMetadataTaskResponse,
+  GetApplicationsMetadataTaskError
+>;
 
 const ZERO_HASH =
   "0000000000000000000000000000000000000000000000000000000000000000";
@@ -61,8 +65,10 @@ export class GetApplicationsMetadataTask {
           .map((catalog) => ({ applications, catalog })),
       );
     if (result.isLeft()) {
-      return CommandResultFactory({
-        error: new InvalidStatusWordError("Cannot get the application catalog"),
+      return DmkResultFactory({
+        error: new GetApplicationsMetadataTaskError(
+          "Cannot get the application catalog",
+        ),
       });
     }
     const { applications, catalog } = result.unsafeCoerce();
@@ -111,7 +117,7 @@ export class GetApplicationsMetadataTask {
     );
     if (languages.isRight()) {
       // Return the application metadata
-      return CommandResultFactory({
+      return DmkResultFactory({
         data: {
           applications: appsWithMetadata,
           applicationsUpdates: filteredCatalog,
@@ -123,8 +129,10 @@ export class GetApplicationsMetadataTask {
         },
       });
     } else {
-      return CommandResultFactory({
-        error: new InvalidStatusWordError("Cannot get the languages catalog"),
+      return DmkResultFactory({
+        error: new GetApplicationsMetadataTaskError(
+          "Cannot get the languages catalog",
+        ),
       });
     }
   }

--- a/packages/device-management-kit/src/api/device-action/task/GetApplicationsMetadataTask.ts
+++ b/packages/device-management-kit/src/api/device-action/task/GetApplicationsMetadataTask.ts
@@ -14,8 +14,6 @@ import { type Application } from "@internal/manager-api/model/Application";
 import { type DeviceVersion } from "@internal/manager-api/model/Device";
 import { type FinalFirmware } from "@internal/manager-api/model/Firmware";
 
-export { GetApplicationsMetadataTaskError } from "@api/device-action/task/Errors";
-
 export type InstalledApp = {
   hash: string;
   hashCode: string;

--- a/packages/device-management-kit/src/api/device-action/task/GetFirmwareMetadataTask.test.ts
+++ b/packages/device-management-kit/src/api/device-action/task/GetFirmwareMetadataTask.test.ts
@@ -1,12 +1,11 @@
 import { EitherAsync } from "purify-ts";
 
-import {
-  InvalidGetFirmwareMetadataResponseError,
-  InvalidStatusWordError,
-} from "@api/command/Errors";
+import { InvalidStatusWordError } from "@api/command/Errors";
 import { CommandResultFactory } from "@api/command/model/CommandResult";
 import { type GetOsVersionResponse } from "@api/command/os/GetOsVersionCommand";
 import { makeDeviceActionInternalApiMock } from "@api/device-action/__test-utils__/makeInternalApi";
+import { InvalidGetFirmwareMetadataResponseError } from "@api/device-action/task/Errors";
+import { DmkResultFactory } from "@api/model/DmkResult";
 import {
   type FinalFirmware,
   type McuFirmware,
@@ -104,7 +103,7 @@ describe("GetFirmwareMetadataTask", () => {
 
     // THEN
     expect(result).toStrictEqual(
-      CommandResultFactory({
+      DmkResultFactory({
         data: {
           deviceVersion: DEVICE_VERSION,
           firmware: FIRMWARE_VERSION,
@@ -137,7 +136,7 @@ describe("GetFirmwareMetadataTask", () => {
 
     // THEN
     expect(result).toStrictEqual(
-      CommandResultFactory({
+      DmkResultFactory({
         data: {
           deviceVersion: DEVICE_VERSION,
           firmware: FIRMWARE_VERSION,
@@ -193,7 +192,7 @@ describe("GetFirmwareMetadataTask", () => {
 
     // THEN
     expect(result).toStrictEqual(
-      CommandResultFactory({
+      DmkResultFactory({
         data: {
           deviceVersion: DEVICE_VERSION,
           firmware: FIRMWARE_VERSION,
@@ -228,7 +227,7 @@ describe("GetFirmwareMetadataTask", () => {
 
     // THEN
     expect(result).toStrictEqual(
-      CommandResultFactory({ error: new InvalidStatusWordError("error") }),
+      DmkResultFactory({ error: new InvalidStatusWordError("error") }),
     );
   });
 
@@ -248,7 +247,7 @@ describe("GetFirmwareMetadataTask", () => {
 
     // THEN
     expect(result).toStrictEqual(
-      CommandResultFactory({
+      DmkResultFactory({
         error: new InvalidGetFirmwareMetadataResponseError(),
       }),
     );
@@ -270,7 +269,7 @@ describe("GetFirmwareMetadataTask", () => {
 
     // THEN
     expect(result).toStrictEqual(
-      CommandResultFactory({
+      DmkResultFactory({
         error: new InvalidGetFirmwareMetadataResponseError(),
       }),
     );

--- a/packages/device-management-kit/src/api/device-action/task/GetFirmwareMetadataTask.ts
+++ b/packages/device-management-kit/src/api/device-action/task/GetFirmwareMetadataTask.ts
@@ -1,28 +1,37 @@
-import { InvalidGetFirmwareMetadataResponseError } from "@api/command/Errors";
 import {
-  type CommandResult,
-  CommandResultFactory,
+  type CommandErrorResult,
   isSuccessCommandResult,
 } from "@api/command/model/CommandResult";
 import { GetBackgroundImageSizeCommand } from "@api/command/os/GetBackgroundImageSizeCommand";
 import { GetOsVersionCommand } from "@api/command/os/GetOsVersionCommand";
 import type { InternalApi } from "@api/device-action/DeviceAction";
+import { InvalidGetFirmwareMetadataResponseError } from "@api/device-action/task/Errors";
 import {
   type CustomImage,
   type FirmwareUpdate,
   type FirmwareUpdateContext,
   type FirmwareVersion,
 } from "@api/device-session/DeviceSessionState";
+import { type DmkResult, DmkResultFactory } from "@api/model/DmkResult";
 import { type DeviceVersion } from "@internal/manager-api/model/Device";
 import { type FinalFirmware } from "@internal/manager-api/model/Firmware";
 
-export type GetFirmwareMetadataTaskResult = CommandResult<{
+export type GetFirmwareMetadataTaskResponse = {
   deviceVersion: DeviceVersion;
   firmware: FinalFirmware;
   firmwareVersion: FirmwareVersion;
   firmwareUpdateContext: FirmwareUpdateContext;
   customImage: CustomImage;
-}>;
+};
+
+export type GetFirmwareMetadataTaskError =
+  | CommandErrorResult["error"]
+  | InvalidGetFirmwareMetadataResponseError;
+
+export type GetFirmwareMetadataTaskResult = DmkResult<
+  GetFirmwareMetadataTaskResponse,
+  GetFirmwareMetadataTaskError
+>;
 
 export class GetFirmwareMetadataTask {
   constructor(private readonly api: InternalApi) {}
@@ -31,7 +40,9 @@ export class GetFirmwareMetadataTask {
     // Get installed firmware metadata
     const osVersion = await this.api.sendCommand(new GetOsVersionCommand());
     if (!isSuccessCommandResult(osVersion)) {
-      return osVersion;
+      return DmkResultFactory({
+        error: osVersion.error,
+      });
     }
     const firmwareVersion: FirmwareVersion = {
       mcu: osVersion.data.mcuSephVersion,
@@ -50,7 +61,7 @@ export class GetFirmwareMetadataTask {
           .map((currentFirmware) => ({ deviceVersion, currentFirmware })),
       );
     if (result.isLeft()) {
-      return CommandResultFactory({
+      return DmkResultFactory({
         error: new InvalidGetFirmwareMetadataResponseError(),
       });
     }
@@ -95,7 +106,7 @@ export class GetFirmwareMetadataTask {
     }
 
     // Return firmware metadata
-    return CommandResultFactory({
+    return DmkResultFactory({
       data: {
         deviceVersion,
         firmware: currentFirmware,

--- a/packages/device-management-kit/src/api/index.ts
+++ b/packages/device-management-kit/src/api/index.ts
@@ -8,7 +8,6 @@ export { ByteArrayBuilder } from "@api/apdu/utils/ByteArrayBuilder";
 export { ByteArrayParser } from "@api/apdu/utils/ByteArrayParser";
 export { type Command } from "@api/command/Command";
 export {
-  InvalidGetFirmwareMetadataResponseError,
   InvalidResponseFormatError,
   InvalidStatusWordError,
 } from "@api/command/Errors";
@@ -116,6 +115,10 @@ export { OpenAppWithDependenciesDeviceAction } from "@api/device-action/os/OpenA
 export { SendCommandInAppDeviceAction } from "@api/device-action/os/SendCommandInAppDeviceAction/SendCommandInAppDeviceAction";
 export { BackupAppStorageTask } from "@api/device-action/task/BackupAppStorageTask";
 export {
+  GetApplicationsMetadataTaskError,
+  InvalidGetFirmwareMetadataResponseError,
+} from "@api/device-action/task/Errors";
+export {
   type DeviceActionStateMachine,
   XStateDeviceAction,
 } from "@api/device-action/xstate-utils/XStateDeviceAction";
@@ -128,6 +131,11 @@ export {
   type DeviceSessionState,
   DeviceSessionStateType,
 } from "@api/device-session/DeviceSessionState";
+export {
+  DmkResultFactory,
+  DmkResultStatus,
+  isSuccessDmkResult,
+} from "@api/model/DmkResult";
 export { GenuineCheckDeviceAction } from "@api/secure-channel/device-action/GenuineCheck/GenuineCheckDeviceAction";
 export { InstallAppDeviceAction } from "@api/secure-channel/device-action/InstallApp/InstallAppDeviceAction";
 export { ListInstalledAppsDeviceAction } from "@api/secure-channel/device-action/ListInstalledApps/ListInstalledAppsDeviceAction";

--- a/packages/device-management-kit/src/api/model/DmkResult.test.ts
+++ b/packages/device-management-kit/src/api/model/DmkResult.test.ts
@@ -1,0 +1,59 @@
+import {
+  DmkResultFactory,
+  DmkResultStatus,
+  isSuccessDmkResult,
+} from "./DmkResult";
+
+describe("DmkResult", () => {
+  describe("DmkResultFactory", () => {
+    it("should create a success result with given data", () => {
+      const data = { lorem: "ipsum" };
+
+      const result = DmkResultFactory({ data });
+
+      expect(result).toStrictEqual({
+        status: DmkResultStatus.Success,
+        data,
+      });
+    });
+
+    it("should create a success result when error is undefined", () => {
+      const data = { lorem: "ipsum" };
+
+      const result = DmkResultFactory({
+        data,
+        error: undefined,
+      });
+
+      expect(result).toStrictEqual({
+        status: DmkResultStatus.Success,
+        data,
+      });
+    });
+
+    it("should create an error result with given error", () => {
+      const error = new Error("test");
+
+      const result = DmkResultFactory({ error });
+
+      expect(result).toStrictEqual({
+        status: DmkResultStatus.Error,
+        error,
+      });
+    });
+  });
+
+  describe("isSuccessDmkResult", () => {
+    it("should return true if dmk result succeeds", () => {
+      const result = DmkResultFactory({ data: { test: "ttest" } });
+
+      expect(isSuccessDmkResult(result)).toBeTruthy();
+    });
+
+    it("should return false if dmk result fails", () => {
+      const result = DmkResultFactory({ error: new Error("test") });
+
+      expect(isSuccessDmkResult(result)).toBeFalsy();
+    });
+  });
+});

--- a/packages/device-management-kit/src/api/model/DmkResult.ts
+++ b/packages/device-management-kit/src/api/model/DmkResult.ts
@@ -1,0 +1,56 @@
+export enum DmkResultStatus {
+  Error = "ERROR",
+  Success = "SUCCESS",
+}
+
+export type DmkSuccessResult<Data> = {
+  status: DmkResultStatus.Success;
+  data: Data;
+};
+
+export type DmkErrorResult<Error> = {
+  status: DmkResultStatus.Error;
+  error: Error;
+};
+
+export type DmkResult<Data, Error> =
+  | DmkSuccessResult<Data>
+  | DmkErrorResult<Error>;
+
+type DmkSuccessInput<Data> = {
+  data: Data;
+};
+
+type DmkErrorInput<Error> = {
+  error: Error;
+};
+
+type DmkResultInput<Data, Error> = DmkSuccessInput<Data> | DmkErrorInput<Error>;
+
+function isDmkErrorInput<Data, Error>(
+  input: DmkResultInput<Data, Error>,
+): input is DmkErrorInput<Error> {
+  return "error" in input && input.error !== undefined;
+}
+
+export function DmkResultFactory<Data, Error>(
+  input: DmkResultInput<Data, Error>,
+): DmkResult<Data, Error> {
+  if (isDmkErrorInput(input)) {
+    return {
+      status: DmkResultStatus.Error,
+      error: input.error,
+    };
+  }
+
+  return {
+    status: DmkResultStatus.Success,
+    data: input.data,
+  };
+}
+
+export function isSuccessDmkResult<Data, Error>(
+  result: DmkResult<Data, Error>,
+): result is DmkSuccessResult<Data> {
+  return result.status === DmkResultStatus.Success;
+}

--- a/packages/device-management-kit/src/api/types.ts
+++ b/packages/device-management-kit/src/api/types.ts
@@ -123,6 +123,11 @@ export type {
   LoggerSubscriberService,
   LogParams,
 } from "@api/logger-subscriber/service/LoggerSubscriberService";
+export type {
+  DmkErrorResult,
+  DmkResult,
+  DmkSuccessResult,
+} from "@api/model/DmkResult";
 export {
   type GenuineCheckDAError,
   type GenuineCheckDAInput,

--- a/packages/signer/signer-eth/src/api/app-binder/GetAddressDeviceActionFactory.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/GetAddressDeviceActionFactory.ts
@@ -5,8 +5,8 @@ import {
   UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
 
-import { type GetAddressTaskError } from "@api/app-binder/GetAddressDeviceActionTypes";
 import { type GetAddressCommandResponse } from "@api/app-binder/GetAddressCommandTypes";
+import { type GetAddressTaskError } from "@api/app-binder/GetAddressDeviceActionTypes";
 import { APP_NAME } from "@internal/app-binder/constants";
 import { SendGetAddressTask } from "@internal/app-binder/task/SendGetAddressTask";
 

--- a/packages/signer/signer-eth/src/api/app-binder/GetAddressDeviceActionFactory.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/GetAddressDeviceActionFactory.ts
@@ -5,8 +5,8 @@ import {
   UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
 
+import { type GetAddressTaskError } from "@api/app-binder/GetAddressDeviceActionTypes";
 import { type GetAddressCommandResponse } from "@api/app-binder/GetAddressCommandTypes";
-import { type EthErrorCodes } from "@internal/app-binder/command/utils/ethAppErrors";
 import { APP_NAME } from "@internal/app-binder/constants";
 import { SendGetAddressTask } from "@internal/app-binder/task/SendGetAddressTask";
 
@@ -20,12 +20,12 @@ export const GetAddressDeviceActionFactory = (args: {
   loggerFactory: (tag: string) => LoggerPublisherService;
 }): CallTaskInAppDeviceAction<
   GetAddressCommandResponse,
-  EthErrorCodes,
+  GetAddressTaskError,
   UserInteractionRequired.VerifyAddress | UserInteractionRequired.None
 > => {
   return new CallTaskInAppDeviceAction<
     GetAddressCommandResponse,
-    EthErrorCodes,
+    GetAddressTaskError,
     UserInteractionRequired.VerifyAddress | UserInteractionRequired.None
   >({
     input: {

--- a/packages/signer/signer-eth/src/api/app-binder/GetAddressDeviceActionTypes.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/GetAddressDeviceActionTypes.ts
@@ -2,6 +2,7 @@ import {
   type CallTaskInAppDAError,
   type CallTaskInAppDAIntermediateValue,
   type CallTaskInAppDAOutput,
+  type CommandErrorResult,
   type ExecuteDeviceActionReturnType,
   type UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
@@ -15,7 +16,8 @@ type GetAddressDAUserInteractionRequired =
 
 export type GetAddressDAOutput =
   CallTaskInAppDAOutput<GetAddressCommandResponse>;
-export type GetAddressDAError = CallTaskInAppDAError<EthErrorCodes>;
+export type GetAddressTaskError = CommandErrorResult<EthErrorCodes>["error"];
+export type GetAddressDAError = CallTaskInAppDAError<GetAddressTaskError>;
 export type GetAddressDAIntermediateValue =
   CallTaskInAppDAIntermediateValue<GetAddressDAUserInteractionRequired>;
 

--- a/packages/signer/signer-eth/src/api/app-binder/SignPersonalMessageDeviceActionFactory.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignPersonalMessageDeviceActionFactory.ts
@@ -4,8 +4,8 @@ import {
   UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
 
+import { type SignPersonalMessageTaskError } from "@api/app-binder/SignPersonalMessageDeviceActionTypes";
 import { type Signature } from "@api/model/Signature";
-import { type EthErrorCodes } from "@internal/app-binder/command/utils/ethAppErrors";
 import { APP_NAME } from "@internal/app-binder/constants";
 import { SendSignPersonalMessageTask } from "@internal/app-binder/task/SendSignPersonalMessageTask";
 
@@ -16,13 +16,13 @@ export const SignPersonalMessageDeviceActionFactory = (args: {
   loggerFactory: (tag: string) => LoggerPublisherService;
 }): CallTaskInAppDeviceAction<
   Signature,
-  EthErrorCodes,
+  SignPersonalMessageTaskError,
   UserInteractionRequired.SignPersonalMessage
 > => {
   const taskLogger = args.loggerFactory("SendSignPersonalMessageTask");
   return new CallTaskInAppDeviceAction<
     Signature,
-    EthErrorCodes,
+    SignPersonalMessageTaskError,
     UserInteractionRequired.SignPersonalMessage
   >({
     input: {

--- a/packages/signer/signer-eth/src/api/app-binder/SignPersonalMessageDeviceActionTypes.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignPersonalMessageDeviceActionTypes.ts
@@ -1,7 +1,7 @@
 import {
+  type CallTaskInAppDAError,
   type CommandErrorResult,
   type ExecuteDeviceActionReturnType,
-  type OpenAppDAError,
   type OpenAppDARequiredInteraction,
   type UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
@@ -11,9 +11,10 @@ import { type EthErrorCodes } from "@internal/app-binder/command/utils/ethAppErr
 
 export type SignPersonalMessageDAOutput = Signature;
 
+export type SignPersonalMessageTaskError =
+  CommandErrorResult<EthErrorCodes>["error"];
 export type SignPersonalMessageDAError =
-  | OpenAppDAError
-  | CommandErrorResult<EthErrorCodes>["error"];
+  CallTaskInAppDAError<SignPersonalMessageTaskError>;
 
 export type SignPersonalMessageDARequiredInteraction =
   | OpenAppDARequiredInteraction

--- a/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.test.ts
@@ -1,5 +1,6 @@
 import {
   CallTaskInAppDeviceAction,
+  type DmkError,
   DeviceActionStatus,
   type DeviceManagementKit,
   type DeviceSessionId,
@@ -42,7 +43,7 @@ type ExecuteDeviceActionTaskCallArgs = {
   sessionId: DeviceSessionId;
   deviceAction: CallTaskInAppDeviceAction<
     unknown,
-    unknown,
+    DmkError,
     UserInteractionRequired.None
   >;
 };

--- a/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.test.ts
@@ -1,9 +1,9 @@
 import {
   CallTaskInAppDeviceAction,
-  type DmkError,
   DeviceActionStatus,
   type DeviceManagementKit,
   type DeviceSessionId,
+  type DmkError,
   type ExecuteDeviceActionReturnType,
   type InternalApi,
   SendCommandInAppDeviceAction,


### PR DESCRIPTION
### 📝 Description

This PR extracts `DmkResult` as a generic base result abstraction for the DMK and rebuilds `CommandResult` as the command-specialized layer on top of it.

The goal is to stop non-command flows from using command-specific result helpers directly. In practice, this PR migrates DMK task and task-wrapper code (`GetFirmwareMetadataTask`, `GetApplicationsMetadataTask`, `BackupAppStorageTask`, `CallTaskInAppDeviceAction`, and `GetDeviceMetadataDeviceAction`) to `DmkResult` while keeping the command send/parse pipeline on `CommandResult`.

It also moves `InvalidGetFirmwareMetadataResponseError` out of the command layer and into task scope, so task-specific errors no longer pollute `CommandResult`.

A repo-wide lint policy is introduced as a warning on `@ledgerhq/device-management-kit` imports of `CommandResultFactory`, while DMK keeps a stricter local error for internal non-command production usage.

This PR mostly covers wrong usages inside the DMK package. The other packages still need to be tackled in order to fully close #1442.

This PR is stacked on top of #1441.
Follow-up tech debt issue: #1442.

### ❓ Context

- **JIRA or GitHub link**: `[NO-ISSUE]`, #1442
- **Feature**: Decouple generic workflow results from command-specific result typing

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - introduce `DmkResult`, `DmkResultFactory`, `DmkResultStatus`, and `isSuccessDmkResult` as the generic base abstraction
  - keep `CommandResult` and `CommandResultFactory` as the command-specialized compatibility layer
  - migrate DMK task flows and `CallTaskInAppDeviceAction` away from command-specific result construction
  - move `InvalidGetFirmwareMetadataResponseError` out of the command layer into task scope
  - add a shared warn-level lint policy and a stricter DMK-local lint guard against non-command `CommandResultFactory` usage
  - tighten type-level compatibility: code that constructs `CommandResultFactory` with `InvalidGetFirmwareMetadataResponseError` will now fail at the type level; non-command flows should use `DmkResultFactory` instead
  - update `signer-eth` and one `signer-zcash` test, covered by dedicated signer package changesets