### PR TITLE
🩹 (cs-tester) [NO-ISSUE]: Stabilise Flex hold-to-sign in nightly tests

### DIFF
--- a/apps/clear-signing-tester/src/infrastructure/adapters/device-controllers/SpeculosTouchscreenController.ts
+++ b/apps/clear-signing-tester/src/infrastructure/adapters/device-controllers/SpeculosTouchscreenController.ts
@@ -10,7 +10,7 @@ import { DeviceController } from "@root/src/domain/adapters/DeviceController";
 import { type SpeculosConfig } from "@root/src/domain/models/config/SpeculosConfig";
 
 const DEFAULT_DELAY_MS = 5000;
-const FLEX_DELAY_MS = 10000;
+const FLEX_DELAY_MS = 15000;
 const SETTINGS_NAV_DELAY_MS = 1000;
 
 /**

--- a/apps/clear-signing-tester/src/infrastructure/services/DefaultFlowOrchestrator.ts
+++ b/apps/clear-signing-tester/src/infrastructure/services/DefaultFlowOrchestrator.ts
@@ -4,7 +4,13 @@ import {
   UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
-import { debounceTime, distinctUntilChanged, tap } from "rxjs";
+import {
+  debounceTime,
+  distinctUntilChanged,
+  tap,
+  throwError,
+  timeout,
+} from "rxjs";
 
 import { TYPES } from "@root/src/di/types";
 import { type SignableInput } from "@root/src/domain/models/SignableInput";
@@ -18,6 +24,7 @@ import { SignTransactionStateHandler } from "@root/src/infrastructure/state-hand
 import { type StateHandlerResult } from "@root/src/infrastructure/state-handlers/StateHandler";
 
 const DEBOUNCE_TIME = 1500;
+const SIGN_INACTIVITY_TIMEOUT_MS = 120_000;
 
 /**
  * Default orchestrator for device signing flows.
@@ -71,6 +78,20 @@ export class DefaultFlowOrchestrator implements FlowOrchestrator {
               prev?.intermediateValue?.requiredUserInteraction ===
                 curr?.intermediateValue?.requiredUserInteraction
             );
+          }),
+          // Fail fast if the signing flow stalls: a healthy signTx should
+          // reach a terminal state well within 2 minutes, so anything beyond
+          // that is treated as a stuck flow (e.g. a user-interaction step
+          // that never resolves) and bubbled up via the error handler.
+          timeout({
+            each: SIGN_INACTIVITY_TIMEOUT_MS,
+            with: () =>
+              throwError(
+                () =>
+                  new Error(
+                    `Signing flow did not progress for ${SIGN_INACTIVITY_TIMEOUT_MS / 1000}s — aborting.`,
+                  ),
+              ),
           }),
         )
         .subscribe({


### PR DESCRIPTION
### 📝 Description

The Flex `Hold to sign` animation now takes a bit longer than the 10s we were holding for, so the gesture releases at ~80% of the progress ring. The device then sits on the signing prompt forever (well, ~5min until Speculos disconnects), and the rest of the batch falls over with `DeviceSessionNotFound`. All 8 failing jobs in the [last nightly](https://github.com/LedgerHQ/device-sdk-ts/actions/runs/26139047378) were on Flex and stalled at the exact same `Performing transaction sign` step.

Two small changes:

- Bump `FLEX_DELAY_MS` from 10s to 15s — fixes the actual failure.
- Add a 120s inactivity `timeout()` to the orchestrator's RxJS pipe — if the signing flow ever stalls again, we fail fast with a clear error instead of burning 5min and the rest of the batch.

No SDK change, no behaviour change for healthy runs.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]

### ✅ Checklist

- [x] **Covered by automatic tests** — internal test infra; validated by re-running the nightly.
- [x] **Changeset is provided** — N/A, `apps/clear-signing-tester` is internal tooling.
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - cs-tester only, Flex-specific delay bump + a defensive timeout in the orchestrator.

Made with [Cursor](https://cursor.com)