### PR TITLE
🐛 (solana-transaction-check) [NO-ISSUE]: Patch and polish transaction check

### DIFF
--- a/.changeset/grumpy-sides-sleep.md
+++ b/.changeset/grumpy-sides-sleep.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": patch
+---
+
+Patch web3check

--- a/.changeset/mean-toys-begin.md
+++ b/.changeset/mean-toys-begin.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/context-module": patch
+---
+
+Patch Solana web3check payload

--- a/packages/signer/context-module/package.json
+++ b/packages/signer/context-module/package.json
@@ -49,6 +49,7 @@
     "ts-node": "catalog:"
   },
   "dependencies": {
+    "bs58": "catalog:",
     "crypto-js": "catalog:",
     "ethers": "catalog:",
     "inversify": "catalog:",

--- a/packages/signer/context-module/src/modules/multichain/transaction-check/loaders/SolanaTransactionCheckLoader.test.ts
+++ b/packages/signer/context-module/src/modules/multichain/transaction-check/loaders/SolanaTransactionCheckLoader.test.ts
@@ -1,0 +1,251 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { DeviceModelId } from "@ledgerhq/device-management-kit";
+import bs58 from "bs58";
+import { Left, Right } from "purify-ts";
+
+import { type PkiCertificateLoader } from "@/modules/multichain/pki/domain/PkiCertificateLoader";
+import { type TransactionCheckDataSource } from "@/modules/multichain/transaction-check/data/TransactionCheckDataSource";
+import { TransactionCheckPaths } from "@/modules/multichain/transaction-check/utils/constants";
+import { ClearSignContextType } from "@/shared/model/ClearSignContext";
+
+import { SolanaTransactionCheckLoader } from "./SolanaTransactionCheckLoader";
+
+const SIG_LENGTH = 64;
+
+const loggerMock = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  subscribers: [],
+};
+const loggerFactory = () => loggerMock;
+
+const certificateLoaderMock: PkiCertificateLoader = {
+  loadCertificate: vi.fn(),
+};
+
+let dataSourceMock: { check: ReturnType<typeof vi.fn> };
+let loader: SolanaTransactionCheckLoader;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  dataSourceMock = { check: vi.fn() };
+  loader = new SolanaTransactionCheckLoader(
+    dataSourceMock as unknown as TransactionCheckDataSource,
+    certificateLoaderMock,
+    loggerFactory,
+  );
+});
+
+describe("SolanaTransactionCheckLoader", () => {
+  describe("canHandle", () => {
+    const validInput = {
+      deviceModelId: DeviceModelId.NANO_X,
+      transactionCheck: {
+        from: "signer",
+        transactionBytes: new Uint8Array([1, 0, 3, 0xde]),
+        chain: 1,
+      },
+    };
+
+    it("returns true for a valid Solana transaction-check input", () => {
+      expect(
+        loader.canHandle(validInput, [
+          ClearSignContextType.SOLANA_TRANSACTION_CHECK,
+        ]),
+      ).toBe(true);
+    });
+
+    it("returns false when expected types do not include SOLANA_TRANSACTION_CHECK", () => {
+      expect(
+        loader.canHandle(validInput, [ClearSignContextType.SOLANA_TOKEN]),
+      ).toBe(false);
+    });
+
+    it("returns false when transactionBytes is not a Uint8Array", () => {
+      expect(
+        loader.canHandle(
+          {
+            ...validInput,
+            transactionCheck: {
+              ...validInput.transactionCheck,
+              transactionBytes: "0xdead" as unknown as Uint8Array,
+            },
+          },
+          [ClearSignContextType.SOLANA_TRANSACTION_CHECK],
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false when transactionBytes is empty", () => {
+      expect(
+        loader.canHandle(
+          {
+            ...validInput,
+            transactionCheck: {
+              ...validInput.transactionCheck,
+              transactionBytes: new Uint8Array(),
+            },
+          },
+          [ClearSignContextType.SOLANA_TRANSACTION_CHECK],
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false when from is empty", () => {
+      expect(
+        loader.canHandle(
+          {
+            ...validInput,
+            transactionCheck: { ...validInput.transactionCheck, from: "" },
+          },
+          [ClearSignContextType.SOLANA_TRANSACTION_CHECK],
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false for unsupported device models (NANO_S)", () => {
+      expect(
+        loader.canHandle(
+          { ...validInput, deviceModelId: DeviceModelId.NANO_S },
+          [ClearSignContextType.SOLANA_TRANSACTION_CHECK],
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("load — wire format", () => {
+    beforeEach(() => {
+      dataSourceMock.check.mockResolvedValue(
+        Right({ publicKeyId: "pk", descriptor: "aabb" }),
+      );
+      (certificateLoaderMock.loadCertificate as any).mockResolvedValue({
+        payload: new Uint8Array([0xcc]),
+        keyUsageNumber: 14,
+      });
+    });
+
+    it("wraps a legacy Message into a serialized Transaction (sig count + zero-filled signatures + message) and bs58-encodes it", async () => {
+      // Legacy message: numRequiredSignatures=2, then arbitrary bytes
+      const message = new Uint8Array([2, 0, 3, 0xaa, 0xbb, 0xcc]);
+
+      await loader.load({
+        deviceModelId: DeviceModelId.NANO_X,
+        transactionCheck: {
+          from: "signer",
+          transactionBytes: message,
+          chain: 1,
+        },
+      });
+
+      const sent = dataSourceMock.check.mock.calls[0]![0];
+      const wrapped = bs58.decode(sent.body.tx.raw);
+
+      expect(sent.path).toBe(TransactionCheckPaths.SOLANA_TRANSACTION);
+      expect(sent.body.tx.from).toBe("signer");
+      expect(sent.body.chain).toBe(1);
+      expect(wrapped.length).toBe(1 + 2 * SIG_LENGTH + message.length);
+      expect(wrapped[0]).toBe(2);
+      expect(Array.from(wrapped.slice(1, 1 + 2 * SIG_LENGTH))).toEqual(
+        new Array(2 * SIG_LENGTH).fill(0),
+      );
+      expect(Array.from(wrapped.slice(1 + 2 * SIG_LENGTH))).toEqual(
+        Array.from(message),
+      );
+    });
+
+    it("wraps a versioned (v0) Message by skipping the version prefix when reading numRequiredSignatures", async () => {
+      // V0 message: [0x80 version prefix, numRequiredSignatures=1, ...]
+      const message = new Uint8Array([0x80, 1, 0, 3, 0xde, 0xad]);
+
+      await loader.load({
+        deviceModelId: DeviceModelId.NANO_X,
+        transactionCheck: {
+          from: "signer",
+          transactionBytes: message,
+          chain: 1,
+        },
+      });
+
+      const wrapped = bs58.decode(
+        dataSourceMock.check.mock.calls[0]![0].body.tx.raw,
+      );
+
+      expect(wrapped.length).toBe(1 + SIG_LENGTH + message.length);
+      expect(wrapped[0]).toBe(1);
+      expect(Array.from(wrapped.slice(1, 1 + SIG_LENGTH))).toEqual(
+        new Array(SIG_LENGTH).fill(0),
+      );
+      expect(Array.from(wrapped.slice(1 + SIG_LENGTH))).toEqual(
+        Array.from(message),
+      );
+    });
+  });
+
+  describe("load — result mapping", () => {
+    it("returns a SOLANA_TRANSACTION_CHECK context with descriptor and certificate on success", async () => {
+      dataSourceMock.check.mockResolvedValue(
+        Right({ publicKeyId: "pk-1", descriptor: "deadbeef" }),
+      );
+      const cert = { payload: new Uint8Array([0x99]), keyUsageNumber: 14 };
+      (certificateLoaderMock.loadCertificate as any).mockResolvedValue(cert);
+
+      const [ctx] = await loader.load({
+        deviceModelId: DeviceModelId.NANO_X,
+        transactionCheck: {
+          from: "signer",
+          transactionBytes: new Uint8Array([1, 0, 3, 0xaa]),
+          chain: 1,
+        },
+      });
+
+      expect(ctx).toEqual({
+        type: ClearSignContextType.SOLANA_TRANSACTION_CHECK,
+        payload: { descriptor: "deadbeef" },
+        certificate: cert,
+      });
+    });
+
+    it("returns an ERROR context when the data source returns Left", async () => {
+      const error = new Error("network fail");
+      dataSourceMock.check.mockResolvedValue(Left(error));
+
+      const [ctx] = await loader.load({
+        deviceModelId: DeviceModelId.NANO_X,
+        transactionCheck: {
+          from: "signer",
+          transactionBytes: new Uint8Array([1, 0, 3, 0xaa]),
+          chain: 1,
+        },
+      });
+
+      expect(ctx).toEqual({ type: ClearSignContextType.ERROR, error });
+      expect(certificateLoaderMock.loadCertificate).not.toHaveBeenCalled();
+    });
+
+    it("returns an ERROR context (and does not call the data source) when numRequiredSignatures exceeds the max", async () => {
+      // numRequiredSignatures = 65, one above SOLANA_MAX_SIGNATURES (64)
+      const message = new Uint8Array([65, 0, 3, 0xaa]);
+
+      const [ctx] = await loader.load({
+        deviceModelId: DeviceModelId.NANO_X,
+        transactionCheck: {
+          from: "signer",
+          transactionBytes: message,
+          chain: 1,
+        },
+      });
+
+      expect(ctx).toMatchObject({
+        type: ClearSignContextType.ERROR,
+        error: expect.any(Error),
+      });
+      expect((ctx as { error: Error }).error.message).toContain(
+        "numRequiredSignatures (65)",
+      );
+      expect(dataSourceMock.check).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/signer/context-module/src/modules/multichain/transaction-check/loaders/SolanaTransactionCheckLoader.ts
+++ b/packages/signer/context-module/src/modules/multichain/transaction-check/loaders/SolanaTransactionCheckLoader.ts
@@ -17,10 +17,15 @@ import {
   ClearSignContext,
   ClearSignContextType,
 } from "@/shared/model/ClearSignContext";
+import {
+  type Bs58Encoder,
+  DefaultBs58Encoder,
+} from "@/shared/utils/bs58Encoder";
+import { uint8ArrayCodec } from "@/shared/utils/uint8ArrayCodec";
 
 export type SolanaTransactionCheckRequest = {
   from: string;
-  rawTx: string;
+  transactionBytes: Uint8Array;
   chain: number;
 };
 
@@ -33,6 +38,13 @@ const SUPPORTED_TYPES: ClearSignContextType[] = [
   ClearSignContextType.SOLANA_TRANSACTION_CHECK,
 ];
 
+const SOLANA_SIGNATURE_LENGTH = 64;
+const SOLANA_MAX_SIGNATURES = 64;
+const VERSIONED_MESSAGE_PREFIX_MASK = 0x80;
+const SHORTVEC_CONTINUATION_BIT = 0x80;
+const SHORTVEC_DATA_MASK = 0x7f;
+const SHORTVEC_DATA_BITS = 7;
+
 const solanaTransactionCheckInputCodec = Codec.interface({
   deviceModelId: oneOf([
     exactly(DeviceModelId.NANO_X),
@@ -42,7 +54,7 @@ const solanaTransactionCheckInputCodec = Codec.interface({
   ]),
   transactionCheck: Codec.interface({
     from: string,
-    rawTx: string,
+    transactionBytes: uint8ArrayCodec,
     chain: number,
   }),
 });
@@ -60,6 +72,7 @@ export class SolanaTransactionCheckLoader
     private readonly certificateLoader: PkiCertificateLoader,
     @inject(configTypes.ContextModuleLoggerFactory)
     loggerFactory: (tag: string) => LoggerPublisherService,
+    private readonly bs58Encoder: Bs58Encoder = DefaultBs58Encoder,
   ) {
     this.logger = loggerFactory("SolanaTransactionCheckLoader");
   }
@@ -72,15 +85,31 @@ export class SolanaTransactionCheckLoader
       return false;
     return solanaTransactionCheckInputCodec.decode(input).caseOf({
       Left: () => false,
-      Right: ({ transactionCheck: { from, rawTx } }) =>
-        from.length > 0 && rawTx.length > 0,
+      Right: ({ transactionCheck: { from, transactionBytes } }) =>
+        from.length > 0 && transactionBytes.length > 0,
     });
   }
 
   async load(
     ctx: SolanaTransactionCheckContextInput,
   ): Promise<ClearSignContext[]> {
-    const { from, rawTx, chain } = ctx.transactionCheck;
+    const { from, transactionBytes, chain } = ctx.transactionCheck;
+
+    let rawTx: string;
+    try {
+      rawTx = this.bs58Encoder.encode(
+        this.wrapMessageAsTransaction(transactionBytes),
+      );
+    } catch (error) {
+      const result: ClearSignContext[] = [
+        {
+          type: ClearSignContextType.ERROR,
+          error: error instanceof Error ? error : new Error(String(error)),
+        },
+      ];
+      this.logger.debug("load result", { data: { result } });
+      return result;
+    }
 
     const txCheck = await this.transactionCheckDataSource.check({
       path: TransactionCheckPaths.SOLANA_TRANSACTION,
@@ -111,5 +140,65 @@ export class SolanaTransactionCheckLoader
     const result = [context];
     this.logger.debug("load result", { data: { result } });
     return result;
+  }
+
+  /**
+   * Wrap a serialized Solana Message into a serialized Transaction expected
+   * by the web3checks endpoint, by prepending a compact-u16 signature count
+   * and the matching number of zero-filled signature placeholders.
+   *
+   * Supports legacy and versioned messages: versioned messages start with a
+   * version prefix byte (high bit set), shifting `numRequiredSignatures` by
+   * one position.
+   */
+  private wrapMessageAsTransaction(message: Uint8Array): Uint8Array {
+    const numRequiredSignatures = this.readNumRequiredSignatures(message);
+    const sigCount = this.encodeShortVec(numRequiredSignatures);
+    const placeholdersLength = numRequiredSignatures * SOLANA_SIGNATURE_LENGTH;
+
+    const wrapped = new Uint8Array(
+      sigCount.length + placeholdersLength + message.length,
+    );
+    wrapped.set(sigCount, 0);
+    wrapped.set(message, sigCount.length + placeholdersLength);
+    return wrapped;
+  }
+
+  private readNumRequiredSignatures(message: Uint8Array): number {
+    const firstByte = message[0];
+    if (firstByte === undefined) {
+      throw new Error(
+        "[ContextModule] SolanaTransactionCheckLoader: empty transaction bytes",
+      );
+    }
+    const isVersioned = (firstByte & VERSIONED_MESSAGE_PREFIX_MASK) !== 0;
+    const headerOffset = isVersioned ? 1 : 0;
+    const numRequiredSignatures = message[headerOffset];
+    if (numRequiredSignatures === undefined) {
+      throw new Error(
+        "[ContextModule] SolanaTransactionCheckLoader: malformed message header",
+      );
+    }
+    if (numRequiredSignatures > SOLANA_MAX_SIGNATURES) {
+      throw new Error(
+        `[ContextModule] SolanaTransactionCheckLoader: numRequiredSignatures (${numRequiredSignatures}) exceeds SOLANA_MAX_SIGNATURES (${SOLANA_MAX_SIGNATURES})`,
+      );
+    }
+    return numRequiredSignatures;
+  }
+
+  private encodeShortVec(value: number): Uint8Array {
+    const bytes: number[] = [];
+    let remaining = value;
+    while (true) {
+      const lowBits = remaining & SHORTVEC_DATA_MASK;
+      remaining >>>= SHORTVEC_DATA_BITS;
+      if (remaining === 0) {
+        bytes.push(lowBits);
+        break;
+      }
+      bytes.push(lowBits | SHORTVEC_CONTINUATION_BIT);
+    }
+    return Uint8Array.from(bytes);
   }
 }

--- a/packages/signer/context-module/src/shared/utils/bs58Encoder.ts
+++ b/packages/signer/context-module/src/shared/utils/bs58Encoder.ts
@@ -1,0 +1,15 @@
+import bs58 from "bs58";
+
+export interface Bs58Encoder {
+  encode(data: Uint8Array): string;
+  decode(encoded: string): Uint8Array;
+}
+
+export class DefaultBs58Encoder {
+  static encode(data: Uint8Array): string {
+    return bs58.encode(data);
+  }
+  static decode(encoded: string): Uint8Array {
+    return bs58.decode(encoded);
+  }
+}

--- a/packages/signer/context-module/src/shared/utils/uint8ArrayCodec.test.ts
+++ b/packages/signer/context-module/src/shared/utils/uint8ArrayCodec.test.ts
@@ -1,0 +1,27 @@
+import { Left, Right } from "purify-ts";
+
+import { uint8ArrayCodec } from "./uint8ArrayCodec";
+
+describe("uint8ArrayCodec", () => {
+  it("decodes a Uint8Array as Right", () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    expect(uint8ArrayCodec.decode(bytes)).toEqual(Right(bytes));
+  });
+
+  it("decodes a non-Uint8Array value as Left", () => {
+    expect(uint8ArrayCodec.decode("not bytes")).toEqual(
+      Left("Expected a Uint8Array"),
+    );
+    expect(uint8ArrayCodec.decode([1, 2, 3])).toEqual(
+      Left("Expected a Uint8Array"),
+    );
+    expect(uint8ArrayCodec.decode(undefined)).toEqual(
+      Left("Expected a Uint8Array"),
+    );
+  });
+
+  it("encodes a Uint8Array as itself", () => {
+    const bytes = new Uint8Array([4, 5, 6]);
+    expect(uint8ArrayCodec.encode(bytes)).toBe(bytes);
+  });
+});

--- a/packages/signer/context-module/src/shared/utils/uint8ArrayCodec.ts
+++ b/packages/signer/context-module/src/shared/utils/uint8ArrayCodec.ts
@@ -1,0 +1,7 @@
+import { Codec, Left, Right } from "purify-ts";
+
+export const uint8ArrayCodec = Codec.custom<Uint8Array>({
+  decode: (value) =>
+    value instanceof Uint8Array ? Right(value) : Left("Expected a Uint8Array"),
+  encode: (value) => value,
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/task/BuildTransactionContextTask.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/BuildTransactionContextTask.test.ts
@@ -84,8 +84,7 @@ describe("BuildTransactionContextTask", () => {
     );
   });
 
-  // TODO-WEB3CHECK: flip this back once transaction-check is ready
-  it.skip("calls contextModule.getContexts with all Solana context types (including transaction-check)", async () => {
+  it("calls contextModule.getContexts with the active Solana context types (transaction-check temporarily disabled)", async () => {
     (contextModuleMock.getContexts as any).mockResolvedValue([
       trustedNameSuccessContext,
     ]);
@@ -107,7 +106,6 @@ describe("BuildTransactionContextTask", () => {
         ClearSignContextType.SOLANA_TOKEN,
         ClearSignContextType.SOLANA_LIFI,
         ClearSignContextType.SOLANA_TRUSTED_NAME,
-        ClearSignContextType.SOLANA_TRANSACTION_CHECK,
       ],
     );
   });
@@ -129,7 +127,7 @@ describe("BuildTransactionContextTask", () => {
       expect.objectContaining({
         transactionCheck: {
           from: "So1anaSignerPubKey111111111111111111111111111",
-          rawTx: expect.any(String),
+          transactionBytes: defaultArgs.transactionBytes,
           chain: SolanaTransactionScanChainId.MAINNET,
         },
       }),

--- a/packages/signer/signer-solana/src/internal/app-binder/task/BuildTransactionContextTask.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/BuildTransactionContextTask.ts
@@ -14,7 +14,6 @@ import {
 
 import { type TransactionResolutionContext } from "@api/model/TransactionResolutionContext";
 import { GetChallengeCommand } from "@internal/app-binder/command/GetChallengeCommand";
-import { DefaultBs58Encoder } from "@internal/app-binder/services/bs58Encoder";
 
 export type { SolanaTransactionContextResultSuccess as SolanaBuildContextResult };
 
@@ -52,7 +51,7 @@ export class BuildTransactionContextTask {
     const transactionCheck = this.args.signerAddress
       ? {
           from: this.args.signerAddress,
-          rawTx: DefaultBs58Encoder.encode(this.args.transactionBytes),
+          transactionBytes: this.args.transactionBytes,
           chain: SolanaTransactionScanChainId.MAINNET,
         }
       : undefined;

--- a/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/loadCertificate.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/loadCertificate.ts
@@ -17,6 +17,6 @@ export async function loadCertificate(
     }),
   );
   if (!isSuccessCommandResult(result)) {
-    throw new Error(errorMessage);
+    throw new Error(`${errorMessage} (keyUsage=${certificate.keyUsageNumber})`);
   }
 }

--- a/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideTransactionCheckContext.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideTransactionCheckContext.test.ts
@@ -79,7 +79,7 @@ describe("provideTransactionCheckContext", () => {
     };
 
     await expect(provideTransactionCheckContext(result, deps)).rejects.toThrow(
-      "Failed to send transaction-check certificate to device",
+      "Failed to send web3-check certificate to device",
     );
   });
 

--- a/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideTransactionCheckContext.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideTransactionCheckContext.ts
@@ -16,13 +16,13 @@ import { type ProvideContextHandler } from "./provideContextTypes";
 export const provideTransactionCheckContext: ProvideContextHandler<
   ClearSignContextType.SOLANA_TRANSACTION_CHECK
 > = async (result: SolanaTransactionCheckContextSuccess, { api, logger }) => {
-  const { payload, certificate } = result;
+  const { payload, certificate: web3CheckCertificate } = result;
 
-  if (certificate) {
+  if (web3CheckCertificate) {
     await loadCertificate(
       api,
-      certificate,
-      "[SignerSolana] provideTransactionCheckContext: Failed to send transaction-check certificate to device",
+      web3CheckCertificate,
+      "[SignerSolana] provideTransactionCheckContext: Failed to send web3-check certificate to device",
     );
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1411,6 +1411,9 @@ importers:
 
   packages/signer/context-module:
     dependencies:
+      bs58:
+        specifier: 'catalog:'
+        version: 6.0.0
       crypto-js:
         specifier: 'catalog:'
         version: 4.2.0


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fix Solana web3checks integration: the `/solana/scan/tx` endpoint was rejecting the requests because we were forwarding a serialised Message, while the endpoint expects a serialised Transaction (compact-u16 signature count + N×64 zero-filled signature placeholders + Message).

Before

`SignTransactionDAInput.transaction` is a serialised Solana Message. `BuildTransactionContextTask` was bs58-encoding those bytes as-is and passing them via `rawTx`, so the backend tried to parse the first 64 message bytes as a signature and failed.

After

- `SolanaTransactionCheckLoader` (context-module) now owns the Solana web3checks wire-format contract. It accepts `transactionBytes: Uint8Array` (the Message), wraps it into a serialised Transaction (compact-u16
sig count + zero-filled signature placeholders + Message), then bs58-encodes it. Supports both legacy and v0 versioned messages by detecting the version-prefix high bit.
- `BuildTransactionContextTask` (signer-solana) stays protocol-agnostic, it just hands over the Message bytes. No more `DefaultBs58Encoder` import, no wrapping helpers.
- Extracted a reusable `uint8ArrayCodec` to `context-module/src/shared/utils/uint8ArrayCodec.ts` so future loaders can validate `Uint8Array` payloads via purify-ts `Codec.interface`.
- `provideTransactionCheckContext.ts` destructure renamed to `web3CheckCertificate`, error message tightened to "web3-check certificate".
- `loadCertificate.ts` failure error now appends (`keyUsage=<n>`) so any future "Failed to send X certificate to device" trace tells you which key usage the device rejected.

Architectural win: this mirrors the existing `EthereumTransactionCheckLoader`, which already takes transaction: `Uint8Array` and owns its own hex encoding. Each chain's loader is the single source of truth for
its wire-format contract.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [NO-ISSUE]

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
