### PR TITLE
✨ (sample) [NO-ISSUE]: Add Blind Signing Reporter URL setting

### DIFF
--- a/apps/sample/src/components/SettingsView/ReporterUrlSetting.tsx
+++ b/apps/sample/src/components/SettingsView/ReporterUrlSetting.tsx
@@ -1,0 +1,46 @@
+import React, { useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Flex, Input } from "@ledgerhq/react-ui";
+
+import { InputLabel } from "@/components/InputLabel";
+import { selectReporterUrl } from "@/state/settings/selectors";
+import { setReporterUrl } from "@/state/settings/slice";
+
+import { ResetSettingCTA } from "./ResetSetting";
+import { SettingBox } from "./SettingBox";
+
+export const ReporterUrlSetting: React.FC = () => {
+  const reporterUrl = useSelector(selectReporterUrl);
+  const dispatch = useDispatch();
+
+  const setReporterUrlFn = useCallback(
+    (value: string) => {
+      dispatch(setReporterUrl({ reporterUrl: value }));
+    },
+    [dispatch],
+  );
+
+  const onValueChange = useCallback(
+    (value: string) => {
+      setReporterUrlFn(value);
+    },
+    [setReporterUrlFn],
+  );
+
+  return (
+    <SettingBox>
+      <Flex flex={1} flexDirection="column" alignItems="stretch">
+        <Input
+          renderLeft={<InputLabel>Blind Signing Reporter URL</InputLabel>}
+          value={reporterUrl}
+          onChange={onValueChange}
+          placeholder="https://blind-signing.api.ledger.com/ingest/v1"
+        />
+      </Flex>
+      <ResetSettingCTA
+        stateSelector={selectReporterUrl}
+        setStateAction={setReporterUrlFn}
+      />
+    </SettingBox>
+  );
+};

--- a/apps/sample/src/components/SettingsView/index.tsx
+++ b/apps/sample/src/components/SettingsView/index.tsx
@@ -15,6 +15,7 @@ import { MockServerToggleSetting } from "./MockServerToggleSetting";
 import { MockServerUrlSetting } from "./MockServerUrlSetting";
 import { OriginTokenSetting } from "./OriginTokenSetting";
 import { PollingIntervalSetting } from "./PollingIntervalSetting";
+import { ReporterUrlSetting } from "./ReporterUrlSetting";
 import { SectionTitle } from "./SectionTitle";
 import { SpeculosDeviceModelSetting } from "./SpeculosDeviceModelSetting";
 import { SpeculosToggleSetting } from "./SpeculosToggleSetting";
@@ -65,6 +66,11 @@ export const SettingsView: React.FC = () => {
         <SectionContainer>
           <SectionTitle>Web3Checks</SectionTitle>
           <Web3ChecksUrlSetting />
+        </SectionContainer>
+
+        <SectionContainer>
+          <SectionTitle>Blind Signing Reporter</SectionTitle>
+          <ReporterUrlSetting />
         </SectionContainer>
 
         <SectionContainer>

--- a/apps/sample/src/providers/SignerEthProvider/index.tsx
+++ b/apps/sample/src/providers/SignerEthProvider/index.tsx
@@ -24,6 +24,7 @@ import {
   selectDatasourceConfig,
   selectMetadataServiceConfig,
   selectOriginToken,
+  selectReporterConfig,
   selectWeb3ChecksConfig,
 } from "@/state/settings/selectors";
 
@@ -47,6 +48,7 @@ export const SignerEthProvider: React.FC<PropsWithChildren> = ({
   const calConfig = useSelector(selectCalConfig);
   const web3ChecksConfig = useSelector(selectWeb3ChecksConfig);
   const metadataServiceConfig = useSelector(selectMetadataServiceConfig);
+  const reporterConfig = useSelector(selectReporterConfig);
   const originToken = useSelector(selectOriginToken);
   const datasourceConfig = useSelector(selectDatasourceConfig);
 
@@ -64,6 +66,7 @@ export const SignerEthProvider: React.FC<PropsWithChildren> = ({
       .setCalConfig(calConfig)
       .setWeb3ChecksConfig(web3ChecksConfig)
       .setMetadataServiceConfig(metadataServiceConfig)
+      .setReporterConfig(reporterConfig)
       .setDatasourceConfig(datasourceConfig)
       .setAppSource("device-management-kit-playground")
       .setChain(ContextModuleChainID.Ethereum)
@@ -82,6 +85,7 @@ export const SignerEthProvider: React.FC<PropsWithChildren> = ({
     sessionId,
     web3ChecksConfig,
     metadataServiceConfig,
+    reporterConfig,
     originToken,
     datasourceConfig,
   ]);

--- a/apps/sample/src/state/settings/schema.ts
+++ b/apps/sample/src/state/settings/schema.ts
@@ -4,6 +4,7 @@ import {
   type ContextModuleCalMode,
   type ContextModuleDatasourceConfig,
   type ContextModuleMetadataServiceConfig,
+  type ContextModuleReporterConfig,
   type ContextModuleWeb3ChecksConfig,
 } from "@ledgerhq/context-module";
 import { DeviceModelId } from "@ledgerhq/device-management-kit";
@@ -48,6 +49,7 @@ export type SettingsState = {
   calConfig: ContextModuleCalConfig;
   web3ChecksConfig: ContextModuleWeb3ChecksConfig;
   metadataServiceConfig: ContextModuleMetadataServiceConfig;
+  reporterConfig: ContextModuleReporterConfig;
   originToken: string;
   datasourceConfig: ContextModuleDatasourceConfig;
 };
@@ -76,6 +78,9 @@ export const initialState: SettingsState = {
   },
   metadataServiceConfig: {
     url: "https://nft.api.live.ledger.com",
+  },
+  reporterConfig: {
+    url: "https://blind-signing.api.ledger.com/ingest/v1",
   },
   originToken: process.env.NEXT_PUBLIC_GATING_TOKEN || "origin-token",
   datasourceConfig: {

--- a/apps/sample/src/state/settings/selectors.ts
+++ b/apps/sample/src/state/settings/selectors.ts
@@ -75,6 +75,12 @@ export const selectMetadataServiceConfig = (state: RootState) =>
 export const selectMetadataServiceUrl = (state: RootState) =>
   state.settings.metadataServiceConfig.url;
 
+// Reporter selectors (blind signing tracking)
+export const selectReporterConfig = (state: RootState) =>
+  state.settings.reporterConfig;
+export const selectReporterUrl = (state: RootState) =>
+  state.settings.reporterConfig.url;
+
 // Datasource config selectors
 export const selectDatasourceConfig = (state: RootState) =>
   state.settings.datasourceConfig;

--- a/apps/sample/src/state/settings/slice.ts
+++ b/apps/sample/src/state/settings/slice.ts
@@ -107,6 +107,14 @@ export const settingsSlice = createSlice({
       };
     },
 
+    // Reporter config (blind signing tracking)
+    setReporterUrl: (state, action: PayloadAction<{ reporterUrl: string }>) => {
+      state.reporterConfig = {
+        ...state.reporterConfig,
+        url: action.payload.reporterUrl,
+      };
+    },
+
     // Datasource config
     setDatasourceProxy: (
       state,
@@ -141,6 +149,7 @@ export const {
   setOriginToken,
   setWeb3ChecksUrl,
   setMetadataServiceUrl,
+  setReporterUrl,
   setDatasourceProxy,
   hydrateSettings,
 } = settingsSlice.actions;


### PR DESCRIPTION
### 📝 Description

Adds a new **Blind Signing Reporter URL** setting in the sample app's settings page, allowing the user to override the URL used by the blind signing reporter (default: `https://blind-signing.api.ledger.com/ingest/v1`).

The setting follows the same pattern as the existing **Metadata Service URL** setting:

- New Redux state field `reporterConfig` (`apps/sample/src/state/settings/schema.ts`)
- New action `setReporterUrl` (`apps/sample/src/state/settings/slice.ts`)
- New selectors `selectReporterConfig` / `selectReporterUrl`
- New `ReporterUrlSetting` component with input + reset-to-default
- New `Blind Signing Reporter` section in `SettingsView`
- Wired into `ContextModuleBuilder.setReporterConfig(...)` in `SignerEthProvider`

Persistence is automatic since `loadPersistedSettings` already merges `{ ...initialState, ...parsed }`, so older persisted settings get the default for the new field without any migration.

### ❓ Context

- **JIRA or GitHub link**: NO-ISSUE
- **Feature**: Allow developers to point the sample app at a non-prod blind-signing reporter endpoint while testing.

### ✅ Checklist

- [ ] **Covered by automatic tests** — UI-only setting wired through existing tested builder method (`setReporterConfig`); no new business logic.
- [ ] **Changeset is provided** — Not needed: changes only affect `apps/sample/` (an app, not a published package). See CONTRIBUTING.md.
- [ ] **Documentation is up-to-date** — N/A, internal sample app setting.
- [ ] **Impact of the changes:**
  - Adds a new optional setting in the sample app's Settings page.
  - When unchanged, behavior is identical to before (uses the default reporter URL).
  - Only affects the Ethereum signer flow in the sample app (the only consumer of `ContextModuleBuilder` in `apps/sample/`).

Made with [Cursor](https://cursor.com)