### PR TITLE
✨ (ci) [NO-ISSUE]: Add manual Slack notification test workflow

### DIFF
--- a/.github/workflows/test_slack_notification.yml
+++ b/.github/workflows/test_slack_notification.yml
@@ -1,4 +1,4 @@
-name: "Test Slack Notification"
+name: "Test Workflow [Slack Notification]"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test_slack_notification.yml
+++ b/.github/workflows/test_slack_notification.yml
@@ -1,0 +1,46 @@
+name: "Test Slack Notification"
+
+on:
+  workflow_dispatch:
+    inputs:
+      text:
+        description: "Notification title/text to display in Slack."
+        required: true
+        type: string
+        default: "Test Slack Notification"
+      status:
+        description: "Status to send to the Slack notify composite action."
+        required: true
+        type: choice
+        default: success
+        options:
+          - success
+          - error
+
+jobs:
+  notify:
+    name: Notify Slack
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Map status to composite action result
+        id: map
+        shell: bash
+        env:
+          STATUS: ${{ inputs.status }}
+        run: |
+          if [ "$STATUS" = "error" ]; then
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=success" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: ./.github/actions/slack-notify-composite
+        with:
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+          title: ${{ inputs.text }}
+          results: ${{ steps.map.outputs.result }}


### PR DESCRIPTION
### 📝 Description

Adds a small manual-only GitHub Actions workflow (`.github/workflows/test_slack_notification.yml`) used to exercise the existing `slack-notify-composite` action without having to wait for a real nightly run.

The workflow:

- Triggers exclusively via `workflow_dispatch` (no push / PR / schedule triggers), so it can only be launched from the GitHub Actions UI (or `gh workflow run`).
- Exposes two inputs:
  - `text` — free-form string used as the Slack notification title.
  - `status` — a `choice` input restricted to `success` or `error` (rendered as a dropdown in the GitHub UI).
- Maps the chosen `status` to the `results` shape expected by `slack-notify-composite` (`error` → `failure`, `success` → `success`) so the composite action computes the matching emoji/label.
- Reuses the existing `SLACK_BOT_TOKEN` secret and `SLACK_CHANNEL_ID` variable — when either is missing, the composite action no-ops gracefully (same behavior as nightly workflows).

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Internal tooling to manually validate the Slack notification composite action and its message rendering.

### ✅ Checklist

- [x] **Covered by automatic tests** — N/A, this is a manually-triggered CI workflow whose only purpose is to exercise the Slack composite action; the composite action itself is unchanged.
- [x] **Changeset is provided** — N/A, changes only affect `.github/workflows/` (internal CI tooling, no published package).
- [x] **Documentation is up-to-date** — no docs change needed; the workflow is self-describing via input descriptions.
- [x] **Impact of the changes:**
  - Adds a new manual-only workflow `Test Workflow [Slack Notification]` visible in the Actions tab. Running it posts a single test message to the configured Slack channel.
  - No changes to existing workflows, the `slack-notify-composite` action, or any package code.


Made with [Cursor](https://cursor.com)