### PR TITLE
✨ (signer-concordium) [LIVE-29692]: Add max-fee display support

### DIFF
--- a/.changeset/weak-webs-eat.md
+++ b/.changeset/weak-webs-eat.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-concordium": minor
+---
+
+`signTransaction` now takes a required `maxFee: bigint` (µCCD) as its third positional argument, ahead of `options`. The value is forwarded to the device for display only and is not part of the canonical signed bytes. Requires Concordium app version 5.6.0+ on the device; on older firmware the value is dropped at the wire boundary and signing falls back to the legacy display layout. Invalid `maxFee` values (non-bigint, negative, or above uint64 range) are rejected with `InvalidMaxFeeError` (errorCode `"invalid_max_fee"`).

--- a/apps/docs/pages/docs/references/signers/concordium.mdx
+++ b/apps/docs/pages/docs/references/signers/concordium.mdx
@@ -147,6 +147,7 @@ Securely sign a Concordium transaction on Ledger devices. Supports both Transfer
 const { observable, cancel } = signerConcordium.signTransaction(
   derivationPath,
   transaction,
+  maxFee,
   options,
 );
 ```
@@ -164,6 +165,14 @@ const { observable, cancel } = signerConcordium.signTransaction(
   - **Required**
   - **Type:** `Uint8Array`
   - The serialized transaction bytes to sign. The transaction type (Transfer or TransferWithMemo) is detected automatically from the type byte at offset 60.
+
+- `maxFee`
+
+  - **Required**
+  - **Type:** `bigint` (µCCD)
+  - The max-fee value to display, as a uint64 in µCCD. Rendered on-device alongside the recipient and amount. The value is **display-only**: it is not part of the canonical signed bytes, so the on-chain transaction hash is unaffected.
+  - Requires Concordium app version **5.6.0 or newer** on the device. On older firmware the value is dropped at the wire boundary and the device falls back to the legacy display. Signing still succeeds; only the on-device display degrades. Callers should always pass a real value; do not gate on detected firmware version.
+  - Invalid values (non-bigint, negative, or above uint64 range) are rejected with `InvalidMaxFeeError` (errorCode `"invalid_max_fee"`).
 
 - `options`
 

--- a/packages/signer/signer-concordium/README.md
+++ b/packages/signer/signer-concordium/README.md
@@ -151,6 +151,7 @@ Securely sign a Concordium transaction on Ledger devices. Supports both Transfer
 const { observable, cancel } = signerConcordium.signTransaction(
   derivationPath,
   transaction,
+  maxFee,
   options,
 );
 ```
@@ -168,6 +169,14 @@ const { observable, cancel } = signerConcordium.signTransaction(
   - **Required**
   - **Type:** `Uint8Array`
   - The serialized transaction bytes to sign. The transaction type (Transfer or TransferWithMemo) is detected automatically from the type byte at offset 60.
+
+- `maxFee`
+
+  - **Required**
+  - **Type:** `bigint` (µCCD)
+  - The max-fee value to display, as a uint64 in µCCD. Rendered on-device alongside the recipient and amount. The value is **display-only**: it is not part of the canonical signed bytes, so the on-chain transaction hash is unaffected.
+  - Requires Concordium app version **5.6.0 or newer** on the device. On older firmware the value is dropped at the wire boundary and the device falls back to the legacy display. Signing still succeeds; only the on-device display degrades. Callers should always pass a real value; do not gate on detected firmware version.
+  - Invalid values (non-bigint, negative, or above uint64 range) are rejected with `InvalidMaxFeeError` (errorCode `"invalid_max_fee"`).
 
 - `options`
 

--- a/packages/signer/signer-concordium/src/api/SignerConcordium.ts
+++ b/packages/signer/signer-concordium/src/api/SignerConcordium.ts
@@ -20,6 +20,7 @@ export interface SignerConcordium {
   signTransaction: (
     derivationPath: string,
     transaction: Uint8Array,
+    maxFee: bigint,
     options?: TransactionOptions,
   ) => SignTransactionDAReturnType;
 

--- a/packages/signer/signer-concordium/src/internal/DefaultSignerConcordium.ts
+++ b/packages/signer/signer-concordium/src/internal/DefaultSignerConcordium.ts
@@ -64,11 +64,12 @@ export class DefaultSignerConcordium implements SignerConcordium {
   signTransaction(
     derivationPath: string,
     transaction: Uint8Array,
+    maxFee: bigint,
     options?: TransactionOptions,
   ): SignTransactionDAReturnType {
     return this._container
       .get<SignTransactionUseCase>(transactionTypes.SignTransactionUseCase)
-      .execute(derivationPath, transaction, options);
+      .execute(derivationPath, transaction, maxFee, options);
   }
 
   signCredentialDeploymentTransaction(

--- a/packages/signer/signer-concordium/src/internal/app-binder/ConcordiumAppBinder.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/ConcordiumAppBinder.ts
@@ -76,6 +76,7 @@ export class ConcordiumAppBinder {
   signTransaction(args: {
     derivationPath: string;
     transaction: Uint8Array;
+    maxFee: bigint;
     skipOpenApp?: boolean;
   }): SignTransactionDAReturnType {
     return this.dmk.executeDeviceAction({

--- a/packages/signer/signer-concordium/src/internal/app-binder/command/SignTransferCommand.test.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/command/SignTransferCommand.test.ts
@@ -12,10 +12,10 @@ import { INS, LEDGER_CLA, P2 } from "@internal/app-binder/constants";
 
 describe("SignTransferCommand", () => {
   describe("getApdu", () => {
-    it("should build APDU with P2=MORE when not last chunk", () => {
+    it("should build APDU with caller-provided P2=LAST", () => {
       const command = new SignTransferCommand({
-        chunkedData: new Uint8Array(50).fill(0x01),
-        isLastChunk: false,
+        data: new Uint8Array(50).fill(0x01),
+        p2: P2.LAST,
       });
 
       const raw = command.getApdu().getRawApdu();
@@ -23,38 +23,38 @@ describe("SignTransferCommand", () => {
       expect(raw[0]).toBe(LEDGER_CLA);
       expect(raw[1]).toBe(INS.SIGN_TRANSFER);
       expect(raw[2]).toBe(0x00);
-      expect(raw[3]).toBe(P2.MORE);
+      expect(raw[3]).toBe(P2.LAST);
     });
 
-    it("should build APDU with P2=LAST when last chunk", () => {
+    it("should build APDU with caller-provided P2=FEE_DISPLAY", () => {
       const command = new SignTransferCommand({
-        chunkedData: new Uint8Array(50).fill(0x01),
-        isLastChunk: true,
+        data: new Uint8Array(50).fill(0x01),
+        p2: P2.FEE_DISPLAY,
       });
 
       const raw = command.getApdu().getRawApdu();
 
-      expect(raw[3]).toBe(P2.LAST);
+      expect(raw[3]).toBe(P2.FEE_DISPLAY);
     });
 
-    it("should include chunked data in APDU payload", () => {
-      const data = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    it("should include data in APDU payload", () => {
+      const buf = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
       const command = new SignTransferCommand({
-        chunkedData: data,
-        isLastChunk: true,
+        data: buf,
+        p2: P2.LAST,
       });
 
       const raw = command.getApdu().getRawApdu();
       // Data starts at byte 5
-      expect(raw.slice(5)).toStrictEqual(data);
+      expect(raw.slice(5)).toStrictEqual(buf);
     });
   });
 
   describe("parseResponse", () => {
     it("should extract signature bytes on success", () => {
       const command = new SignTransferCommand({
-        chunkedData: new Uint8Array(10),
-        isLastChunk: true,
+        data: new Uint8Array(10),
+        p2: P2.LAST,
       });
 
       const signature = new Uint8Array(64).fill(0xab);
@@ -71,26 +71,10 @@ describe("SignTransferCommand", () => {
       }
     });
 
-    it("should return empty data for intermediate chunk response", () => {
-      const command = new SignTransferCommand({
-        chunkedData: new Uint8Array(10),
-        isLastChunk: false,
-      });
-
-      const response = new ApduResponse({
-        statusCode: new Uint8Array([0x90, 0x00]),
-        data: new Uint8Array([]),
-      });
-
-      const result = command.parseResponse(response);
-
-      expect(isSuccessCommandResult(result)).toBe(true);
-    });
-
     it("should return ConcordiumAppCommandError on user rejection", () => {
       const command = new SignTransferCommand({
-        chunkedData: new Uint8Array(10),
-        isLastChunk: true,
+        data: new Uint8Array(10),
+        p2: P2.LAST,
       });
 
       const response = new ApduResponse({
@@ -109,8 +93,8 @@ describe("SignTransferCommand", () => {
 
     it("should return ConcordiumAppCommandError on data invalid", () => {
       const command = new SignTransferCommand({
-        chunkedData: new Uint8Array(10),
-        isLastChunk: false,
+        data: new Uint8Array(10),
+        p2: P2.LAST,
       });
 
       const response = new ApduResponse({

--- a/packages/signer/signer-concordium/src/internal/app-binder/command/SignTransferCommand.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/command/SignTransferCommand.ts
@@ -16,11 +16,11 @@ import {
   ConcordiumAppCommandErrorFactory,
   type ConcordiumErrorCodes,
 } from "@internal/app-binder/command/utils/ConcordiumApplicationErrors";
-import { INS, LEDGER_CLA, P2 } from "@internal/app-binder/constants";
+import { INS, LEDGER_CLA } from "@internal/app-binder/constants";
 
 export type SignTransferCommandArgs = {
-  readonly chunkedData: Uint8Array;
-  readonly isLastChunk: boolean;
+  readonly data: Uint8Array;
+  readonly p2: number;
 };
 
 export type SignTransferCommandResponse = Signature;
@@ -51,10 +51,10 @@ export class SignTransferCommand
       cla: LEDGER_CLA,
       ins: INS.SIGN_TRANSFER,
       p1: 0x00,
-      p2: this.args.isLastChunk ? P2.LAST : P2.MORE,
+      p2: this.args.p2,
     });
 
-    apduBuilder.addBufferToData(this.args.chunkedData);
+    apduBuilder.addBufferToData(this.args.data);
 
     return apduBuilder.build();
   }

--- a/packages/signer/signer-concordium/src/internal/app-binder/command/SignTransferWithMemoCommand.test.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/command/SignTransferWithMemoCommand.test.ts
@@ -15,6 +15,7 @@ describe("SignTransferWithMemoCommand", () => {
     it("should build APDU with INS=SIGN_TRANSFER_WITH_MEMO and given P1", () => {
       const command = new SignTransferWithMemoCommand({
         p1: P1.INITIAL_WITH_MEMO,
+        p2: P2.NONE,
         data: new Uint8Array(50).fill(0x01),
       });
 
@@ -29,6 +30,7 @@ describe("SignTransferWithMemoCommand", () => {
     it("should use P1=MEMO for memo chunks", () => {
       const command = new SignTransferWithMemoCommand({
         p1: P1.MEMO,
+        p2: P2.NONE,
         data: new Uint8Array(100).fill(0xcc),
       });
 
@@ -40,6 +42,7 @@ describe("SignTransferWithMemoCommand", () => {
     it("should use P1=AMOUNT for final amount step", () => {
       const command = new SignTransferWithMemoCommand({
         p1: P1.AMOUNT,
+        p2: P2.NONE,
         data: new Uint8Array(8).fill(0x00),
       });
 
@@ -52,6 +55,7 @@ describe("SignTransferWithMemoCommand", () => {
       const data = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
       const command = new SignTransferWithMemoCommand({
         p1: P1.MEMO,
+        p2: P2.NONE,
         data,
       });
 
@@ -65,6 +69,7 @@ describe("SignTransferWithMemoCommand", () => {
     it("should extract signature bytes on success", () => {
       const command = new SignTransferWithMemoCommand({
         p1: P1.AMOUNT,
+        p2: P2.NONE,
         data: new Uint8Array(8),
       });
 
@@ -85,6 +90,7 @@ describe("SignTransferWithMemoCommand", () => {
     it("should return empty data for intermediate step response", () => {
       const command = new SignTransferWithMemoCommand({
         p1: P1.INITIAL_WITH_MEMO,
+        p2: P2.NONE,
         data: new Uint8Array(50),
       });
 
@@ -101,6 +107,7 @@ describe("SignTransferWithMemoCommand", () => {
     it("should return ConcordiumAppCommandError on user rejection", () => {
       const command = new SignTransferWithMemoCommand({
         p1: P1.AMOUNT,
+        p2: P2.NONE,
         data: new Uint8Array(8),
       });
 
@@ -121,6 +128,7 @@ describe("SignTransferWithMemoCommand", () => {
     it("should return ConcordiumAppCommandError on data invalid", () => {
       const command = new SignTransferWithMemoCommand({
         p1: P1.MEMO,
+        p2: P2.NONE,
         data: new Uint8Array(10),
       });
 

--- a/packages/signer/signer-concordium/src/internal/app-binder/command/SignTransferWithMemoCommand.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/command/SignTransferWithMemoCommand.ts
@@ -16,10 +16,11 @@ import {
   ConcordiumAppCommandErrorFactory,
   type ConcordiumErrorCodes,
 } from "@internal/app-binder/command/utils/ConcordiumApplicationErrors";
-import { INS, LEDGER_CLA, P2 } from "@internal/app-binder/constants";
+import { INS, LEDGER_CLA } from "@internal/app-binder/constants";
 
 export type SignTransferWithMemoCommandArgs = {
   readonly p1: number;
+  readonly p2: number;
   readonly data: Uint8Array;
 };
 
@@ -51,7 +52,7 @@ export class SignTransferWithMemoCommand
       cla: LEDGER_CLA,
       ins: INS.SIGN_TRANSFER_WITH_MEMO,
       p1: this.args.p1,
-      p2: P2.NONE,
+      p2: this.args.p2,
     });
 
     apduBuilder.addBufferToData(this.args.data);

--- a/packages/signer/signer-concordium/src/internal/app-binder/command/utils/ConcordiumApplicationErrors.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/command/utils/ConcordiumApplicationErrors.ts
@@ -15,6 +15,7 @@ export enum ConcordiumErrorCodes {
   UNSUPPORTED_TRANSACTION_TYPE = "unsupported_transaction_type",
   TRUSTED_METADATA_SERVICE_ERROR = "trusted_metadata_service_error",
   ADDRESS_VERIFICATION_FAILED = "address_verification_failed",
+  INVALID_MAX_FEE = "invalid_max_fee",
 }
 
 export const CONCORDIUM_APP_ERRORS: CommandErrors<ConcordiumErrorCodes> = {
@@ -31,6 +32,9 @@ export const CONCORDIUM_APP_ERRORS: CommandErrors<ConcordiumErrorCodes> = {
   },
   address_verification_failed: {
     message: "Address verification failed",
+  },
+  invalid_max_fee: {
+    message: "Invalid maxFee value",
   },
 };
 

--- a/packages/signer/signer-concordium/src/internal/app-binder/command/utils/EncodeMaxFee.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/command/utils/EncodeMaxFee.ts
@@ -1,0 +1,19 @@
+import { FEE_DISPLAY_SIZE } from "@internal/app-binder/constants";
+
+/**
+ * Encode µCCD max-fee as big-endian uint64 for the fee-display APDU extension.
+ */
+export function encodeMaxFeeBigEndian(value: bigint): Uint8Array {
+  if (value < 0n || value > 0xffffffffffffffffn) {
+    throw new RangeError(
+      `maxFee out of uint64 range: ${value.toString()} (µCCD)`,
+    );
+  }
+  const out = new Uint8Array(FEE_DISPLAY_SIZE);
+  let v = value;
+  for (let i = FEE_DISPLAY_SIZE - 1; i >= 0; i--) {
+    out[i] = Number(v & 0xffn);
+    v >>= 8n;
+  }
+  return out;
+}

--- a/packages/signer/signer-concordium/src/internal/app-binder/command/utils/InvalidMaxFeeError.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/command/utils/InvalidMaxFeeError.ts
@@ -1,0 +1,28 @@
+import { DeviceExchangeError } from "@ledgerhq/device-management-kit";
+
+import { ConcordiumErrorCodes } from "@internal/app-binder/command/utils/ConcordiumApplicationErrors";
+
+const UINT64_MAX = 0xffffffffffffffffn;
+
+export class InvalidMaxFeeError extends DeviceExchangeError<ConcordiumErrorCodes> {
+  constructor(value: unknown) {
+    super({
+      tag: "InvalidMaxFeeError",
+      message: buildMessage(value),
+      errorCode: ConcordiumErrorCodes.INVALID_MAX_FEE,
+    });
+  }
+}
+
+function buildMessage(value: unknown): string {
+  if (typeof value !== "bigint") {
+    return `Invalid maxFee: expected bigint, got ${typeof value}.`;
+  }
+  if (value < 0n) {
+    return `Invalid maxFee: must be non-negative, got ${value.toString()} µCCD.`;
+  }
+  if (value > UINT64_MAX) {
+    return `Invalid maxFee: exceeds uint64 range, got ${value.toString()} µCCD.`;
+  }
+  return `Invalid maxFee: ${String(value)}.`;
+}

--- a/packages/signer/signer-concordium/src/internal/app-binder/constants.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/constants.ts
@@ -43,4 +43,7 @@ export const P2 = {
   NONE: 0x00,
   MORE: 0x80,
   LAST: 0x00,
+  FEE_DISPLAY: 0x01,
 } as const;
+
+export const FEE_DISPLAY_SIZE = 8;

--- a/packages/signer/signer-concordium/src/internal/app-binder/task/SendTransferTask.test.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/task/SendTransferTask.test.ts
@@ -2,6 +2,7 @@ import {
   APDU_MAX_PAYLOAD,
   CommandResultFactory,
   type InternalApi,
+  InvalidStatusWordError,
   isSuccessCommandResult,
   type LoggerPublisherService,
 } from "@ledgerhq/device-management-kit";
@@ -12,6 +13,7 @@ import {
   ConcordiumAppCommandError,
   ConcordiumErrorCodes,
 } from "@internal/app-binder/command/utils/ConcordiumApplicationErrors";
+import { FEE_DISPLAY_SIZE } from "@internal/app-binder/constants";
 import { SendTransferTask } from "@internal/app-binder/task/SendTransferTask";
 
 const DERIVATION_PATH = "44'/919'/0'/0'/0'";
@@ -19,18 +21,21 @@ const DERIVATION_PATH = "44'/919'/0'/0'/0'";
 // Path encoding: [length=5][5 x 4-byte BE hardened values] = 21 bytes
 const PATH_BYTES_LENGTH = 21;
 
-// Extract the raw APDU data bytes from a command (skipping the 5-byte header)
 function getApduData(cmd: SignTransferCommand): Uint8Array {
   const apdu = cmd.getApdu();
   const raw = apdu.getRawApdu();
   return raw.slice(5);
 }
 
-// Extract P2 byte from command APDU
 function getApduP2(cmd: SignTransferCommand): number {
   const raw = cmd.getApdu().getRawApdu();
   return raw[3]!;
 }
+
+const NO_FEE = {
+  maxFee: 0n,
+  supportsFeeDisplay: false,
+};
 
 describe("SendTransferTask", () => {
   let sentCommands: SignTransferCommand[];
@@ -59,7 +64,7 @@ describe("SendTransferTask", () => {
     });
   }
 
-  it("should send small transaction in a single chunk with path prepended", async () => {
+  it("should send the transaction in a single APDU with path prepended", async () => {
     const signature = new Uint8Array(64).fill(0xab);
     const transaction = new Uint8Array(50).fill(0x01);
 
@@ -67,7 +72,7 @@ describe("SendTransferTask", () => {
 
     const task = new SendTransferTask(
       apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
+      { derivationPath: DERIVATION_PATH, transaction, ...NO_FEE },
       loggerMock,
     );
 
@@ -78,7 +83,7 @@ describe("SendTransferTask", () => {
     const data = getApduData(sentCommands[0]!);
     expect(data).toHaveLength(PATH_BYTES_LENGTH + transaction.length);
 
-    // P2 = LAST (0x00) for single chunk
+    // P2 = LAST (0x00) when fee display is not supported
     expect(getApduP2(sentCommands[0]!)).toBe(0x00);
 
     expect(isSuccessCommandResult(result)).toBe(true);
@@ -87,56 +92,14 @@ describe("SendTransferTask", () => {
     }
   });
 
-  it("should split large transaction into multiple chunks", async () => {
-    const signature = new Uint8Array(64).fill(0xcd);
-    const totalPayload = PATH_BYTES_LENGTH + 600;
-    const expectedChunks = Math.ceil(totalPayload / APDU_MAX_PAYLOAD);
-    const transaction = new Uint8Array(600).fill(0x02);
-
-    const results = Array.from({ length: expectedChunks }, (_, i) =>
-      i === expectedChunks - 1
-        ? CommandResultFactory({ data: signature })
-        : CommandResultFactory({ data: new Uint8Array(0) }),
-    );
-    captureCommands(...results);
-
-    const task = new SendTransferTask(
-      apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
-      loggerMock,
-    );
-
-    const result = await task.run();
-
-    expect(sentCommands).toHaveLength(expectedChunks);
-
-    // Non-last chunks: P2 = MORE (0x80), full APDU_MAX_PAYLOAD size
-    for (let i = 0; i < expectedChunks - 1; i++) {
-      expect(getApduP2(sentCommands[i]!)).toBe(0x80);
-      expect(getApduData(sentCommands[i]!)).toHaveLength(APDU_MAX_PAYLOAD);
-    }
-
-    // Last chunk: P2 = LAST (0x00), remainder size (or full size if exact multiple)
-    const lastCmd = sentCommands[expectedChunks - 1]!;
-    const expectedLastChunkLength =
-      totalPayload % APDU_MAX_PAYLOAD || APDU_MAX_PAYLOAD;
-    expect(getApduP2(lastCmd)).toBe(0x00);
-    expect(getApduData(lastCmd)).toHaveLength(expectedLastChunkLength);
-
-    expect(isSuccessCommandResult(result)).toBe(true);
-    if (isSuccessCommandResult(result)) {
-      expect(result.data).toStrictEqual(signature);
-    }
-  });
-
-  it("should prepend derivation path bytes to the first chunk", async () => {
+  it("should prepend derivation path bytes to the payload", async () => {
     const transaction = new Uint8Array(10).fill(0xff);
 
     captureCommands(CommandResultFactory({ data: new Uint8Array(64) }));
 
     const task = new SendTransferTask(
       apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
+      { derivationPath: DERIVATION_PATH, transaction, ...NO_FEE },
       loggerMock,
     );
 
@@ -152,7 +115,7 @@ describe("SendTransferTask", () => {
     expect(txPortion).toStrictEqual(transaction);
   });
 
-  it("should return error when a chunk fails", async () => {
+  it("should return error when send fails", async () => {
     const transaction = new Uint8Array(50).fill(0x03);
 
     captureCommands(
@@ -166,7 +129,7 @@ describe("SendTransferTask", () => {
 
     const task = new SendTransferTask(
       apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
+      { derivationPath: DERIVATION_PATH, transaction, ...NO_FEE },
       loggerMock,
     );
 
@@ -176,61 +139,6 @@ describe("SendTransferTask", () => {
     if (!isSuccessCommandResult(result)) {
       expect(result.error).toBeInstanceOf(ConcordiumAppCommandError);
     }
-  });
-
-  it("should return error on mid-stream chunk failure", async () => {
-    const transaction = new Uint8Array(600).fill(0x04);
-
-    captureCommands(
-      CommandResultFactory({ data: new Uint8Array(0) }),
-      CommandResultFactory({
-        error: new ConcordiumAppCommandError({
-          message: "Data invalid",
-          errorCode: ConcordiumErrorCodes.DATA_INVALID,
-        }),
-      }),
-    );
-
-    const task = new SendTransferTask(
-      apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
-      loggerMock,
-    );
-
-    const result = await task.run();
-
-    expect(sentCommands).toHaveLength(2);
-    expect(isSuccessCommandResult(result)).toBe(false);
-    if (!isSuccessCommandResult(result)) {
-      expect(result.error).toBeInstanceOf(ConcordiumAppCommandError);
-      expect((result.error as ConcordiumAppCommandError).errorCode).toBe(
-        ConcordiumErrorCodes.DATA_INVALID,
-      );
-    }
-  });
-
-  it("should handle transaction that exactly fills APDU chunks", async () => {
-    const signature = new Uint8Array(64).fill(0xee);
-    const txSize = 2 * APDU_MAX_PAYLOAD - PATH_BYTES_LENGTH;
-    const transaction = new Uint8Array(txSize).fill(0x05);
-
-    captureCommands(
-      CommandResultFactory({ data: new Uint8Array(0) }),
-      CommandResultFactory({ data: signature }),
-    );
-
-    const task = new SendTransferTask(
-      apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
-      loggerMock,
-    );
-
-    const result = await task.run();
-
-    expect(sentCommands).toHaveLength(2);
-    expect(getApduData(sentCommands[0]!)).toHaveLength(APDU_MAX_PAYLOAD);
-    expect(getApduData(sentCommands[1]!)).toHaveLength(APDU_MAX_PAYLOAD);
-    expect(isSuccessCommandResult(result)).toBe(true);
   });
 
   it("should still send path bytes for empty transaction", async () => {
@@ -240,7 +148,7 @@ describe("SendTransferTask", () => {
 
     const task = new SendTransferTask(
       apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
+      { derivationPath: DERIVATION_PATH, transaction, ...NO_FEE },
       loggerMock,
     );
 
@@ -248,5 +156,143 @@ describe("SendTransferTask", () => {
 
     expect(sentCommands).toHaveLength(1);
     expect(getApduData(sentCommands[0]!)).toHaveLength(PATH_BYTES_LENGTH);
+  });
+
+  describe("APDU size guard", () => {
+    it("returns an error when path + transaction exceeds APDU_MAX_PAYLOAD", async () => {
+      const oversizedTransaction = new Uint8Array(
+        APDU_MAX_PAYLOAD - PATH_BYTES_LENGTH + 1,
+      ).fill(0x05);
+
+      const task = new SendTransferTask(
+        apiMock,
+        {
+          derivationPath: DERIVATION_PATH,
+          transaction: oversizedTransaction,
+          ...NO_FEE,
+        },
+        loggerMock,
+      );
+
+      const result = await task.run();
+
+      expect(sentCommands).toHaveLength(0);
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(InvalidStatusWordError);
+        expect(
+          (result.error as InvalidStatusWordError).originalError?.message,
+        ).toContain("exceeds APDU limit");
+      }
+    });
+
+    it("returns an error when fee suffix pushes payload past APDU_MAX_PAYLOAD", async () => {
+      // Payload without fee fits exactly; with fee it overflows by FEE_DISPLAY_SIZE.
+      const transaction = new Uint8Array(
+        APDU_MAX_PAYLOAD - PATH_BYTES_LENGTH,
+      ).fill(0x06);
+
+      const task = new SendTransferTask(
+        apiMock,
+        {
+          derivationPath: DERIVATION_PATH,
+          transaction,
+          maxFee: 1n,
+          supportsFeeDisplay: true,
+        },
+        loggerMock,
+      );
+
+      const result = await task.run();
+
+      expect(sentCommands).toHaveLength(0);
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(InvalidStatusWordError);
+      }
+    });
+
+    it("accepts a payload that fits exactly at APDU_MAX_PAYLOAD", async () => {
+      const signature = new Uint8Array(64).fill(0xee);
+      const transaction = new Uint8Array(
+        APDU_MAX_PAYLOAD - PATH_BYTES_LENGTH,
+      ).fill(0x07);
+
+      captureCommands(CommandResultFactory({ data: signature }));
+
+      const task = new SendTransferTask(
+        apiMock,
+        { derivationPath: DERIVATION_PATH, transaction, ...NO_FEE },
+        loggerMock,
+      );
+
+      const result = await task.run();
+
+      expect(sentCommands).toHaveLength(1);
+      expect(getApduData(sentCommands[0]!)).toHaveLength(APDU_MAX_PAYLOAD);
+      expect(isSuccessCommandResult(result)).toBe(true);
+    });
+  });
+
+  describe("fee display (P2=0x01)", () => {
+    it("appends 8-byte BE max-fee and sets P2=0x01 when supported", async () => {
+      const signature = new Uint8Array(64).fill(0xab);
+      const transaction = new Uint8Array(50).fill(0x01);
+      const maxFee = 0x0102030405060708n;
+
+      captureCommands(CommandResultFactory({ data: signature }));
+
+      const task = new SendTransferTask(
+        apiMock,
+        {
+          derivationPath: DERIVATION_PATH,
+          transaction,
+          maxFee,
+          supportsFeeDisplay: true,
+        },
+        loggerMock,
+      );
+
+      const result = await task.run();
+
+      expect(sentCommands).toHaveLength(1);
+
+      const data = getApduData(sentCommands[0]!);
+      expect(data).toHaveLength(
+        PATH_BYTES_LENGTH + transaction.length + FEE_DISPLAY_SIZE,
+      );
+
+      const tail = data.slice(data.length - FEE_DISPLAY_SIZE);
+      expect(Array.from(tail)).toEqual([
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+      ]);
+
+      expect(getApduP2(sentCommands[0]!)).toBe(0x01);
+      expect(isSuccessCommandResult(result)).toBe(true);
+    });
+
+    it("sends legacy bytes and P2=0x00 when not supported even if maxFee provided", async () => {
+      const signature = new Uint8Array(64).fill(0xab);
+      const transaction = new Uint8Array(50).fill(0x01);
+
+      captureCommands(CommandResultFactory({ data: signature }));
+
+      const task = new SendTransferTask(
+        apiMock,
+        {
+          derivationPath: DERIVATION_PATH,
+          transaction,
+          maxFee: 12345n,
+          supportsFeeDisplay: false,
+        },
+        loggerMock,
+      );
+
+      await task.run();
+
+      const data = getApduData(sentCommands[0]!);
+      expect(data).toHaveLength(PATH_BYTES_LENGTH + transaction.length);
+      expect(getApduP2(sentCommands[0]!)).toBe(0x00);
+    });
   });
 });

--- a/packages/signer/signer-concordium/src/internal/app-binder/task/SendTransferTask.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/task/SendTransferTask.ts
@@ -15,10 +15,18 @@ import {
 } from "@internal/app-binder/command/SignTransferCommand";
 import { type ConcordiumErrorCodes } from "@internal/app-binder/command/utils/ConcordiumApplicationErrors";
 import { encodeDerivationPath } from "@internal/app-binder/command/utils/EncodeDerivationPath";
+import { encodeMaxFeeBigEndian } from "@internal/app-binder/command/utils/EncodeMaxFee";
+import { P2 } from "@internal/app-binder/constants";
+
+// Serialized transaction layout:
+// [sender:32][nonce:8][energy:8][payloadSize:4][expiry:8][type:1] = 61 bytes header
+// [recipient:32][amount:8]
 
 type SendTransferTaskArgs = {
   derivationPath: string;
   transaction: Uint8Array;
+  maxFee: bigint;
+  supportsFeeDisplay: boolean;
 };
 
 export class SendTransferTask {
@@ -35,56 +43,54 @@ export class SendTransferTask {
       data: {
         derivationPath: this.args.derivationPath,
         transactionLength: this.args.transaction.length,
+        supportsFeeDisplay: this.args.supportsFeeDisplay,
       },
     });
 
-    const { derivationPath, transaction } = this.args;
+    const { derivationPath, transaction, maxFee, supportsFeeDisplay } =
+      this.args;
     const pathBytes = encodeDerivationPath(derivationPath);
 
-    // Prepend derivation path to the transaction data so the first chunk
-    // contains the path followed by as much transaction data as fits.
-    const fullPayload = new Uint8Array(pathBytes.length + transaction.length);
-    fullPayload.set(pathBytes, 0);
-    fullPayload.set(transaction, pathBytes.length);
+    const feeSuffix = supportsFeeDisplay
+      ? encodeMaxFeeBigEndian(maxFee)
+      : new Uint8Array(0);
 
-    for (
-      let offset = 0;
-      offset < fullPayload.length;
-      offset += APDU_MAX_PAYLOAD
-    ) {
-      const isLastChunk = offset + APDU_MAX_PAYLOAD >= fullPayload.length;
-      const chunkedData = fullPayload.slice(offset, offset + APDU_MAX_PAYLOAD);
+    const payload = new Uint8Array(
+      pathBytes.length + transaction.length + feeSuffix.length,
+    );
+    payload.set(pathBytes, 0);
+    payload.set(transaction, pathBytes.length);
+    payload.set(feeSuffix, pathBytes.length + transaction.length);
 
-      const result = await this.api.sendCommand(
-        new SignTransferCommand({
-          chunkedData,
-          isLastChunk,
-        }),
-      );
-
-      if (!isSuccessCommandResult(result)) {
-        this.logger.debug("[run] Failed to send chunk", {
-          data: {
-            chunkNumber: Math.floor(offset / APDU_MAX_PAYLOAD),
-            chunkOffset: offset,
-            error: result.error,
-          },
-        });
-        return result;
-      }
-
-      if (isLastChunk) {
-        this.logger.debug("[run] All chunks sent successfully", {
-          data: { signature: result.data },
-        });
-        return CommandResultFactory({
-          data: result.data as Signature,
-        });
-      }
+    // The firmware handler for SIGN_TRANSFER is single-shot: the full payload
+    // (path + canonical bytes + optional fee suffix) must fit in one APDU.
+    if (payload.length > APDU_MAX_PAYLOAD) {
+      return CommandResultFactory({
+        error: new InvalidStatusWordError(
+          `Transfer payload exceeds APDU limit: ${payload.length} > ${APDU_MAX_PAYLOAD}`,
+        ),
+      });
     }
 
+    const result = await this.api.sendCommand(
+      new SignTransferCommand({
+        data: payload,
+        p2: supportsFeeDisplay ? P2.FEE_DISPLAY : P2.LAST,
+      }),
+    );
+
+    if (!isSuccessCommandResult(result)) {
+      this.logger.debug("[run] Send failed", {
+        data: { error: result.error },
+      });
+      return result;
+    }
+
+    this.logger.debug("[run] Signed successfully", {
+      data: { signature: result.data },
+    });
     return CommandResultFactory({
-      error: new InvalidStatusWordError("No signature returned"),
+      data: result.data as Signature,
     });
   }
 }

--- a/packages/signer/signer-concordium/src/internal/app-binder/task/SendTransferWithMemoTask.test.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/task/SendTransferWithMemoTask.test.ts
@@ -13,7 +13,7 @@ import {
   ConcordiumAppCommandError,
   ConcordiumErrorCodes,
 } from "@internal/app-binder/command/utils/ConcordiumApplicationErrors";
-import { P1 } from "@internal/app-binder/constants";
+import { FEE_DISPLAY_SIZE, P1 } from "@internal/app-binder/constants";
 import { SendTransferWithMemoTask } from "@internal/app-binder/task/SendTransferWithMemoTask";
 
 const DERIVATION_PATH = "44'/919'/0'/0'/0'";
@@ -26,6 +26,11 @@ const HEADER_LENGTH = 61;
 const RECIPIENT_LENGTH = 32;
 const MEMO_LENGTH_FIELD = 2;
 const AMOUNT_LENGTH = 8;
+
+const NO_FEE = {
+  maxFee: 0n,
+  supportsFeeDisplay: false,
+};
 
 /**
  * Build a fake serialized TransferWithMemo transaction.
@@ -71,6 +76,10 @@ function getApduP1(cmd: SignTransferWithMemoCommand): number {
   return cmd.getApdu().getRawApdu()[2]!;
 }
 
+function getApduP2(cmd: SignTransferWithMemoCommand): number {
+  return cmd.getApdu().getRawApdu()[3]!;
+}
+
 describe("SendTransferWithMemoTask", () => {
   let sentCommands: SignTransferWithMemoCommand[];
   let sendCommandMock: ReturnType<typeof vi.fn>;
@@ -112,7 +121,7 @@ describe("SendTransferWithMemoTask", () => {
 
     const task = new SendTransferWithMemoTask(
       apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
+      { derivationPath: DERIVATION_PATH, transaction, ...NO_FEE },
       loggerMock,
     );
 
@@ -122,6 +131,7 @@ describe("SendTransferWithMemoTask", () => {
 
     // Step 1: header
     expect(getApduP1(sentCommands[0]!)).toBe(P1.INITIAL_WITH_MEMO);
+    expect(getApduP2(sentCommands[0]!)).toBe(0x00);
     const headerData = getApduData(sentCommands[0]!);
     expect(headerData).toHaveLength(
       PATH_BYTES_LENGTH + HEADER_LENGTH + RECIPIENT_LENGTH + MEMO_LENGTH_FIELD,
@@ -129,10 +139,12 @@ describe("SendTransferWithMemoTask", () => {
 
     // Step 2: memo
     expect(getApduP1(sentCommands[1]!)).toBe(P1.MEMO);
+    expect(getApduP2(sentCommands[1]!)).toBe(0x00);
     expect(getApduData(sentCommands[1]!)).toHaveLength(memoSize);
 
     // Step 3: amount
     expect(getApduP1(sentCommands[2]!)).toBe(P1.AMOUNT);
+    expect(getApduP2(sentCommands[2]!)).toBe(0x00);
     expect(getApduData(sentCommands[2]!)).toHaveLength(AMOUNT_LENGTH);
 
     expect(isSuccessCommandResult(result)).toBe(true);
@@ -159,7 +171,7 @@ describe("SendTransferWithMemoTask", () => {
 
     const task = new SendTransferWithMemoTask(
       apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
+      { derivationPath: DERIVATION_PATH, transaction, ...NO_FEE },
       loggerMock,
     );
 
@@ -200,7 +212,7 @@ describe("SendTransferWithMemoTask", () => {
 
     const task = new SendTransferWithMemoTask(
       apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
+      { derivationPath: DERIVATION_PATH, transaction, ...NO_FEE },
       loggerMock,
     );
 
@@ -225,7 +237,7 @@ describe("SendTransferWithMemoTask", () => {
 
     const task = new SendTransferWithMemoTask(
       apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
+      { derivationPath: DERIVATION_PATH, transaction, ...NO_FEE },
       loggerMock,
     );
 
@@ -253,7 +265,7 @@ describe("SendTransferWithMemoTask", () => {
 
     const task = new SendTransferWithMemoTask(
       apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
+      { derivationPath: DERIVATION_PATH, transaction, ...NO_FEE },
       loggerMock,
     );
 
@@ -279,7 +291,7 @@ describe("SendTransferWithMemoTask", () => {
 
     const task = new SendTransferWithMemoTask(
       apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
+      { derivationPath: DERIVATION_PATH, transaction, ...NO_FEE },
       loggerMock,
     );
 
@@ -300,7 +312,7 @@ describe("SendTransferWithMemoTask", () => {
 
     const task = new SendTransferWithMemoTask(
       apiMock,
-      { derivationPath: DERIVATION_PATH, transaction: tx },
+      { derivationPath: DERIVATION_PATH, transaction: tx, ...NO_FEE },
       loggerMock,
     );
 
@@ -318,7 +330,7 @@ describe("SendTransferWithMemoTask", () => {
 
     const task = new SendTransferWithMemoTask(
       apiMock,
-      { derivationPath: DERIVATION_PATH, transaction: shortTx },
+      { derivationPath: DERIVATION_PATH, transaction: shortTx, ...NO_FEE },
       loggerMock,
     );
 
@@ -329,5 +341,87 @@ describe("SendTransferWithMemoTask", () => {
     if (!isSuccessCommandResult(result)) {
       expect(result.error).toBeInstanceOf(InvalidStatusWordError);
     }
+  });
+
+  describe("fee display (P2=0x01)", () => {
+    it("appends 8-byte BE max-fee to header and uses P2=0x01 on initial step", async () => {
+      const memoSize = 10;
+      const transaction = buildTransaction(memoSize);
+      const signature = new Uint8Array(64).fill(0xab);
+      const maxFee = 0x0102030405060708n;
+
+      captureCommands(
+        CommandResultFactory({ data: new Uint8Array(0) }),
+        CommandResultFactory({ data: new Uint8Array(0) }),
+        CommandResultFactory({ data: signature }),
+      );
+
+      const task = new SendTransferWithMemoTask(
+        apiMock,
+        {
+          derivationPath: DERIVATION_PATH,
+          transaction,
+          maxFee,
+          supportsFeeDisplay: true,
+        },
+        loggerMock,
+      );
+
+      const result = await task.run();
+
+      expect(sentCommands).toHaveLength(3);
+
+      expect(getApduP2(sentCommands[0]!)).toBe(0x01);
+      const headerData = getApduData(sentCommands[0]!);
+      expect(headerData).toHaveLength(
+        PATH_BYTES_LENGTH +
+          HEADER_LENGTH +
+          RECIPIENT_LENGTH +
+          MEMO_LENGTH_FIELD +
+          FEE_DISPLAY_SIZE,
+      );
+      const tail = headerData.slice(headerData.length - FEE_DISPLAY_SIZE);
+      expect(Array.from(tail)).toEqual([
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+      ]);
+
+      expect(getApduP2(sentCommands[1]!)).toBe(0x00);
+      expect(getApduP2(sentCommands[2]!)).toBe(0x00);
+
+      expect(isSuccessCommandResult(result)).toBe(true);
+    });
+
+    it("falls back to legacy header layout when fee display is not supported", async () => {
+      const transaction = buildTransaction(10);
+      const signature = new Uint8Array(64).fill(0xab);
+
+      captureCommands(
+        CommandResultFactory({ data: new Uint8Array(0) }),
+        CommandResultFactory({ data: new Uint8Array(0) }),
+        CommandResultFactory({ data: signature }),
+      );
+
+      const task = new SendTransferWithMemoTask(
+        apiMock,
+        {
+          derivationPath: DERIVATION_PATH,
+          transaction,
+          maxFee: 99999n,
+          supportsFeeDisplay: false,
+        },
+        loggerMock,
+      );
+
+      await task.run();
+
+      expect(getApduP2(sentCommands[0]!)).toBe(0x00);
+      const headerData = getApduData(sentCommands[0]!);
+      expect(headerData).toHaveLength(
+        PATH_BYTES_LENGTH +
+          HEADER_LENGTH +
+          RECIPIENT_LENGTH +
+          MEMO_LENGTH_FIELD,
+      );
+    });
   });
 });

--- a/packages/signer/signer-concordium/src/internal/app-binder/task/SendTransferWithMemoTask.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/task/SendTransferWithMemoTask.ts
@@ -15,11 +15,13 @@ import {
 } from "@internal/app-binder/command/SignTransferWithMemoCommand";
 import { type ConcordiumErrorCodes } from "@internal/app-binder/command/utils/ConcordiumApplicationErrors";
 import { encodeDerivationPath } from "@internal/app-binder/command/utils/EncodeDerivationPath";
-import { P1 } from "@internal/app-binder/constants";
+import { encodeMaxFeeBigEndian } from "@internal/app-binder/command/utils/EncodeMaxFee";
+import { P1, P2 } from "@internal/app-binder/constants";
 
 // Serialized transaction layout:
 // [sender:32][nonce:8][energy:8][payloadSize:4][expiry:8][type:1] = 61 bytes header
 // [recipient:32][memoLength:2][memo:N][amount:8]
+
 const HEADER_LENGTH = 61;
 const RECIPIENT_LENGTH = 32;
 const MEMO_LENGTH_FIELD = 2;
@@ -28,6 +30,8 @@ const AMOUNT_LENGTH = 8;
 type SendTransferWithMemoTaskArgs = {
   derivationPath: string;
   transaction: Uint8Array;
+  maxFee: bigint;
+  supportsFeeDisplay: boolean;
 };
 
 export class SendTransferWithMemoTask {
@@ -44,10 +48,12 @@ export class SendTransferWithMemoTask {
       data: {
         derivationPath: this.args.derivationPath,
         transactionLength: this.args.transaction.length,
+        supportsFeeDisplay: this.args.supportsFeeDisplay,
       },
     });
 
-    const { derivationPath, transaction } = this.args;
+    const { derivationPath, transaction, maxFee, supportsFeeDisplay } =
+      this.args;
     const pathBytes = encodeDerivationPath(derivationPath);
 
     const minLength =
@@ -95,12 +101,18 @@ export class SendTransferWithMemoTask {
     // Amount (8 bytes)
     const amount = transaction.slice(offset, offset + AMOUNT_LENGTH);
 
-    // Step 1: Send header payload (path + header + recipient + memoLength)
+    // Step 1: Send header payload (path + header + recipient + memoLength).
+    // Fee suffix is parsed for UI but not hashed by the firmware.
+    const feeSuffix = supportsFeeDisplay
+      ? encodeMaxFeeBigEndian(maxFee)
+      : new Uint8Array(0);
+
     const headerPayload = new Uint8Array(
       pathBytes.length +
         header.length +
         recipient.length +
-        memoLengthBytes.length,
+        memoLengthBytes.length +
+        feeSuffix.length,
     );
 
     if (headerPayload.length > APDU_MAX_PAYLOAD) {
@@ -117,10 +129,18 @@ export class SendTransferWithMemoTask {
       memoLengthBytes,
       pathBytes.length + header.length + recipient.length,
     );
+    headerPayload.set(
+      feeSuffix,
+      pathBytes.length +
+        header.length +
+        recipient.length +
+        memoLengthBytes.length,
+    );
 
     const headerResult = await this.api.sendCommand(
       new SignTransferWithMemoCommand({
         p1: P1.INITIAL_WITH_MEMO,
+        p2: supportsFeeDisplay ? P2.FEE_DISPLAY : P2.NONE,
         data: headerPayload,
       }),
     );
@@ -142,6 +162,7 @@ export class SendTransferWithMemoTask {
       const memoResult = await this.api.sendCommand(
         new SignTransferWithMemoCommand({
           p1: P1.MEMO,
+          p2: P2.NONE,
           data: chunk,
         }),
       );
@@ -158,6 +179,7 @@ export class SendTransferWithMemoTask {
     const amountResult = await this.api.sendCommand(
       new SignTransferWithMemoCommand({
         p1: P1.AMOUNT,
+        p2: P2.NONE,
         data: amount,
       }),
     );

--- a/packages/signer/signer-concordium/src/internal/app-binder/task/SignTransactionTaskFactory.test.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/task/SignTransactionTaskFactory.test.ts
@@ -1,11 +1,15 @@
 import {
+  type Command,
   CommandResultFactory,
+  DeviceModelId,
+  DeviceSessionStateType,
   type InternalApi,
   isSuccessCommandResult,
   type LoggerPublisherService,
 } from "@ledgerhq/device-management-kit";
 import { vi } from "vitest";
 
+import { InvalidMaxFeeError } from "@internal/app-binder/command/utils/InvalidMaxFeeError";
 import { UnsupportedTransactionTypeError } from "@internal/app-binder/command/utils/UnsupportedTransactionTypeError";
 import { createSignTransactionTask } from "@internal/app-binder/task/SignTransactionTaskFactory";
 
@@ -18,18 +22,43 @@ function buildTransaction(typeValue: number): Uint8Array {
   return tx;
 }
 
+function makeReadyDeviceState(appVersion: string) {
+  return {
+    sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+    deviceModelId: DeviceModelId.NANO_X,
+    currentApp: { name: "Concordium", version: appVersion },
+  };
+}
+
+function makeApiMock(deviceState: unknown): {
+  api: InternalApi;
+  sentCommands: Command<unknown, unknown>[];
+} {
+  const sentCommands: Command<unknown, unknown>[] = [];
+  const sendCommandMock = vi
+    .fn()
+    .mockImplementation((cmd: Command<unknown, unknown>) => {
+      sentCommands.push(cmd);
+      return Promise.resolve(
+        CommandResultFactory({ data: new Uint8Array(64).fill(0xab) }),
+      );
+    });
+  const api = {
+    sendCommand: sendCommandMock,
+    getDeviceSessionState: () => deviceState,
+  } as unknown as InternalApi;
+  return { api, sentCommands };
+}
+
+function getApduP2(cmd: Command<unknown, unknown>): number {
+  return cmd.getApdu().getRawApdu()[3]!;
+}
+
 describe("createSignTransactionTask", () => {
-  let apiMock: InternalApi;
   let loggerFactory: (tag: string) => LoggerPublisherService;
   let loggerTags: string[];
 
   beforeEach(() => {
-    apiMock = {
-      sendCommand: vi
-        .fn()
-        .mockResolvedValue(CommandResultFactory({ data: new Uint8Array(64) })),
-    } as unknown as InternalApi;
-
     loggerTags = [];
     loggerFactory = (tag: string) => {
       loggerTags.push(tag);
@@ -38,11 +67,12 @@ describe("createSignTransactionTask", () => {
   });
 
   it("should create SendTransferTask for Transfer type (3)", () => {
+    const { api } = makeApiMock(makeReadyDeviceState("5.6.0"));
     const transaction = buildTransaction(3);
 
     createSignTransactionTask(
-      apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
+      api,
+      { derivationPath: DERIVATION_PATH, transaction, maxFee: 0n },
       loggerFactory,
     );
 
@@ -50,11 +80,12 @@ describe("createSignTransactionTask", () => {
   });
 
   it("should create SendTransferWithMemoTask for TransferWithMemo type (22)", () => {
+    const { api } = makeApiMock(makeReadyDeviceState("5.6.0"));
     const transaction = buildTransaction(22);
 
     createSignTransactionTask(
-      apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
+      api,
+      { derivationPath: DERIVATION_PATH, transaction, maxFee: 0n },
       loggerFactory,
     );
 
@@ -62,11 +93,12 @@ describe("createSignTransactionTask", () => {
   });
 
   it("should return error for unsupported transaction type", async () => {
+    const { api } = makeApiMock(makeReadyDeviceState("5.6.0"));
     const transaction = buildTransaction(99);
 
     const task = createSignTransactionTask(
-      apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
+      api,
+      { derivationPath: DERIVATION_PATH, transaction, maxFee: 0n },
       loggerFactory,
     );
 
@@ -81,11 +113,12 @@ describe("createSignTransactionTask", () => {
   });
 
   it("should return error for transaction too short to read type", async () => {
+    const { api } = makeApiMock(makeReadyDeviceState("5.6.0"));
     const transaction = new Uint8Array(10);
 
     const task = createSignTransactionTask(
-      apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
+      api,
+      { derivationPath: DERIVATION_PATH, transaction, maxFee: 0n },
       loggerFactory,
     );
 
@@ -100,11 +133,12 @@ describe("createSignTransactionTask", () => {
   });
 
   it("should return error for transaction exactly at type offset boundary", async () => {
+    const { api } = makeApiMock(makeReadyDeviceState("5.6.0"));
     const transaction = new Uint8Array(TYPE_OFFSET);
 
     const task = createSignTransactionTask(
-      apiMock,
-      { derivationPath: DERIVATION_PATH, transaction },
+      api,
+      { derivationPath: DERIVATION_PATH, transaction, maxFee: 0n },
       loggerFactory,
     );
 
@@ -114,5 +148,179 @@ describe("createSignTransactionTask", () => {
     if (!isSuccessCommandResult(result)) {
       expect(result.error).toBeInstanceOf(UnsupportedTransactionTypeError);
     }
+  });
+
+  describe("fee-display capability detection", () => {
+    it("forwards supportsFeeDisplay=true when device app version >= 5.6.0 (Transfer)", async () => {
+      const { api, sentCommands } = makeApiMock(makeReadyDeviceState("5.6.0"));
+      const transaction = buildTransaction(3);
+
+      await createSignTransactionTask(
+        api,
+        { derivationPath: DERIVATION_PATH, transaction, maxFee: 1000n },
+        loggerFactory,
+      )();
+
+      // Simple transfer sends a single APDU; P2=0x01 means fee display was enabled.
+      expect(sentCommands).toHaveLength(1);
+      expect(getApduP2(sentCommands[0]!)).toBe(0x01);
+    });
+
+    it("forwards supportsFeeDisplay=false when device app version < 5.6.0 (Transfer)", async () => {
+      const { api, sentCommands } = makeApiMock(makeReadyDeviceState("5.5.9"));
+      const transaction = buildTransaction(3);
+
+      await createSignTransactionTask(
+        api,
+        { derivationPath: DERIVATION_PATH, transaction, maxFee: 1000n },
+        loggerFactory,
+      )();
+
+      expect(sentCommands).toHaveLength(1);
+      expect(getApduP2(sentCommands[0]!)).toBe(0x00);
+    });
+
+    it("falls back to legacy when device session has no active Concordium app", async () => {
+      const { api, sentCommands } = makeApiMock({
+        sessionStateType: DeviceSessionStateType.Connected,
+        deviceModelId: DeviceModelId.NANO_X,
+      });
+      const transaction = buildTransaction(3);
+
+      await createSignTransactionTask(
+        api,
+        { derivationPath: DERIVATION_PATH, transaction, maxFee: 1000n },
+        loggerFactory,
+      )();
+
+      expect(sentCommands).toHaveLength(1);
+      expect(getApduP2(sentCommands[0]!)).toBe(0x00);
+    });
+
+    it("forwards supportsFeeDisplay=true on initial step for TransferWithMemo when version >= 5.6.0", async () => {
+      const { api, sentCommands } = makeApiMock(makeReadyDeviceState("5.6.0"));
+      // Build a minimal TransferWithMemo: header(61) + recipient(32) + memoLen(2)=0 + amount(8) = 103
+      const transaction = new Uint8Array(61 + 32 + 2 + 8);
+      transaction[TYPE_OFFSET] = 22;
+
+      await createSignTransactionTask(
+        api,
+        { derivationPath: DERIVATION_PATH, transaction, maxFee: 1000n },
+        loggerFactory,
+      )();
+
+      // First sent APDU is the initial step
+      expect(sentCommands.length).toBeGreaterThanOrEqual(1);
+      expect(getApduP2(sentCommands[0]!)).toBe(0x01);
+    });
+  });
+
+  describe("maxFee validation", () => {
+    const UINT64_MAX = 0xffffffffffffffffn;
+
+    it("rejects negative maxFee with InvalidMaxFeeError on supported firmware", async () => {
+      const { api, sentCommands } = makeApiMock(makeReadyDeviceState("5.6.0"));
+      const transaction = buildTransaction(3);
+
+      const result = await createSignTransactionTask(
+        api,
+        { derivationPath: DERIVATION_PATH, transaction, maxFee: -1n },
+        loggerFactory,
+      )();
+
+      expect(sentCommands).toHaveLength(0);
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(InvalidMaxFeeError);
+      }
+    });
+
+    it("rejects negative maxFee with InvalidMaxFeeError on legacy firmware", async () => {
+      const { api, sentCommands } = makeApiMock(makeReadyDeviceState("5.5.9"));
+      const transaction = buildTransaction(3);
+
+      const result = await createSignTransactionTask(
+        api,
+        { derivationPath: DERIVATION_PATH, transaction, maxFee: -1n },
+        loggerFactory,
+      )();
+
+      expect(sentCommands).toHaveLength(0);
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(InvalidMaxFeeError);
+      }
+    });
+
+    it("rejects maxFee above uint64 range", async () => {
+      const { api, sentCommands } = makeApiMock(makeReadyDeviceState("5.6.0"));
+      const transaction = buildTransaction(3);
+
+      const result = await createSignTransactionTask(
+        api,
+        {
+          derivationPath: DERIVATION_PATH,
+          transaction,
+          maxFee: UINT64_MAX + 1n,
+        },
+        loggerFactory,
+      )();
+
+      expect(sentCommands).toHaveLength(0);
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(InvalidMaxFeeError);
+      }
+    });
+
+    it("rejects non-bigint maxFee (defends against untyped JS callers)", async () => {
+      const { api, sentCommands } = makeApiMock(makeReadyDeviceState("5.6.0"));
+      const transaction = buildTransaction(3);
+
+      const result = await createSignTransactionTask(
+        api,
+        {
+          derivationPath: DERIVATION_PATH,
+          transaction,
+          // Simulates a JS caller passing an options object as the 3rd arg.
+          maxFee: { skipOpenApp: true } as unknown as bigint,
+        },
+        loggerFactory,
+      )();
+
+      expect(sentCommands).toHaveLength(0);
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(InvalidMaxFeeError);
+      }
+    });
+
+    it("accepts maxFee = 0n as a valid uint64 value", async () => {
+      const { api, sentCommands } = makeApiMock(makeReadyDeviceState("5.6.0"));
+      const transaction = buildTransaction(3);
+
+      const result = await createSignTransactionTask(
+        api,
+        { derivationPath: DERIVATION_PATH, transaction, maxFee: 0n },
+        loggerFactory,
+      )();
+
+      expect(sentCommands).toHaveLength(1);
+      expect(isSuccessCommandResult(result)).toBe(true);
+    });
+
+    it("accepts maxFee at uint64 max boundary", async () => {
+      const { api, sentCommands } = makeApiMock(makeReadyDeviceState("5.6.0"));
+      const transaction = buildTransaction(3);
+
+      const result = await createSignTransactionTask(
+        api,
+        { derivationPath: DERIVATION_PATH, transaction, maxFee: UINT64_MAX },
+        loggerFactory,
+      )();
+
+      expect(sentCommands).toHaveLength(1);
+      expect(isSuccessCommandResult(result)).toBe(true);
+    });
   });
 });

--- a/packages/signer/signer-concordium/src/internal/app-binder/task/SignTransactionTaskFactory.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/task/SignTransactionTaskFactory.ts
@@ -1,4 +1,5 @@
 import {
+  ApplicationChecker,
   type CommandResult,
   CommandResultFactory,
   type InternalApi,
@@ -7,17 +8,22 @@ import {
 
 import { type Signature } from "@api/model/Signature";
 import { type ConcordiumErrorCodes } from "@internal/app-binder/command/utils/ConcordiumApplicationErrors";
+import { InvalidMaxFeeError } from "@internal/app-binder/command/utils/InvalidMaxFeeError";
 import { UnsupportedTransactionTypeError } from "@internal/app-binder/command/utils/UnsupportedTransactionTypeError";
+import { ConcordiumApplicationResolver } from "@internal/app-binder/ConcordiumApplicationResolver";
 import { SendTransferTask } from "@internal/app-binder/task/SendTransferTask";
 import { SendTransferWithMemoTask } from "@internal/app-binder/task/SendTransferWithMemoTask";
+import { MIN_APP_VERSION_FOR_FEE_DISPLAY } from "@internal/shared/ConcordiumAppVersions";
 
 const TYPE_OFFSET = 60;
 const TRANSACTION_TYPE_TRANSFER = 3;
 const TRANSACTION_TYPE_TRANSFER_WITH_MEMO = 22;
+const UINT64_MAX = 0xffffffffffffffffn;
 
 type TaskArgs = {
   derivationPath: string;
   transaction: Uint8Array;
+  maxFee: bigint;
 };
 
 export function createSignTransactionTask(
@@ -25,6 +31,15 @@ export function createSignTransactionTask(
   args: TaskArgs,
   loggerFactory: (tag: string) => LoggerPublisherService,
 ): () => Promise<CommandResult<Signature, ConcordiumErrorCodes>> {
+  if (!isValidMaxFee(args.maxFee)) {
+    return () =>
+      Promise.resolve(
+        CommandResultFactory({
+          error: new InvalidMaxFeeError(args.maxFee),
+        }),
+      );
+  }
+
   const txType = getTransactionType(args.transaction);
 
   if (txType === undefined) {
@@ -40,13 +55,21 @@ export function createSignTransactionTask(
       );
   }
 
+  const supportsFeeDisplay = checkFeeDisplaySupport(internalApi);
+  const taskArgs = { ...args, supportsFeeDisplay };
+
   if (txType === TRANSACTION_TYPE_TRANSFER_WITH_MEMO) {
     const logger = loggerFactory("SendTransferWithMemoTask");
-    return () => new SendTransferWithMemoTask(internalApi, args, logger).run();
+    return () =>
+      new SendTransferWithMemoTask(internalApi, taskArgs, logger).run();
   }
 
   const logger = loggerFactory("SendTransferTask");
-  return () => new SendTransferTask(internalApi, args, logger).run();
+  return () => new SendTransferTask(internalApi, taskArgs, logger).run();
+}
+
+function isValidMaxFee(value: unknown): value is bigint {
+  return typeof value === "bigint" && value >= 0n && value <= UINT64_MAX;
 }
 
 function getTransactionType(transaction: Uint8Array): number | undefined {
@@ -61,4 +84,18 @@ function getTransactionType(transaction: Uint8Array): number | undefined {
     return type;
   }
   return undefined;
+}
+
+function checkFeeDisplaySupport(internalApi: InternalApi): boolean {
+  try {
+    return new ApplicationChecker(
+      internalApi.getDeviceSessionState(),
+      { version: "" },
+      new ConcordiumApplicationResolver(),
+    )
+      .withMinVersionInclusive(MIN_APP_VERSION_FOR_FEE_DISPLAY)
+      .check();
+  } catch {
+    return false;
+  }
 }

--- a/packages/signer/signer-concordium/src/internal/shared/ConcordiumAppVersions.ts
+++ b/packages/signer/signer-concordium/src/internal/shared/ConcordiumAppVersions.ts
@@ -1,0 +1,5 @@
+/**
+ * Minimum Concordium app version that supports the fee-display extension
+ * (P2=0x01 + trailing 8-byte big-endian µCCD on sign INS).
+ */
+export const MIN_APP_VERSION_FOR_FEE_DISPLAY = "5.6.0";

--- a/packages/signer/signer-concordium/src/internal/use-cases/transaction/SignTransactionUseCase.ts
+++ b/packages/signer/signer-concordium/src/internal/use-cases/transaction/SignTransactionUseCase.ts
@@ -18,11 +18,13 @@ export class SignTransactionUseCase {
   execute(
     derivationPath: string,
     transaction: Uint8Array,
+    maxFee: bigint,
     options?: TransactionOptions,
   ): SignTransactionDAReturnType {
     return this._appBinder.signTransaction({
       derivationPath,
       transaction,
+      maxFee,
       skipOpenApp: options?.skipOpenApp,
     });
   }


### PR DESCRIPTION
### 📝 Description

Adds support for the Concordium app's fee-display extension (introduced in app 5.6.0). `signTransaction` gains a required `maxFee: bigint` (µCCD) argument; the value is forwarded to the device on capable firmware and rendered on-device as "Max fees".

- Device app **≥ 5.6.0** → APDU carries the fee suffix (`P2=0x01` + trailing 8-byte big-endian µCCD); device displays it alongside the recipient and amount.
- Device app **< 5.6.0** → the value is dropped at the wire boundary; signing falls back to the legacy layout. No error surfaced.
- Invalid `maxFee` (non-bigint, negative, > uint64) → rejected at the API boundary with `InvalidMaxFeeError` (`errorCode: "invalid_max_fee"`), regardless of firmware version.

## Implementation

- Firmware capability resolved via `ApplicationChecker` + the existing `ConcordiumApplicationResolver` against the device session state — no extra APDU round-trip per sign.
- Version branching lives in `createSignTransactionTask`. Tasks themselves are version-agnostic; they receive a resolved `supportsFeeDisplay: boolean` and a validated `maxFee`.
- `SendTransferTask` reworked to a single send with an explicit APDU size guard. The firmware handler for `INS 0x02` is single-shot, so the previous chunking loop was dead code.
- `maxFee` plumbed through `SignerConcordium` → `DefaultSignerConcordium` → `SignTransactionUseCase` → `ConcordiumAppBinder` → factory → tasks.
- New `InvalidMaxFeeError` typed under `ConcordiumErrorCodes`, alongside existing typed errors.

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [LIVE-29692](https://ledgerhq.atlassian.net/browse/LIVE-29692)

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [x] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [x] **Impact of the changes:** inroducting breaking change on the public API; maintains backward compatibility with the firmware app
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
