### PR TITLE
🔧 (context-module) [DSDK-1102]: Update default blind signing reporter URL to production

### DIFF
--- a/.changeset/blind-signing-prod-url.md
+++ b/.changeset/blind-signing-prod-url.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/context-module": patch
+---
+
+Update default blind signing reporter URL to production endpoint `https://blind-signing.api.ledger.com`

--- a/packages/signer/context-module/src/ContextModuleBuilder.ts
+++ b/packages/signer/context-module/src/ContextModuleBuilder.ts
@@ -25,7 +25,7 @@ import { DefaultContextModule } from "./DefaultContextModule";
 const DEFAULT_CAL_URL = "https://crypto-assets-service.api.ledger.com/v1";
 const DEFAULT_WEB3_CHECKS_URL = "https://web3checks-backend.api.ledger.com/v3";
 const DEFAULT_METADATA_SERVICE_DOMAIN = "https://nft.api.live.ledger.com";
-const DEFAULT_REPORTER_URL = "https://ingest.aws.stg.ldg-tech.com/ingest/v1";
+const DEFAULT_REPORTER_URL = "https://blind-signing.api.ledger.com/ingest/v1";
 
 /**
  * Default configuration for the context module


### PR DESCRIPTION
### 📝 Description

Updates the default blind signing reporter URL in `ContextModuleBuilder` from the staging endpoint to the production endpoint.

| Before | After |
| ------ | ----- |
| `https://ingest.aws.stg.ldg-tech.com` | `https://blind-signing.api.ledger.com` |

This ensures blind signing events emitted by `HttpBlindSigningReporterDatasource` are posted to `https://blind-signing.api.ledger.com/ingest/v1/blind-signing-events` instead of the staging ingest service.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1102](https://ledgerhq.atlassian.net/browse/DSDK-1102)
- **Feature**: Blind signing tracking

### ✅ Checklist

- [x] **Covered by automatic tests** — existing reporter tests are URL-agnostic (use a mock `config.reporter.url`), no test asserted on the staging URL value
- [x] **Changeset is provided** — `.changeset/blind-signing-prod-url.md` (patch bump for `@ledgerhq/context-module`)
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - Default reporter URL now points to the production blind signing API
  - Consumers that did not override `setReporterConfig` will start sending events to production
  - QA should verify blind signing events are correctly received on `blind-signing.api.ledger.com`

---

### 🧐 Checklist for the PR Reviewers

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.

Made with [Cursor](https://cursor.com)

[DSDK-1102]: https://ledgerhq.atlassian.net/browse/DSDK-1102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ