### PR TITLE
♻️ (context-module) [NO-ISSUE]: Share network client factory

### DIFF
--- a/.changeset/fresh-facts-do.md
+++ b/.changeset/fresh-facts-do.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/context-module": patch
+---
+
+Add a default network client factory so context-module data sources used outside of dependency injection keep the same headers without requiring callers to provide a client.

--- a/packages/signer/context-module/src/network/di/networkModuleFactory.ts
+++ b/packages/signer/context-module/src/network/di/networkModuleFactory.ts
@@ -1,24 +1,13 @@
-import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
+import { type DmkNetworkClient } from "@ledgerhq/device-management-kit";
 import { ContainerModule } from "inversify";
 
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { networkTypes } from "@/network/di/networkTypes";
-import {
-  LEDGER_CLIENT_VERSION_HEADER,
-  LEDGER_ORIGIN_TOKEN_HEADER,
-} from "@/shared/constant/HttpHeaders";
-import PACKAGE from "@root/package.json";
+import { networkClientFactory } from "@/network/networkClientFactory";
 
 export const networkModuleFactory = (config: ContextModuleServiceConfig) =>
   new ContainerModule(({ bind }) => {
     bind<DmkNetworkClient>(networkTypes.NetworkClient).toConstantValue(
-      new DmkNetworkClient({
-        headers: {
-          [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
-          ...(config.originToken && {
-            [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
-          }),
-        },
-      }),
+      networkClientFactory(config),
     );
   });

--- a/packages/signer/context-module/src/network/networkClientFactory.test.ts
+++ b/packages/signer/context-module/src/network/networkClientFactory.test.ts
@@ -1,0 +1,73 @@
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
+import { networkClientFactory } from "@/network/networkClientFactory";
+import {
+  LEDGER_CLIENT_VERSION_HEADER,
+  LEDGER_ORIGIN_TOKEN_HEADER,
+} from "@/shared/constant/HttpHeaders";
+import PACKAGE from "@root/package.json";
+
+describe("networkClientFactory", () => {
+  let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
+
+  beforeEach(() => {
+    fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const getRequestHeaders = () => {
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const requestInit = fetchMock.mock.calls[0]?.[1];
+    expect(requestInit).toBeDefined();
+
+    return requestInit?.headers as Record<string, string>;
+  };
+
+  it("should set the context-module client version header", async () => {
+    // GIVEN
+    const config = {} as ContextModuleServiceConfig;
+    const client = networkClientFactory(config);
+
+    // WHEN
+    await client.get("https://example.test", { responseType: "void" });
+
+    // THEN
+    expect(getRequestHeaders()).toMatchObject({
+      [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+    });
+  });
+
+  it("should set the origin token header when configured", async () => {
+    // GIVEN
+    const config = {
+      originToken: "origin-token",
+    } as ContextModuleServiceConfig;
+    const client = networkClientFactory(config);
+
+    // WHEN
+    await client.get("https://example.test", { responseType: "void" });
+
+    // THEN
+    expect(getRequestHeaders()).toMatchObject({
+      [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
+    });
+  });
+
+  it("should not set the origin token header when it is missing", async () => {
+    // GIVEN
+    const config = {} as ContextModuleServiceConfig;
+    const client = networkClientFactory(config);
+
+    // WHEN
+    await client.get("https://example.test", { responseType: "void" });
+
+    // THEN
+    expect(getRequestHeaders()).not.toHaveProperty(LEDGER_ORIGIN_TOKEN_HEADER);
+  });
+});

--- a/packages/signer/context-module/src/network/networkClientFactory.ts
+++ b/packages/signer/context-module/src/network/networkClientFactory.ts
@@ -1,0 +1,18 @@
+import { DmkNetworkClient } from "@ledgerhq/device-management-kit";
+
+import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
+import {
+  LEDGER_CLIENT_VERSION_HEADER,
+  LEDGER_ORIGIN_TOKEN_HEADER,
+} from "@/shared/constant/HttpHeaders";
+import PACKAGE from "@root/package.json";
+
+export const networkClientFactory = (config: ContextModuleServiceConfig) =>
+  new DmkNetworkClient({
+    headers: {
+      [LEDGER_CLIENT_VERSION_HEADER]: `context-module/${PACKAGE.version}`,
+      ...(config.originToken && {
+        [LEDGER_ORIGIN_TOKEN_HEADER]: config.originToken,
+      }),
+    },
+  });

--- a/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
+++ b/packages/signer/context-module/src/reporter/data/HttpBlindSigningReporterDatasource.ts
@@ -5,6 +5,7 @@ import { type Either, Left, Right } from "purify-ts";
 import { configTypes } from "@/config/di/configTypes";
 import { type ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { networkTypes } from "@/network/di/networkTypes";
+import { networkClientFactory } from "@/network/networkClientFactory";
 
 import {
   type BlindSigningReporterDatasource,
@@ -15,12 +16,16 @@ import {
 export class HttpBlindSigningReporterDatasource
   implements BlindSigningReporterDatasource
 {
+  private readonly http: DmkNetworkClient;
+
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
     @inject(networkTypes.NetworkClient)
-    private readonly http: DmkNetworkClient,
-  ) {}
+    networkClient?: DmkNetworkClient,
+  ) {
+    this.http = networkClient ?? networkClientFactory(config);
+  }
 
   async report(params: BlindSigningReportParams): Promise<Either<Error, void>> {
     try {

--- a/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.ts
+++ b/packages/signer/context-module/src/trusted-name/data/HttpTrustedNameDataSource.ts
@@ -5,6 +5,7 @@ import { Either, Left, Right } from "purify-ts";
 import { configTypes } from "@/config/di/configTypes";
 import type { ContextModuleServiceConfig } from "@/config/model/ContextModuleConfig";
 import { networkTypes } from "@/network/di/networkTypes";
+import { networkClientFactory } from "@/network/networkClientFactory";
 import {
   GetDomainNameInfosParams,
   GetTrustedNameInfosParams,
@@ -16,12 +17,15 @@ import { TrustedNameDto } from "./TrustedNameDto";
 
 @injectable()
 export class HttpTrustedNameDataSource implements TrustedNameDataSource {
+  private readonly http: DmkNetworkClient;
   constructor(
     @inject(configTypes.Config)
     private readonly config: ContextModuleServiceConfig,
     @inject(networkTypes.NetworkClient)
-    private readonly http: DmkNetworkClient,
-  ) {}
+    networkClient?: DmkNetworkClient,
+  ) {
+    this.http = networkClient ?? networkClientFactory(config);
+  }
 
   public async getDomainNamePayload({
     chainId,


### PR DESCRIPTION
### 📝 Description

Some context-module data sources are used outside of the context module dependency injection setup, including by LES musig and Ledger Wallet consumers. This PR avoids a breaking change for those callers by adding a default network client factory, while preserving the expected context-module client version and origin token headers.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]

- **Feature**: Preserve compatibility for context-module data sources consumed outside DI.

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** New `networkClientFactory` coverage verifies the default headers.
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date** No documentation update needed.
- [x] **Impact of the changes:**
  - Context-module data sources can still be instantiated without an injected `NetworkClient` while keeping the expected request headers.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.

Made with [Cursor](https://cursor.com)