### PR TITLE
🐛 (device-management-kit) [DSDK-1153]: Fix out of memory prediction

### DIFF
--- a/.changeset/pink-jokes-wonder.md
+++ b/.changeset/pink-jokes-wonder.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Fix out of memory prediction

--- a/packages/device-management-kit/src/api/device-action/task/PredictOutOfMemoryTask.test.ts
+++ b/packages/device-management-kit/src/api/device-action/task/PredictOutOfMemoryTask.test.ts
@@ -44,7 +44,7 @@ describe("PredictOutOfMemoryTask", () => {
     const result = new PredictOutOfMemoryTask(apiMock, {
       installPlan: [
         { bytes: 1324 },
-        { bytes: 6559 },
+        { bytes: 6496 },
       ] as unknown as Application[],
     }).run();
 
@@ -76,8 +76,7 @@ describe("PredictOutOfMemoryTask", () => {
     const result = new PredictOutOfMemoryTask(apiMock, {
       installPlan: [
         { bytes: 1324 },
-        { bytes: 6559 },
-        { bytes: 1 },
+        { bytes: 6497 },
       ] as unknown as Application[],
     }).run();
 
@@ -87,7 +86,7 @@ describe("PredictOutOfMemoryTask", () => {
     });
   });
 
-  it("Success enough memory (recent Nano S, 2kB block size)", () => {
+  it("Success not enough memory with no remaining block (recent Nano S, 2kB block size)", () => {
     // GIVEN
     apiMock.getDeviceModel.mockReturnValueOnce({
       memorySize: 12 * 1024,
@@ -119,9 +118,9 @@ describe("PredictOutOfMemoryTask", () => {
     // 6x2kB blocks of total memory (12kB total)
     //  -3*2kB block for firmware (to fit 6kB)
     //  -3*2kB block for install plan (to fit 6kB)
-    //  = 0 blocks left, enough memory
+    //  = 0 blocks left, not enough memory
     expect(result).toStrictEqual({
-      outOfMemory: false,
+      outOfMemory: true,
     });
   });
 

--- a/packages/device-management-kit/src/api/device-action/task/PredictOutOfMemoryTask.ts
+++ b/packages/device-management-kit/src/api/device-action/task/PredictOutOfMemoryTask.ts
@@ -22,6 +22,8 @@ export type PredictOutOfMemoryTaskResult =
       error: UnknownDAError;
     };
 
+const RESERVED_BLOCKS = 1;
+
 export class PredictOutOfMemoryTask {
   private readonly deviceModel: TransportDeviceModel;
 
@@ -74,7 +76,8 @@ export class PredictOutOfMemoryTask {
 
     return {
       outOfMemory:
-        currentMemoryBlocksUsage + installPlanBlocksUsage > totalMemoryBlocks,
+        currentMemoryBlocksUsage + installPlanBlocksUsage >=
+        totalMemoryBlocks - RESERVED_BLOCKS,
     };
   }
 

--- a/packages/device-management-kit/src/api/device-model/data/StaticDeviceModelDataSource.test.ts
+++ b/packages/device-management-kit/src/api/device-model/data/StaticDeviceModelDataSource.test.ts
@@ -263,19 +263,19 @@ describe("StaticDeviceModelDataSource", () => {
         { firmwareVersion: "2.0.0-rc1", expectedBlockSize: 2 * 1024 },
       ],
       [DeviceModelId.NANO_SP]: [
-        { firmwareVersion: "1.0.0", expectedBlockSize: 32 },
+        { firmwareVersion: "1.0.0", expectedBlockSize: 512 },
       ],
       [DeviceModelId.NANO_X]: [
         { firmwareVersion: "1.0.0", expectedBlockSize: 4 * 1024 },
       ],
       [DeviceModelId.STAX]: [
-        { firmwareVersion: "1.0.0", expectedBlockSize: 32 },
+        { firmwareVersion: "1.0.0", expectedBlockSize: 512 },
       ],
       [DeviceModelId.FLEX]: [
-        { firmwareVersion: "1.0.0", expectedBlockSize: 32 },
+        { firmwareVersion: "1.0.0", expectedBlockSize: 512 },
       ],
       [DeviceModelId.APEX]: [
-        { firmwareVersion: "1.0.0", expectedBlockSize: 32 },
+        { firmwareVersion: "1.0.0", expectedBlockSize: 512 },
       ],
     };
 

--- a/packages/device-management-kit/src/api/device-model/data/StaticDeviceModelDataSource.ts
+++ b/packages/device-management-kit/src/api/device-model/data/StaticDeviceModelDataSource.ts
@@ -34,7 +34,7 @@ export class StaticDeviceModelDataSource implements DeviceModelDataSource {
       bootloaderUsbProductId: 0x0005,
       usbOnly: true,
       memorySize: 1533 * 1024,
-      getBlockSize: () => 32,
+      getBlockSize: () => 512,
       masks: [0x33100000],
     }),
     [DeviceModelId.NANO_X]: new TransportDeviceModel({
@@ -62,7 +62,7 @@ export class StaticDeviceModelDataSource implements DeviceModelDataSource {
       bootloaderUsbProductId: 0x0006,
       usbOnly: false,
       memorySize: 1533 * 1024,
-      getBlockSize: () => 32,
+      getBlockSize: () => 512,
       masks: [0x33200000],
       bluetoothSpec: [
         {
@@ -80,7 +80,7 @@ export class StaticDeviceModelDataSource implements DeviceModelDataSource {
       bootloaderUsbProductId: 0x0007,
       usbOnly: false,
       memorySize: 1533 * 1024,
-      getBlockSize: () => 32,
+      getBlockSize: () => 512,
       masks: [0x33300000],
       bluetoothSpec: [
         {
@@ -98,7 +98,7 @@ export class StaticDeviceModelDataSource implements DeviceModelDataSource {
       bootloaderUsbProductId: 0x0008,
       usbOnly: false,
       memorySize: 1533 * 1024,
-      getBlockSize: () => 32,
+      getBlockSize: () => 512,
       masks: [0x33400000],
       bluetoothSpec: [
         {


### PR DESCRIPTION
### 📝 Description

PredictOutOfMemoryTask does not reliably detect when the device is full.
Description in ticket: https://ledgerhq.atlassian.net/browse/DSDK-1153

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**:

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
