### PR TITLE
✨ (signer-zcash) [LIVE-23291]: Add full viewing key export

### DIFF
--- a/.changeset/four-rivers-doubt.md
+++ b/.changeset/four-rivers-doubt.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-zcash": minor
+---
+
+Add `getFullViewingKey` to export the Zcash full viewing key from the device.

--- a/apps/docs/pages/docs/references/signers/zcash.mdx
+++ b/apps/docs/pages/docs/references/signers/zcash.mdx
@@ -3,6 +3,7 @@
 This module provides the implementation of the Ledger zcash signer of the Device Management Kit. It enables interaction with the zcash application on a Ledger device including:
 
 - Retrieving the zcash address using a given derivation path
+- Retrieving the zcash full viewing key (UFVK or Orchard FVK)
 - Signing a zcash transaction
 - Signing a message displayed on a Ledger device
 - Retrieving the app configuration
@@ -15,8 +16,9 @@ This module provides the implementation of the Ledger zcash signer of the Device
 4. [Use Cases](#-use-cases)
    - [Get App Configuration](#use-case-1-get-app-configuration)
    - [Get Address](#use-case-2-get-address)
-   - [Sign Transaction](#use-case-3-sign-transaction)
-   - [Sign Message](#use-case-4-sign-message)
+   - [Get Full Viewing Key](#use-case-3-get-full-viewing-key)
+   - [Sign Transaction](#use-case-4-sign-transaction)
+   - [Sign Message](#use-case-5-sign-message)
 5. [Observable Behavior](#-observable-behavior)
 6. [Example](#-example)
 
@@ -44,7 +46,7 @@ const signerZcash = new SignerZcashBuilder({ dmk, sessionId }).build();
 
 ## 🔹 Use Cases
 
-The `SignerZcashBuilder.build()` method will return a `SignerZcash` instance that exposes 4 dedicated methods, each of which calls an independent use case. Each use case will return an object that contains an observable and a method called `cancel`.
+The `SignerZcashBuilder.build()` method will return a `SignerZcash` instance that exposes 5 dedicated methods, each of which calls an independent use case. Each use case will return an object that contains an observable and a method called `cancel`.
 
 ---
 
@@ -119,7 +121,63 @@ type GetAddressCommandResponse = {
 
 ---
 
-### Use Case 3: Sign Transaction
+### Use Case 3: Get Full Viewing Key
+
+This method allows users to retrieve the zcash full viewing key based on a given ZIP-32 account `derivationPath`.
+
+```typescript
+const { observable, cancel } = signerZcash.getFullViewingKey(
+  derivationPath,
+  options,
+);
+```
+
+#### **Parameters**
+
+- `derivationPath`
+
+  - **Required**
+  - **Type:** `string` (e.g., `"32'/133'/0'"`)
+  - The account-level ZIP-32 derivation path used for the zcash full viewing key.
+
+- `options`
+
+  - Optional
+  - Type: `FullViewingKeyOptions`
+
+    ```typescript
+    type FullViewingKeyOptions = {
+      mode?: "ufvk" | "orchardFvk";
+      skipOpenApp?: boolean;
+    };
+    ```
+
+  - `mode`: Optional export mode. Defaults to `"ufvk"`.
+    - `"ufvk"` returns the Unified Full Viewing Key as a UTF-8 string.
+    - `"orchardFvk"` returns the raw Orchard Full Viewing Key bytes (`Uint8Array`).
+  - `skipOpenApp`: An optional boolean indicating whether to skip opening the zcash app automatically (`true`) or not (`false`).
+
+#### **Returns**
+
+- `observable` Emits DeviceActionState updates, including the following details:
+
+```typescript
+type GetFullViewingKeyResult =
+  | {
+      mode: "ufvk";
+      fullViewingKey: string;
+    }
+  | {
+      mode: "orchardFvk";
+      fullViewingKey: Uint8Array;
+    };
+```
+
+- `cancel` A function to cancel the action on the Ledger device.
+
+---
+
+### Use Case 4: Sign Transaction
 
 This method allows users to sign a zcash transaction.
 
@@ -174,7 +232,7 @@ type Signature = {
 
 ---
 
-### Use Case 4: Sign Message
+### Use Case 5: Sign Message
 
 This method allows users to sign a text string that is displayed on Ledger devices.
 

--- a/apps/sample/src/components/SignerZcashView/index.tsx
+++ b/apps/sample/src/components/SignerZcashView/index.tsx
@@ -7,6 +7,9 @@ import {
   type GetAppConfigDAError,
   type GetAppConfigDAIntermediateValue,
   type GetAppConfigDAOutput,
+  type GetFullViewingKeyDAError,
+  type GetFullViewingKeyDAIntermediateValue,
+  type GetFullViewingKeyDAOutput,
   type GetTrustedInputDAError,
   type GetTrustedInputDAIntermediateValue,
   type GetTrustedInputDAOutput,
@@ -16,6 +19,7 @@ import {
   type SignTransactionDAError,
   type SignTransactionDAIntermediateValue,
   type SignTransactionDAOutput,
+  type ZcashFullViewingKeyMode,
 } from "@ledgerhq/device-signer-kit-zcash";
 
 import { DeviceActionsList } from "@/components/DeviceActionsView/DeviceActionsList";
@@ -84,6 +88,34 @@ export const SignerZcashView: React.FC<{ sessionId: string }> = ({
         },
         GetAddressDAError,
         GetAddressDAIntermediateValue
+      >,
+      {
+        title: "Get Full Viewing Key",
+        description: "Get a full viewing key from the device",
+        executeDeviceAction: ({ derivationPath, mode, skipOpenApp }) => {
+          if (!signer) {
+            throw new Error("Signer not initialized");
+          }
+          return signer.getFullViewingKey(derivationPath, {
+            mode,
+            skipOpenApp,
+          });
+        },
+        initialValues: {
+          derivationPath: "44'/133'/0'/0/0",
+          mode: "ufvk",
+          skipOpenApp: false,
+        },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        GetFullViewingKeyDAOutput,
+        {
+          derivationPath: string;
+          mode?: ZcashFullViewingKeyMode;
+          skipOpenApp?: boolean;
+        },
+        GetFullViewingKeyDAError,
+        GetFullViewingKeyDAIntermediateValue
       >,
       {
         title: "Sign Transaction",

--- a/apps/sample/src/components/SignerZcashView/index.tsx
+++ b/apps/sample/src/components/SignerZcashView/index.tsx
@@ -24,8 +24,15 @@ import {
 
 import { DeviceActionsList } from "@/components/DeviceActionsView/DeviceActionsList";
 import { type DeviceActionProps } from "@/components/DeviceActionsView/DeviceActionTester";
+import { type ValueSelector } from "@/components/Form";
+import { type FieldType } from "@/hooks/useForm";
 import { useDmk } from "@/providers/DeviceManagementKitProvider";
 import { useSignerZcash } from "@/providers/SignerZcashProvider";
+
+const fullViewingKeyModeOptions: ValueSelector<FieldType>["mode"] = [
+  { label: "UFVK (string, P2=0x00)", value: "ufvk" },
+  { label: "Orchard FVK (96 raw bytes, P2=0x01)", value: "orchardFvk" },
+];
 
 export const SignerZcashView: React.FC<{ sessionId: string }> = ({
   sessionId,
@@ -91,27 +98,36 @@ export const SignerZcashView: React.FC<{ sessionId: string }> = ({
       >,
       {
         title: "Get Full Viewing Key",
-        description: "Get a full viewing key from the device",
+        description:
+          "Exports a full viewing key (UFVK/FVK) from the device. It does not spend funds, but it allows watching shielded balance and activity for this derivation — treat it as highly sensitive secret material. Do not share, log, or commit sample output; use only for local SDK testing.",
         executeDeviceAction: ({ derivationPath, mode, skipOpenApp }) => {
           if (!signer) {
             throw new Error("Signer not initialized");
           }
+          const resolvedMode: ZcashFullViewingKeyMode =
+            mode === "orchardFvk" ? "orchardFvk" : "ufvk";
           return signer.getFullViewingKey(derivationPath, {
-            mode,
+            mode: resolvedMode,
             skipOpenApp,
           });
         },
         initialValues: {
-          derivationPath: "44'/133'/0'/0/0",
+          derivationPath: "32'/133'/0'",
           mode: "ufvk",
           skipOpenApp: false,
+        },
+        valueSelector: { mode: fullViewingKeyModeOptions },
+        labelSelector: {
+          mode: "Export mode (GET_VK P2)",
+          derivationPath: "Derivation path",
+          skipOpenApp: "Skip open app",
         },
         deviceModelId,
       } satisfies DeviceActionProps<
         GetFullViewingKeyDAOutput,
         {
           derivationPath: string;
-          mode?: ZcashFullViewingKeyMode;
+          mode: ZcashFullViewingKeyMode;
           skipOpenApp?: boolean;
         },
         GetFullViewingKeyDAError,

--- a/packages/signer/signer-zcash/README.md
+++ b/packages/signer/signer-zcash/README.md
@@ -12,26 +12,57 @@ pnpm add @ledgerhq/device-signer-kit-zcash
 
 ```typescript
 import { SignerZcashBuilder } from "@ledgerhq/device-signer-kit-zcash";
+import { DeviceActionStatus } from "@ledgerhq/device-management-kit";
 
 const signer = new SignerZcashBuilder({ dmk, sessionId }).build();
 
-// Get address (BIP44 path: m/44'/133'/account'/change/index — 133' is Zcash on SLIP-44)
-const address = await signer.getAddress("m/44'/133'/0'/0/0");
+// Derivation paths must NOT include an "m/" prefix.
+// getAddress/signTransaction use ZIP-44: 44'/133'/account'/change/index.
+const { observable: getAddress$ } = signer.getAddress("44'/133'/0'/0/0");
+getAddress$.subscribe({
+  next: (state) => {
+    if (state.status === DeviceActionStatus.Completed) {
+      console.log("Address:", state.output.address);
+    }
+  },
+});
 
-// Get full viewing key — same derivation convention as getAddress.
+// getFullViewingKey uses ZIP-32 account path: 32'/133'/account'.
 // Default mode "ufvk": success output is { mode: "ufvk", fullViewingKey: string }.
 // mode "orchardFvk": success output is { mode: "orchardFvk", fullViewingKey: Uint8Array }.
-const fullViewingKey = await signer.getFullViewingKey("m/44'/133'/0'/0/0");
-const orchardFvk = await signer.getFullViewingKey("m/44'/133'/0'/0/0", {
+const { observable: getUfvk$ } = signer.getFullViewingKey("32'/133'/0'");
+getUfvk$.subscribe({
+  next: (state) => {
+    if (state.status === DeviceActionStatus.Completed) {
+      console.log("UFVK:", state.output.fullViewingKey);
+    }
+  },
+});
+
+const { observable: getOrchardFvk$ } = signer.getFullViewingKey("32'/133'/0'", {
   mode: "orchardFvk",
+});
+getOrchardFvk$.subscribe({
+  next: (state) => {
+    if (state.status === DeviceActionStatus.Completed) {
+      console.log("Orchard FVK bytes:", state.output.fullViewingKey);
+    }
+  },
 });
 // When the Zcash app is already open: { skipOpenApp: true }
 
 // Sign transaction
-const signature = await signer.signTransaction(
-  "m/44'/133'/0'/0/0",
+const { observable: signTransaction$ } = signer.signTransaction(
+  "44'/133'/0'/0/0",
   transactionBytes,
 );
+signTransaction$.subscribe({
+  next: (state) => {
+    if (state.status === DeviceActionStatus.Completed) {
+      console.log("Signature:", state.output);
+    }
+  },
+});
 ```
 
 ## Development

--- a/packages/signer/signer-zcash/README.md
+++ b/packages/signer/signer-zcash/README.md
@@ -15,12 +15,21 @@ import { SignerZcashBuilder } from "@ledgerhq/device-signer-kit-zcash";
 
 const signer = new SignerZcashBuilder({ dmk, sessionId }).build();
 
-// Get address
-const address = await signer.getAddress("m/44'/0'/0'/0/0");
+// Get address (BIP44 path: m/44'/133'/account'/change/index — 133' is Zcash on SLIP-44)
+const address = await signer.getAddress("m/44'/133'/0'/0/0");
+
+// Get full viewing key — same derivation convention as getAddress.
+// Default mode "ufvk": success output is { mode: "ufvk", fullViewingKey: string }.
+// mode "orchardFvk": success output is { mode: "orchardFvk", fullViewingKey: Uint8Array }.
+const fullViewingKey = await signer.getFullViewingKey("m/44'/133'/0'/0/0");
+const orchardFvk = await signer.getFullViewingKey("m/44'/133'/0'/0/0", {
+  mode: "orchardFvk",
+});
+// When the Zcash app is already open: { skipOpenApp: true }
 
 // Sign transaction
 const signature = await signer.signTransaction(
-  "m/44'/0'/0'/0/0",
+  "m/44'/133'/0'/0/0",
   transactionBytes,
 );
 ```

--- a/packages/signer/signer-zcash/src/api/SignerZcash.ts
+++ b/packages/signer/signer-zcash/src/api/SignerZcash.ts
@@ -1,9 +1,11 @@
 import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
 import { type GetAppConfigDAReturnType } from "@api/app-binder/GetAppConfigDeviceActionTypes";
+import { type GetFullViewingKeyDAReturnType } from "@api/app-binder/GetFullViewingKeyDeviceActionTypes";
 import { type GetTrustedInputDAReturnType } from "@api/app-binder/GetTrustedInputActionTypes";
 import { type SignMessageDAReturnType } from "@api/app-binder/SignMessageDeviceActionTypes";
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { type AddressOptions } from "@api/model/AddressOptions";
+import { type FullViewingKeyOptions } from "@api/model/FullViewingKeyOptions";
 import { type TransactionOptions } from "@api/model/TransactionOptions";
 
 export interface SignerZcash {
@@ -13,6 +15,11 @@ export interface SignerZcash {
     derivationPath: string,
     options?: AddressOptions,
   ) => GetAddressDAReturnType;
+
+  getFullViewingKey: (
+    derivationPath: string,
+    options?: FullViewingKeyOptions,
+  ) => GetFullViewingKeyDAReturnType;
 
   signTransaction: (
     derivationPath: string,

--- a/packages/signer/signer-zcash/src/api/app-binder/GetFullViewingKeyDeviceActionTypes.ts
+++ b/packages/signer/signer-zcash/src/api/app-binder/GetFullViewingKeyDeviceActionTypes.ts
@@ -1,0 +1,32 @@
+import {
+  type CommandErrorResult,
+  type ExecuteDeviceActionReturnType,
+  type OpenAppDAError,
+  type OpenAppDARequiredInteraction,
+  type UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import { type GetFullViewingKeyTaskData } from "@internal/app-binder/task/GetFullViewingKeyTask";
+import { type ZcashErrorCodes } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+type GetFullViewingKeyDAUserInteractionRequired = UserInteractionRequired.None;
+
+export type GetFullViewingKeyDAOutput = GetFullViewingKeyTaskData;
+
+export type GetFullViewingKeyDAError =
+  | OpenAppDAError
+  | CommandErrorResult<ZcashErrorCodes>["error"];
+
+type GetFullViewingKeyDARequiredInteraction =
+  | OpenAppDARequiredInteraction
+  | GetFullViewingKeyDAUserInteractionRequired;
+
+export type GetFullViewingKeyDAIntermediateValue = {
+  readonly requiredUserInteraction: GetFullViewingKeyDARequiredInteraction;
+};
+
+export type GetFullViewingKeyDAReturnType = ExecuteDeviceActionReturnType<
+  GetFullViewingKeyDAOutput,
+  GetFullViewingKeyDAError,
+  GetFullViewingKeyDAIntermediateValue
+>;

--- a/packages/signer/signer-zcash/src/api/app-binder/GetFullViewingKeyDeviceActionTypes.ts
+++ b/packages/signer/signer-zcash/src/api/app-binder/GetFullViewingKeyDeviceActionTypes.ts
@@ -6,8 +6,8 @@ import {
   type UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
 
-import { type GetFullViewingKeyTaskData } from "@internal/app-binder/task/GetFullViewingKeyTask";
 import { type ZcashErrorCodes } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+import { type GetFullViewingKeyTaskData } from "@internal/app-binder/task/GetFullViewingKeyTask";
 
 type GetFullViewingKeyDAUserInteractionRequired = UserInteractionRequired.None;
 

--- a/packages/signer/signer-zcash/src/api/index.ts
+++ b/packages/signer/signer-zcash/src/api/index.ts
@@ -4,16 +4,16 @@ export type {
   GetAddressDAOutput,
 } from "@api/app-binder/GetAddressDeviceActionTypes";
 export type {
+  GetAppConfigDAError,
+  GetAppConfigDAIntermediateValue,
+  GetAppConfigDAOutput,
+} from "@api/app-binder/GetAppConfigDeviceActionTypes";
+export type {
   GetFullViewingKeyDAError,
   GetFullViewingKeyDAIntermediateValue,
   GetFullViewingKeyDAOutput,
   GetFullViewingKeyDAReturnType,
 } from "@api/app-binder/GetFullViewingKeyDeviceActionTypes";
-export type {
-  GetAppConfigDAError,
-  GetAppConfigDAIntermediateValue,
-  GetAppConfigDAOutput,
-} from "@api/app-binder/GetAppConfigDeviceActionTypes";
 export type {
   GetTrustedInputDAError,
   GetTrustedInputDAIntermediateValue,

--- a/packages/signer/signer-zcash/src/api/index.ts
+++ b/packages/signer/signer-zcash/src/api/index.ts
@@ -4,6 +4,12 @@ export type {
   GetAddressDAOutput,
 } from "@api/app-binder/GetAddressDeviceActionTypes";
 export type {
+  GetFullViewingKeyDAError,
+  GetFullViewingKeyDAIntermediateValue,
+  GetFullViewingKeyDAOutput,
+  GetFullViewingKeyDAReturnType,
+} from "@api/app-binder/GetFullViewingKeyDeviceActionTypes";
+export type {
   GetAppConfigDAError,
   GetAppConfigDAIntermediateValue,
   GetAppConfigDAOutput,
@@ -23,6 +29,10 @@ export type {
   SignTransactionDAIntermediateValue,
   SignTransactionDAOutput,
 } from "@api/app-binder/SignTransactionDeviceActionTypes";
+export type {
+  FullViewingKeyOptions,
+  ZcashFullViewingKeyMode,
+} from "@api/model/FullViewingKeyOptions";
 export * from "@api/SignerZcash";
 export * from "@api/SignerZcashBuilder";
 // Export other types as needed

--- a/packages/signer/signer-zcash/src/api/model/FullViewingKeyOptions.ts
+++ b/packages/signer/signer-zcash/src/api/model/FullViewingKeyOptions.ts
@@ -1,0 +1,13 @@
+/**
+ * Device `P2` mode for GET_VK: UFVK string (default) or raw Orchard FVK bytes.
+ */
+export type ZcashFullViewingKeyMode = "ufvk" | "orchardFvk";
+
+/**
+ * - `mode`: which device `P2` encoding to use. Defaults to `ufvk`.
+ * - `skipOpenApp`: when true, the flow assumes the Zcash app is already open.
+ */
+export type FullViewingKeyOptions = {
+  readonly mode?: ZcashFullViewingKeyMode;
+  readonly skipOpenApp?: boolean;
+};

--- a/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.test.ts
+++ b/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.test.ts
@@ -1,8 +1,22 @@
 import {
+  CallTaskInAppDeviceAction,
+  CommandResultFactory,
   type DeviceManagementKit,
   type DeviceSessionId,
+  type DmkError,
+  type InternalApi,
+  SendCommandInAppDeviceAction,
+  UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
+import { from } from "rxjs";
 import { vi } from "vitest";
+
+import { GetAddressCommand } from "@internal/app-binder/command/GetAddressCommand";
+import {
+  GetFullViewingKeyCommand,
+  zcashFvkP2FromMode,
+} from "@internal/app-binder/command/GetFullViewingKeyCommand";
+import { APP_NAME } from "@internal/app-binder/constants";
 
 import { DefaultSignerZcash } from "./DefaultSignerZcash";
 
@@ -15,27 +29,95 @@ describe("DefaultSignerZcash", () => {
     expect(signer).toBeDefined();
   });
 
-  it("should call getAddress via device action", () => {
+  it("should call getAddress via device action with derivation path and defaults", () => {
+    const sessionId = "test-session-id" as DeviceSessionId;
+    const derivationPath = "44'/133'/0'/0/0";
+    const executeDeviceAction = vi.fn().mockReturnValue({
+      observable: from([]),
+      cancel: vi.fn(),
+    });
     const dmk = {
-      executeDeviceAction: vi.fn(),
+      executeDeviceAction,
     } as unknown as DeviceManagementKit;
-    const sessionId = {} as DeviceSessionId;
     const signer = new DefaultSignerZcash({ dmk, sessionId });
 
-    signer.getAddress("44'/133'/0'/0/0", {});
+    signer.getAddress(derivationPath, {});
 
-    expect(dmk.executeDeviceAction).toHaveBeenCalled();
+    expect(executeDeviceAction).toHaveBeenCalledTimes(1);
+    const call = executeDeviceAction.mock.calls[0]![0] as {
+      sessionId: DeviceSessionId;
+      deviceAction: {
+        input: {
+          command: GetAddressCommand;
+          appName: string;
+          requiredUserInteraction: UserInteractionRequired;
+          skipOpenApp: boolean;
+        };
+      };
+    };
+    expect(call.sessionId).toBe(sessionId);
+    expect(call.deviceAction).toBeInstanceOf(SendCommandInAppDeviceAction);
+    expect(call.deviceAction.input.command).toBeInstanceOf(GetAddressCommand);
+    expect(call.deviceAction.input.appName).toBe(APP_NAME);
+    expect(call.deviceAction.input.requiredUserInteraction).toBe(
+      UserInteractionRequired.None,
+    );
+    expect(call.deviceAction.input.skipOpenApp).toBe(false);
+    expect(call.deviceAction.input.command.getApdu()).toEqual(
+      new GetAddressCommand({
+        derivationPath,
+        checkOnDevice: false,
+      }).getApdu(),
+    );
   });
 
-  it("should call getFullViewingKey via device action", () => {
+  it("should call getFullViewingKey via device action with derivation path and default UFVK mode", async () => {
+    const sessionId = "test-session-id" as DeviceSessionId;
+    const derivationPath = "44'/133'/0'/0/0";
+    const ufvkPayload = new Uint8Array([0, 0]);
+    const executeDeviceAction = vi.fn().mockReturnValue({
+      observable: from([]),
+      cancel: vi.fn(),
+    });
     const dmk = {
-      executeDeviceAction: vi.fn(),
+      executeDeviceAction,
     } as unknown as DeviceManagementKit;
-    const sessionId = {} as DeviceSessionId;
     const signer = new DefaultSignerZcash({ dmk, sessionId });
 
-    signer.getFullViewingKey("44'/133'/0'/0/0", {});
+    signer.getFullViewingKey(derivationPath, {});
 
-    expect(dmk.executeDeviceAction).toHaveBeenCalled();
+    expect(executeDeviceAction).toHaveBeenCalledTimes(1);
+    const call = executeDeviceAction.mock.calls[0]![0] as {
+      sessionId: DeviceSessionId;
+      deviceAction: CallTaskInAppDeviceAction<
+        unknown,
+        DmkError,
+        UserInteractionRequired.None
+      >;
+    };
+    expect(call.sessionId).toBe(sessionId);
+    expect(call.deviceAction).toBeInstanceOf(CallTaskInAppDeviceAction);
+    expect(call.deviceAction.input.appName).toBe(APP_NAME);
+    expect(call.deviceAction.input.requiredUserInteraction).toBe(
+      UserInteractionRequired.None,
+    );
+    expect(call.deviceAction.input.skipOpenApp).toBe(false);
+
+    const sendCommand = vi
+      .fn()
+      .mockResolvedValue(CommandResultFactory({ data: { data: ufvkPayload } }));
+    await call.deviceAction.input.task({
+      sendCommand,
+    } as unknown as InternalApi);
+
+    const firstCommand = sendCommand.mock
+      .calls[0]![0] as GetFullViewingKeyCommand;
+    expect(firstCommand.getApdu()).toEqual(
+      new GetFullViewingKeyCommand({
+        isContinue: false,
+        derivationPath,
+        p2: zcashFvkP2FromMode("ufvk"),
+      }).getApdu(),
+    );
   });
 });

--- a/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.test.ts
+++ b/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.test.ts
@@ -26,4 +26,16 @@ describe("DefaultSignerZcash", () => {
 
     expect(dmk.executeDeviceAction).toHaveBeenCalled();
   });
+
+  it("should call getFullViewingKey via device action", () => {
+    const dmk = {
+      executeDeviceAction: vi.fn(),
+    } as unknown as DeviceManagementKit;
+    const sessionId = {} as DeviceSessionId;
+    const signer = new DefaultSignerZcash({ dmk, sessionId });
+
+    signer.getFullViewingKey("44'/133'/0'/0/0", {});
+
+    expect(dmk.executeDeviceAction).toHaveBeenCalled();
+  });
 });

--- a/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.ts
+++ b/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.ts
@@ -6,15 +6,18 @@ import { type Container } from "inversify";
 
 import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
 import { type GetAppConfigDAReturnType } from "@api/app-binder/GetAppConfigDeviceActionTypes";
+import { type GetFullViewingKeyDAReturnType } from "@api/app-binder/GetFullViewingKeyDeviceActionTypes";
 import { type GetTrustedInputDAReturnType } from "@api/app-binder/GetTrustedInputActionTypes";
 import { type SignMessageDAReturnType } from "@api/app-binder/SignMessageDeviceActionTypes";
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { type AddressOptions } from "@api/model/AddressOptions";
+import { type FullViewingKeyOptions } from "@api/model/FullViewingKeyOptions";
 import { type TransactionOptions } from "@api/model/TransactionOptions";
 import { type SignerZcash } from "@api/SignerZcash";
 import { makeContainer } from "@internal/di";
 import { addressTypes } from "@internal/use-cases/address/di/addressTypes";
 import { type GetAddressUseCase } from "@internal/use-cases/address/GetAddressUseCase";
+import { type GetFullViewingKeyUseCase } from "@internal/use-cases/address/GetFullViewingKeyUseCase";
 import { configTypes } from "@internal/use-cases/config/di/configTypes";
 import { type GetAppConfigUseCase } from "@internal/use-cases/config/GetAppConfigUseCase";
 import { messageTypes } from "@internal/use-cases/message/di/messageTypes";
@@ -47,6 +50,15 @@ export class DefaultSignerZcash implements SignerZcash {
   ): GetAddressDAReturnType {
     return this._container
       .get<GetAddressUseCase>(addressTypes.GetAddressUseCase)
+      .execute(derivationPath, options);
+  }
+
+  getFullViewingKey(
+    derivationPath: string,
+    options?: FullViewingKeyOptions,
+  ): GetFullViewingKeyDAReturnType {
+    return this._container
+      .get<GetFullViewingKeyUseCase>(addressTypes.GetFullViewingKeyUseCase)
       .execute(derivationPath, options);
   }
 

--- a/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.test.ts
@@ -24,6 +24,7 @@ import {
 } from "@internal/app-binder/command/GetAddressCommand";
 import type { ZcashErrorCodes } from "@internal/app-binder/command/utils/zcashApplicationErrors";
 import { APP_NAME } from "@internal/app-binder/constants";
+import { GetFullViewingKeyTask } from "@internal/app-binder/task/GetFullViewingKeyTask";
 import { GetTrustedInputTask } from "@internal/app-binder/task/GetTrustedInputTask";
 import { ZcashAppBinder } from "@internal/app-binder/ZcashAppBinder";
 
@@ -146,6 +147,45 @@ describe("ZcashAppBinder", () => {
         UserInteractionRequired.None,
       );
       expect(args.deviceAction.input.skipOpenApp).toBe(true);
+    });
+  });
+
+  describe("getFullViewingKey", () => {
+    it("should call dmk.executeDeviceAction with CallTaskInAppDeviceAction and run GetFullViewingKeyTask", async () => {
+      const sessionId = "test-session-id";
+      const expectedResult = {
+        observable: from([]),
+        cancel: vi.fn(),
+      };
+      const executeDeviceActionMock = vi.fn().mockReturnValue(expectedResult);
+      const dmkMock = {
+        executeDeviceAction: executeDeviceActionMock,
+      } as unknown as DeviceManagementKit;
+      const binder = new ZcashAppBinder(dmkMock, sessionId);
+      const runSpy = vi
+        .spyOn(GetFullViewingKeyTask.prototype, "run")
+        .mockResolvedValue({} as never);
+
+      const result = binder.getFullViewingKey({
+        derivationPath: "44'/133'/0'/0/0",
+        mode: "ufvk",
+        skipOpenApp: false,
+      });
+
+      expect(executeDeviceActionMock).toHaveBeenCalledTimes(1);
+      const args = executeDeviceActionMock.mock
+        .calls[0]![0] as ExecuteDeviceActionTaskCallArgs;
+      expect(args.sessionId).toBe(sessionId);
+      expect(args.deviceAction).toBeInstanceOf(CallTaskInAppDeviceAction);
+      expect(args.deviceAction.input.appName).toBe(APP_NAME);
+      expect(args.deviceAction.input.requiredUserInteraction).toBe(
+        UserInteractionRequired.None,
+      );
+      expect(args.deviceAction.input.skipOpenApp).toBe(false);
+      expect(result).toBe(expectedResult);
+
+      await args.deviceAction.input.task({} as InternalApi);
+      expect(runSpy).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.ts
@@ -6,6 +6,8 @@ import {
   SendCommandInAppDeviceAction,
   UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
+import { type GetFullViewingKeyDAReturnType } from "@api/app-binder/GetFullViewingKeyDeviceActionTypes";
+import { type ZcashFullViewingKeyMode } from "@api/model/FullViewingKeyOptions";
 import { inject, injectable } from "inversify";
 
 import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
@@ -19,6 +21,7 @@ import { externalTypes } from "@internal/externalTypes";
 import { GetAddressCommand } from "./command/GetAddressCommand";
 import { GetAppConfigCommand } from "./command/GetAppConfigCommand";
 import { SignMessageCommand } from "./command/SignMessageCommand";
+import { GetFullViewingKeyTask } from "./task/GetFullViewingKeyTask";
 import { GetTrustedInputTask } from "./task/GetTrustedInputTask";
 import { SignTransactionTask } from "./task/SignTransactionTask";
 
@@ -57,6 +60,28 @@ export class ZcashAppBinder {
           requiredUserInteraction: args.checkOnDevice
             ? UserInteractionRequired.VerifyAddress
             : UserInteractionRequired.None,
+          skipOpenApp: args.skipOpenApp,
+        },
+      }),
+    });
+  }
+
+  getFullViewingKey(args: {
+    derivationPath: string;
+    mode: ZcashFullViewingKeyMode;
+    skipOpenApp: boolean;
+  }): GetFullViewingKeyDAReturnType {
+    return this.dmk.executeDeviceAction({
+      sessionId: this.sessionId,
+      deviceAction: new CallTaskInAppDeviceAction({
+        input: {
+          task: async (internalApi: InternalApi) =>
+            new GetFullViewingKeyTask(internalApi, {
+              derivationPath: args.derivationPath,
+              mode: args.mode,
+            }).run(),
+          appName: APP_NAME,
+          requiredUserInteraction: UserInteractionRequired.None,
           skipOpenApp: args.skipOpenApp,
         },
       }),

--- a/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.ts
@@ -6,15 +6,15 @@ import {
   SendCommandInAppDeviceAction,
   UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
-import { type GetFullViewingKeyDAReturnType } from "@api/app-binder/GetFullViewingKeyDeviceActionTypes";
-import { type ZcashFullViewingKeyMode } from "@api/model/FullViewingKeyOptions";
 import { inject, injectable } from "inversify";
 
 import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
 import { type GetAppConfigDAReturnType } from "@api/app-binder/GetAppConfigDeviceActionTypes";
+import { type GetFullViewingKeyDAReturnType } from "@api/app-binder/GetFullViewingKeyDeviceActionTypes";
 import { type GetTrustedInputDAReturnType } from "@api/app-binder/GetTrustedInputActionTypes";
 import { type SignMessageDAReturnType } from "@api/app-binder/SignMessageDeviceActionTypes";
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
+import { type ZcashFullViewingKeyMode } from "@api/model/FullViewingKeyOptions";
 import { APP_NAME } from "@internal/app-binder/constants";
 import { externalTypes } from "@internal/externalTypes";
 

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetAddressCommand.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetAddressCommand.test.ts
@@ -8,13 +8,13 @@ import { GetAddressCommand } from "@internal/app-binder/command/GetAddressComman
 import { ZCASH_CLA } from "@internal/app-binder/command/utils/apduHeaderUtils";
 import { type ZcashAppCommandError } from "@internal/app-binder/command/utils/zcashApplicationErrors";
 
-const INS = 0x40;
+const GET_ADDRESS_INS = 0x40;
 
 // Standard Zcash BIP44 path: m/44'/133'/0'/0/0
 // Path elements (BE u32): 0x8000002C, 0x80000085, 0x80000000, 0x00000000, 0x00000000
 const GET_ADDRESS_APDU_NO_DISPLAY = Uint8Array.from([
   ZCASH_CLA,
-  INS,
+  GET_ADDRESS_INS,
   0x00, // P1 (no display)
   0x00, // P2
   0x15, // Data length: 1 (path len) + 5*4 (path elements) = 21
@@ -43,7 +43,7 @@ const GET_ADDRESS_APDU_NO_DISPLAY = Uint8Array.from([
 
 const GET_ADDRESS_APDU_WITH_DISPLAY = Uint8Array.from([
   ZCASH_CLA,
-  INS,
+  GET_ADDRESS_INS,
   0x01, // P1 (display on device)
   0x00, // P2
   0x15, // Data length: 21
@@ -73,7 +73,7 @@ const GET_ADDRESS_APDU_WITH_DISPLAY = Uint8Array.from([
 // m/44'/133'/1'/0/5
 const GET_ADDRESS_APDU_CUSTOM_PATH = Uint8Array.from([
   ZCASH_CLA,
-  INS,
+  GET_ADDRESS_INS,
   0x00, // P1 (no display)
   0x00, // P2
   0x15, // Data length: 21

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetAddressCommand.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetAddressCommand.test.ts
@@ -5,17 +5,16 @@ import {
 } from "@ledgerhq/device-management-kit";
 
 import { GetAddressCommand } from "@internal/app-binder/command/GetAddressCommand";
-import {
-  INS,
-  ZCASH_CLA,
-} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import { ZCASH_CLA } from "@internal/app-binder/command/utils/apduHeaderUtils";
 import { type ZcashAppCommandError } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+const INS = 0x40;
 
 // Standard Zcash BIP44 path: m/44'/133'/0'/0/0
 // Path elements (BE u32): 0x8000002C, 0x80000085, 0x80000000, 0x00000000, 0x00000000
 const GET_ADDRESS_APDU_NO_DISPLAY = Uint8Array.from([
   ZCASH_CLA,
-  INS.GET_WALLET_PUBLIC_KEY,
+  INS,
   0x00, // P1 (no display)
   0x00, // P2
   0x15, // Data length: 1 (path len) + 5*4 (path elements) = 21
@@ -44,7 +43,7 @@ const GET_ADDRESS_APDU_NO_DISPLAY = Uint8Array.from([
 
 const GET_ADDRESS_APDU_WITH_DISPLAY = Uint8Array.from([
   ZCASH_CLA,
-  INS.GET_WALLET_PUBLIC_KEY,
+  INS,
   0x01, // P1 (display on device)
   0x00, // P2
   0x15, // Data length: 21
@@ -74,7 +73,7 @@ const GET_ADDRESS_APDU_WITH_DISPLAY = Uint8Array.from([
 // m/44'/133'/1'/0/5
 const GET_ADDRESS_APDU_CUSTOM_PATH = Uint8Array.from([
   ZCASH_CLA,
-  INS.GET_WALLET_PUBLIC_KEY,
+  INS,
   0x00, // P1 (no display)
   0x00, // P2
   0x15, // Data length: 21

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetAddressCommand.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetAddressCommand.test.ts
@@ -5,13 +5,17 @@ import {
 } from "@ledgerhq/device-management-kit";
 
 import { GetAddressCommand } from "@internal/app-binder/command/GetAddressCommand";
+import {
+  INS,
+  ZCASH_CLA,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
 import { type ZcashAppCommandError } from "@internal/app-binder/command/utils/zcashApplicationErrors";
 
 // Standard Zcash BIP44 path: m/44'/133'/0'/0/0
 // Path elements (BE u32): 0x8000002C, 0x80000085, 0x80000000, 0x00000000, 0x00000000
 const GET_ADDRESS_APDU_NO_DISPLAY = Uint8Array.from([
-  0xe0, // CLA
-  0x40, // INS (GET_WALLET_PUBLIC_KEY)
+  ZCASH_CLA,
+  INS.GET_WALLET_PUBLIC_KEY,
   0x00, // P1 (no display)
   0x00, // P2
   0x15, // Data length: 1 (path len) + 5*4 (path elements) = 21
@@ -39,8 +43,8 @@ const GET_ADDRESS_APDU_NO_DISPLAY = Uint8Array.from([
 ]);
 
 const GET_ADDRESS_APDU_WITH_DISPLAY = Uint8Array.from([
-  0xe0, // CLA
-  0x40, // INS
+  ZCASH_CLA,
+  INS.GET_WALLET_PUBLIC_KEY,
   0x01, // P1 (display on device)
   0x00, // P2
   0x15, // Data length: 21
@@ -69,8 +73,8 @@ const GET_ADDRESS_APDU_WITH_DISPLAY = Uint8Array.from([
 
 // m/44'/133'/1'/0/5
 const GET_ADDRESS_APDU_CUSTOM_PATH = Uint8Array.from([
-  0xe0, // CLA
-  0x40, // INS
+  ZCASH_CLA,
+  INS.GET_WALLET_PUBLIC_KEY,
   0x00, // P1 (no display)
   0x00, // P2
   0x15, // Data length: 21

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetAddressCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetAddressCommand.ts
@@ -16,6 +16,11 @@ import {
 import { Maybe } from "purify-ts";
 
 import {
+  INS,
+  ZCASH_CLA,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
+
+import {
   ZCASH_APP_ERRORS,
   ZcashAppCommandErrorFactory,
   type ZcashErrorCodes,
@@ -53,8 +58,8 @@ export class GetAddressCommand
 
   getApdu(): Apdu {
     const getAddressArgs: ApduBuilderArgs = {
-      cla: 0xe0,
-      ins: 0x40,
+      cla: ZCASH_CLA,
+      ins: INS.GET_WALLET_PUBLIC_KEY,
       p1: this.args.checkOnDevice ? 0x01 : 0x00,
       p2: 0x00,
     };

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetAddressCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetAddressCommand.ts
@@ -15,10 +15,7 @@ import {
 } from "@ledgerhq/signer-utils";
 import { Maybe } from "purify-ts";
 
-import {
-  INS,
-  ZCASH_CLA,
-} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import { ZCASH_CLA } from "@internal/app-binder/command/utils/apduHeaderUtils";
 
 import {
   ZCASH_APP_ERRORS,
@@ -27,6 +24,7 @@ import {
 } from "./utils/zcashApplicationErrors";
 
 const CHAIN_CODE_LENGTH = 32;
+const INS = 0x40;
 
 export type GetAddressCommandArgs = {
   readonly derivationPath: string;
@@ -59,7 +57,7 @@ export class GetAddressCommand
   getApdu(): Apdu {
     const getAddressArgs: ApduBuilderArgs = {
       cla: ZCASH_CLA,
-      ins: INS.GET_WALLET_PUBLIC_KEY,
+      ins: INS,
       p1: this.args.checkOnDevice ? 0x01 : 0x00,
       p2: 0x00,
     };

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetAddressCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetAddressCommand.ts
@@ -24,7 +24,7 @@ import {
 } from "./utils/zcashApplicationErrors";
 
 const CHAIN_CODE_LENGTH = 32;
-const INS = 0x40;
+const GET_ADDRESS_INS = 0x40;
 
 export type GetAddressCommandArgs = {
   readonly derivationPath: string;
@@ -57,7 +57,7 @@ export class GetAddressCommand
   getApdu(): Apdu {
     const getAddressArgs: ApduBuilderArgs = {
       cla: ZCASH_CLA,
-      ins: INS,
+      ins: GET_ADDRESS_INS,
       p1: this.args.checkOnDevice ? 0x01 : 0x00,
       p2: 0x00,
     };

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.test.ts
@@ -142,5 +142,25 @@ describe("GetFullViewingKeyCommand", () => {
         expect((result.error as ZcashAppCommandError).errorCode).toBe("6b00");
       }
     });
+
+    it("should map status 0xB007 to BadStateError", () => {
+      const command = new GetFullViewingKeyCommand({
+        isContinue: false,
+        p2: P2_VK.UFVK,
+        derivationPath: path,
+      });
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: new Uint8Array([0xb0, 0x07]),
+          data: new Uint8Array(),
+        }),
+      );
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as ZcashAppCommandError;
+        expect(err.errorCode).toBe("b007");
+        expect(err.message).toBe("BadStateError");
+      }
+    });
   });
 });

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.test.ts
@@ -1,0 +1,146 @@
+import {
+  ApduResponse,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { GetFullViewingKeyCommand } from "@internal/app-binder/command/GetFullViewingKeyCommand";
+import { P2_VK } from "@internal/app-binder/command/utils/apduHeaderUtils";
+import { type ZcashAppCommandError } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+// m/44'/133'/0'/0/0 — same path bytes as GetAddress tests
+const GET_FVK_PATH_BYTES = Uint8Array.from([
+  0x15, // Data length: 21
+  0x05,
+  0x80,
+  0x00,
+  0x00,
+  0x2c,
+  0x80,
+  0x00,
+  0x00,
+  0x85,
+  0x80,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+]);
+
+const GET_FVK_UFVK_FIRST_APDU = Uint8Array.from([
+  0xe0,
+  0x50,
+  0x00,
+  P2_VK.UFVK,
+  ...GET_FVK_PATH_BYTES,
+]);
+
+const GET_FVK_ORCHARD_FIRST_APDU = Uint8Array.from([
+  0xe0,
+  0x50,
+  0x00,
+  P2_VK.ORCHARD_FVK,
+  ...GET_FVK_PATH_BYTES,
+]);
+
+const GET_FVK_CONTINUE_UFVK_APDU = Uint8Array.from([
+  0xe0,
+  0x50,
+  0x80,
+  P2_VK.UFVK,
+  0x00,
+]);
+
+describe("GetFullViewingKeyCommand", () => {
+  const path = "44'/133'/0'/0/0";
+
+  describe("name", () => {
+    it("should be 'GetFullViewingKey'", () => {
+      const command = new GetFullViewingKeyCommand({
+        isContinue: false,
+        p2: P2_VK.UFVK,
+        derivationPath: path,
+      });
+      expect(command.name).toBe("GetFullViewingKey");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("should return first GET_VK APDU for UFVK (P2=0)", () => {
+      const command = new GetFullViewingKeyCommand({
+        isContinue: false,
+        p2: P2_VK.UFVK,
+        derivationPath: path,
+      });
+      expect(command.getApdu().getRawApdu()).toStrictEqual(
+        GET_FVK_UFVK_FIRST_APDU,
+      );
+    });
+
+    it("should return first GET_VK APDU for Orchard (P2=1)", () => {
+      const command = new GetFullViewingKeyCommand({
+        isContinue: false,
+        p2: P2_VK.ORCHARD_FVK,
+        derivationPath: path,
+      });
+      expect(command.getApdu().getRawApdu()).toStrictEqual(
+        GET_FVK_ORCHARD_FIRST_APDU,
+      );
+    });
+
+    it("should return CONTINUE APDU with empty data", () => {
+      const command = new GetFullViewingKeyCommand({
+        isContinue: true,
+        p2: P2_VK.UFVK,
+      });
+      expect(command.getApdu().getRawApdu()).toStrictEqual(
+        GET_FVK_CONTINUE_UFVK_APDU,
+      );
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("should return response data chunk on success", () => {
+      const payload = new Uint8Array([0x01, 0x02, 0x03]);
+      const command = new GetFullViewingKeyCommand({
+        isContinue: false,
+        p2: P2_VK.UFVK,
+        derivationPath: path,
+      });
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: new Uint8Array([0x90, 0x00]),
+          data: payload,
+        }),
+      );
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data.data).toStrictEqual(payload);
+      }
+    });
+
+    it("should map device error status to Zcash app error", () => {
+      const command = new GetFullViewingKeyCommand({
+        isContinue: false,
+        p2: P2_VK.UFVK,
+        derivationPath: path,
+      });
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: new Uint8Array([0x6b, 0x00]),
+          data: new Uint8Array(),
+        }),
+      );
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect((result.error as ZcashAppCommandError).errorCode).toBe("6b00");
+      }
+    });
+  });
+});

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.test.ts
@@ -3,8 +3,10 @@ import {
   isSuccessCommandResult,
 } from "@ledgerhq/device-management-kit";
 
-import { GetFullViewingKeyCommand } from "@internal/app-binder/command/GetFullViewingKeyCommand";
-import { P2_VK } from "@internal/app-binder/command/utils/apduHeaderUtils";
+import {
+  GetFullViewingKeyCommand,
+  P2_VK,
+} from "@internal/app-binder/command/GetFullViewingKeyCommand";
 import { type ZcashAppCommandError } from "@internal/app-binder/command/utils/zcashApplicationErrors";
 
 // m/44'/133'/0'/0/0 — same path bytes as GetAddress tests

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.ts
@@ -15,7 +15,7 @@ import { Maybe } from "purify-ts";
 
 import {
   INS,
-  P1_VK,
+  P1,
   P2_VK,
   ZCASH_CLA,
 } from "@internal/app-binder/command/utils/apduHeaderUtils";
@@ -27,14 +27,19 @@ import {
 
 export type ZcashFvkP2 = (typeof P2_VK)[keyof typeof P2_VK];
 
-export type GetFullViewingKeyCommandArgs = {
-  /** When true, P1=CONTINUE and APDU data must be empty. */
-  readonly isContinue: boolean;
-  /** See app `P2VkMode` (UFVK string vs raw Orchard FVK bytes). */
-  readonly p2: ZcashFvkP2;
-  /** Required for the first exchange only. */
-  readonly derivationPath?: string;
-};
+export type GetFullViewingKeyCommandArgs =
+  | {
+      /** First GET_VK exchange: P1=FIRST and path in APDU data. */
+      readonly isContinue: false;
+      readonly derivationPath: string;
+      /** See app `P2VkMode` (UFVK string vs raw Orchard FVK bytes). */
+      readonly p2: ZcashFvkP2;
+    }
+  | {
+      /** Subsequent chunk(s): P1=NEXT and empty APDU data. */
+      readonly isContinue: true;
+      readonly p2: ZcashFvkP2;
+    };
 
 /**
  * One GET_VK APDU. Response is a single chunk; the host task concatenates
@@ -64,13 +69,7 @@ export class GetFullViewingKeyCommand
   }
 
   getApdu(): Apdu {
-    if (!this.args.isContinue && this.args.derivationPath === undefined) {
-      throw new Error(
-        "derivationPath is required for the first GetFullViewingKey APDU",
-      );
-    }
-
-    const p1 = this.args.isContinue ? P1_VK.CONTINUE : P1_VK.FIRST;
+    const p1 = this.args.isContinue ? P1.NEXT : P1.FIRST;
 
     const getVkArgs: ApduBuilderArgs = {
       cla: ZCASH_CLA,
@@ -81,7 +80,7 @@ export class GetFullViewingKeyCommand
 
     const builder = new ApduBuilder(getVkArgs);
 
-    if (!this.args.isContinue && this.args.derivationPath !== undefined) {
+    if (!this.args.isContinue) {
       const path = DerivationPathUtils.splitPath(this.args.derivationPath);
       builder.add8BitUIntToData(path.length);
       path.forEach((element) => {

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.ts
@@ -7,7 +7,10 @@ import {
   type CommandResult,
   CommandResultFactory,
 } from "@ledgerhq/device-management-kit";
-import { CommandErrorHelper, DerivationPathUtils } from "@ledgerhq/signer-utils";
+import {
+  CommandErrorHelper,
+  DerivationPathUtils,
+} from "@ledgerhq/signer-utils";
 import { Maybe } from "purify-ts";
 
 import {
@@ -62,7 +65,9 @@ export class GetFullViewingKeyCommand
 
   getApdu(): Apdu {
     if (!this.args.isContinue && this.args.derivationPath === undefined) {
-      throw new Error("derivationPath is required for the first GetFullViewingKey APDU");
+      throw new Error(
+        "derivationPath is required for the first GetFullViewingKey APDU",
+      );
     }
 
     const p1 = this.args.isContinue ? P1_VK.CONTINUE : P1_VK.FIRST;

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.ts
@@ -14,9 +14,7 @@ import {
 import { Maybe } from "purify-ts";
 
 import {
-  INS,
   P1,
-  P2_VK,
   ZCASH_CLA,
 } from "@internal/app-binder/command/utils/apduHeaderUtils";
 import {
@@ -24,6 +22,12 @@ import {
   ZcashAppCommandErrorFactory,
   type ZcashErrorCodes,
 } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+export const P2_VK = {
+  UFVK: 0x00,
+  ORCHARD_FVK: 0x01,
+} as const;
+const INS = 0x50;
 
 export type ZcashFvkP2 = (typeof P2_VK)[keyof typeof P2_VK];
 
@@ -73,7 +77,7 @@ export class GetFullViewingKeyCommand
 
     const getVkArgs: ApduBuilderArgs = {
       cla: ZCASH_CLA,
-      ins: INS.GET_VK,
+      ins: INS,
       p1,
       p2: this.args.p2,
     };

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.ts
@@ -27,7 +27,7 @@ export const P2_VK = {
   UFVK: 0x00,
   ORCHARD_FVK: 0x01,
 } as const;
-const INS = 0x50;
+const GET_VK_INS = 0x50;
 
 export type ZcashFvkP2 = (typeof P2_VK)[keyof typeof P2_VK];
 
@@ -47,7 +47,7 @@ export type GetFullViewingKeyCommandArgs =
 
 /**
  * One GET_VK APDU. Response is a single chunk; the host task concatenates
- * until the last chunk has length < `VK_RESPONSE_CHUNK_SIZE` (255).
+ * until the last chunk has length < `APDU_MAX_PAYLOAD` (255).
  */
 export type GetFullViewingKeyCommandResponse = {
   readonly data: Uint8Array;
@@ -77,7 +77,7 @@ export class GetFullViewingKeyCommand
 
     const getVkArgs: ApduBuilderArgs = {
       cla: ZCASH_CLA,
-      ins: INS,
+      ins: GET_VK_INS,
       p1,
       p2: this.args.p2,
     };

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.ts
@@ -1,0 +1,105 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper, DerivationPathUtils } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import {
+  INS,
+  P1_VK,
+  P2_VK,
+  ZCASH_CLA,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import {
+  ZCASH_APP_ERRORS,
+  ZcashAppCommandErrorFactory,
+  type ZcashErrorCodes,
+} from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+export type ZcashFvkP2 = (typeof P2_VK)[keyof typeof P2_VK];
+
+export type GetFullViewingKeyCommandArgs = {
+  /** When true, P1=CONTINUE and APDU data must be empty. */
+  readonly isContinue: boolean;
+  /** See app `P2VkMode` (UFVK string vs raw Orchard FVK bytes). */
+  readonly p2: ZcashFvkP2;
+  /** Required for the first exchange only. */
+  readonly derivationPath?: string;
+};
+
+/**
+ * One GET_VK APDU. Response is a single chunk; the host task concatenates
+ * until the last chunk has length < `VK_RESPONSE_CHUNK_SIZE` (255).
+ */
+export type GetFullViewingKeyCommandResponse = {
+  readonly data: Uint8Array;
+};
+
+export class GetFullViewingKeyCommand
+  implements
+    Command<
+      GetFullViewingKeyCommandResponse,
+      GetFullViewingKeyCommandArgs,
+      ZcashErrorCodes
+    >
+{
+  readonly name = "GetFullViewingKey";
+  private readonly errorHelper = new CommandErrorHelper<
+    GetFullViewingKeyCommandResponse,
+    ZcashErrorCodes
+  >(ZCASH_APP_ERRORS, ZcashAppCommandErrorFactory);
+  private readonly args: GetFullViewingKeyCommandArgs;
+
+  constructor(args: GetFullViewingKeyCommandArgs) {
+    this.args = args;
+  }
+
+  getApdu(): Apdu {
+    if (!this.args.isContinue && this.args.derivationPath === undefined) {
+      throw new Error("derivationPath is required for the first GetFullViewingKey APDU");
+    }
+
+    const p1 = this.args.isContinue ? P1_VK.CONTINUE : P1_VK.FIRST;
+
+    const getVkArgs: ApduBuilderArgs = {
+      cla: ZCASH_CLA,
+      ins: INS.GET_VK,
+      p1,
+      p2: this.args.p2,
+    };
+
+    const builder = new ApduBuilder(getVkArgs);
+
+    if (!this.args.isContinue && this.args.derivationPath !== undefined) {
+      const path = DerivationPathUtils.splitPath(this.args.derivationPath);
+      builder.add8BitUIntToData(path.length);
+      path.forEach((element) => {
+        builder.add32BitUIntToData(element);
+      });
+    }
+
+    return builder.build();
+  }
+
+  parseResponse(
+    response: ApduResponse,
+  ): CommandResult<GetFullViewingKeyCommandResponse, ZcashErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(response),
+    ).orDefaultLazy(() =>
+      CommandResultFactory({ data: { data: new Uint8Array(response.data) } }),
+    );
+  }
+}
+
+export function zcashFvkP2FromMode(
+  mode: "ufvk" | "orchardFvk",
+): (typeof P2_VK)[keyof typeof P2_VK] {
+  return mode === "orchardFvk" ? P2_VK.ORCHARD_FVK : P2_VK.UFVK;
+}

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetTrustedInputCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetTrustedInputCommand.ts
@@ -11,7 +11,6 @@ import { CommandErrorHelper } from "@ledgerhq/signer-utils";
 import { Maybe } from "purify-ts";
 
 import {
-  INS,
   P1,
   P2,
   ZCASH_CLA,
@@ -34,6 +33,7 @@ export type GetTrustedInputCommandResponse = ApduResponse;
  * The length of the prefix for the index lookup in bytes.
  */
 export const INDEX_LOOKUP_PREFIX_LENGTH = 4;
+const INS = 0x42;
 
 export class GetTrustedInputCommand
   implements
@@ -77,7 +77,7 @@ export class GetTrustedInputCommand
 
     const getTrustedInputCommandArgs: ApduBuilderArgs = {
       cla: ZCASH_CLA,
-      ins: INS.GET_TRUSTED_INPUT,
+      ins: INS,
       p1: firstRound ? P1.FIRST : P1.NEXT,
       p2: P2.DEFAULT,
     };

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetTrustedInputCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetTrustedInputCommand.ts
@@ -33,7 +33,7 @@ export type GetTrustedInputCommandResponse = ApduResponse;
  * The length of the prefix for the index lookup in bytes.
  */
 export const INDEX_LOOKUP_PREFIX_LENGTH = 4;
-const INS = 0x42;
+const GET_TRUSTED_INPUT_INS = 0x42;
 
 export class GetTrustedInputCommand
   implements
@@ -77,7 +77,7 @@ export class GetTrustedInputCommand
 
     const getTrustedInputCommandArgs: ApduBuilderArgs = {
       cla: ZCASH_CLA,
-      ins: INS,
+      ins: GET_TRUSTED_INPUT_INS,
       p1: firstRound ? P1.FIRST : P1.NEXT,
       p2: P2.DEFAULT,
     };

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/utils/apduHeaderUtils.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/utils/apduHeaderUtils.ts
@@ -1,15 +1,11 @@
+import { APDU_MAX_PAYLOAD } from "@ledgerhq/device-management-kit";
+
 export const ZCASH_CLA = 0xe0 as const;
 
 /**
  * APDU max payload in response chunks (see app-zcash-rust `VK_RESPONSE_CHUNK_LEN`).
  */
-export const VK_RESPONSE_CHUNK_SIZE = 255 as const;
-
-export const INS = {
-  GET_WALLET_PUBLIC_KEY: 0x40,
-  GET_TRUSTED_INPUT: 0x42,
-  GET_VK: 0x50,
-} as const;
+export const VK_RESPONSE_CHUNK_SIZE = APDU_MAX_PAYLOAD;
 
 export const P1 = {
   FIRST: 0x00,
@@ -18,9 +14,4 @@ export const P1 = {
 
 export const P2 = {
   DEFAULT: 0x00,
-} as const;
-
-export const P2_VK = {
-  UFVK: 0x00,
-  ORCHARD_FVK: 0x01,
 } as const;

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/utils/apduHeaderUtils.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/utils/apduHeaderUtils.ts
@@ -16,11 +16,6 @@ export const P1 = {
   NEXT: 0x80,
 } as const;
 
-export const P1_VK = {
-  FIRST: 0x00,
-  CONTINUE: 0x80,
-} as const;
-
 export const P2 = {
   DEFAULT: 0x00,
 } as const;

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/utils/apduHeaderUtils.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/utils/apduHeaderUtils.ts
@@ -1,11 +1,4 @@
-import { APDU_MAX_PAYLOAD } from "@ledgerhq/device-management-kit";
-
 export const ZCASH_CLA = 0xe0 as const;
-
-/**
- * APDU max payload in response chunks (see app-zcash-rust `VK_RESPONSE_CHUNK_LEN`).
- */
-export const VK_RESPONSE_CHUNK_SIZE = APDU_MAX_PAYLOAD;
 
 export const P1 = {
   FIRST: 0x00,

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/utils/apduHeaderUtils.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/utils/apduHeaderUtils.ts
@@ -1,7 +1,14 @@
 export const ZCASH_CLA = 0xe0 as const;
 
+/**
+ * APDU max payload in response chunks (see app-zcash-rust `VK_RESPONSE_CHUNK_LEN`).
+ */
+export const VK_RESPONSE_CHUNK_SIZE = 255 as const;
+
 export const INS = {
+  GET_WALLET_PUBLIC_KEY: 0x40,
   GET_TRUSTED_INPUT: 0x42,
+  GET_VK: 0x50,
 } as const;
 
 export const P1 = {
@@ -9,6 +16,16 @@ export const P1 = {
   NEXT: 0x80,
 } as const;
 
+export const P1_VK = {
+  FIRST: 0x00,
+  CONTINUE: 0x80,
+} as const;
+
 export const P2 = {
   DEFAULT: 0x00,
+} as const;
+
+export const P2_VK = {
+  UFVK: 0x00,
+  ORCHARD_FVK: 0x01,
 } as const;

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/utils/zcashApplicationErrors.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/utils/zcashApplicationErrors.ts
@@ -70,7 +70,7 @@ export const ZCASH_APP_ERRORS: CommandErrors<ZcashErrorCodes> = {
   "9810": { message: "ContradictionInvalidationError" },
   "9840": { message: "CodeBlockedError" },
   "9850": { message: "MaxValueReachedError" },
-  "b007": { message: "BadStateError" },
+  b007: { message: "BadStateError" },
 };
 
 export class ZcashAppCommandError extends DeviceExchangeError<ZcashErrorCodes> {

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/utils/zcashApplicationErrors.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/utils/zcashApplicationErrors.ts
@@ -35,7 +35,8 @@ export type ZcashErrorCodes =
   | "9808"
   | "9810"
   | "9840"
-  | "9850";
+  | "9850"
+  | "b007";
 
 export const ZCASH_APP_ERRORS: CommandErrors<ZcashErrorCodes> = {
   "6300": { message: "GPAuthFailedError" },
@@ -69,6 +70,7 @@ export const ZCASH_APP_ERRORS: CommandErrors<ZcashErrorCodes> = {
   "9810": { message: "ContradictionInvalidationError" },
   "9840": { message: "CodeBlockedError" },
   "9850": { message: "MaxValueReachedError" },
+  "b007": { message: "BadStateError" },
 };
 
 export class ZcashAppCommandError extends DeviceExchangeError<ZcashErrorCodes> {

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.test.ts
@@ -1,0 +1,78 @@
+import {
+  CommandResultFactory,
+  isSuccessCommandResult,
+  type InternalApi,
+} from "@ledgerhq/device-management-kit";
+import { describe, expect, it, vi } from "vitest";
+
+import { GetFullViewingKeyCommand } from "@internal/app-binder/command/GetFullViewingKeyCommand";
+import { P2_VK, VK_RESPONSE_CHUNK_SIZE } from "@internal/app-binder/command/utils/apduHeaderUtils";
+
+import { GetFullViewingKeyTask } from "./GetFullViewingKeyTask";
+
+describe("GetFullViewingKeyTask", () => {
+  const path = "44'/133'/0'/0/0";
+
+  it("should parse single-chunk UFVK (u16 length + UTF-8)", async () => {
+    const ufvk = "uviewtest";
+    const te = new TextEncoder();
+    const utf8 = te.encode(ufvk);
+    const data = new Uint8Array(2 + utf8.length);
+    new DataView(data.buffer).setUint16(0, utf8.length, false);
+    data.set(utf8, 2);
+
+    const sendCommand = vi.fn().mockResolvedValue(
+      CommandResultFactory({
+        data: { data },
+      }),
+    );
+    const api = { sendCommand } as unknown as InternalApi;
+    const result = await new GetFullViewingKeyTask(api, {
+      derivationPath: path,
+      mode: "ufvk",
+    }).run();
+
+    expect(isSuccessCommandResult(result)).toBe(true);
+    if (isSuccessCommandResult(result) && result.data.mode === "ufvk") {
+      expect(result.data.fullViewingKey).toBe(ufvk);
+    }
+    expect(sendCommand).toHaveBeenCalledOnce();
+  });
+
+  it("should reassemble multiple chunks in orchardFvk mode", async () => {
+    const a = new Uint8Array(VK_RESPONSE_CHUNK_SIZE).fill(0xab);
+    const b = new Uint8Array(10).fill(0xcd);
+
+    const sendCommand = vi
+      .fn()
+      .mockResolvedValueOnce(
+        CommandResultFactory({ data: { data: a } }),
+      )
+      .mockResolvedValueOnce(
+        CommandResultFactory({ data: { data: b } }),
+      );
+
+    const api = { sendCommand } as unknown as InternalApi;
+    const result = await new GetFullViewingKeyTask(api, {
+      derivationPath: path,
+      mode: "orchardFvk",
+    }).run();
+
+    expect(isSuccessCommandResult(result)).toBe(true);
+    if (isSuccessCommandResult(result) && result.data.mode === "orchardFvk") {
+      expect(result.data.fullViewingKey.length).toBe(
+        VK_RESPONSE_CHUNK_SIZE + 10,
+      );
+      expect(result.data.fullViewingKey.at(0)).toBe(0xab);
+      expect(result.data.fullViewingKey.at(-1)).toBe(0xcd);
+    }
+    expect(sendCommand).toHaveBeenCalledTimes(2);
+    const c1 = sendCommand.mock.calls[0]![0] as GetFullViewingKeyCommand;
+    const c2 = sendCommand.mock.calls[1]![0] as GetFullViewingKeyCommand;
+    expect(c1.getApdu().getRawApdu()[1]).toBe(0x50);
+    expect(c1.getApdu().getRawApdu()[2]).toBe(0x00);
+    expect(c1.getApdu().getRawApdu()[3]).toBe(P2_VK.ORCHARD_FVK);
+    expect(c2.getApdu().getRawApdu()[2]).toBe(0x80);
+    expect(c2.getApdu().getRawApdu()[3]).toBe(P2_VK.ORCHARD_FVK);
+  });
+});

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.test.ts
@@ -1,6 +1,7 @@
 import {
   CommandResultFactory,
   type InternalApi,
+  InvalidStatusWordError,
   isSuccessCommandResult,
 } from "@ledgerhq/device-management-kit";
 import { describe, expect, it, vi } from "vitest";
@@ -11,7 +12,10 @@ import {
   VK_RESPONSE_CHUNK_SIZE,
 } from "@internal/app-binder/command/utils/apduHeaderUtils";
 
-import { GetFullViewingKeyTask } from "./GetFullViewingKeyTask";
+import {
+  GetFullViewingKeyTask,
+  ORCHARD_FVK_BYTE_LENGTH,
+} from "./GetFullViewingKeyTask";
 
 describe("GetFullViewingKeyTask", () => {
   const path = "44'/133'/0'/0/0";
@@ -42,7 +46,93 @@ describe("GetFullViewingKeyTask", () => {
     expect(sendCommand).toHaveBeenCalledOnce();
   });
 
-  it("should reassemble multiple chunks in orchardFvk mode", async () => {
+  it("should return a single-chunk Orchard FVK when length is exactly 96 bytes", async () => {
+    const data = new Uint8Array(ORCHARD_FVK_BYTE_LENGTH).fill(0xab);
+
+    const sendCommand = vi.fn().mockResolvedValue(
+      CommandResultFactory({
+        data: { data },
+      }),
+    );
+    const api = { sendCommand } as unknown as InternalApi;
+    const result = await new GetFullViewingKeyTask(api, {
+      derivationPath: path,
+      mode: "orchardFvk",
+    }).run();
+
+    expect(isSuccessCommandResult(result)).toBe(true);
+    if (isSuccessCommandResult(result) && result.data.mode === "orchardFvk") {
+      expect(result.data.fullViewingKey.length).toBe(ORCHARD_FVK_BYTE_LENGTH);
+      expect(result.data.fullViewingKey.at(0)).toBe(0xab);
+      expect(result.data.fullViewingKey.at(-1)).toBe(0xab);
+    }
+    expect(sendCommand).toHaveBeenCalledOnce();
+    const c1 = sendCommand.mock.calls[0]![0] as GetFullViewingKeyCommand;
+    expect(c1.getApdu().getRawApdu()[1]).toBe(0x50);
+    expect(c1.getApdu().getRawApdu()[2]).toBe(0x00);
+    expect(c1.getApdu().getRawApdu()[3]).toBe(P2_VK.ORCHARD_FVK);
+  });
+
+  it("should hint UFVK framing when Orchard mode receives u16-length-prefixed payload (device returned UFVK bytes)", async () => {
+    const strLen = 302;
+    const assembled = new Uint8Array(2 + strLen);
+    new DataView(assembled.buffer).setUint16(0, strLen, false);
+    assembled.fill(0x61, 2, 2 + strLen);
+
+    const chunk0 = assembled.slice(0, VK_RESPONSE_CHUNK_SIZE);
+    const chunk1 = assembled.slice(VK_RESPONSE_CHUNK_SIZE);
+    expect(chunk0.length).toBe(255);
+    expect(chunk1.length).toBe(49);
+    expect(chunk0.length + chunk1.length).toBe(304);
+
+    const sendCommand = vi
+      .fn()
+      .mockResolvedValueOnce(CommandResultFactory({ data: { data: chunk0 } }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: { data: chunk1 } }));
+
+    const api = { sendCommand } as unknown as InternalApi;
+    const result = await new GetFullViewingKeyTask(api, {
+      derivationPath: path,
+      mode: "orchardFvk",
+    }).run();
+
+    expect(isSuccessCommandResult(result)).toBe(false);
+    if (!isSuccessCommandResult(result)) {
+      const err = result.error as InvalidStatusWordError;
+      expect((err.originalError as { message: string }).message).toContain(
+        "Payload matches UFVK framing",
+      );
+      expect((err.originalError as { message: string }).message).toContain(
+        "302",
+      );
+    }
+  });
+
+  it("should reject Orchard FVK when assembled length is not 96 bytes", async () => {
+    const data = new Uint8Array(ORCHARD_FVK_BYTE_LENGTH - 1).fill(0xcd);
+
+    const sendCommand = vi.fn().mockResolvedValue(
+      CommandResultFactory({
+        data: { data },
+      }),
+    );
+    const api = { sendCommand } as unknown as InternalApi;
+    const result = await new GetFullViewingKeyTask(api, {
+      derivationPath: path,
+      mode: "orchardFvk",
+    }).run();
+
+    expect(isSuccessCommandResult(result)).toBe(false);
+    if (!isSuccessCommandResult(result)) {
+      expect(result.error).toBeInstanceOf(InvalidStatusWordError);
+      const err = result.error as InvalidStatusWordError;
+      expect((err.originalError as { message: string }).message).toBe(
+        `Orchard FVK must be ${ORCHARD_FVK_BYTE_LENGTH} bytes (got ${ORCHARD_FVK_BYTE_LENGTH - 1})`,
+      );
+    }
+  });
+
+  it("should reassemble multiple chunks then validate Orchard FVK length", async () => {
     const a = new Uint8Array(VK_RESPONSE_CHUNK_SIZE).fill(0xab);
     const b = new Uint8Array(10).fill(0xcd);
 
@@ -57,13 +147,13 @@ describe("GetFullViewingKeyTask", () => {
       mode: "orchardFvk",
     }).run();
 
-    expect(isSuccessCommandResult(result)).toBe(true);
-    if (isSuccessCommandResult(result) && result.data.mode === "orchardFvk") {
-      expect(result.data.fullViewingKey.length).toBe(
-        VK_RESPONSE_CHUNK_SIZE + 10,
+    expect(isSuccessCommandResult(result)).toBe(false);
+    if (!isSuccessCommandResult(result)) {
+      expect(result.error).toBeInstanceOf(InvalidStatusWordError);
+      const err = result.error as InvalidStatusWordError;
+      expect((err.originalError as { message: string }).message).toBe(
+        `Orchard FVK must be ${ORCHARD_FVK_BYTE_LENGTH} bytes (got ${VK_RESPONSE_CHUNK_SIZE + 10})`,
       );
-      expect(result.data.fullViewingKey.at(0)).toBe(0xab);
-      expect(result.data.fullViewingKey.at(-1)).toBe(0xcd);
     }
     expect(sendCommand).toHaveBeenCalledTimes(2);
     const c1 = sendCommand.mock.calls[0]![0] as GetFullViewingKeyCommand;
@@ -73,5 +163,36 @@ describe("GetFullViewingKeyTask", () => {
     expect(c1.getApdu().getRawApdu()[3]).toBe(P2_VK.ORCHARD_FVK);
     expect(c2.getApdu().getRawApdu()[2]).toBe(0x80);
     expect(c2.getApdu().getRawApdu()[3]).toBe(P2_VK.ORCHARD_FVK);
+  });
+
+  it("should issue another GET_VK continue when a chunk is exactly VK_RESPONSE_CHUNK_SIZE and more data follows", async () => {
+    const full1 = new Uint8Array(VK_RESPONSE_CHUNK_SIZE).fill(0x11);
+    const full2 = new Uint8Array(VK_RESPONSE_CHUNK_SIZE).fill(0x22);
+    const tail = new Uint8Array(12).fill(0x33);
+
+    const sendCommand = vi
+      .fn()
+      .mockResolvedValueOnce(CommandResultFactory({ data: { data: full1 } }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: { data: full2 } }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: { data: tail } }));
+
+    const api = { sendCommand } as unknown as InternalApi;
+    const result = await new GetFullViewingKeyTask(api, {
+      derivationPath: path,
+      mode: "orchardFvk",
+    }).run();
+
+    expect(isSuccessCommandResult(result)).toBe(false);
+    if (!isSuccessCommandResult(result)) {
+      expect(result.error).toBeInstanceOf(InvalidStatusWordError);
+      const err = result.error as InvalidStatusWordError;
+      expect((err.originalError as { message: string }).message).toBe(
+        `Orchard FVK must be ${ORCHARD_FVK_BYTE_LENGTH} bytes (got ${VK_RESPONSE_CHUNK_SIZE * 2 + tail.length})`,
+      );
+    }
+    expect(sendCommand).toHaveBeenCalledTimes(3);
+    const c3 = sendCommand.mock.calls[2]![0] as GetFullViewingKeyCommand;
+    expect(c3.getApdu().getRawApdu()[2]).toBe(0x80);
+    expect(c3.getApdu().getRawApdu()[3]).toBe(P2_VK.ORCHARD_FVK);
   });
 });

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.test.ts
@@ -46,6 +46,146 @@ describe("GetFullViewingKeyTask", () => {
     expect(sendCommand).toHaveBeenCalledOnce();
   });
 
+  it("should not send CONTINUE when UFVK assembled size is exactly 255 bytes (one full chunk)", async () => {
+    const strLen = 253;
+    const assembled = new Uint8Array(255);
+    new DataView(assembled.buffer).setUint16(0, strLen, false);
+    assembled.fill(0x61, 2, 2 + strLen);
+    const expectedKey = "a".repeat(strLen);
+
+    const sendCommand = vi.fn().mockResolvedValue(
+      CommandResultFactory({
+        data: { data: assembled },
+      }),
+    );
+    const api = { sendCommand } as unknown as InternalApi;
+    const result = await new GetFullViewingKeyTask(api, {
+      derivationPath: path,
+      mode: "ufvk",
+    }).run();
+
+    expect(isSuccessCommandResult(result)).toBe(true);
+    if (isSuccessCommandResult(result) && result.data.mode === "ufvk") {
+      expect(result.data.fullViewingKey).toBe(expectedKey);
+    }
+    expect(sendCommand).toHaveBeenCalledOnce();
+    const c1 = sendCommand.mock.calls[0]![0] as GetFullViewingKeyCommand;
+    expect(c1.getApdu().getRawApdu()[2]).toBe(0x00);
+    expect(c1.getApdu().getRawApdu()[3]).toBe(P2_VK.UFVK);
+  });
+
+  it("should not send CONTINUE after the last UFVK chunk when assembled size is exactly 510 bytes (two full chunks)", async () => {
+    const strLen = 508;
+    const assembled = new Uint8Array(510);
+    new DataView(assembled.buffer).setUint16(0, strLen, false);
+    assembled.fill(0x62, 2, 2 + strLen);
+    const chunk0 = assembled.slice(0, VK_RESPONSE_CHUNK_SIZE);
+    const chunk1 = assembled.slice(VK_RESPONSE_CHUNK_SIZE);
+    expect(chunk0.length).toBe(255);
+    expect(chunk1.length).toBe(255);
+    const expectedKey = "b".repeat(strLen);
+
+    const sendCommand = vi
+      .fn()
+      .mockResolvedValueOnce(CommandResultFactory({ data: { data: chunk0 } }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: { data: chunk1 } }));
+
+    const api = { sendCommand } as unknown as InternalApi;
+    const result = await new GetFullViewingKeyTask(api, {
+      derivationPath: path,
+      mode: "ufvk",
+    }).run();
+
+    expect(isSuccessCommandResult(result)).toBe(true);
+    if (isSuccessCommandResult(result) && result.data.mode === "ufvk") {
+      expect(result.data.fullViewingKey).toBe(expectedKey);
+    }
+    expect(sendCommand).toHaveBeenCalledTimes(2);
+    const c1 = sendCommand.mock.calls[0]![0] as GetFullViewingKeyCommand;
+    const c2 = sendCommand.mock.calls[1]![0] as GetFullViewingKeyCommand;
+    expect(c1.getApdu().getRawApdu()[2]).toBe(0x00);
+    expect(c1.getApdu().getRawApdu()[3]).toBe(P2_VK.UFVK);
+    expect(c2.getApdu().getRawApdu()[2]).toBe(0x80);
+    expect(c2.getApdu().getRawApdu()[3]).toBe(P2_VK.UFVK);
+  });
+
+  it("should reject UFVK when declared string length exceeds available bytes", async () => {
+    const assembled = new Uint8Array([0x00, 0x05, 0x61, 0x62, 0x63]);
+
+    const sendCommand = vi.fn().mockResolvedValue(
+      CommandResultFactory({
+        data: { data: assembled },
+      }),
+    );
+    const api = { sendCommand } as unknown as InternalApi;
+    const result = await new GetFullViewingKeyTask(api, {
+      derivationPath: path,
+      mode: "ufvk",
+    }).run();
+
+    expect(isSuccessCommandResult(result)).toBe(false);
+    if (!isSuccessCommandResult(result)) {
+      expect(result.error).toBeInstanceOf(InvalidStatusWordError);
+      const err = result.error as InvalidStatusWordError;
+      expect((err.originalError as { message: string }).message).toBe(
+        "UFVK string is truncated",
+      );
+    }
+  });
+
+  it("should reject UFVK when payload is not valid UTF-8", async () => {
+    const assembled = new Uint8Array([0x00, 0x02, 0xc3, 0x28]);
+
+    const sendCommand = vi.fn().mockResolvedValue(
+      CommandResultFactory({
+        data: { data: assembled },
+      }),
+    );
+    const api = { sendCommand } as unknown as InternalApi;
+    const result = await new GetFullViewingKeyTask(api, {
+      derivationPath: path,
+      mode: "ufvk",
+    }).run();
+
+    expect(isSuccessCommandResult(result)).toBe(false);
+    if (!isSuccessCommandResult(result)) {
+      expect(result.error).toBeInstanceOf(InvalidStatusWordError);
+      const err = result.error as InvalidStatusWordError;
+      expect((err.originalError as { message: string }).message).toBe(
+        "UFVK is not valid UTF-8",
+      );
+    }
+  });
+
+  it("should reject UFVK when response contains trailing bytes after declared string", async () => {
+    const ufvk = "uviewtest";
+    const utf8 = new TextEncoder().encode(ufvk);
+    const assembled = new Uint8Array(2 + utf8.length + 1);
+    new DataView(assembled.buffer).setUint16(0, utf8.length, false);
+    assembled.set(utf8, 2);
+    assembled[assembled.length - 1] = 0xff;
+
+    const sendCommand = vi.fn().mockResolvedValue(
+      CommandResultFactory({
+        data: { data: assembled },
+      }),
+    );
+    const api = { sendCommand } as unknown as InternalApi;
+    const result = await new GetFullViewingKeyTask(api, {
+      derivationPath: path,
+      mode: "ufvk",
+    }).run();
+
+    expect(isSuccessCommandResult(result)).toBe(false);
+    if (!isSuccessCommandResult(result)) {
+      expect(result.error).toBeInstanceOf(InvalidStatusWordError);
+      const err = result.error as InvalidStatusWordError;
+      expect((err.originalError as { message: string }).message).toBe(
+        "UFVK response has extra trailing bytes",
+      );
+    }
+  });
+
   it("should return a single-chunk Orchard FVK when length is exactly 96 bytes", async () => {
     const data = new Uint8Array(ORCHARD_FVK_BYTE_LENGTH).fill(0xab);
 
@@ -194,5 +334,54 @@ describe("GetFullViewingKeyTask", () => {
     const c3 = sendCommand.mock.calls[2]![0] as GetFullViewingKeyCommand;
     expect(c3.getApdu().getRawApdu()[2]).toBe(0x80);
     expect(c3.getApdu().getRawApdu()[3]).toBe(P2_VK.ORCHARD_FVK);
+  });
+
+  it("should return initial GET_VK error without requesting continuation", async () => {
+    const failingResult = CommandResultFactory({
+      error: new InvalidStatusWordError("first GET_VK failed"),
+    });
+    const sendCommand = vi.fn().mockResolvedValueOnce(failingResult);
+
+    const api = { sendCommand } as unknown as InternalApi;
+    const result = await new GetFullViewingKeyTask(api, {
+      derivationPath: path,
+      mode: "orchardFvk",
+    }).run();
+
+    expect(result).toBe(failingResult);
+    expect(isSuccessCommandResult(result)).toBe(false);
+    expect(sendCommand).toHaveBeenCalledOnce();
+    const c1 = sendCommand.mock.calls[0]![0] as GetFullViewingKeyCommand;
+    expect(c1.getApdu().getRawApdu()[2]).toBe(0x00);
+    expect(c1.getApdu().getRawApdu()[3]).toBe(P2_VK.ORCHARD_FVK);
+  });
+
+  it("should return continuation GET_VK error immediately without extra continuation calls", async () => {
+    const firstChunk = new Uint8Array(VK_RESPONSE_CHUNK_SIZE).fill(0x42);
+    const failingResult = CommandResultFactory({
+      error: new InvalidStatusWordError("continuation GET_VK failed"),
+    });
+    const sendCommand = vi
+      .fn()
+      .mockResolvedValueOnce(
+        CommandResultFactory({ data: { data: firstChunk } }),
+      )
+      .mockResolvedValueOnce(failingResult);
+
+    const api = { sendCommand } as unknown as InternalApi;
+    const result = await new GetFullViewingKeyTask(api, {
+      derivationPath: path,
+      mode: "orchardFvk",
+    }).run();
+
+    expect(result).toBe(failingResult);
+    expect(isSuccessCommandResult(result)).toBe(false);
+    expect(sendCommand).toHaveBeenCalledTimes(2);
+    const c1 = sendCommand.mock.calls[0]![0] as GetFullViewingKeyCommand;
+    const c2 = sendCommand.mock.calls[1]![0] as GetFullViewingKeyCommand;
+    expect(c1.getApdu().getRawApdu()[2]).toBe(0x00);
+    expect(c1.getApdu().getRawApdu()[3]).toBe(P2_VK.ORCHARD_FVK);
+    expect(c2.getApdu().getRawApdu()[2]).toBe(0x80);
+    expect(c2.getApdu().getRawApdu()[3]).toBe(P2_VK.ORCHARD_FVK);
   });
 });

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.test.ts
@@ -4,13 +4,13 @@ import {
   InvalidStatusWordError,
   isSuccessCommandResult,
 } from "@ledgerhq/device-management-kit";
+import { APDU_MAX_PAYLOAD } from "@ledgerhq/device-management-kit";
 import { describe, expect, it, vi } from "vitest";
 
 import {
   type GetFullViewingKeyCommand,
   P2_VK,
 } from "@internal/app-binder/command/GetFullViewingKeyCommand";
-import { VK_RESPONSE_CHUNK_SIZE } from "@internal/app-binder/command/utils/apduHeaderUtils";
 
 import {
   GetFullViewingKeyTask,
@@ -79,8 +79,8 @@ describe("GetFullViewingKeyTask", () => {
     const assembled = new Uint8Array(510);
     new DataView(assembled.buffer).setUint16(0, strLen, false);
     assembled.fill(0x62, 2, 2 + strLen);
-    const chunk0 = assembled.slice(0, VK_RESPONSE_CHUNK_SIZE);
-    const chunk1 = assembled.slice(VK_RESPONSE_CHUNK_SIZE);
+    const chunk0 = assembled.slice(0, APDU_MAX_PAYLOAD);
+    const chunk1 = assembled.slice(APDU_MAX_PAYLOAD);
     expect(chunk0.length).toBe(255);
     expect(chunk1.length).toBe(255);
     const expectedKey = "b".repeat(strLen);
@@ -219,8 +219,8 @@ describe("GetFullViewingKeyTask", () => {
     new DataView(assembled.buffer).setUint16(0, strLen, false);
     assembled.fill(0x61, 2, 2 + strLen);
 
-    const chunk0 = assembled.slice(0, VK_RESPONSE_CHUNK_SIZE);
-    const chunk1 = assembled.slice(VK_RESPONSE_CHUNK_SIZE);
+    const chunk0 = assembled.slice(0, APDU_MAX_PAYLOAD);
+    const chunk1 = assembled.slice(APDU_MAX_PAYLOAD);
     expect(chunk0.length).toBe(255);
     expect(chunk1.length).toBe(49);
     expect(chunk0.length + chunk1.length).toBe(304);
@@ -273,7 +273,7 @@ describe("GetFullViewingKeyTask", () => {
   });
 
   it("should reassemble multiple chunks then validate Orchard FVK length", async () => {
-    const a = new Uint8Array(VK_RESPONSE_CHUNK_SIZE).fill(0xab);
+    const a = new Uint8Array(APDU_MAX_PAYLOAD).fill(0xab);
     const b = new Uint8Array(10).fill(0xcd);
 
     const sendCommand = vi
@@ -292,7 +292,7 @@ describe("GetFullViewingKeyTask", () => {
       expect(result.error).toBeInstanceOf(InvalidStatusWordError);
       const err = result.error as InvalidStatusWordError;
       expect((err.originalError as { message: string }).message).toBe(
-        `Orchard FVK must be ${ORCHARD_FVK_BYTE_LENGTH} bytes (got ${VK_RESPONSE_CHUNK_SIZE + 10})`,
+        `Orchard FVK must be ${ORCHARD_FVK_BYTE_LENGTH} bytes (got ${APDU_MAX_PAYLOAD + 10})`,
       );
     }
     expect(sendCommand).toHaveBeenCalledTimes(2);
@@ -305,9 +305,9 @@ describe("GetFullViewingKeyTask", () => {
     expect(c2.getApdu().getRawApdu()[3]).toBe(P2_VK.ORCHARD_FVK);
   });
 
-  it("should issue another GET_VK continue when a chunk is exactly VK_RESPONSE_CHUNK_SIZE and more data follows", async () => {
-    const full1 = new Uint8Array(VK_RESPONSE_CHUNK_SIZE).fill(0x11);
-    const full2 = new Uint8Array(VK_RESPONSE_CHUNK_SIZE).fill(0x22);
+  it("should issue another GET_VK continue when a chunk is exactly APDU_MAX_PAYLOAD and more data follows", async () => {
+    const full1 = new Uint8Array(APDU_MAX_PAYLOAD).fill(0x11);
+    const full2 = new Uint8Array(APDU_MAX_PAYLOAD).fill(0x22);
     const tail = new Uint8Array(12).fill(0x33);
 
     const sendCommand = vi
@@ -327,7 +327,7 @@ describe("GetFullViewingKeyTask", () => {
       expect(result.error).toBeInstanceOf(InvalidStatusWordError);
       const err = result.error as InvalidStatusWordError;
       expect((err.originalError as { message: string }).message).toBe(
-        `Orchard FVK must be ${ORCHARD_FVK_BYTE_LENGTH} bytes (got ${VK_RESPONSE_CHUNK_SIZE * 2 + tail.length})`,
+        `Orchard FVK must be ${ORCHARD_FVK_BYTE_LENGTH} bytes (got ${APDU_MAX_PAYLOAD * 2 + tail.length})`,
       );
     }
     expect(sendCommand).toHaveBeenCalledTimes(3);
@@ -357,7 +357,7 @@ describe("GetFullViewingKeyTask", () => {
   });
 
   it("should return continuation GET_VK error immediately without extra continuation calls", async () => {
-    const firstChunk = new Uint8Array(VK_RESPONSE_CHUNK_SIZE).fill(0x42);
+    const firstChunk = new Uint8Array(APDU_MAX_PAYLOAD).fill(0x42);
     const failingResult = CommandResultFactory({
       error: new InvalidStatusWordError("continuation GET_VK failed"),
     });

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.test.ts
@@ -1,12 +1,15 @@
 import {
   CommandResultFactory,
-  isSuccessCommandResult,
   type InternalApi,
+  isSuccessCommandResult,
 } from "@ledgerhq/device-management-kit";
 import { describe, expect, it, vi } from "vitest";
 
-import { GetFullViewingKeyCommand } from "@internal/app-binder/command/GetFullViewingKeyCommand";
-import { P2_VK, VK_RESPONSE_CHUNK_SIZE } from "@internal/app-binder/command/utils/apduHeaderUtils";
+import { type GetFullViewingKeyCommand } from "@internal/app-binder/command/GetFullViewingKeyCommand";
+import {
+  P2_VK,
+  VK_RESPONSE_CHUNK_SIZE,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
 
 import { GetFullViewingKeyTask } from "./GetFullViewingKeyTask";
 
@@ -45,12 +48,8 @@ describe("GetFullViewingKeyTask", () => {
 
     const sendCommand = vi
       .fn()
-      .mockResolvedValueOnce(
-        CommandResultFactory({ data: { data: a } }),
-      )
-      .mockResolvedValueOnce(
-        CommandResultFactory({ data: { data: b } }),
-      );
+      .mockResolvedValueOnce(CommandResultFactory({ data: { data: a } }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: { data: b } }));
 
     const api = { sendCommand } as unknown as InternalApi;
     const result = await new GetFullViewingKeyTask(api, {

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.test.ts
@@ -6,11 +6,11 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { describe, expect, it, vi } from "vitest";
 
-import { type GetFullViewingKeyCommand } from "@internal/app-binder/command/GetFullViewingKeyCommand";
 import {
+  type GetFullViewingKeyCommand,
   P2_VK,
-  VK_RESPONSE_CHUNK_SIZE,
-} from "@internal/app-binder/command/utils/apduHeaderUtils";
+} from "@internal/app-binder/command/GetFullViewingKeyCommand";
+import { VK_RESPONSE_CHUNK_SIZE } from "@internal/app-binder/command/utils/apduHeaderUtils";
 
 import {
   GetFullViewingKeyTask,
@@ -348,7 +348,7 @@ describe("GetFullViewingKeyTask", () => {
       mode: "orchardFvk",
     }).run();
 
-    expect(result).toBe(failingResult);
+    expect(result).toStrictEqual(failingResult);
     expect(isSuccessCommandResult(result)).toBe(false);
     expect(sendCommand).toHaveBeenCalledOnce();
     const c1 = sendCommand.mock.calls[0]![0] as GetFullViewingKeyCommand;
@@ -374,7 +374,7 @@ describe("GetFullViewingKeyTask", () => {
       mode: "orchardFvk",
     }).run();
 
-    expect(result).toBe(failingResult);
+    expect(result).toStrictEqual(failingResult);
     expect(isSuccessCommandResult(result)).toBe(false);
     expect(sendCommand).toHaveBeenCalledTimes(2);
     const c1 = sendCommand.mock.calls[0]![0] as GetFullViewingKeyCommand;

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
@@ -38,7 +38,7 @@ export type GetFullViewingKeyTaskData =
 export type GetFullViewingKeyTaskError =
   CommandErrorResult<ZcashErrorCodes>["error"];
 
-  export type GetFullViewingKeyTaskResult = DmkResult<
+export type GetFullViewingKeyTaskResult = DmkResult<
   GetFullViewingKeyTaskData,
   GetFullViewingKeyTaskError
 >;

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
@@ -73,6 +73,25 @@ function parseAssembledOrchardFvk(
   });
 }
 
+/**
+ * True when `assembled` already contains the u16 BE string length prefix plus
+ * the declared UTF-8 payload. Used to stop chunking when the last payload chunk
+ * is exactly `VK_RESPONSE_CHUNK_SIZE` bytes (otherwise the host would send a
+ * spurious CONTINUE APDU).
+ */
+function isCompleteUfvkLengthFraming(assembled: Uint8Array): boolean {
+  if (assembled.length < 2) {
+    return false;
+  }
+  const view = new DataView(
+    assembled.buffer,
+    assembled.byteOffset,
+    assembled.byteLength,
+  );
+  const strLength = view.getUint16(0, false);
+  return assembled.length >= 2 + strLength;
+}
+
 function parseAssembledUfvk(
   assembled: Uint8Array,
 ): CommandResult<GetFullViewingKeyTaskSuccessUfvk, ZcashErrorCodes> {
@@ -143,6 +162,9 @@ export class GetFullViewingKeyTask {
     let assembled: Uint8Array = lastChunk;
 
     while (lastChunk.length === VK_RESPONSE_CHUNK_SIZE) {
+      if (this.args.mode === "ufvk" && isCompleteUfvkLengthFraming(assembled)) {
+        break;
+      }
       const next = await this.api.sendCommand(
         new GetFullViewingKeyCommand({
           isContinue: true,

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
@@ -1,0 +1,137 @@
+import {
+  type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
+  type InternalApi,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import {
+  GetFullViewingKeyCommand,
+  type ZcashFvkP2,
+  zcashFvkP2FromMode,
+} from "@internal/app-binder/command/GetFullViewingKeyCommand";
+import { VK_RESPONSE_CHUNK_SIZE } from "@internal/app-binder/command/utils/apduHeaderUtils";
+import { type ZcashErrorCodes } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+import { type ZcashFullViewingKeyMode } from "@api/model/FullViewingKeyOptions";
+
+const concat = (a: Uint8Array, b: Uint8Array): Uint8Array<ArrayBufferLike> => {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
+};
+
+export type GetFullViewingKeyTaskArgs = {
+  derivationPath: string;
+  mode: ZcashFullViewingKeyMode;
+};
+
+export type GetFullViewingKeyTaskSuccessUfvk = {
+  readonly mode: "ufvk";
+  readonly fullViewingKey: string;
+};
+
+export type GetFullViewingKeyTaskSuccessOrchard = {
+  readonly mode: "orchardFvk";
+  readonly fullViewingKey: Uint8Array;
+};
+
+export type GetFullViewingKeyTaskData =
+  | GetFullViewingKeyTaskSuccessUfvk
+  | GetFullViewingKeyTaskSuccessOrchard;
+
+function parseAssembledUfvk(
+  assembled: Uint8Array,
+): CommandResult<GetFullViewingKeyTaskSuccessUfvk, ZcashErrorCodes> {
+  if (assembled.length < 2) {
+    return CommandResultFactory({
+      error: new InvalidStatusWordError("UFVK string length is missing"),
+    });
+  }
+  const view = new DataView(
+    assembled.buffer,
+    assembled.byteOffset,
+    assembled.byteLength,
+  );
+  const strLength = view.getUint16(0, false);
+  if (2 + strLength > assembled.length) {
+    return CommandResultFactory({
+      error: new InvalidStatusWordError("UFVK string is truncated"),
+    });
+  }
+  const utf8 = assembled.slice(2, 2 + strLength);
+  let fullViewingKey: string;
+  try {
+    fullViewingKey = new TextDecoder("utf-8", { fatal: true }).decode(utf8);
+  } catch {
+    return CommandResultFactory({
+      error: new InvalidStatusWordError("UFVK is not valid UTF-8"),
+    });
+  }
+  if (2 + strLength < assembled.length) {
+    return CommandResultFactory({
+      error: new InvalidStatusWordError(
+        "UFVK response has extra trailing bytes",
+      ),
+    });
+  }
+  return CommandResultFactory({
+    data: { mode: "ufvk", fullViewingKey },
+  });
+}
+
+/**
+ * Fetches the full viewing key (UFVK string or raw Orchard FVK) with GET_VK
+ * multi-chunk responses (255-byte chunks until the last is shorter).
+ */
+export class GetFullViewingKeyTask {
+  constructor(
+    private api: InternalApi,
+    private args: GetFullViewingKeyTaskArgs,
+  ) {}
+
+  async run(): Promise<
+    CommandResult<GetFullViewingKeyTaskData, ZcashErrorCodes>
+  > {
+    const p2: ZcashFvkP2 = zcashFvkP2FromMode(this.args.mode);
+
+    const firstResult = await this.api.sendCommand(
+      new GetFullViewingKeyCommand({
+        isContinue: false,
+        p2,
+        derivationPath: this.args.derivationPath,
+      }),
+    );
+    if (!isSuccessCommandResult(firstResult)) {
+      return firstResult;
+    }
+
+    let lastChunk: Uint8Array<ArrayBufferLike> = new Uint8Array(
+      firstResult.data.data,
+    );
+    let assembled: Uint8Array<ArrayBufferLike> = lastChunk;
+
+    while (lastChunk.length === VK_RESPONSE_CHUNK_SIZE) {
+      const next = await this.api.sendCommand(
+        new GetFullViewingKeyCommand({
+          isContinue: true,
+          p2,
+        }),
+      );
+      if (!isSuccessCommandResult(next)) {
+        return next;
+      }
+      lastChunk = new Uint8Array(next.data.data);
+      assembled = concat(assembled, lastChunk);
+    }
+
+    if (this.args.mode === "ufvk") {
+      return parseAssembledUfvk(assembled);
+    }
+
+    return CommandResultFactory({
+      data: { mode: "orchardFvk", fullViewingKey: assembled },
+    });
+  }
+}

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
@@ -14,13 +14,7 @@ import {
 } from "@internal/app-binder/command/GetFullViewingKeyCommand";
 import { VK_RESPONSE_CHUNK_SIZE } from "@internal/app-binder/command/utils/apduHeaderUtils";
 import { type ZcashErrorCodes } from "@internal/app-binder/command/utils/zcashApplicationErrors";
-
-const concat = (a: Uint8Array, b: Uint8Array): Uint8Array<ArrayBufferLike> => {
-  const out = new Uint8Array(a.length + b.length);
-  out.set(a, 0);
-  out.set(b, a.length);
-  return out;
-};
+import { concatUint8Arrays } from "@internal/utils/concatUint8Arrays";
 
 export type GetFullViewingKeyTaskArgs = {
   derivationPath: string;
@@ -40,6 +34,44 @@ export type GetFullViewingKeyTaskSuccessOrchard = {
 export type GetFullViewingKeyTaskData =
   | GetFullViewingKeyTaskSuccessUfvk
   | GetFullViewingKeyTaskSuccessOrchard;
+
+/**
+ * Serialized Orchard full viewing key length (see Zcash protocol / `orchard` crate).
+ * GET_VK with P2_ORCHARD_FVK returns exactly this many raw bytes when successful.
+ */
+export const ORCHARD_FVK_BYTE_LENGTH = 96 as const;
+
+function orchardFvkLengthMismatchMessage(assembled: Uint8Array): string {
+  const base = `Orchard FVK must be ${ORCHARD_FVK_BYTE_LENGTH} bytes (got ${assembled.length})`;
+  if (assembled.length < 2) {
+    return base;
+  }
+  const view = new DataView(
+    assembled.buffer,
+    assembled.byteOffset,
+    assembled.byteLength,
+  );
+  const strLength = view.getUint16(0, false);
+  if (2 + strLength === assembled.length) {
+    return `${base}. Payload matches UFVK framing (u16 BE length + ${strLength} bytes). Use mode "ufvk" for this response, or use a Zcash app build that exports raw Orchard FVK for GET_VK P2=0x01.`;
+  }
+  return base;
+}
+
+function parseAssembledOrchardFvk(
+  assembled: Uint8Array,
+): CommandResult<GetFullViewingKeyTaskSuccessOrchard, ZcashErrorCodes> {
+  if (assembled.length !== ORCHARD_FVK_BYTE_LENGTH) {
+    return CommandResultFactory({
+      error: new InvalidStatusWordError(
+        orchardFvkLengthMismatchMessage(assembled),
+      ),
+    });
+  }
+  return CommandResultFactory({
+    data: { mode: "orchardFvk", fullViewingKey: assembled },
+  });
+}
 
 function parseAssembledUfvk(
   assembled: Uint8Array,
@@ -107,10 +139,8 @@ export class GetFullViewingKeyTask {
       return firstResult;
     }
 
-    let lastChunk: Uint8Array<ArrayBufferLike> = new Uint8Array(
-      firstResult.data.data,
-    );
-    let assembled: Uint8Array<ArrayBufferLike> = lastChunk;
+    let lastChunk: Uint8Array = new Uint8Array(firstResult.data.data);
+    let assembled: Uint8Array = lastChunk;
 
     while (lastChunk.length === VK_RESPONSE_CHUNK_SIZE) {
       const next = await this.api.sendCommand(
@@ -123,15 +153,13 @@ export class GetFullViewingKeyTask {
         return next;
       }
       lastChunk = new Uint8Array(next.data.data);
-      assembled = concat(assembled, lastChunk);
+      assembled = concatUint8Arrays(assembled, lastChunk);
     }
 
     if (this.args.mode === "ufvk") {
       return parseAssembledUfvk(assembled);
     }
 
-    return CommandResultFactory({
-      data: { mode: "orchardFvk", fullViewingKey: assembled },
-    });
+    return parseAssembledOrchardFvk(assembled);
   }
 }

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
@@ -1,11 +1,12 @@
 import {
   type CommandResult,
   CommandResultFactory,
-  InvalidStatusWordError,
   type InternalApi,
+  InvalidStatusWordError,
   isSuccessCommandResult,
 } from "@ledgerhq/device-management-kit";
 
+import { type ZcashFullViewingKeyMode } from "@api/model/FullViewingKeyOptions";
 import {
   GetFullViewingKeyCommand,
   type ZcashFvkP2,
@@ -13,7 +14,6 @@ import {
 } from "@internal/app-binder/command/GetFullViewingKeyCommand";
 import { VK_RESPONSE_CHUNK_SIZE } from "@internal/app-binder/command/utils/apduHeaderUtils";
 import { type ZcashErrorCodes } from "@internal/app-binder/command/utils/zcashApplicationErrors";
-import { type ZcashFullViewingKeyMode } from "@api/model/FullViewingKeyOptions";
 
 const concat = (a: Uint8Array, b: Uint8Array): Uint8Array<ArrayBufferLike> => {
   const out = new Uint8Array(a.length + b.length);
@@ -87,8 +87,8 @@ function parseAssembledUfvk(
  */
 export class GetFullViewingKeyTask {
   constructor(
-    private api: InternalApi,
-    private args: GetFullViewingKeyTaskArgs,
+    private readonly api: InternalApi,
+    private readonly args: GetFullViewingKeyTaskArgs,
   ) {}
 
   async run(): Promise<

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
@@ -1,6 +1,7 @@
 import {
-  type CommandResult,
-  CommandResultFactory,
+  type CommandErrorResult,
+  type DmkResult,
+  DmkResultFactory,
   type InternalApi,
   InvalidStatusWordError,
   isSuccessCommandResult,
@@ -34,6 +35,13 @@ export type GetFullViewingKeyTaskSuccessOrchard = {
 export type GetFullViewingKeyTaskData =
   | GetFullViewingKeyTaskSuccessUfvk
   | GetFullViewingKeyTaskSuccessOrchard;
+export type GetFullViewingKeyTaskError =
+  CommandErrorResult<ZcashErrorCodes>["error"];
+
+  export type GetFullViewingKeyTaskResult = DmkResult<
+  GetFullViewingKeyTaskData,
+  GetFullViewingKeyTaskError
+>;
 
 /**
  * Serialized Orchard full viewing key length (see Zcash protocol / `orchard` crate).
@@ -60,15 +68,15 @@ function orchardFvkLengthMismatchMessage(assembled: Uint8Array): string {
 
 function parseAssembledOrchardFvk(
   assembled: Uint8Array,
-): CommandResult<GetFullViewingKeyTaskSuccessOrchard, ZcashErrorCodes> {
+): DmkResult<GetFullViewingKeyTaskSuccessOrchard, GetFullViewingKeyTaskError> {
   if (assembled.length !== ORCHARD_FVK_BYTE_LENGTH) {
-    return CommandResultFactory({
+    return DmkResultFactory({
       error: new InvalidStatusWordError(
         orchardFvkLengthMismatchMessage(assembled),
       ),
     });
   }
-  return CommandResultFactory({
+  return DmkResultFactory({
     data: { mode: "orchardFvk", fullViewingKey: assembled },
   });
 }
@@ -94,9 +102,9 @@ function isCompleteUfvkLengthFraming(assembled: Uint8Array): boolean {
 
 function parseAssembledUfvk(
   assembled: Uint8Array,
-): CommandResult<GetFullViewingKeyTaskSuccessUfvk, ZcashErrorCodes> {
+): DmkResult<GetFullViewingKeyTaskSuccessUfvk, GetFullViewingKeyTaskError> {
   if (assembled.length < 2) {
-    return CommandResultFactory({
+    return DmkResultFactory({
       error: new InvalidStatusWordError("UFVK string length is missing"),
     });
   }
@@ -107,7 +115,7 @@ function parseAssembledUfvk(
   );
   const strLength = view.getUint16(0, false);
   if (2 + strLength > assembled.length) {
-    return CommandResultFactory({
+    return DmkResultFactory({
       error: new InvalidStatusWordError("UFVK string is truncated"),
     });
   }
@@ -116,18 +124,18 @@ function parseAssembledUfvk(
   try {
     fullViewingKey = new TextDecoder("utf-8", { fatal: true }).decode(utf8);
   } catch {
-    return CommandResultFactory({
+    return DmkResultFactory({
       error: new InvalidStatusWordError("UFVK is not valid UTF-8"),
     });
   }
   if (2 + strLength < assembled.length) {
-    return CommandResultFactory({
+    return DmkResultFactory({
       error: new InvalidStatusWordError(
         "UFVK response has extra trailing bytes",
       ),
     });
   }
-  return CommandResultFactory({
+  return DmkResultFactory({
     data: { mode: "ufvk", fullViewingKey },
   });
 }
@@ -142,9 +150,7 @@ export class GetFullViewingKeyTask {
     private readonly args: GetFullViewingKeyTaskArgs,
   ) {}
 
-  async run(): Promise<
-    CommandResult<GetFullViewingKeyTaskData, ZcashErrorCodes>
-  > {
+  async run(): Promise<GetFullViewingKeyTaskResult> {
     const p2: ZcashFvkP2 = zcashFvkP2FromMode(this.args.mode);
 
     const firstResult = await this.api.sendCommand(
@@ -155,7 +161,9 @@ export class GetFullViewingKeyTask {
       }),
     );
     if (!isSuccessCommandResult(firstResult)) {
-      return firstResult;
+      return DmkResultFactory({
+        error: firstResult.error,
+      });
     }
 
     let lastChunk: Uint8Array = new Uint8Array(firstResult.data.data);
@@ -172,7 +180,9 @@ export class GetFullViewingKeyTask {
         }),
       );
       if (!isSuccessCommandResult(next)) {
-        return next;
+        return DmkResultFactory({
+          error: next.error,
+        });
       }
       lastChunk = new Uint8Array(next.data.data);
       assembled = concatUint8Arrays(assembled, lastChunk);

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
@@ -6,6 +6,7 @@ import {
   InvalidStatusWordError,
   isSuccessCommandResult,
 } from "@ledgerhq/device-management-kit";
+import { APDU_MAX_PAYLOAD } from "@ledgerhq/device-management-kit";
 
 import { type ZcashFullViewingKeyMode } from "@api/model/FullViewingKeyOptions";
 import {
@@ -13,7 +14,6 @@ import {
   type ZcashFvkP2,
   zcashFvkP2FromMode,
 } from "@internal/app-binder/command/GetFullViewingKeyCommand";
-import { VK_RESPONSE_CHUNK_SIZE } from "@internal/app-binder/command/utils/apduHeaderUtils";
 import { type ZcashErrorCodes } from "@internal/app-binder/command/utils/zcashApplicationErrors";
 import { concatUint8Arrays } from "@internal/utils/concatUint8Arrays";
 
@@ -84,7 +84,7 @@ function parseAssembledOrchardFvk(
 /**
  * True when `assembled` already contains the u16 BE string length prefix plus
  * the declared UTF-8 payload. Used to stop chunking when the last payload chunk
- * is exactly `VK_RESPONSE_CHUNK_SIZE` bytes (otherwise the host would send a
+ * is exactly `APDU_MAX_PAYLOAD` bytes (otherwise the host would send a
  * spurious CONTINUE APDU).
  */
 function isCompleteUfvkLengthFraming(assembled: Uint8Array): boolean {
@@ -169,7 +169,7 @@ export class GetFullViewingKeyTask {
     let lastChunk: Uint8Array = new Uint8Array(firstResult.data.data);
     let assembled: Uint8Array = lastChunk;
 
-    while (lastChunk.length === VK_RESPONSE_CHUNK_SIZE) {
+    while (lastChunk.length === APDU_MAX_PAYLOAD) {
       if (this.args.mode === "ufvk" && isCompleteUfvkLengthFraming(assembled)) {
         break;
       }

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.test.ts
@@ -1,8 +1,9 @@
 import {
   CommandResultFactory,
+  DmkResultFactory,
   type InternalApi,
   InvalidStatusWordError,
-  isSuccessCommandResult,
+  isSuccessDmkResult,
 } from "@ledgerhq/device-management-kit";
 
 import { GetTrustedInputCommand } from "@internal/app-binder/command/GetTrustedInputCommand";
@@ -73,8 +74,8 @@ describe("GetTrustedInputTask", () => {
       expect(apdu).toEqual(hexToBytes(expectedApduHex));
     });
 
-    expect(isSuccessCommandResult(result)).toBe(true);
-    if (isSuccessCommandResult(result)) {
+    expect(isSuccessDmkResult(result)).toBe(true);
+    if (isSuccessDmkResult(result)) {
       expect(result.data).toEqual(lastResponse);
     }
   });
@@ -95,7 +96,7 @@ describe("GetTrustedInputTask", () => {
     }).run();
 
     expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
-    expect(result).toEqual(CommandResultFactory({ error: expectedError }));
+    expect(result).toEqual(DmkResultFactory({ error: expectedError }));
   });
 
   it("uses the v4 trailing bytes as the final chunk", async () => {

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.ts
@@ -10,6 +10,7 @@ import {
   type GetTrustedInputCommandResponse,
 } from "@internal/app-binder/command/GetTrustedInputCommand";
 import { type ZcashErrorCodes } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+import { concatUint8Arrays } from "@internal/utils/concatUint8Arrays";
 
 const MAX_APDU_DATA_LENGTH = 0xff;
 const INDEX_LOOKUP_LENGTH = 4;
@@ -36,19 +37,6 @@ type CompactSize = {
   value: number;
   byteLength: number;
   nextOffset: number;
-};
-
-const concatArrays = (...chunks: Uint8Array[]): Uint8Array => {
-  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
-  const buffer = new Uint8Array(totalLength);
-  let offset = 0;
-
-  chunks.forEach((chunk) => {
-    buffer.set(chunk, offset);
-    offset += chunk.length;
-  });
-
-  return buffer;
 };
 
 const readUInt8 = (buffer: Uint8Array, offset: number): number => {
@@ -161,7 +149,7 @@ const splitForApduData = (chunks: Uint8Array[]): Uint8Array[] => {
 const splitV5ExtraData = (
   locktime: Uint8Array,
   expiry: Uint8Array,
-): Uint8Array => concatArrays(locktime, new Uint8Array([0x04]), expiry);
+): Uint8Array => concatUint8Arrays(locktime, new Uint8Array([0x04]), expiry);
 
 const splitTransactionToTrustedInputChunks = (
   transaction: Uint8Array,
@@ -187,7 +175,7 @@ const splitTransactionToTrustedInputChunks = (
   const vin = readCompactSize(transaction, offset);
   offset = vin.nextOffset;
   chunks.push(
-    concatArrays(
+    concatUint8Arrays(
       transaction.slice(0, HEADER_V4_SIZE),
       transaction.slice(offset - vin.byteLength, offset),
     ),

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.ts
@@ -1,6 +1,7 @@
 import {
-  type CommandResult,
-  CommandResultFactory,
+  type CommandErrorResult,
+  type DmkResult,
+  DmkResultFactory,
   type InternalApi,
   isSuccessCommandResult,
 } from "@ledgerhq/device-management-kit";
@@ -32,6 +33,11 @@ type GetTrustedInputTaskArgs = {
   transaction: Uint8Array;
   indexLookup?: number;
 };
+type GetTrustedInputTaskError = CommandErrorResult<ZcashErrorCodes>["error"];
+type GetTrustedInputTaskResult = DmkResult<
+  GetTrustedInputCommandResponse,
+  GetTrustedInputTaskError
+>;
 
 type CompactSize = {
   value: number;
@@ -348,9 +354,7 @@ export class GetTrustedInputTask {
     private args: GetTrustedInputTaskArgs,
   ) {}
 
-  async run(): Promise<
-    CommandResult<GetTrustedInputCommandResponse, ZcashErrorCodes>
-  > {
+  async run(): Promise<GetTrustedInputTaskResult> {
     const trustedInputIndex = this.args.indexLookup ?? 0;
     const chunks = splitTransactionToTrustedInputChunks(this.args.transaction);
 
@@ -367,7 +371,9 @@ export class GetTrustedInputTask {
     );
 
     if (!isSuccessCommandResult(firstResult)) {
-      return firstResult;
+      return DmkResultFactory({
+        error: firstResult.error,
+      });
     }
 
     let lastResponse = firstResult.data;
@@ -383,14 +389,16 @@ export class GetTrustedInputTask {
       );
 
       if (!isSuccessCommandResult(nextResult)) {
-        return nextResult;
+        return DmkResultFactory({
+          error: nextResult.error,
+        });
       }
 
       lastResponse = nextResult.data;
       chunkIndex += 1;
     }
 
-    return CommandResultFactory({
+    return DmkResultFactory({
       data: lastResponse,
     });
   }

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/SignTransactionTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/SignTransactionTask.ts
@@ -1,6 +1,7 @@
 import {
-  type CommandResult,
-  CommandResultFactory,
+  type CommandErrorResult,
+  type DmkResult,
+  DmkResultFactory,
   type InternalApi,
   isSuccessCommandResult,
 } from "@ledgerhq/device-management-kit";
@@ -13,6 +14,8 @@ type SignTransactionTaskArgs = {
   derivationPath: string;
   transaction: Uint8Array;
 };
+type SignTransactionTaskError = CommandErrorResult<ZcashErrorCodes>["error"];
+type SignTransactionTaskResult = DmkResult<Signature, SignTransactionTaskError>;
 
 export class SignTransactionTask {
   constructor(
@@ -20,7 +23,7 @@ export class SignTransactionTask {
     private args: SignTransactionTaskArgs,
   ) {}
 
-  async run(): Promise<CommandResult<Signature, ZcashErrorCodes>> {
+  async run(): Promise<SignTransactionTaskResult> {
     // TODO: Adapt this implementation to your blockchain's signing protocol
     // For transactions larger than a single APDU, you may need to:
     // 1. Split the transaction into chunks
@@ -35,10 +38,12 @@ export class SignTransactionTask {
     );
 
     if (!isSuccessCommandResult(result)) {
-      return result;
+      return DmkResultFactory({
+        error: result.error,
+      });
     }
 
-    return CommandResultFactory({
+    return DmkResultFactory({
       data: result.data.signature,
     });
   }

--- a/packages/signer/signer-zcash/src/internal/use-cases/address/GetFullViewingKeyUseCase.test.ts
+++ b/packages/signer/signer-zcash/src/internal/use-cases/address/GetFullViewingKeyUseCase.test.ts
@@ -1,0 +1,69 @@
+import {
+  DeviceActionStatus,
+  type ExecuteDeviceActionReturnType,
+} from "@ledgerhq/device-management-kit";
+import { from } from "rxjs";
+import { vi } from "vitest";
+
+import {
+  type GetFullViewingKeyDAError,
+  type GetFullViewingKeyDAIntermediateValue,
+  type GetFullViewingKeyDAOutput,
+} from "@api/app-binder/GetFullViewingKeyDeviceActionTypes";
+import { type ZcashAppBinder } from "@internal/app-binder/ZcashAppBinder";
+
+import { GetFullViewingKeyUseCase } from "./GetFullViewingKeyUseCase";
+
+describe("GetFullViewingKeyUseCase", () => {
+  it("should call getFullViewingKey on appBinder with default options", () => {
+    const derivationPath = "44'/133'/0'/0/0";
+    const getFullViewingKey = vi.fn();
+    const appBinder = {
+      getFullViewingKey,
+    } as unknown as ZcashAppBinder;
+    const expectedResult: ExecuteDeviceActionReturnType<
+      GetFullViewingKeyDAOutput,
+      GetFullViewingKeyDAError,
+      GetFullViewingKeyDAIntermediateValue
+    > = {
+      observable: from([
+        {
+          status: DeviceActionStatus.Completed as const,
+          output: { mode: "ufvk" as const, fullViewingKey: "uview" },
+        },
+      ]),
+      cancel: vi.fn(),
+    };
+    getFullViewingKey.mockReturnValue(expectedResult);
+
+    const useCase = new GetFullViewingKeyUseCase(appBinder);
+    const result = useCase.execute(derivationPath);
+
+    expect(getFullViewingKey).toHaveBeenCalledWith({
+      derivationPath,
+      mode: "ufvk",
+      skipOpenApp: false,
+    });
+    expect(result).toBe(expectedResult);
+  });
+
+  it("should forward mode and skipOpenApp from options", () => {
+    const getFullViewingKey = vi.fn().mockReturnValue({
+      observable: from([]),
+      cancel: vi.fn(),
+    });
+    const appBinder = {
+      getFullViewingKey,
+    } as unknown as ZcashAppBinder;
+    const useCase = new GetFullViewingKeyUseCase(appBinder);
+    useCase.execute("44'/133'/0'/0/0", {
+      mode: "orchardFvk",
+      skipOpenApp: true,
+    });
+    expect(getFullViewingKey).toHaveBeenCalledWith({
+      derivationPath: "44'/133'/0'/0/0",
+      mode: "orchardFvk",
+      skipOpenApp: true,
+    });
+  });
+});

--- a/packages/signer/signer-zcash/src/internal/use-cases/address/GetFullViewingKeyUseCase.ts
+++ b/packages/signer/signer-zcash/src/internal/use-cases/address/GetFullViewingKeyUseCase.ts
@@ -1,0 +1,26 @@
+import { inject, injectable } from "inversify";
+
+import { type GetFullViewingKeyDAReturnType } from "@api/app-binder/GetFullViewingKeyDeviceActionTypes";
+import { type FullViewingKeyOptions } from "@api/model/FullViewingKeyOptions";
+import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
+import { ZcashAppBinder } from "@internal/app-binder/ZcashAppBinder";
+
+@injectable()
+export class GetFullViewingKeyUseCase {
+  private readonly _appBinder: ZcashAppBinder;
+
+  constructor(@inject(appBinderTypes.AppBinding) appBinder: ZcashAppBinder) {
+    this._appBinder = appBinder;
+  }
+
+  execute(
+    derivationPath: string,
+    options?: FullViewingKeyOptions,
+  ): GetFullViewingKeyDAReturnType {
+    return this._appBinder.getFullViewingKey({
+      derivationPath,
+      mode: options?.mode ?? "ufvk",
+      skipOpenApp: options?.skipOpenApp ?? false,
+    });
+  }
+}

--- a/packages/signer/signer-zcash/src/internal/use-cases/address/di/addressModule.test.ts
+++ b/packages/signer/signer-zcash/src/internal/use-cases/address/di/addressModule.test.ts
@@ -20,5 +20,11 @@ describe("addressModuleFactory", () => {
     it("should bind GetAddressUseCase", () => {
       expect(container.isBound(addressTypes.GetAddressUseCase)).toBeTruthy();
     });
+
+    it("should bind GetFullViewingKeyUseCase", () => {
+      expect(
+        container.isBound(addressTypes.GetFullViewingKeyUseCase),
+      ).toBeTruthy();
+    });
   });
 });

--- a/packages/signer/signer-zcash/src/internal/use-cases/address/di/addressModule.ts
+++ b/packages/signer/signer-zcash/src/internal/use-cases/address/di/addressModule.ts
@@ -2,8 +2,10 @@ import { ContainerModule } from "inversify";
 
 import { addressTypes } from "@internal/use-cases/address/di/addressTypes";
 import { GetAddressUseCase } from "@internal/use-cases/address/GetAddressUseCase";
+import { GetFullViewingKeyUseCase } from "@internal/use-cases/address/GetFullViewingKeyUseCase";
 
 export const addressModuleFactory = () =>
   new ContainerModule(({ bind }) => {
     bind(addressTypes.GetAddressUseCase).to(GetAddressUseCase);
+    bind(addressTypes.GetFullViewingKeyUseCase).to(GetFullViewingKeyUseCase);
   });

--- a/packages/signer/signer-zcash/src/internal/use-cases/address/di/addressTypes.ts
+++ b/packages/signer/signer-zcash/src/internal/use-cases/address/di/addressTypes.ts
@@ -1,3 +1,4 @@
 export const addressTypes = {
   GetAddressUseCase: Symbol.for("GetAddressUseCase"),
+  GetFullViewingKeyUseCase: Symbol.for("GetFullViewingKeyUseCase"),
 } as const;

--- a/packages/signer/signer-zcash/src/internal/utils/concatUint8Arrays.test.ts
+++ b/packages/signer/signer-zcash/src/internal/utils/concatUint8Arrays.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { concatUint8Arrays } from "./concatUint8Arrays";
+
+describe("concatUint8Arrays", () => {
+  it("returns empty array when given no chunks", () => {
+    expect(concatUint8Arrays()).toEqual(new Uint8Array());
+  });
+
+  it("returns a copy of a single chunk", () => {
+    const a = new Uint8Array([1, 2, 3]);
+    const out = concatUint8Arrays(a);
+    expect(out).toEqual(a);
+    expect(out.buffer).not.toBe(a.buffer);
+  });
+
+  it("concatenates multiple chunks in order", () => {
+    const a = new Uint8Array([1, 2]);
+    const b = new Uint8Array([3]);
+    const c = new Uint8Array([4, 5, 6]);
+    expect(concatUint8Arrays(a, b, c)).toEqual(
+      new Uint8Array([1, 2, 3, 4, 5, 6]),
+    );
+  });
+});

--- a/packages/signer/signer-zcash/src/internal/utils/concatUint8Arrays.ts
+++ b/packages/signer/signer-zcash/src/internal/utils/concatUint8Arrays.ts
@@ -1,0 +1,15 @@
+/**
+ * Concatenates one or more Uint8Arrays into a new Uint8Array.
+ */
+export function concatUint8Arrays(...chunks: Uint8Array[]): Uint8Array {
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const buffer = new Uint8Array(totalLength);
+  let offset = 0;
+
+  chunks.forEach((chunk) => {
+    buffer.set(chunk, offset);
+    offset += chunk.length;
+  });
+
+  return buffer;
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This change adds full viewing key (FVK) export for Zcash on the device signer: new public API, device flow (command / task / use case), error and APDU helpers where needed, and sample app wiring so the flow can be exercised manually.

Why: Wallets and integrations need the FVK to watch balances and build transactions without holding spend authority; the key must come from the device when policy requires it.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [LIVE-23291](https://ledgerhq.atlassian.net/browse/LIVE-23291)
- Device part was implemented in [NAPPS-1261](https://ledgerhq.atlassian.net/browse/NAPPS-1261)
<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**: Export Zcash full viewing key from the Ledger Zcash app via @ledgerhq/device-signer-kit-zcash, with tests and sample UI.

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [x] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - introduces full viewing key export functionality for zcash with, commands, tasks, and binder update


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[LIVE-23291]: https://ledgerhq.atlassian.net/browse/LIVE-23291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[NAPPS-1261]: https://ledgerhq.atlassian.net/browse/NAPPS-1261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ