### PR TITLE
🔧 (ci) [NO-ISSUE]: Use vars instead of secrets for SLACK_CHANNEL_ID

### DIFF
--- a/.github/workflows/nightly_ethereum.yml
+++ b/.github/workflows/nightly_ethereum.yml
@@ -151,5 +151,5 @@ jobs:
       - uses: ./.github/actions/slack-notify-composite
         with:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-channel-id: ${{ vars.SLACK_CHANNEL_ID }}
           results: ${{ join(needs.*.result, ',') }}

--- a/.github/workflows/nightly_solana.yml
+++ b/.github/workflows/nightly_solana.yml
@@ -108,5 +108,5 @@ jobs:
       - uses: ./.github/actions/slack-notify-composite
         with:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-channel-id: ${{ vars.SLACK_CHANNEL_ID }}
           results: ${{ join(needs.*.result, ',') }}


### PR DESCRIPTION
### 📝 Description

`SLACK_CHANNEL_ID` is configured as a repository **variable**, not a secret. The nightly Ethereum and Solana workflows were referencing it from the `secrets` context, which would resolve to an empty string and silently disable the Slack notification (the `slack-notify-composite` action no-ops when the channel id is empty).

This PR updates both workflows to read `SLACK_CHANNEL_ID` from `vars`:

| Before | After |
| ------ | ----- |
| `slack-channel-id: \${{ secrets.SLACK_CHANNEL_ID }}` | `slack-channel-id: \${{ vars.SLACK_CHANNEL_ID }}` |

Affected files:

- `.github/workflows/nightly_ethereum.yml`
- `.github/workflows/nightly_solana.yml`

### ❓ Context

- **JIRA or GitHub link**: NO-ISSUE
- **Feature**: CI / nightly Slack notifications

### ✅ Checklist

- [x] **Covered by automatic tests** — N/A, CI configuration only; will be validated by the next nightly run.
- [ ] **Changeset is provided** — Not required: changes only affect CI workflows, no published package is impacted.
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - Nightly Ethereum and Solana workflows now correctly resolve `SLACK_CHANNEL_ID` from repository variables and post their status to Slack.


Made with [Cursor](https://cursor.com)