### PR TITLE
👷 (config) [NO-ISSUE]: Add diff-only ESLint check with no-magic-numbers rule

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -105,8 +105,28 @@ jobs:
       - name: Build apps
         run: pnpm build
 
-  health-check:
-    name: Run health check
+  lint-strict:
+    name: Lint (strict, diff-only)
+    needs: [build-libraries]
+    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@develop
+
+      - name: Fetch base branch
+        run: git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+
+      - name: Compute PR diff base
+        run: echo "ESLINT_PLUGIN_DIFF_COMMIT=$(git merge-base HEAD origin/${{ github.base_ref }})" >> "$GITHUB_ENV"
+
+      - name: Lint with zero warnings on diff lines
+        run: pnpm turbo run lint -- --max-warnings 0
+
+  prettier:
+    name: Run prettier check
     needs: [build-libraries]
     runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
     steps:
@@ -114,9 +134,20 @@ jobs:
 
       - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@develop
 
-      - name: Health check
-        id: health-check
-        run: pnpm health-check
+      - name: Prettier
+        run: pnpm prettier
+
+  typecheck:
+    name: Run typecheck
+    needs: [build-libraries]
+    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@develop
+
+      - name: Typecheck
+        run: pnpm typecheck
 
   tests:
     name: Run unit tests
@@ -166,6 +197,26 @@ jobs:
           gh-bot-private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
           gating-token: ${{ secrets.GATING_TOKEN }}
           solana-rpc-url: ${{ secrets.SOLANA_LEDGER_RPC_URL }}
+
+  health-check:
+    name: Run health check
+    if: ${{ always() }}
+    needs:
+      - build-libraries
+      - build-apps
+      - lint-strict
+      - prettier
+      - typecheck
+      - tests
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Verify all required checks passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required checks failed or were cancelled"
+            exit 1
+          fi
+          echo "All required checks passed"
 
   solana-cs-tester:
     needs: [build-libraries, detect-changes]

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "test:watch": "turbo run test:watch",
     "test:coverage": "turbo run test:coverage",
     "typecheck": "turbo run typecheck",
-    "health-check": "turbo run health-check --output-logs=errors-only --continue",
     "dmk": "pnpm --filter @ledgerhq/device-management-kit",
     "devtools": "pnpm --filter @ledgerhq/device-management-kit-devtools",
     "speculos-device-controller": "pnpm --filter @ledgerhq/speculos-device-controller",

--- a/packages/config/eslint/index.js
+++ b/packages/config/eslint/index.js
@@ -5,6 +5,7 @@ import simpleImportSort from "eslint-plugin-simple-import-sort";
 import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
 import eslintPluginReact from "eslint-plugin-react";
 import eslintPluginReactHooks from "eslint-plugin-react-hooks";
+import diffPlugin from "eslint-plugin-diff";
 import { fixupPluginRules } from "@eslint/compat";
 
 export default [
@@ -132,6 +133,19 @@ export default [
           ignoreRestSiblings: true,
         },
       ],
+      "@typescript-eslint/no-magic-numbers": [
+        "warn",
+        {
+          ignore: [-1, 0, 1, 2],
+          ignoreArrayIndexes: true,
+          ignoreDefaultValues: true,
+          ignoreClassFieldInitialValues: true,
+          ignoreEnums: true,
+          ignoreNumericLiteralTypes: true,
+          ignoreReadonlyClassProperties: true,
+          ignoreTypeIndexes: true,
+        },
+      ],
     },
   },
   {
@@ -169,4 +183,6 @@ export default [
       },
     },
   },
+
+  ...diffPlugin.configs["flat/ci"],
 ];

--- a/packages/config/eslint/package.json
+++ b/packages/config/eslint/package.json
@@ -13,6 +13,7 @@
     "@eslint/compat": "catalog:",
     "@eslint/core": "catalog:",
     "@eslint/js": "catalog:",
+    "eslint-plugin-diff": "catalog:",
     "eslint-plugin-prettier": "catalog:",
     "eslint-plugin-react": "catalog:",
     "eslint-plugin-react-hooks": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ catalogs:
     eslint:
       specifier: 9.34.0
       version: 9.34.0
+    eslint-plugin-diff:
+      specifier: 2.1.7
+      version: 2.1.7
     eslint-plugin-prettier:
       specifier: 5.5.4
       version: 5.5.4
@@ -1019,6 +1022,9 @@ importers:
       '@eslint/js':
         specifier: 'catalog:'
         version: 9.34.0
+      eslint-plugin-diff:
+        specifier: 'catalog:'
+        version: 2.1.7(eslint@9.34.0(jiti@1.21.6))
       eslint-plugin-prettier:
         specifier: 'catalog:'
         version: 5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.34.0(jiti@1.21.6)))(eslint@9.34.0(jiti@1.21.6))(prettier@3.5.3)
@@ -8054,6 +8060,12 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
+
+  eslint-plugin-diff@2.1.7:
+    resolution: {integrity: sha512-F0EP5knbELQRPX7A4ogFFty+Pyru6CtUFmt52VSJ+7I84UsOj5s+BtY/ZhQFdvmPkFzKqVy+g5IHP+iiaUu/Aw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      eslint: '>=6.7.0'
 
   eslint-plugin-prettier@5.5.4:
     resolution: {integrity: sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==}
@@ -20146,6 +20158,10 @@ snapshots:
       source-map: 0.6.1
 
   eslint-config-prettier@10.1.8(eslint@9.34.0(jiti@1.21.6)):
+    dependencies:
+      eslint: 9.34.0(jiti@1.21.6)
+
+  eslint-plugin-diff@2.1.7(eslint@9.34.0(jiti@1.21.6)):
     dependencies:
       eslint: 9.34.0(jiti@1.21.6)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -77,6 +77,7 @@ catalog:
   esbuild: 0.25.4
   esbuild-node-externals: 1.18.0
   eslint: 9.34.0
+  eslint-plugin-diff: 2.1.7
   eslint-plugin-prettier: 5.5.4
   eslint-plugin-react: 7.37.5
   eslint-plugin-react-hooks: 5.2.0

--- a/turbo.json
+++ b/turbo.json
@@ -8,16 +8,15 @@
       "inputs": ["src/**/*.ts", "index.ts"]
     },
     "lint": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "env": ["ESLINT_PLUGIN_DIFF_COMMIT"]
     },
     "lint:fix": {
-      "dependsOn": ["build"]
+      "cache": false
     },
-    "prettier": {
-      "dependsOn": ["^prettier"]
-    },
+    "prettier": {},
     "prettier:fix": {
-      "dependsOn": ["^prettier:fix"]
+      "cache": false
     },
     "dev": {
       "dependsOn": ["^build"],
@@ -34,16 +33,13 @@
       "inputs": ["src/**/*.ts"]
     },
     "typecheck": {
-      "dependsOn": ["^build", "^typecheck"]
+      "dependsOn": ["^build"]
     },
     "@ledgerhq/device-management-kit-sample#typecheck": {
-      "dependsOn": ["build", "^typecheck"]
+      "dependsOn": ["build", "^build"]
     },
     "@ledgerhq/ledger-dmk-docs#typecheck": {
-      "dependsOn": ["build", "^typecheck"]
-    },
-    "health-check": {
-      "dependsOn": ["build", "prettier", "lint", "typecheck"]
+      "dependsOn": ["build", "^build"]
     }
   }
 }


### PR DESCRIPTION
### 📝 Description

Introduce a strict, diff-only ESLint check on PRs to gradually enforce stricter rules without flagging the entire pre-existing codebase.

- Adds a new GitHub Actions job `lint-strict` that runs after library builds and executes `pnpm turbo run lint -- --max-warnings 0`.
- Fetches the PR base branch in CI, computes the merge base, and exports `ESLINT_PLUGIN_DIFF_COMMIT` so `eslint-plugin-diff` only reports issues on changed PR lines.
- Wires `eslint-plugin-diff`'s `flat/ci` config into the shared ESLint config (`@ledgerhq/eslint-config-dsdk`).
- Enables `@typescript-eslint/no-magic-numbers` as a warning, with sensible ignores (`-1, 0, 1, 2`, array indexes, default values, enums, numeric literal types, readonly class properties, and type indexes).
- Adds `eslint-plugin-diff@2.1.7` to the workspace catalog and the ESLint config package dependencies.
- Splits the previous PR `health-check` flow into explicit `prettier`, `typecheck`, `tests`, and final aggregate `health-check` jobs, and removes the root `pnpm health-check` script.
- Updates Turbo configuration so lint receives `ESLINT_PLUGIN_DIFF_COMMIT`, fix tasks are uncached, and typecheck dependencies are simplified.

This means new or modified lines must pass stricter rules with zero lint warnings, while existing untouched code stays unaffected.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Diff-only strict lint enforcement on PRs

### ✅ Checklist

- [x] **Covered by automatic tests** — N/A, CI/tooling change validated by the PR workflow itself.
- [x] **Changeset is provided** — _Not required_: changes only affect CI workflow and internal tooling/configuration.
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - New CI job `lint-strict` runs on every PR and fails on any ESLint warning reported on diff lines.
  - `no-magic-numbers` is now active as a warning, scoped to changed lines by the strict diff-only lint job.
  - PR checks are now exposed as explicit jobs with a final aggregate `health-check` gate.

Made with [Cursor](https://cursor.com)