### PR TITLE
🐛 (signer-eth) [DSDK-1135]: Normalize EIP-712 domain chainId before reporting blind signing events

### DIFF
--- a/.changeset/normalize-typed-data-chain-id.md
+++ b/.changeset/normalize-typed-data-chain-id.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": patch
+---
+
+Normalize EIP-712 `domain.chainId` to `number | null` before reporting blind signing events, fixing a "chainId invalid type" error when dapps provide a hex string (e.g. `"0x1"`)

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.test.ts
@@ -1270,4 +1270,86 @@ describe("SignTypedDataDeviceAction", () => {
         });
       }));
   });
+
+  describe("Blind signing detection input", () => {
+    function runDeviceAction(domain: Record<string, unknown>) {
+      return new Promise<void>((resolve, reject) => {
+        setupOpenAppDAMock();
+        setupAppConfig("1.15.0", false, false);
+        getAddressMock.mockResolvedValueOnce(
+          CommandResultFactory({
+            data: { address: FROM },
+          }),
+        );
+
+        const deviceAction = new SignTypedDataDeviceAction({
+          input: {
+            derivationPath: "44'/60'/0'/0/0",
+            data: { ...TEST_MESSAGE, domain } as typeof TEST_MESSAGE,
+            contextModule: mockContextModule as unknown as ContextModule,
+            parser: mockParser,
+            transactionParser: mockTransactionParser,
+            transactionMapper: mockTransactionMapper,
+            skipOpenApp: false,
+          },
+        });
+
+        vi.spyOn(deviceAction, "extractDependencies").mockReturnValue(
+          extractDependenciesMock(),
+        );
+        buildContextMock.mockResolvedValueOnce(TEST_BUILT_CONTEXT);
+        provideContextMock.mockResolvedValueOnce(
+          CommandResultFactory({ data: undefined }),
+        );
+        signTypedDataMock.mockResolvedValueOnce(
+          CommandResultFactory({
+            data: {
+              v: 0x1c,
+              r: "0x8a540510e13b0f2b11a451275716d29e08caad07e89a1c84964782fb5e1ad788",
+              s: "0x64a0de235b270fbe81e8e40688f4a9f9ad9d283d690552c9331d7773ceafa513",
+            },
+          }),
+        );
+
+        const { observable } = deviceAction._execute(apiMock);
+        observable.subscribe({
+          error: reject,
+          complete: () => resolve(),
+        });
+      });
+    }
+
+    it("should normalize a hex-string domain.chainId to a number before reporting", async () => {
+      await runDeviceAction({
+        chainId: "0x1",
+        verifyingContract: "0xabc",
+      });
+
+      expect(detectBlindSigningMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            input: expect.objectContaining({
+              type: "typedData",
+              chainId: 1,
+              targetAddress: "0xabc",
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("should pass null when domain.chainId is missing", async () => {
+      await runDeviceAction({ verifyingContract: "0xabc" });
+
+      expect(detectBlindSigningMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            input: expect.objectContaining({
+              chainId: null,
+            }),
+          }),
+        }),
+      );
+    });
+  });
 });

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.ts
@@ -57,6 +57,7 @@ import {
 } from "@internal/app-binder/task/ProvideEIP712ContextTask";
 import { SignTypedDataLegacyTask } from "@internal/app-binder/task/SignTypedDataLegacyTask";
 import { MIN_ETH_APP_VERSION_FOR_WEB3_CHECKS } from "@internal/shared/EthAppVersions";
+import { normalizeChainId } from "@internal/shared/utils/normalizeChainId";
 import { type TransactionMapperService } from "@internal/transaction/service/mapper/TransactionMapperService";
 import { type TransactionParserService } from "@internal/transaction/service/parser/TransactionParserService";
 import { type TypedDataParserService } from "@internal/typed-data/service/TypedDataParserService";
@@ -598,7 +599,7 @@ export class SignTypedDataDeviceAction extends XStateDeviceAction<
                     context._internalState.typedDataContext?.clearSignContext.isJust() ??
                     false,
                   usedFallback: context._internalState.usedFallback,
-                  chainId: context.input.data.domain.chainId ?? null,
+                  chainId: normalizeChainId(context.input.data.domain.chainId),
                   targetAddress:
                     context.input.data.domain.verifyingContract ?? null,
                   deviceModelId: internalApi.getDeviceModel().id,

--- a/packages/signer/signer-eth/src/internal/shared/utils/normalizeChainId.test.ts
+++ b/packages/signer/signer-eth/src/internal/shared/utils/normalizeChainId.test.ts
@@ -1,0 +1,59 @@
+import { normalizeChainId } from "./normalizeChainId";
+
+describe("normalizeChainId", () => {
+  it("should return null for null", () => {
+    expect(normalizeChainId(null)).toBeNull();
+  });
+
+  it("should return null for undefined", () => {
+    expect(normalizeChainId(undefined)).toBeNull();
+  });
+
+  it("should return the number for a safe integer number", () => {
+    expect(normalizeChainId(1)).toBe(1);
+    expect(normalizeChainId(137)).toBe(137);
+    expect(normalizeChainId(0)).toBe(0);
+  });
+
+  it("should return null for NaN", () => {
+    expect(normalizeChainId(NaN)).toBeNull();
+  });
+
+  it("should return null for a non-integer number", () => {
+    expect(normalizeChainId(1.5)).toBeNull();
+  });
+
+  it("should return null for an unsafe integer", () => {
+    expect(normalizeChainId(Number.MAX_SAFE_INTEGER + 1)).toBeNull();
+  });
+
+  it("should parse a decimal string", () => {
+    expect(normalizeChainId("1")).toBe(1);
+    expect(normalizeChainId("137")).toBe(137);
+  });
+
+  it("should parse a hex string", () => {
+    expect(normalizeChainId("0x1")).toBe(1);
+    expect(normalizeChainId("0x89")).toBe(137);
+  });
+
+  it("should return null for an empty string", () => {
+    expect(normalizeChainId("")).toBeNull();
+    expect(normalizeChainId("   ")).toBeNull();
+  });
+
+  it("should return null for a non-numeric string", () => {
+    expect(normalizeChainId("abc")).toBeNull();
+    expect(normalizeChainId("0xZZ")).toBeNull();
+  });
+
+  it("should return null for an object", () => {
+    expect(normalizeChainId({})).toBeNull();
+    expect(normalizeChainId([])).toBeNull();
+  });
+
+  it("should return null for a boolean", () => {
+    expect(normalizeChainId(true)).toBeNull();
+    expect(normalizeChainId(false)).toBeNull();
+  });
+});

--- a/packages/signer/signer-eth/src/internal/shared/utils/normalizeChainId.ts
+++ b/packages/signer/signer-eth/src/internal/shared/utils/normalizeChainId.ts
@@ -1,0 +1,19 @@
+export function normalizeChainId(value: unknown): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) ? value : null;
+  }
+
+  if (typeof value === "string") {
+    if (value.trim() === "") {
+      return null;
+    }
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) ? parsed : null;
+  }
+
+  return null;
+}


### PR DESCRIPTION
### 📝 Description

Fixes a `400 Bad Request` error from the blind signing reporter API:

```json
{
  "error": "Bad Request",
  "message": "chainId invalid type. expected: [integer,null], given: string"
}
```

`TypedDataDomain.chainId` is typed as `number`, but at runtime dapps/Live Apps frequently send a hex string (e.g. `"0x1"` for Ethereum mainnet). That string was forwarded as-is to the reporter via `BlindSigningDetectionTask`, breaking the API contract.

This PR introduces a small `normalizeChainId(value: unknown): number | null` util in `signer-eth` and uses it at the typed data report site in `SignTypedDataDeviceAction` so:

- numbers (safe integers) pass through,
- decimal strings (`"1"`) and hex strings (`"0x1"`) are parsed,
- `null` / `undefined` / `NaN` / unsafe integers / non-numeric values become `null`.

The signing flow itself is unchanged; only the value sent to the reporter is normalized.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1135](https://ledgerhq.atlassian.net/browse/DSDK-1135)
- **Feature**: Bugfix — blind signing event reporting

### ✅ Checklist

- [x] **Covered by automatic tests**
  - Unit tests for `normalizeChainId` (number, hex string, decimal string, `null`, `undefined`, `NaN`, unsafe integer, non-numeric, object, boolean).
  - Device-action tests in `SignTypedDataDeviceAction.test.ts` asserting the reporter receives `chainId: 1` for `domain.chainId: "0x1"` and `chainId: null` when missing.
- [x] **Changeset is provided** (`.changeset/normalize-typed-data-chain-id.md`, patch on `@ledgerhq/device-signer-kit-ethereum`)
- [x] **Documentation is up-to-date** (no public API changes)
- [x] **Impact of the changes:**
  - `SignTypedDataDeviceAction` now normalizes `domain.chainId` before reporting blind signing events. QA should verify EIP-712 signing flows still produce blind-signing reports successfully (200 OK) for dapps that send `chainId` as a hex string and as a number.

---

### 🧐 Checklist for the PR Reviewers

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.

Made with [Cursor](https://cursor.com)

[DSDK-1135]: https://ledgerhq.atlassian.net/browse/DSDK-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ