### PR TITLE
🔧 (chore) [NO-ISSUE]: Use -F instead of -T for gh pr create in backmerge skill

### DIFF
--- a/.cursor/skills/backmerge/SKILL.md
+++ b/.cursor/skills/backmerge/SKILL.md
@@ -69,7 +69,7 @@ git commit -m "🔧 (release): Reset private packages after release"
 
 ```bash
 git push -u origin chore/backmerge
-gh pr create -B develop --title "🔀 (release) [NO-ISSUE]: Backmerge release into develop" -T .github/pull_request_backmerge_template.md
+gh pr create -B develop --title "🔀 (release) [NO-ISSUE]: Backmerge release into develop" -F .github/pull_request_backmerge_template.md
 ```
 
 - Report the PR URL to the user.


### PR DESCRIPTION
### 📝 Description

Fixes an incorrect flag in the backmerge skill instructions. The `gh pr create` command was documented with `-T` (template flag) when it should be `-F` (file flag) to properly load the PR body from `.github/pull_request_backmerge_template.md`.

The `-T`/`--template` flag is for issue/PR templates by name, while `-F`/`--body-file` reads the body content from a file path, which is what we actually need here.

### ❓ Context

- **JIRA or GitHub link**: NO-ISSUE
- **Feature**: Internal tooling fix for the `backmerge` Cursor skill.

### ✅ Checklist

- [x] **Covered by automatic tests** — N/A, documentation/skill file only
- [x] **Changeset is provided** — No changeset needed; the change only affects an internal Cursor skill (`.cursor/skills/backmerge/SKILL.md`), not a published package or app
- [x] **Documentation is up-to-date** — This PR updates the documentation itself
- [x] **Impact of the changes:**
  - Fix `gh pr create` command in the backmerge skill to use `-F` (body file) instead of `-T` (template)

---

### 🧐 Checklist for the PR Reviewers

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.

Made with [Cursor](https://cursor.com)