### PR TITLE
✨ (solana-signer) [DSDK-1143]: Add clear sign commands

### DIFF
--- a/.changeset/public-cases-slide.md
+++ b/.changeset/public-cases-slide.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": minor
+---
+
+Add solana clear sign commands

--- a/packages/signer/signer-solana/src/internal/app-binder/command/DelayedSignTransactionCommand.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/DelayedSignTransactionCommand.ts
@@ -14,6 +14,7 @@ import { Just, Maybe, Nothing } from "purify-ts";
 import { type Signature } from "@api/model/Signature";
 import { UserInputType } from "@api/model/TransactionResolutionContext";
 
+import { buildChunkP2, P2_EXTEND, P2_MORE } from "./utils/apduChunking";
 import {
   SOLANA_APP_ERRORS,
   SolanaAppCommandErrorFactory,
@@ -26,8 +27,8 @@ export const P1 = 0x01;
 
 export const P2 = {
   INIT: 0x00,
-  EXTEND: 0x01,
-  MORE: 0x02,
+  EXTEND: P2_EXTEND,
+  MORE: P2_MORE,
   ATA: 0x08,
 };
 
@@ -63,9 +64,7 @@ export class DelayedSignTransactionCommand
 
   getApdu(): Apdu {
     const { more, extend, serializedTransaction, userInputType } = this.args;
-    let p2 = P2.INIT;
-    if (more) p2 |= P2.MORE;
-    if (extend) p2 |= P2.EXTEND;
+    let p2 = buildChunkP2(!extend, more);
     if (userInputType === UserInputType.ATA) {
       p2 |= P2.ATA;
     }

--- a/packages/signer/signer-solana/src/internal/app-binder/command/PromptUiDisplayCommand.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/PromptUiDisplayCommand.test.ts
@@ -1,0 +1,96 @@
+import {
+  ApduResponse,
+  CommandResultFactory,
+  InvalidStatusWordError,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { SolanaAppCommandError } from "./utils/SolanaApplicationErrors";
+import {
+  CLA,
+  INS,
+  P1,
+  P2,
+  PromptUiDisplayCommand,
+} from "./PromptUiDisplayCommand";
+
+describe("PromptUiDisplayCommand", () => {
+  const command = new PromptUiDisplayCommand();
+
+  describe("name", () => {
+    it("should be 'promptUiDisplay'", () => {
+      expect(command.name).toBe("promptUiDisplay");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("builds an empty-data APDU with CLA/INS/P1/P2 = 0xE0/0x0B/0x00/0x00", () => {
+      const apdu = command.getApdu();
+
+      expect(apdu.cla).toBe(CLA);
+      expect(apdu.ins).toBe(INS);
+      expect(apdu.p1).toBe(P1);
+      expect(apdu.p2).toBe(P2);
+      expect(apdu.data).toStrictEqual(new Uint8Array());
+      expect(apdu.getRawApdu()).toStrictEqual(
+        Uint8Array.from([0xe0, 0x0b, 0x00, 0x00, 0x00]),
+      );
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("returns success on 9000 (user approved)", () => {
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x90, 0x00]),
+          data: new Uint8Array(),
+        }),
+      );
+
+      expect(result).toStrictEqual(CommandResultFactory({ data: undefined }));
+    });
+
+    it("maps 6985 to a typed Solana app error (user-refused / session incomplete)", () => {
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x69, 0x85]),
+          data: new Uint8Array(),
+        }),
+      );
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      // @ts-expect-error narrowed by isSuccessCommandResult
+      expect(result.error).toBeInstanceOf(SolanaAppCommandError);
+      // @ts-expect-error narrowed by isSuccessCommandResult
+      expect(result.error.errorCode).toBe("6985");
+    });
+
+    it("maps 6A80 to a typed Solana app error (merge engine failure)", () => {
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x6a, 0x80]),
+          data: new Uint8Array(),
+        }),
+      );
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      // @ts-expect-error narrowed by isSuccessCommandResult
+      expect(result.error).toBeInstanceOf(SolanaAppCommandError);
+      // @ts-expect-error narrowed by isSuccessCommandResult
+      expect(result.error.errorCode).toBe("6a80");
+    });
+
+    it("rejects unexpected data on 9000", () => {
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x90, 0x00]),
+          data: Uint8Array.from([0x01]),
+        }),
+      );
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      // @ts-expect-error narrowed by isSuccessCommandResult
+      expect(result.error).toBeInstanceOf(InvalidStatusWordError);
+    });
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/command/PromptUiDisplayCommand.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/PromptUiDisplayCommand.ts
@@ -1,0 +1,55 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import {
+  SOLANA_APP_ERRORS,
+  SolanaAppCommandErrorFactory,
+  type SolanaAppErrorCodes,
+} from "./utils/SolanaApplicationErrors";
+
+export const CLA = 0xe0;
+export const INS = 0x0b;
+export const P1 = 0x00;
+export const P2 = 0x00;
+
+/**
+ * Triggers the review UI on the device. Sends an empty payload and returns no
+ * data; non-success status words are surfaced as errors.
+ */
+export class PromptUiDisplayCommand
+  implements Command<void, void, SolanaAppErrorCodes>
+{
+  readonly name = "promptUiDisplay";
+  private readonly errorHelper = new CommandErrorHelper<
+    void,
+    SolanaAppErrorCodes
+  >(SOLANA_APP_ERRORS, SolanaAppCommandErrorFactory);
+
+  getApdu(): Apdu {
+    return new ApduBuilder({ cla: CLA, ins: INS, p1: P1, p2: P2 }).build();
+  }
+
+  parseResponse(
+    response: ApduResponse,
+  ): CommandResult<void, SolanaAppErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(response),
+    ).orDefaultLazy(() => {
+      if (response.data.length !== 0) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Unexpected data in response"),
+        });
+      }
+      return CommandResultFactory({ data: undefined });
+    });
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/command/ProvideAltResolutionCommand.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/ProvideAltResolutionCommand.test.ts
@@ -5,42 +5,38 @@ import {
 
 import { P2_EXTEND, P2_MORE } from "./utils/apduChunking";
 import { ChunkTooLargeError } from "./utils/Errors";
-import { ProvideTLVDescriptorCommand } from "./ProvideTLVDescriptorCommand";
+import { ProvideAltResolutionCommand } from "./ProvideAltResolutionCommand";
 
-const LEGACY_EXPECTED_APDU = Uint8Array.from([
-  0xe0, 0x21, 0x00, 0x00, 0x04, 0xde, 0xad, 0xbe, 0xef,
-]);
-
-describe("ProvideTLVDescriptorCommand", () => {
+describe("ProvideAltResolutionCommand", () => {
   const payload = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
 
   describe("name", () => {
-    it("should be 'provideTLVDescriptor'", () => {
-      const command = new ProvideTLVDescriptorCommand({
+    it("should be 'provideAltResolution'", () => {
+      const command = new ProvideAltResolutionCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
       });
-      expect(command.name).toBe("provideTLVDescriptor");
+      expect(command.name).toBe("provideAltResolution");
     });
   });
 
   describe("getApdu", () => {
-    it("uses CLA=0xE0, INS=0x21, P1=0x00 and carries the payload", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+    it("uses CLA=0xE0, INS=0x28, P1=0x00 and carries the payload", () => {
+      const apdu = new ProvideAltResolutionCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
       }).getApdu();
 
       expect(apdu.cla).toBe(0xe0);
-      expect(apdu.ins).toBe(0x21);
+      expect(apdu.ins).toBe(0x28);
       expect(apdu.p1).toBe(0x00);
       expect(apdu.data).toStrictEqual(payload);
     });
 
     it("single chunk: P2 = 0x00 (no EXTEND, no MORE)", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideAltResolutionCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
@@ -50,7 +46,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("first of many: P2 = P2_MORE", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideAltResolutionCommand({
         payload,
         isFirstChunk: true,
         hasMore: true,
@@ -60,7 +56,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("middle chunk: P2 = P2_MORE | P2_EXTEND", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideAltResolutionCommand({
         payload,
         isFirstChunk: false,
         hasMore: true,
@@ -70,7 +66,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("last chunk: P2 = P2_EXTEND", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideAltResolutionCommand({
         payload,
         isFirstChunk: false,
         hasMore: false,
@@ -80,19 +76,13 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("defaults the chunking flags to a single-chunk send (P2 = 0x00)", () => {
-      const apdu = new ProvideTLVDescriptorCommand({ payload }).getApdu();
+      const apdu = new ProvideAltResolutionCommand({ payload }).getApdu();
 
       expect(apdu.p2).toBe(0x00);
     });
 
-    it("produces the same APDU bytes as the pre-chunking implementation when called without flags", () => {
-      const apdu = new ProvideTLVDescriptorCommand({ payload }).getApdu();
-
-      expect(apdu.getRawApdu()).toStrictEqual(LEGACY_EXPECTED_APDU);
-    });
-
     it("throws ChunkTooLargeError if the chunk exceeds APDU_MAX_PAYLOAD", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideAltResolutionCommand({
         payload: new Uint8Array(256),
         isFirstChunk: true,
         hasMore: false,
@@ -104,7 +94,7 @@ describe("ProvideTLVDescriptorCommand", () => {
 
   describe("parseResponse", () => {
     it("should return success on 0x9000 with empty payload", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideAltResolutionCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
@@ -120,7 +110,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("should return error on unexpected response data", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideAltResolutionCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
@@ -136,7 +126,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("should return error on non-success status", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideAltResolutionCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,

--- a/packages/signer/signer-solana/src/internal/app-binder/command/ProvideAltResolutionCommand.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/ProvideAltResolutionCommand.ts
@@ -19,9 +19,9 @@ import {
 
 const CLA = 0xe0;
 const P1 = 0x00;
-export const INS = 0x21;
+export const INS = 0x28;
 
-export type ProvideTLVDescriptorCommandArgs = {
+export type ProvideAltResolutionCommandArgs = {
   readonly payload: Uint8Array;
   /**
    * Chunking flags following the standard Solana P2_MORE / P2_EXTEND
@@ -33,23 +33,23 @@ export type ProvideTLVDescriptorCommandArgs = {
 };
 
 /**
- * Provides one signed TLV descriptor to the device.
+ * Provides one signed `ALT_RESOLUTION` TLV carrying
+ * `(altAddress, entryIndex, resolvedAddress)`. The caller must issue
+ * `GET CHALLENGE` immediately before this command.
  *
- * The chunking flags `isFirstChunk` / `hasMore` are optional and default to a
- * single-chunk send (P2 = 0x00) so existing single-chunk callers stay
- * byte-compatible. Pass them explicitly when a payload needs more than one
- * APDU.
+ * The caller pre-builds the wire payload (2-byte BE length prefix followed
+ * by the `ALT_RESOLUTION` TLV) and splits it into ≤255-byte chunks.
  */
-export class ProvideTLVDescriptorCommand
-  implements Command<void, ProvideTLVDescriptorCommandArgs, SolanaAppErrorCodes>
+export class ProvideAltResolutionCommand
+  implements Command<void, ProvideAltResolutionCommandArgs, SolanaAppErrorCodes>
 {
-  readonly name = "provideTLVDescriptor";
+  readonly name = "provideAltResolution";
   private readonly errorHelper = new CommandErrorHelper<
     void,
     SolanaAppErrorCodes
   >(SOLANA_APP_ERRORS, SolanaAppCommandErrorFactory);
 
-  constructor(readonly args: ProvideTLVDescriptorCommandArgs) {}
+  constructor(readonly args: ProvideAltResolutionCommandArgs) {}
 
   getApdu(): Apdu {
     const { payload, isFirstChunk = true, hasMore = false } = this.args;

--- a/packages/signer/signer-solana/src/internal/app-binder/command/ProvideEnumVariantCommand.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/ProvideEnumVariantCommand.test.ts
@@ -5,42 +5,38 @@ import {
 
 import { P2_EXTEND, P2_MORE } from "./utils/apduChunking";
 import { ChunkTooLargeError } from "./utils/Errors";
-import { ProvideTLVDescriptorCommand } from "./ProvideTLVDescriptorCommand";
+import { ProvideEnumVariantCommand } from "./ProvideEnumVariantCommand";
 
-const LEGACY_EXPECTED_APDU = Uint8Array.from([
-  0xe0, 0x21, 0x00, 0x00, 0x04, 0xde, 0xad, 0xbe, 0xef,
-]);
-
-describe("ProvideTLVDescriptorCommand", () => {
+describe("ProvideEnumVariantCommand", () => {
   const payload = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
 
   describe("name", () => {
-    it("should be 'provideTLVDescriptor'", () => {
-      const command = new ProvideTLVDescriptorCommand({
+    it("should be 'provideEnumVariant'", () => {
+      const command = new ProvideEnumVariantCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
       });
-      expect(command.name).toBe("provideTLVDescriptor");
+      expect(command.name).toBe("provideEnumVariant");
     });
   });
 
   describe("getApdu", () => {
-    it("uses CLA=0xE0, INS=0x21, P1=0x00 and carries the payload", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+    it("uses CLA=0xE0, INS=0x26, P1=0x00 and carries the payload", () => {
+      const apdu = new ProvideEnumVariantCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
       }).getApdu();
 
       expect(apdu.cla).toBe(0xe0);
-      expect(apdu.ins).toBe(0x21);
+      expect(apdu.ins).toBe(0x26);
       expect(apdu.p1).toBe(0x00);
       expect(apdu.data).toStrictEqual(payload);
     });
 
     it("single chunk: P2 = 0x00 (no EXTEND, no MORE)", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideEnumVariantCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
@@ -50,7 +46,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("first of many: P2 = P2_MORE", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideEnumVariantCommand({
         payload,
         isFirstChunk: true,
         hasMore: true,
@@ -60,7 +56,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("middle chunk: P2 = P2_MORE | P2_EXTEND", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideEnumVariantCommand({
         payload,
         isFirstChunk: false,
         hasMore: true,
@@ -70,7 +66,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("last chunk: P2 = P2_EXTEND", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideEnumVariantCommand({
         payload,
         isFirstChunk: false,
         hasMore: false,
@@ -80,19 +76,13 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("defaults the chunking flags to a single-chunk send (P2 = 0x00)", () => {
-      const apdu = new ProvideTLVDescriptorCommand({ payload }).getApdu();
+      const apdu = new ProvideEnumVariantCommand({ payload }).getApdu();
 
       expect(apdu.p2).toBe(0x00);
     });
 
-    it("produces the same APDU bytes as the pre-chunking implementation when called without flags", () => {
-      const apdu = new ProvideTLVDescriptorCommand({ payload }).getApdu();
-
-      expect(apdu.getRawApdu()).toStrictEqual(LEGACY_EXPECTED_APDU);
-    });
-
     it("throws ChunkTooLargeError if the chunk exceeds APDU_MAX_PAYLOAD", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideEnumVariantCommand({
         payload: new Uint8Array(256),
         isFirstChunk: true,
         hasMore: false,
@@ -104,7 +94,7 @@ describe("ProvideTLVDescriptorCommand", () => {
 
   describe("parseResponse", () => {
     it("should return success on 0x9000 with empty payload", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideEnumVariantCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
@@ -120,7 +110,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("should return error on unexpected response data", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideEnumVariantCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
@@ -136,7 +126,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("should return error on non-success status", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideEnumVariantCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,

--- a/packages/signer/signer-solana/src/internal/app-binder/command/ProvideEnumVariantCommand.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/ProvideEnumVariantCommand.ts
@@ -19,9 +19,9 @@ import {
 
 const CLA = 0xe0;
 const P1 = 0x00;
-export const INS = 0x21;
+export const INS = 0x26;
 
-export type ProvideTLVDescriptorCommandArgs = {
+export type ProvideEnumVariantCommandArgs = {
   readonly payload: Uint8Array;
   /**
    * Chunking flags following the standard Solana P2_MORE / P2_EXTEND
@@ -33,23 +33,22 @@ export type ProvideTLVDescriptorCommandArgs = {
 };
 
 /**
- * Provides one signed TLV descriptor to the device.
+ * Provides one signed `ENUM_VARIANT` TLV for a specific
+ * `(PROGRAM_ID, ENUM_ID, VARIANT_INDEX)` triple.
  *
- * The chunking flags `isFirstChunk` / `hasMore` are optional and default to a
- * single-chunk send (P2 = 0x00) so existing single-chunk callers stay
- * byte-compatible. Pass them explicitly when a payload needs more than one
- * APDU.
+ * The caller pre-builds the wire payload (2-byte BE length prefix followed
+ * by the `ENUM_VARIANT` TLV) and splits it into ≤255-byte chunks.
  */
-export class ProvideTLVDescriptorCommand
-  implements Command<void, ProvideTLVDescriptorCommandArgs, SolanaAppErrorCodes>
+export class ProvideEnumVariantCommand
+  implements Command<void, ProvideEnumVariantCommandArgs, SolanaAppErrorCodes>
 {
-  readonly name = "provideTLVDescriptor";
+  readonly name = "provideEnumVariant";
   private readonly errorHelper = new CommandErrorHelper<
     void,
     SolanaAppErrorCodes
   >(SOLANA_APP_ERRORS, SolanaAppCommandErrorFactory);
 
-  constructor(readonly args: ProvideTLVDescriptorCommandArgs) {}
+  constructor(readonly args: ProvideEnumVariantCommandArgs) {}
 
   getApdu(): Apdu {
     const { payload, isFirstChunk = true, hasMore = false } = this.args;

--- a/packages/signer/signer-solana/src/internal/app-binder/command/ProvideInstructionInfoCommand.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/ProvideInstructionInfoCommand.test.ts
@@ -5,42 +5,38 @@ import {
 
 import { P2_EXTEND, P2_MORE } from "./utils/apduChunking";
 import { ChunkTooLargeError } from "./utils/Errors";
-import { ProvideTLVDescriptorCommand } from "./ProvideTLVDescriptorCommand";
+import { ProvideInstructionInfoCommand } from "./ProvideInstructionInfoCommand";
 
-const LEGACY_EXPECTED_APDU = Uint8Array.from([
-  0xe0, 0x21, 0x00, 0x00, 0x04, 0xde, 0xad, 0xbe, 0xef,
-]);
-
-describe("ProvideTLVDescriptorCommand", () => {
+describe("ProvideInstructionInfoCommand", () => {
   const payload = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
 
   describe("name", () => {
-    it("should be 'provideTLVDescriptor'", () => {
-      const command = new ProvideTLVDescriptorCommand({
+    it("should be 'provideInstructionInfo'", () => {
+      const command = new ProvideInstructionInfoCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
       });
-      expect(command.name).toBe("provideTLVDescriptor");
+      expect(command.name).toBe("provideInstructionInfo");
     });
   });
 
   describe("getApdu", () => {
-    it("uses CLA=0xE0, INS=0x21, P1=0x00 and carries the payload", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+    it("uses CLA=0xE0, INS=0x24, P1=0x00 and carries the payload", () => {
+      const apdu = new ProvideInstructionInfoCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
       }).getApdu();
 
       expect(apdu.cla).toBe(0xe0);
-      expect(apdu.ins).toBe(0x21);
+      expect(apdu.ins).toBe(0x24);
       expect(apdu.p1).toBe(0x00);
       expect(apdu.data).toStrictEqual(payload);
     });
 
     it("single chunk: P2 = 0x00 (no EXTEND, no MORE)", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideInstructionInfoCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
@@ -50,7 +46,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("first of many: P2 = P2_MORE", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideInstructionInfoCommand({
         payload,
         isFirstChunk: true,
         hasMore: true,
@@ -60,7 +56,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("middle chunk: P2 = P2_MORE | P2_EXTEND", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideInstructionInfoCommand({
         payload,
         isFirstChunk: false,
         hasMore: true,
@@ -70,7 +66,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("last chunk: P2 = P2_EXTEND", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideInstructionInfoCommand({
         payload,
         isFirstChunk: false,
         hasMore: false,
@@ -80,19 +76,13 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("defaults the chunking flags to a single-chunk send (P2 = 0x00)", () => {
-      const apdu = new ProvideTLVDescriptorCommand({ payload }).getApdu();
+      const apdu = new ProvideInstructionInfoCommand({ payload }).getApdu();
 
       expect(apdu.p2).toBe(0x00);
     });
 
-    it("produces the same APDU bytes as the pre-chunking implementation when called without flags", () => {
-      const apdu = new ProvideTLVDescriptorCommand({ payload }).getApdu();
-
-      expect(apdu.getRawApdu()).toStrictEqual(LEGACY_EXPECTED_APDU);
-    });
-
     it("throws ChunkTooLargeError if the chunk exceeds APDU_MAX_PAYLOAD", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideInstructionInfoCommand({
         payload: new Uint8Array(256),
         isFirstChunk: true,
         hasMore: false,
@@ -104,7 +94,7 @@ describe("ProvideTLVDescriptorCommand", () => {
 
   describe("parseResponse", () => {
     it("should return success on 0x9000 with empty payload", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideInstructionInfoCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
@@ -120,7 +110,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("should return error on unexpected response data", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideInstructionInfoCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
@@ -136,7 +126,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("should return error on non-success status", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideInstructionInfoCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,

--- a/packages/signer/signer-solana/src/internal/app-binder/command/ProvideInstructionInfoCommand.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/ProvideInstructionInfoCommand.ts
@@ -19,9 +19,9 @@ import {
 
 const CLA = 0xe0;
 const P1 = 0x00;
-export const INS = 0x21;
+export const INS = 0x24;
 
-export type ProvideTLVDescriptorCommandArgs = {
+export type ProvideInstructionInfoCommandArgs = {
   readonly payload: Uint8Array;
   /**
    * Chunking flags following the standard Solana P2_MORE / P2_EXTEND
@@ -33,23 +33,24 @@ export type ProvideTLVDescriptorCommandArgs = {
 };
 
 /**
- * Provides one signed TLV descriptor to the device.
+ * Provides one signed `INSTRUCTION_INFO` TLV to the device.
  *
- * The chunking flags `isFirstChunk` / `hasMore` are optional and default to a
- * single-chunk send (P2 = 0x00) so existing single-chunk callers stay
- * byte-compatible. Pass them explicitly when a payload needs more than one
- * APDU.
+ * The caller pre-builds the wire payload (2-byte BE length prefix followed by
+ * the `INSTRUCTION_INFO` TLV) and splits it into ≤255-byte chunks, then sends
+ * each chunk through this command with `isFirstChunk` / `hasMore` flags driving
+ * the standard `P2_MORE` / `P2_EXTEND` chunking convention.
  */
-export class ProvideTLVDescriptorCommand
-  implements Command<void, ProvideTLVDescriptorCommandArgs, SolanaAppErrorCodes>
+export class ProvideInstructionInfoCommand
+  implements
+    Command<void, ProvideInstructionInfoCommandArgs, SolanaAppErrorCodes>
 {
-  readonly name = "provideTLVDescriptor";
+  readonly name = "provideInstructionInfo";
   private readonly errorHelper = new CommandErrorHelper<
     void,
     SolanaAppErrorCodes
   >(SOLANA_APP_ERRORS, SolanaAppCommandErrorFactory);
 
-  constructor(readonly args: ProvideTLVDescriptorCommandArgs) {}
+  constructor(readonly args: ProvideInstructionInfoCommandArgs) {}
 
   getApdu(): Apdu {
     const { payload, isFirstChunk = true, hasMore = false } = this.args;

--- a/packages/signer/signer-solana/src/internal/app-binder/command/ProvideInstructionSubstructureCommand.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/ProvideInstructionSubstructureCommand.test.ts
@@ -5,42 +5,50 @@ import {
 
 import { P2_EXTEND, P2_MORE } from "./utils/apduChunking";
 import { ChunkTooLargeError } from "./utils/Errors";
-import { ProvideTLVDescriptorCommand } from "./ProvideTLVDescriptorCommand";
+import {
+  ProvideInstructionSubstructureCommand,
+  SubstructureType,
+} from "./ProvideInstructionSubstructureCommand";
 
-const LEGACY_EXPECTED_APDU = Uint8Array.from([
-  0xe0, 0x21, 0x00, 0x00, 0x04, 0xde, 0xad, 0xbe, 0xef,
-]);
-
-describe("ProvideTLVDescriptorCommand", () => {
+describe("ProvideInstructionSubstructureCommand", () => {
   const payload = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
 
+  describe("SubstructureType", () => {
+    it("matches the spec's first-data-byte selector values", () => {
+      expect(SubstructureType.DisplayField).toBe(0x00);
+      expect(SubstructureType.ValueFlowPort).toBe(0x01);
+      expect(SubstructureType.HideRule).toBe(0x02);
+      expect(SubstructureType.AccountReset).toBe(0x03);
+    });
+  });
+
   describe("name", () => {
-    it("should be 'provideTLVDescriptor'", () => {
-      const command = new ProvideTLVDescriptorCommand({
+    it("should be 'provideInstructionSubstructure'", () => {
+      const command = new ProvideInstructionSubstructureCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
       });
-      expect(command.name).toBe("provideTLVDescriptor");
+      expect(command.name).toBe("provideInstructionSubstructure");
     });
   });
 
   describe("getApdu", () => {
-    it("uses CLA=0xE0, INS=0x21, P1=0x00 and carries the payload", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+    it("uses CLA=0xE0, INS=0x25, P1=0x00 and carries the payload", () => {
+      const apdu = new ProvideInstructionSubstructureCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
       }).getApdu();
 
       expect(apdu.cla).toBe(0xe0);
-      expect(apdu.ins).toBe(0x21);
+      expect(apdu.ins).toBe(0x25);
       expect(apdu.p1).toBe(0x00);
       expect(apdu.data).toStrictEqual(payload);
     });
 
     it("single chunk: P2 = 0x00 (no EXTEND, no MORE)", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideInstructionSubstructureCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
@@ -50,7 +58,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("first of many: P2 = P2_MORE", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideInstructionSubstructureCommand({
         payload,
         isFirstChunk: true,
         hasMore: true,
@@ -60,7 +68,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("middle chunk: P2 = P2_MORE | P2_EXTEND", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideInstructionSubstructureCommand({
         payload,
         isFirstChunk: false,
         hasMore: true,
@@ -70,7 +78,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("last chunk: P2 = P2_EXTEND", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideInstructionSubstructureCommand({
         payload,
         isFirstChunk: false,
         hasMore: false,
@@ -80,19 +88,15 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("defaults the chunking flags to a single-chunk send (P2 = 0x00)", () => {
-      const apdu = new ProvideTLVDescriptorCommand({ payload }).getApdu();
+      const apdu = new ProvideInstructionSubstructureCommand({
+        payload,
+      }).getApdu();
 
       expect(apdu.p2).toBe(0x00);
     });
 
-    it("produces the same APDU bytes as the pre-chunking implementation when called without flags", () => {
-      const apdu = new ProvideTLVDescriptorCommand({ payload }).getApdu();
-
-      expect(apdu.getRawApdu()).toStrictEqual(LEGACY_EXPECTED_APDU);
-    });
-
     it("throws ChunkTooLargeError if the chunk exceeds APDU_MAX_PAYLOAD", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideInstructionSubstructureCommand({
         payload: new Uint8Array(256),
         isFirstChunk: true,
         hasMore: false,
@@ -104,7 +108,7 @@ describe("ProvideTLVDescriptorCommand", () => {
 
   describe("parseResponse", () => {
     it("should return success on 0x9000 with empty payload", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideInstructionSubstructureCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
@@ -120,7 +124,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("should return error on unexpected response data", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideInstructionSubstructureCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
@@ -136,7 +140,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("should return error on non-success status", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideInstructionSubstructureCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,

--- a/packages/signer/signer-solana/src/internal/app-binder/command/ProvideInstructionSubstructureCommand.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/ProvideInstructionSubstructureCommand.ts
@@ -19,9 +19,20 @@ import {
 
 const CLA = 0xe0;
 const P1 = 0x00;
-export const INS = 0x21;
+export const INS = 0x25;
 
-export type ProvideTLVDescriptorCommandArgs = {
+/**
+ * Substructure-type selector byte. The caller prepends it as the first byte
+ * of the first chunk's payload.
+ */
+export enum SubstructureType {
+  DisplayField = 0x00,
+  ValueFlowPort = 0x01,
+  HideRule = 0x02,
+  AccountReset = 0x03,
+}
+
+export type ProvideInstructionSubstructureCommandArgs = {
   readonly payload: Uint8Array;
   /**
    * Chunking flags following the standard Solana P2_MORE / P2_EXTEND
@@ -33,23 +44,28 @@ export type ProvideTLVDescriptorCommandArgs = {
 };
 
 /**
- * Provides one signed TLV descriptor to the device.
+ * Provides one substructure TLV (DISPLAY_FIELD / VALUE_FLOW_PORT /
+ * HIDE_RULE / ACCOUNT_RESET) referenced by the current `INSTRUCTION_INFO`.
  *
- * The chunking flags `isFirstChunk` / `hasMore` are optional and default to a
- * single-chunk send (P2 = 0x00) so existing single-chunk callers stay
- * byte-compatible. Pass them explicitly when a payload needs more than one
- * APDU.
+ * The caller pre-builds the wire payload — 2-byte BE length prefix, 1-byte
+ * substructure-type selector, then the substructure TLV — and splits it into
+ * ≤255-byte chunks.
  */
-export class ProvideTLVDescriptorCommand
-  implements Command<void, ProvideTLVDescriptorCommandArgs, SolanaAppErrorCodes>
+export class ProvideInstructionSubstructureCommand
+  implements
+    Command<
+      void,
+      ProvideInstructionSubstructureCommandArgs,
+      SolanaAppErrorCodes
+    >
 {
-  readonly name = "provideTLVDescriptor";
+  readonly name = "provideInstructionSubstructure";
   private readonly errorHelper = new CommandErrorHelper<
     void,
     SolanaAppErrorCodes
   >(SOLANA_APP_ERRORS, SolanaAppCommandErrorFactory);
 
-  constructor(readonly args: ProvideTLVDescriptorCommandArgs) {}
+  constructor(readonly args: ProvideInstructionSubstructureCommandArgs) {}
 
   getApdu(): Apdu {
     const { payload, isFirstChunk = true, hasMore = false } = this.args;

--- a/packages/signer/signer-solana/src/internal/app-binder/command/ProvideTokenAccountStateCommand.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/ProvideTokenAccountStateCommand.test.ts
@@ -5,42 +5,38 @@ import {
 
 import { P2_EXTEND, P2_MORE } from "./utils/apduChunking";
 import { ChunkTooLargeError } from "./utils/Errors";
-import { ProvideTLVDescriptorCommand } from "./ProvideTLVDescriptorCommand";
+import { ProvideTokenAccountStateCommand } from "./ProvideTokenAccountStateCommand";
 
-const LEGACY_EXPECTED_APDU = Uint8Array.from([
-  0xe0, 0x21, 0x00, 0x00, 0x04, 0xde, 0xad, 0xbe, 0xef,
-]);
-
-describe("ProvideTLVDescriptorCommand", () => {
+describe("ProvideTokenAccountStateCommand", () => {
   const payload = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
 
   describe("name", () => {
-    it("should be 'provideTLVDescriptor'", () => {
-      const command = new ProvideTLVDescriptorCommand({
+    it("should be 'provideTokenAccountState'", () => {
+      const command = new ProvideTokenAccountStateCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
       });
-      expect(command.name).toBe("provideTLVDescriptor");
+      expect(command.name).toBe("provideTokenAccountState");
     });
   });
 
   describe("getApdu", () => {
-    it("uses CLA=0xE0, INS=0x21, P1=0x00 and carries the payload", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+    it("uses CLA=0xE0, INS=0x27, P1=0x00 and carries the payload", () => {
+      const apdu = new ProvideTokenAccountStateCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
       }).getApdu();
 
       expect(apdu.cla).toBe(0xe0);
-      expect(apdu.ins).toBe(0x21);
+      expect(apdu.ins).toBe(0x27);
       expect(apdu.p1).toBe(0x00);
       expect(apdu.data).toStrictEqual(payload);
     });
 
     it("single chunk: P2 = 0x00 (no EXTEND, no MORE)", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideTokenAccountStateCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
@@ -50,7 +46,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("first of many: P2 = P2_MORE", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideTokenAccountStateCommand({
         payload,
         isFirstChunk: true,
         hasMore: true,
@@ -60,7 +56,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("middle chunk: P2 = P2_MORE | P2_EXTEND", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideTokenAccountStateCommand({
         payload,
         isFirstChunk: false,
         hasMore: true,
@@ -70,7 +66,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("last chunk: P2 = P2_EXTEND", () => {
-      const apdu = new ProvideTLVDescriptorCommand({
+      const apdu = new ProvideTokenAccountStateCommand({
         payload,
         isFirstChunk: false,
         hasMore: false,
@@ -80,19 +76,13 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("defaults the chunking flags to a single-chunk send (P2 = 0x00)", () => {
-      const apdu = new ProvideTLVDescriptorCommand({ payload }).getApdu();
+      const apdu = new ProvideTokenAccountStateCommand({ payload }).getApdu();
 
       expect(apdu.p2).toBe(0x00);
     });
 
-    it("produces the same APDU bytes as the pre-chunking implementation when called without flags", () => {
-      const apdu = new ProvideTLVDescriptorCommand({ payload }).getApdu();
-
-      expect(apdu.getRawApdu()).toStrictEqual(LEGACY_EXPECTED_APDU);
-    });
-
     it("throws ChunkTooLargeError if the chunk exceeds APDU_MAX_PAYLOAD", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideTokenAccountStateCommand({
         payload: new Uint8Array(256),
         isFirstChunk: true,
         hasMore: false,
@@ -104,7 +94,7 @@ describe("ProvideTLVDescriptorCommand", () => {
 
   describe("parseResponse", () => {
     it("should return success on 0x9000 with empty payload", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideTokenAccountStateCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
@@ -120,7 +110,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("should return error on unexpected response data", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideTokenAccountStateCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,
@@ -136,7 +126,7 @@ describe("ProvideTLVDescriptorCommand", () => {
     });
 
     it("should return error on non-success status", () => {
-      const command = new ProvideTLVDescriptorCommand({
+      const command = new ProvideTokenAccountStateCommand({
         payload,
         isFirstChunk: true,
         hasMore: false,

--- a/packages/signer/signer-solana/src/internal/app-binder/command/ProvideTokenAccountStateCommand.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/ProvideTokenAccountStateCommand.ts
@@ -19,9 +19,9 @@ import {
 
 const CLA = 0xe0;
 const P1 = 0x00;
-export const INS = 0x21;
+export const INS = 0x27;
 
-export type ProvideTLVDescriptorCommandArgs = {
+export type ProvideTokenAccountStateCommandArgs = {
   readonly payload: Uint8Array;
   /**
    * Chunking flags following the standard Solana P2_MORE / P2_EXTEND
@@ -33,23 +33,24 @@ export type ProvideTLVDescriptorCommandArgs = {
 };
 
 /**
- * Provides one signed TLV descriptor to the device.
+ * Provides one signed `TOKEN_ACCOUNT_STATE` TLV carrying
+ * `(account, mint, owner, preBalance)`. The caller must issue `GET CHALLENGE`
+ * immediately before this command.
  *
- * The chunking flags `isFirstChunk` / `hasMore` are optional and default to a
- * single-chunk send (P2 = 0x00) so existing single-chunk callers stay
- * byte-compatible. Pass them explicitly when a payload needs more than one
- * APDU.
+ * The caller pre-builds the wire payload (2-byte BE length prefix followed
+ * by the `TOKEN_ACCOUNT_STATE` TLV) and splits it into ≤255-byte chunks.
  */
-export class ProvideTLVDescriptorCommand
-  implements Command<void, ProvideTLVDescriptorCommandArgs, SolanaAppErrorCodes>
+export class ProvideTokenAccountStateCommand
+  implements
+    Command<void, ProvideTokenAccountStateCommandArgs, SolanaAppErrorCodes>
 {
-  readonly name = "provideTLVDescriptor";
+  readonly name = "provideTokenAccountState";
   private readonly errorHelper = new CommandErrorHelper<
     void,
     SolanaAppErrorCodes
   >(SOLANA_APP_ERRORS, SolanaAppCommandErrorFactory);
 
-  constructor(readonly args: ProvideTLVDescriptorCommandArgs) {}
+  constructor(readonly args: ProvideTokenAccountStateCommandArgs) {}
 
   getApdu(): Apdu {
     const { payload, isFirstChunk = true, hasMore = false } = this.args;

--- a/packages/signer/signer-solana/src/internal/app-binder/command/ProvideWeb3CheckCommand.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/ProvideWeb3CheckCommand.test.ts
@@ -1,13 +1,15 @@
 import { isSuccessCommandResult } from "@ledgerhq/device-management-kit";
 
 import {
-  P2_EXTEND,
-  P2_MORE,
   ProvideWeb3CheckCommand,
   TRANSACTION_CHECK_CLA,
   TRANSACTION_CHECK_INS,
   TRANSACTION_CHECK_P1_PROVIDE,
 } from "@internal/app-binder/command/ProvideWeb3CheckCommand";
+import {
+  P2_EXTEND,
+  P2_MORE,
+} from "@internal/app-binder/command/utils/apduChunking";
 
 describe("ProvideWeb3CheckCommand", () => {
   describe("name", () => {

--- a/packages/signer/signer-solana/src/internal/app-binder/command/ProvideWeb3CheckCommand.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/ProvideWeb3CheckCommand.ts
@@ -10,6 +10,7 @@ import {
 import { CommandErrorHelper } from "@ledgerhq/signer-utils";
 import { Maybe } from "purify-ts";
 
+import { buildChunkP2 } from "./utils/apduChunking";
 import {
   SOLANA_APP_ERRORS,
   SolanaAppCommandErrorFactory,
@@ -19,8 +20,6 @@ import {
 export const TRANSACTION_CHECK_CLA = 0xe0;
 export const TRANSACTION_CHECK_INS = 0x23;
 export const TRANSACTION_CHECK_P1_PROVIDE = 0x00;
-export const P2_EXTEND = 0x01;
-export const P2_MORE = 0x02;
 
 export type ProvideWeb3CheckCommandArgs = {
   readonly payload: Uint8Array;
@@ -48,9 +47,7 @@ export class ProvideWeb3CheckCommand
   constructor(private readonly args: ProvideWeb3CheckCommandArgs) {}
 
   getApdu(): Apdu {
-    let p2 = 0x00;
-    if (!this.args.isFirstChunk) p2 |= P2_EXTEND;
-    if (this.args.hasMore) p2 |= P2_MORE;
+    const p2 = buildChunkP2(this.args.isFirstChunk, this.args.hasMore);
 
     const apduBuilderArgs: ApduBuilderArgs = {
       cla: TRANSACTION_CHECK_CLA,

--- a/packages/signer/signer-solana/src/internal/app-binder/command/SignMessageGenericPreviewCommand.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/SignMessageGenericPreviewCommand.test.ts
@@ -1,0 +1,128 @@
+import {
+  ApduResponse,
+  CommandResultFactory,
+  InvalidStatusWordError,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { P2_EXTEND, P2_MORE } from "./utils/apduChunking";
+import { ChunkTooLargeError } from "./utils/Errors";
+import {
+  CLA,
+  INS,
+  P1,
+  SignMessageGenericPreviewCommand,
+  type SignMessageGenericPreviewCommandArgs,
+} from "./SignMessageGenericPreviewCommand";
+
+describe("SignMessageGenericPreviewCommand", () => {
+  const defaultArgs: SignMessageGenericPreviewCommandArgs = {
+    serializedMessage: new Uint8Array(),
+    isFirstChunk: true,
+    hasMore: false,
+  };
+
+  describe("name", () => {
+    it("should be 'signMessageGenericPreview'", () => {
+      const command = new SignMessageGenericPreviewCommand(defaultArgs);
+      expect(command.name).toBe("signMessageGenericPreview");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("returns INS=0x0A, P1=0x01 and P2=0x00 for a single chunk", () => {
+      const command = new SignMessageGenericPreviewCommand({
+        serializedMessage: new Uint8Array([0x01, 0x02, 0x03]),
+        isFirstChunk: true,
+        hasMore: false,
+      });
+
+      const apdu = command.getApdu();
+
+      expect(apdu.cla).toBe(CLA);
+      expect(apdu.ins).toBe(INS);
+      expect(apdu.p1).toBe(P1);
+      expect(apdu.p2).toBe(0x00);
+      expect(apdu.data).toStrictEqual(new Uint8Array([0x01, 0x02, 0x03]));
+    });
+
+    it("sets P2_MORE on the first of many (isFirstChunk=true, hasMore=true)", () => {
+      const command = new SignMessageGenericPreviewCommand({
+        serializedMessage: new Uint8Array([0xaa]),
+        isFirstChunk: true,
+        hasMore: true,
+      });
+      expect(command.getApdu().p2).toBe(P2_MORE);
+    });
+
+    it("sets P2_EXTEND on the last chunk (isFirstChunk=false, hasMore=false)", () => {
+      const command = new SignMessageGenericPreviewCommand({
+        serializedMessage: new Uint8Array([0xaa]),
+        isFirstChunk: false,
+        hasMore: false,
+      });
+      expect(command.getApdu().p2).toBe(P2_EXTEND);
+    });
+
+    it("combines P2_MORE | P2_EXTEND for middle chunks", () => {
+      const command = new SignMessageGenericPreviewCommand({
+        serializedMessage: new Uint8Array([0xaa]),
+        isFirstChunk: false,
+        hasMore: true,
+      });
+      expect(command.getApdu().p2).toBe(P2_MORE | P2_EXTEND);
+    });
+
+    it("throws ChunkTooLargeError when the chunk exceeds APDU_MAX_PAYLOAD", () => {
+      const command = new SignMessageGenericPreviewCommand({
+        serializedMessage: new Uint8Array(256),
+        isFirstChunk: true,
+        hasMore: false,
+      });
+      expect(() => command.getApdu()).toThrow(ChunkTooLargeError);
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("returns void on 9000 with empty payload", () => {
+      const command = new SignMessageGenericPreviewCommand(defaultArgs);
+
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x90, 0x00]),
+          data: new Uint8Array(),
+        }),
+      );
+
+      expect(result).toStrictEqual(CommandResultFactory({ data: undefined }));
+    });
+
+    it("rejects unexpected data on 9000", () => {
+      const command = new SignMessageGenericPreviewCommand(defaultArgs);
+
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x90, 0x00]),
+          data: Uint8Array.from([0xff]),
+        }),
+      );
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      // @ts-expect-error result.error is narrowed by isSuccessCommandResult
+      expect(result.error).toBeInstanceOf(InvalidStatusWordError);
+    });
+
+    it("surfaces a typed error on a non-success status word", () => {
+      const command = new SignMessageGenericPreviewCommand(defaultArgs);
+
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x6a, 0x80]),
+          data: new Uint8Array(),
+        }),
+      );
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+    });
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/command/SignMessageGenericPreviewCommand.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/SignMessageGenericPreviewCommand.ts
@@ -17,47 +17,40 @@ import {
   type SolanaAppErrorCodes,
 } from "./utils/SolanaApplicationErrors";
 
-const CLA = 0xe0;
-const P1 = 0x00;
-export const INS = 0x21;
+export const CLA = 0xe0;
+export const INS = 0x0a;
+export const P1 = 0x01;
 
-export type ProvideTLVDescriptorCommandArgs = {
-  readonly payload: Uint8Array;
-  /**
-   * Chunking flags following the standard Solana P2_MORE / P2_EXTEND
-   * convention. Default to a single-chunk send (P2 = 0x00) so callers that
-   * fit their payload in one APDU don't need to pass them.
-   */
-  readonly isFirstChunk?: boolean;
-  readonly hasMore?: boolean;
+export type SignMessageGenericPreviewCommandArgs = {
+  readonly serializedMessage: Uint8Array;
+  readonly isFirstChunk: boolean;
+  readonly hasMore: boolean;
 };
 
 /**
- * Provides one signed TLV descriptor to the device.
- *
- * The chunking flags `isFirstChunk` / `hasMore` are optional and default to a
- * single-chunk send (P2 = 0x00) so existing single-chunk callers stay
- * byte-compatible. Pass them explicitly when a payload needs more than one
- * APDU.
+ * Sends the serialized message to the device in chunks — the first chunk
+ * carries the derivation path — using the `isFirstChunk` / `hasMore` flags to
+ * drive the P2 chunking. Returns no data.
  */
-export class ProvideTLVDescriptorCommand
-  implements Command<void, ProvideTLVDescriptorCommandArgs, SolanaAppErrorCodes>
+export class SignMessageGenericPreviewCommand
+  implements
+    Command<void, SignMessageGenericPreviewCommandArgs, SolanaAppErrorCodes>
 {
-  readonly name = "provideTLVDescriptor";
+  readonly name = "signMessageGenericPreview";
   private readonly errorHelper = new CommandErrorHelper<
     void,
     SolanaAppErrorCodes
   >(SOLANA_APP_ERRORS, SolanaAppCommandErrorFactory);
 
-  constructor(readonly args: ProvideTLVDescriptorCommandArgs) {}
+  constructor(readonly args: SignMessageGenericPreviewCommandArgs) {}
 
   getApdu(): Apdu {
-    const { payload, isFirstChunk = true, hasMore = false } = this.args;
-    assertChunkSize(payload, INS);
+    const { serializedMessage, isFirstChunk, hasMore } = this.args;
+    assertChunkSize(serializedMessage, INS);
     const p2 = buildChunkP2(isFirstChunk, hasMore);
 
     return new ApduBuilder({ cla: CLA, ins: INS, p1: P1, p2 })
-      .addBufferToData(payload)
+      .addBufferToData(serializedMessage)
       .build();
   }
 

--- a/packages/signer/signer-solana/src/internal/app-binder/command/SignOffChainMessageCommand.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/SignOffChainMessageCommand.ts
@@ -13,6 +13,7 @@ import {
 } from "@ledgerhq/signer-utils";
 import { Maybe } from "purify-ts";
 
+import { buildChunkP2 } from "./utils/apduChunking";
 import {
   SOLANA_APP_ERRORS,
   SolanaAppCommandErrorFactory,
@@ -24,12 +25,6 @@ export const INS = 0x07;
 export const P1 = 0x01;
 
 const SIGNATURE_LENGTH = 64;
-
-export const SOL_P2 = {
-  INIT: 0x00,
-  EXTEND: 0x01,
-  MORE: 0x02,
-};
 
 export type SignOffChainRawResponse = Uint8Array;
 
@@ -46,9 +41,7 @@ export class SignOffChainMessageCommand
   constructor(readonly args: ChunkableCommandArgs) {}
 
   getApdu(): Apdu {
-    const p2 =
-      (this.args.extend ? SOL_P2.EXTEND : SOL_P2.INIT) |
-      (this.args.more ? SOL_P2.MORE : 0);
+    const p2 = buildChunkP2(!this.args.extend, this.args.more);
 
     return new ApduBuilder({
       cla: CLA,

--- a/packages/signer/signer-solana/src/internal/app-binder/command/SignTransactionCommand.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/SignTransactionCommand.ts
@@ -15,6 +15,7 @@ import { Just, Maybe, Nothing } from "purify-ts";
 import { type Signature } from "@api/model/Signature";
 import { UserInputType } from "@api/model/TransactionResolutionContext";
 
+import { buildChunkP2 } from "./utils/apduChunking";
 import {
   SOLANA_APP_ERRORS,
   SolanaAppCommandErrorFactory,
@@ -56,9 +57,7 @@ export class SignTransactionCommand
 
   getApdu(): Apdu {
     const { more, extend, serializedTransaction, userInputType } = this.args;
-    let p2 = 0x00;
-    if (more) p2 |= 0x02;
-    if (extend) p2 |= 0x01;
+    let p2 = buildChunkP2(!extend, more);
     if (userInputType === UserInputType.ATA) {
       // `ata` requires the 0x08 flag, `sol` uses the default (no extra flag).
       p2 |= 0x08;

--- a/packages/signer/signer-solana/src/internal/app-binder/command/SignTransactionPreviewCommand.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/SignTransactionPreviewCommand.ts
@@ -14,6 +14,7 @@ import { Just, Maybe, Nothing } from "purify-ts";
 import { type Signature } from "@api/model/Signature";
 import { UserInputType } from "@api/model/TransactionResolutionContext";
 
+import { buildChunkP2, P2_EXTEND, P2_MORE } from "./utils/apduChunking";
 import {
   SOLANA_APP_ERRORS,
   SolanaAppCommandErrorFactory,
@@ -26,8 +27,8 @@ export const P1 = 0x01;
 
 export const P2 = {
   INIT: 0x00,
-  EXTEND: 0x01,
-  MORE: 0x02,
+  EXTEND: P2_EXTEND,
+  MORE: P2_MORE,
   ATA: 0x08,
 };
 
@@ -63,9 +64,7 @@ export class SignTransactionPreviewCommand
 
   getApdu(): Apdu {
     const { more, extend, serializedTransaction, userInputType } = this.args;
-    let p2 = P2.INIT;
-    if (more) p2 |= P2.MORE;
-    if (extend) p2 |= P2.EXTEND;
+    let p2 = buildChunkP2(!extend, more);
     if (userInputType === UserInputType.ATA) {
       p2 |= P2.ATA;
     }

--- a/packages/signer/signer-solana/src/internal/app-binder/command/utils/Errors.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/utils/Errors.ts
@@ -1,0 +1,25 @@
+import {
+  APDU_MAX_PAYLOAD,
+  type DmkError,
+} from "@ledgerhq/device-management-kit";
+
+/**
+ * Thrown by `assertChunkSize` when the caller passes a payload that exceeds
+ * the short-APDU data limit.
+ */
+export class ChunkTooLargeError extends Error implements DmkError {
+  readonly _tag = "ChunkTooLargeError";
+  readonly ins: number;
+  readonly payloadSize: number;
+
+  constructor(payloadSize: number, ins: number) {
+    super(
+      `Chunk too large for short APDU (INS=0x${ins
+        .toString(16)
+        .padStart(2, "0")}): ${payloadSize} > ${APDU_MAX_PAYLOAD}`,
+    );
+    this.name = "ChunkTooLargeError";
+    this.ins = ins;
+    this.payloadSize = payloadSize;
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/command/utils/apduChunking.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/utils/apduChunking.test.ts
@@ -1,0 +1,84 @@
+import { APDU_MAX_PAYLOAD } from "@ledgerhq/device-management-kit";
+
+import {
+  assertChunkSize,
+  buildChunkP2,
+  P2_EXTEND,
+  P2_MORE,
+} from "./apduChunking";
+import { ChunkTooLargeError } from "./Errors";
+
+describe("apduChunking", () => {
+  describe("constants", () => {
+    it("matches the Solana chunking convention", () => {
+      expect(P2_EXTEND).toBe(0x01);
+      expect(P2_MORE).toBe(0x02);
+    });
+  });
+
+  describe("buildChunkP2", () => {
+    it("returns 0x00 for a single chunk (first=true, more=false)", () => {
+      expect(buildChunkP2(true, false)).toBe(0x00);
+    });
+
+    it("returns P2_MORE for the first of many (first=true, more=true)", () => {
+      expect(buildChunkP2(true, true)).toBe(P2_MORE);
+    });
+
+    it("returns P2_MORE | P2_EXTEND for a middle chunk (first=false, more=true)", () => {
+      expect(buildChunkP2(false, true)).toBe(P2_MORE | P2_EXTEND);
+    });
+
+    it("returns P2_EXTEND for the last chunk (first=false, more=false)", () => {
+      expect(buildChunkP2(false, false)).toBe(P2_EXTEND);
+    });
+  });
+
+  describe("assertChunkSize", () => {
+    it("accepts an empty payload", () => {
+      expect(() => assertChunkSize(new Uint8Array(), 0x24)).not.toThrow();
+    });
+
+    it("accepts a payload of exactly APDU_MAX_PAYLOAD bytes", () => {
+      expect(() =>
+        assertChunkSize(new Uint8Array(APDU_MAX_PAYLOAD), 0x24),
+      ).not.toThrow();
+    });
+
+    it("throws ChunkTooLargeError when the payload exceeds APDU_MAX_PAYLOAD", () => {
+      expect(() =>
+        assertChunkSize(new Uint8Array(APDU_MAX_PAYLOAD + 1), 0x24),
+      ).toThrow(ChunkTooLargeError);
+    });
+
+    it("includes the INS byte in the error message for debuggability", () => {
+      expect(() => assertChunkSize(new Uint8Array(300), 0x25)).toThrow(
+        /INS=0x25/,
+      );
+      expect(() => assertChunkSize(new Uint8Array(300), 0x0a)).toThrow(
+        /INS=0x0a/,
+      );
+    });
+
+    it("includes the actual and max sizes in the error message", () => {
+      expect(() => assertChunkSize(new Uint8Array(300), 0x24)).toThrow(
+        new RegExp(`300 > ${APDU_MAX_PAYLOAD}`),
+      );
+    });
+
+    it("ChunkTooLargeError carries the payload size, INS, and DmkError _tag", () => {
+      try {
+        assertChunkSize(new Uint8Array(300), 0x25);
+        throw new Error("expected to throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ChunkTooLargeError);
+        expect(err).toBeInstanceOf(Error);
+        const e = err as ChunkTooLargeError;
+        expect(e.payloadSize).toBe(300);
+        expect(e.ins).toBe(0x25);
+        expect(e._tag).toBe("ChunkTooLargeError");
+        expect(e.message).toMatch(/INS=0x25/);
+      }
+    });
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/command/utils/apduChunking.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/utils/apduChunking.ts
@@ -1,0 +1,31 @@
+import { APDU_MAX_PAYLOAD } from "@ledgerhq/device-management-kit";
+
+import { ChunkTooLargeError } from "./Errors";
+
+export const P2_EXTEND = 0x01;
+export const P2_MORE = 0x02;
+
+/**
+ * Compute the P2 byte for a chunked Solana APDU.
+ *
+ * Single chunk:  0x00
+ * First of many: P2_MORE
+ * Middle:        P2_MORE | P2_EXTEND
+ * Last:          P2_EXTEND
+ */
+export function buildChunkP2(isFirstChunk: boolean, hasMore: boolean): number {
+  let p2 = 0x00;
+  if (!isFirstChunk) p2 |= P2_EXTEND;
+  if (hasMore) p2 |= P2_MORE;
+  return p2;
+}
+
+/**
+ * Throws `ChunkTooLargeError` when a chunk is larger than a single
+ * APDU payload can carry.
+ */
+export function assertChunkSize(payload: Uint8Array, ins: number): void {
+  if (payload.length > APDU_MAX_PAYLOAD) {
+    throw new ChunkTooLargeError(payload.length, ins);
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Added 7 new APDU command classes the Solana embedded app exposes for the generic clear-signing flow, plus a tiny chunking helper and a factory shared across them.

## New commands

| INS  | Command class                          | Status   | Notes |
| ---- | -------------------------------------- | -------- | ----- |
| 0x0A | SignMessageGenericPreviewCommand       | new      | Derivation path + serialized message, chunked. No review UI shown. Uses `isFirstChunk` / `hasMore` flags consistent with the rest of the family. |
| 0x0B | PromptUiDisplayCommand                 | new      | Empty payload. 9000 = approved, 6985 = refused / incomplete, 6A80 = merge engine failure. |
| 0x21 | ProvideTLVDescriptorCommand            | extended | Added optional `isFirstChunk` / `hasMore` flags. Legacy single-chunk callers stay byte-compatible (defaults reproduce P2 =
0x00). |
| 0x24 | ProvideInstructionInfoCommand          | new      | Chunked TLV. First chunk: u16 BE length + INSTRUCTION_INFO TLV. |
| 0x25 | ProvideInstructionSubstructureCommand  | new      | Chunked TLV. First chunk: u16 BE length + 1-byte `SubstructureType` selector + TLV. Must be streamed in CAL hash order. |
| 0x26 | ProvideEnumVariantCommand              | new      | Chunked TLV. Signed `(programId, enumId, variantIndex)`. |
| 0x27 | ProvideTokenAccountStateCommand        | new      | Chunked TLV. Challenge-bound — GET CHALLENGE immediately before. |
| 0x28 | ProvideAltResolutionCommand            | new      | Chunked TLV. Challenge-bound — GET CHALLENGE immediately before. |

## Existing command extended

- `ProvideTLVDescriptorCommand` (INS 0x21, `PROVIDE TRUSTED NAME`) previously hardcoded `P2 = 0x00` and only handled single-chunk sends. Now it goes through the same factory as the other PROVIDE commands, with
optional `isFirstChunk` / `hasMore` flags defaulting to single-chunk so the legacy caller stays byte-compatible.

## Shared infrastructure

- **`command/utils/clearSignChunking.ts`** centralises `P2_MORE` / `P2_EXTEND` constants, `buildChunkP2(isFirstChunk, hasMore)`, and `assertChunkSize(payload, ins)`. The chunk-size limit comes from `APDU_MAX_PAYLOAD` imported from `@ledgerhq/device-management-kit` 
- **`command/utils/createProvideClearSignTLVCommand.ts`** is a factory that builds a Solana "PROVIDE …" command class for a given `(name, ins)` pair. The 6 PROVIDE commands now share one wire-format / status-word / oversize-rejection implementation.

## Notes

- **Oversize rejection.** `assertChunkSize` throws `ClearSignChunkTooLargeError` before APDU construction when a chunk exceeds `APDU_MAX_PAYLOAD`, so a caller bug surfaces here rather than as silent `ByteArrayBuilder` truncation or a `0x6700` round-trip from the device.

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [DSDK-1143](https://ledgerhq.atlassian.net/browse/DSDK-1143)

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
