### PR TITLE
✨ (eslint-config) [NO-ISSUE]: Add diff-scoped no-magic-numbers rule

### DIFF
--- a/packages/config/eslint/index.js
+++ b/packages/config/eslint/index.js
@@ -5,7 +5,10 @@ import simpleImportSort from "eslint-plugin-simple-import-sort";
 import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
 import eslintPluginReact from "eslint-plugin-react";
 import eslintPluginReactHooks from "eslint-plugin-react-hooks";
+import eslintPluginDiff from "eslint-plugin-diff";
 import { fixupPluginRules } from "@eslint/compat";
+
+process.env.ESLINT_PLUGIN_DIFF_COMMIT ??= "origin/develop";
 
 export default [
   {
@@ -167,6 +170,33 @@ export default [
       react: {
         version: "detect",
       },
+    },
+  },
+
+  // Diff-scoped no-magic-numbers: the `diff/diff` processor filters this
+  // override's diagnostics to lines changed vs origin/develop, so the rule
+  // only flags magic numbers in code added/modified on the current branch.
+  // Other rules are unaffected because they live in earlier config blocks
+  // without this processor.
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    ignores: ["**/*.test.ts", "**/*.test.tsx"],
+    plugins: { diff: eslintPluginDiff },
+    processor: "diff/diff",
+    rules: {
+      "no-magic-numbers": "off",
+      "@typescript-eslint/no-magic-numbers": [
+        "error",
+        {
+          ignore: [-1, 0, 1, 2],
+          ignoreArrayIndexes: true,
+          ignoreDefaultValues: true,
+          ignoreEnums: true,
+          ignoreNumericLiteralTypes: true,
+          ignoreReadonlyClassProperties: true,
+          ignoreTypeIndexes: true,
+        },
+      ],
     },
   },
 ];

--- a/packages/config/eslint/package.json
+++ b/packages/config/eslint/package.json
@@ -13,6 +13,7 @@
     "@eslint/compat": "catalog:",
     "@eslint/core": "catalog:",
     "@eslint/js": "catalog:",
+    "eslint-plugin-diff": "catalog:",
     "eslint-plugin-prettier": "catalog:",
     "eslint-plugin-react": "catalog:",
     "eslint-plugin-react-hooks": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ catalogs:
     eslint:
       specifier: 9.34.0
       version: 9.34.0
+    eslint-plugin-diff:
+      specifier: 2.1.7
+      version: 2.1.7
     eslint-plugin-prettier:
       specifier: 5.5.4
       version: 5.5.4
@@ -1016,6 +1019,9 @@ importers:
       '@eslint/js':
         specifier: 'catalog:'
         version: 9.34.0
+      eslint-plugin-diff:
+        specifier: 'catalog:'
+        version: 2.1.7(eslint@9.34.0(jiti@1.21.6))
       eslint-plugin-prettier:
         specifier: 'catalog:'
         version: 5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.34.0(jiti@1.21.6)))(eslint@9.34.0(jiti@1.21.6))(prettier@3.5.3)
@@ -8051,6 +8057,12 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
+
+  eslint-plugin-diff@2.1.7:
+    resolution: {integrity: sha512-F0EP5knbELQRPX7A4ogFFty+Pyru6CtUFmt52VSJ+7I84UsOj5s+BtY/ZhQFdvmPkFzKqVy+g5IHP+iiaUu/Aw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      eslint: '>=6.7.0'
 
   eslint-plugin-prettier@5.5.4:
     resolution: {integrity: sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==}
@@ -20143,6 +20155,10 @@ snapshots:
       source-map: 0.6.1
 
   eslint-config-prettier@10.1.8(eslint@9.34.0(jiti@1.21.6)):
+    dependencies:
+      eslint: 9.34.0(jiti@1.21.6)
+
+  eslint-plugin-diff@2.1.7(eslint@9.34.0(jiti@1.21.6)):
     dependencies:
       eslint: 9.34.0(jiti@1.21.6)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -77,6 +77,7 @@ catalog:
   esbuild: 0.25.4
   esbuild-node-externals: 1.18.0
   eslint: 9.34.0
+  eslint-plugin-diff: 2.1.7
   eslint-plugin-prettier: 5.5.4
   eslint-plugin-react: 7.37.5
   eslint-plugin-react-hooks: 5.2.0


### PR DESCRIPTION
### 📝 Description

Adds a diff-scoped `@typescript-eslint/no-magic-numbers` rule to the shared ESLint config (`@ledgerhq/eslint-config-dsdk`).

The rule is wired through `eslint-plugin-diff`'s `diff/diff` processor so diagnostics are filtered to lines added/modified versus `origin/develop`. This means:

- Magic numbers are flagged **only** in code introduced on the current branch.
- Existing code is left untouched, avoiding a massive cleanup PR.
- All other ESLint rules are unaffected — the processor is scoped to a dedicated override block placed after the existing TypeScript config.

The rule ignores common safe values (`-1, 0, 1, 2`), array indexes, default values, enums, numeric literal types, readonly class properties, and type indexes. Test files (`*.test.ts(x)`) are excluded.

The base commit defaults to `origin/develop` via `process.env.ESLINT_PLUGIN_DIFF_COMMIT ??= "origin/develop"`, but can be overridden in CI/locally if needed.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Progressively enforce no-magic-numbers on new code without forcing a repo-wide rewrite.

### ✅ Checklist

- [x] **Covered by automatic tests** — ESLint config change; behavior is exercised by running lint on any TS/TSX file with new magic numbers.
- [ ] **Changeset is provided** — _Not needed_: `@ledgerhq/eslint-config-dsdk` is a `private` internal tooling package and is not published.
- [x] **Documentation is up-to-date** — Inline comment in `packages/config/eslint/index.js` explains the diff-scoped behavior.
- [x] **Impact of the changes:**
  - Adds `eslint-plugin-diff@2.1.7` to the workspace catalog and as a devDependency of the eslint config package.
  - Adds a new override block in the shared ESLint config enabling `@typescript-eslint/no-magic-numbers` only on diffed lines.
  - QA focus: run `pnpm lint` across packages and confirm only newly added magic numbers are reported, and no false positives appear on unchanged code.

Made with [Cursor](https://cursor.com)