### PR TITLE
🐛 (device-management-kit) [NO-ISSUE]: Only read OS version on dashboard for onboarding check

### DIFF
--- a/.changeset/fix-onboarding-os-version-dashboard.md
+++ b/.changeset/fix-onboarding-os-version-dashboard.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Fix `GetDeviceStatusDeviceAction` breaking when connecting while a non-BOLOS app is open. The OS version (used to read the onboarding flag) can only be fetched on the dashboard, so the current app is now determined first and `GetOsVersionCommand` is only sent when the device is on the dashboard (BOLOS). A device running an application is considered onboarded without reading the OS version.

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.test.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.test.ts
@@ -614,67 +614,6 @@ describe("GetDeviceStatusDeviceAction", () => {
         );
       }));
 
-    it("should end in an error if cached metadata says the device is not onboarded", () =>
-      new Promise<void>((resolve, reject) => {
-        const osVersionData = getOsVersionCommandResponseMockBuilder(
-          DeviceModelId.NANO_X,
-          {
-            secureElementFlags: {
-              ...getOsVersionCommandResponseMockBuilder().secureElementFlags,
-              isOnboarded: false,
-            },
-          },
-        );
-        getDeviceSessionStateMock.mockReturnValue({
-          sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-          deviceStatus: DeviceStatus.CONNECTED,
-          currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
-          installedApps: [],
-          deviceModelId: DeviceModelId.NANO_X,
-          isSecureConnectionAllowed: false,
-          firmwareVersion: {
-            mcu: osVersionData.mcuSephVersion,
-            bootloader: osVersionData.mcuBootloaderVersion,
-            os: osVersionData.seVersion,
-            metadata: osVersionData,
-          },
-        });
-
-        getAppAndVersionMock.mockResolvedValue(
-          appAndVersionResult("BOLOS", "1.0.0"),
-        );
-
-        const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
-          input: { unlockTimeout: 500 },
-        });
-
-        vi.spyOn(
-          getDeviceStateDeviceAction,
-          "extractDependencies",
-        ).mockReturnValue(extractDependenciesMock());
-
-        const expectedStates: Array<GetDeviceStatusDAState> = [
-          onboardCheckPendingState(),
-          {
-            error: new DeviceNotOnboardedError(),
-            status: DeviceActionStatus.Error,
-          },
-        ];
-
-        testDeviceActionStates(
-          getDeviceStateDeviceAction,
-          expectedStates,
-          makeDeviceActionInternalApiMock(),
-          {
-            onDone: () => {
-              expect(getOsVersionMock).not.toHaveBeenCalled();
-              resolve();
-            },
-            onError: reject,
-          },
-        );
-      }));
-
     it("should end in an error if the device is locked and the user does not unlock", () =>
       new Promise<void>((resolve, reject) => {
         getDeviceSessionStateMock.mockReturnValue({

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.test.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.test.ts
@@ -34,6 +34,22 @@ const osVersionCommandResult = (
     data: getOsVersionCommandResponseMockBuilder(deviceModelId, props),
   });
 
+const appAndVersionResult = (name: string, version: string) =>
+  CommandResultFactory({
+    data: {
+      name,
+      version,
+    },
+  });
+
+const lockedErrorResult = () =>
+  CommandResultFactory({
+    error: new GlobalCommandError({
+      ...GLOBAL_ERRORS["5515"],
+      errorCode: "5515",
+    }),
+  });
+
 const onboardCheckPendingState = (): GetDeviceStatusDAState => ({
   intermediateValue: {
     requiredUserInteraction: UserInteractionRequired.None,
@@ -47,6 +63,22 @@ const onboardCheckPendingStatesWithOsVersionFetch =
     onboardCheckPendingState(),
     onboardCheckPendingState(),
   ];
+
+const unlockRequestedPendingState = (): GetDeviceStatusDAState => ({
+  intermediateValue: {
+    requiredUserInteraction: UserInteractionRequired.UnlockDevice,
+    step: getDeviceStatusDAStateStep.UNLOCK_DEVICE,
+  },
+  status: DeviceActionStatus.Pending,
+});
+
+const unlockResolvedPendingState = (): GetDeviceStatusDAState => ({
+  intermediateValue: {
+    requiredUserInteraction: UserInteractionRequired.None,
+    step: getDeviceStatusDAStateStep.UNLOCK_DEVICE,
+  },
+  status: DeviceActionStatus.Pending,
+});
 
 describe("GetDeviceStatusDeviceAction", () => {
   const getAppAndVersionMock = vi.fn();
@@ -88,16 +120,13 @@ describe("GetDeviceStatusDeviceAction", () => {
           deviceModelId: DeviceModelId.NANO_X,
         });
 
-        sendCommandMock
-          .mockResolvedValueOnce(osVersionCommandResult())
-          .mockResolvedValue(
-            CommandResultFactory({
-              data: {
-                name: "BOLOS",
-                version: "1.0.0",
-              },
-            }),
-          );
+        // GetAppAndVersion is called first to determine the current app, then
+        // GetOsVersion is called because the app is BOLOS (dashboard).
+        sendCommandMock.mockImplementation((command) =>
+          command.name === "getOsVersion"
+            ? Promise.resolve(osVersionCommandResult())
+            : Promise.resolve(appAndVersionResult("BOLOS", "1.0.0")),
+        );
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
           ...onboardCheckPendingStatesWithOsVersionFetch(),
@@ -136,41 +165,25 @@ describe("GetDeviceStatusDeviceAction", () => {
           isSecureConnectionAllowed: false,
         });
 
-        sendCommandMock
-          .mockResolvedValueOnce(osVersionCommandResult())
-          .mockResolvedValueOnce(
-            CommandResultFactory({
-              error: new GlobalCommandError({
-                ...GLOBAL_ERRORS["5515"],
-                errorCode: "5515",
-              }),
-            }),
-          )
-          .mockResolvedValue(
-            CommandResultFactory({
-              data: {
-                name: "BOLOS",
-                version: "1.0.0",
-              },
-            }),
-          );
+        // First GetAppAndVersion fails because the device is locked, then it
+        // succeeds (BOLOS) once unlocked, then GetOsVersion is fetched.
+        let appCall = 0;
+        sendCommandMock.mockImplementation((command) => {
+          if (command.name === "getOsVersion") {
+            return Promise.resolve(osVersionCommandResult());
+          }
+          appCall += 1;
+          if (appCall === 1) {
+            return Promise.resolve(lockedErrorResult());
+          }
+          return Promise.resolve(appAndVersionResult("BOLOS", "1.0.0"));
+        });
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
-          ...onboardCheckPendingStatesWithOsVersionFetch(),
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.UnlockDevice,
-              step: getDeviceStatusDAStateStep.UNLOCK_DEVICE,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-              step: getDeviceStatusDAStateStep.UNLOCK_DEVICE,
-            },
-            status: DeviceActionStatus.Pending,
-          },
+          onboardCheckPendingState(),
+          unlockRequestedPendingState(),
+          unlockResolvedPendingState(),
+          unlockResolvedPendingState(),
           {
             output: {
               currentApp: "BOLOS",
@@ -206,34 +219,17 @@ describe("GetDeviceStatusDeviceAction", () => {
           isSecureConnectionAllowed: false,
         });
 
-        sendCommandMock
-          .mockResolvedValueOnce(osVersionCommandResult())
-          .mockResolvedValueOnce(
-            CommandResultFactory({
-              error: new GlobalCommandError({
-                ...GLOBAL_ERRORS["5515"],
-                errorCode: "5515",
-              }),
-            }),
-          )
-          .mockResolvedValue(
-            CommandResultFactory({
-              data: {
-                name: "BOLOS",
-                version: "1.0.0",
-              },
-            }),
-          );
+        // GetAppAndVersion always reports a locked device, so the unlock
+        // polling times out.
+        sendCommandMock.mockImplementation((command) =>
+          command.name === "getOsVersion"
+            ? Promise.resolve(osVersionCommandResult())
+            : Promise.resolve(lockedErrorResult()),
+        );
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
-          ...onboardCheckPendingStatesWithOsVersionFetch(),
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.UnlockDevice,
-              step: getDeviceStatusDAStateStep.UNLOCK_DEVICE,
-            },
-            status: DeviceActionStatus.Pending,
-          },
+          onboardCheckPendingState(),
+          unlockRequestedPendingState(),
           {
             error: new DeviceLockedError("Device locked."),
             status: DeviceActionStatus.Error,
@@ -263,16 +259,21 @@ describe("GetDeviceStatusDeviceAction", () => {
           deviceModelId: DeviceModelId.NANO_X,
         });
 
-        sendCommandMock
-          .mockResolvedValueOnce(osVersionCommandResult())
-          .mockResolvedValue(
-            CommandResultFactory({
-              error: new GlobalCommandError({
-                ...GLOBAL_ERRORS["6e00"],
-                errorCode: "6e00",
-              }),
-            }),
-          );
+        // GetAppAndVersion is not supported (CLA_NOT_SUPPORTED), which means we
+        // are on the dashboard of an old firmware: the current app is BOLOS so
+        // the OS version can still be fetched.
+        sendCommandMock.mockImplementation((command) =>
+          command.name === "getOsVersion"
+            ? Promise.resolve(osVersionCommandResult())
+            : Promise.resolve(
+                CommandResultFactory({
+                  error: new GlobalCommandError({
+                    ...GLOBAL_ERRORS["6e00"],
+                    errorCode: "6e00",
+                  }),
+                }),
+              ),
+        );
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
           ...onboardCheckPendingStatesWithOsVersionFetch(),
@@ -307,12 +308,7 @@ describe("GetDeviceStatusDeviceAction", () => {
         });
 
         getAppAndVersionMock.mockResolvedValue(
-          CommandResultFactory({
-            data: {
-              name: "BOLOS",
-              version: "1.0.0",
-            },
-          }),
+          appAndVersionResult("BOLOS", "1.0.0"),
         );
 
         const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
@@ -360,19 +356,21 @@ describe("GetDeviceStatusDeviceAction", () => {
 
     it("should return the device status and update session if the device is not ready", () =>
       new Promise<void>((resolve, reject) => {
-        getDeviceSessionStateMock.mockReturnValue({
+        // The session state is stateful so the firmware version enrichment from
+        // the OS version (which reads back the ready state) can be observed.
+        let sessionState: object = {
           sessionStateType: DeviceSessionStateType.Connected,
           deviceStatus: DeviceStatus.CONNECTED,
           deviceModelId: DeviceModelId.NANO_X,
+        };
+        getDeviceSessionStateMock.mockImplementation(() => sessionState);
+        setDeviceSessionState.mockImplementation((state) => {
+          sessionState = state;
+          return state;
         });
 
         getAppAndVersionMock.mockResolvedValue(
-          CommandResultFactory({
-            data: {
-              name: "BOLOS",
-              version: "1.0.0",
-            },
-          }),
+          appAndVersionResult("BOLOS", "1.0.0"),
         );
 
         const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
@@ -405,6 +403,7 @@ describe("GetDeviceStatusDeviceAction", () => {
           {
             onDone: () => {
               // Session should be set as ready if GetAppAndVersionCommand was successful
+              // and then enriched with the firmware version from the OS version.
               expect(setDeviceSessionState).toHaveBeenCalledWith({
                 deviceModelId: DeviceModelId.NANO_X,
                 sessionStateType:
@@ -431,6 +430,54 @@ describe("GetDeviceStatusDeviceAction", () => {
         );
       }));
 
+    it("should not fetch the OS version when an app other than BOLOS is open", () =>
+      new Promise<void>((resolve, reject) => {
+        getDeviceSessionStateMock.mockReturnValue({
+          sessionStateType: DeviceSessionStateType.Connected,
+          deviceStatus: DeviceStatus.CONNECTED,
+          deviceModelId: DeviceModelId.NANO_X,
+        });
+
+        // An application is open: the device is necessarily onboarded and the
+        // OS version cannot be read outside of the dashboard.
+        getAppAndVersionMock.mockResolvedValue(
+          appAndVersionResult("Bitcoin", "2.1.0"),
+        );
+
+        const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
+          input: { unlockTimeout: undefined },
+        });
+
+        vi.spyOn(
+          getDeviceStateDeviceAction,
+          "extractDependencies",
+        ).mockReturnValue(extractDependenciesMock());
+
+        const expectedStates: Array<GetDeviceStatusDAState> = [
+          onboardCheckPendingState(),
+          {
+            status: DeviceActionStatus.Completed,
+            output: {
+              currentApp: "Bitcoin",
+              currentAppVersion: "2.1.0",
+            },
+          },
+        ];
+
+        testDeviceActionStates(
+          getDeviceStateDeviceAction,
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          {
+            onDone: () => {
+              expect(getOsVersionMock).not.toHaveBeenCalled();
+              resolve();
+            },
+            onError: reject,
+          },
+        );
+      }));
+
     it("should return the device status if the device is locked and the user unlocks the device", () =>
       new Promise<void>((resolve, reject) => {
         getDeviceSessionStateMock.mockReturnValue({
@@ -440,22 +487,8 @@ describe("GetDeviceStatusDeviceAction", () => {
         });
 
         getAppAndVersionMock
-          .mockResolvedValueOnce(
-            CommandResultFactory({
-              error: new GlobalCommandError({
-                ...GLOBAL_ERRORS["5515"],
-                errorCode: "5515",
-              }),
-            }),
-          )
-          .mockResolvedValueOnce(
-            CommandResultFactory({
-              data: {
-                name: "BOLOS",
-                version: "1.0.0",
-              },
-            }),
-          );
+          .mockResolvedValueOnce(lockedErrorResult())
+          .mockResolvedValueOnce(appAndVersionResult("BOLOS", "1.0.0"));
 
         waitForDeviceUnlockMock.mockImplementation(
           () =>
@@ -503,21 +536,10 @@ describe("GetDeviceStatusDeviceAction", () => {
         ).mockReturnValue(extractDependenciesMock());
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
-          ...onboardCheckPendingStatesWithOsVersionFetch(),
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.UnlockDevice,
-              step: getDeviceStatusDAStateStep.UNLOCK_DEVICE,
-            },
-            status: DeviceActionStatus.Pending,
-          },
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.None,
-              step: getDeviceStatusDAStateStep.UNLOCK_DEVICE,
-            },
-            status: DeviceActionStatus.Pending,
-          },
+          onboardCheckPendingState(),
+          unlockRequestedPendingState(),
+          unlockResolvedPendingState(),
+          unlockResolvedPendingState(),
           {
             status: DeviceActionStatus.Completed,
             output: {
@@ -544,12 +566,17 @@ describe("GetDeviceStatusDeviceAction", () => {
       new Promise<void>((resolve, reject) => {
         getDeviceSessionStateMock.mockReturnValue({
           sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-          deviceStatus: DeviceStatus.LOCKED,
-          currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
+          deviceStatus: DeviceStatus.CONNECTED,
+          currentApp: { name: "BOLOS", version: "1.0.0" },
           installedApps: [],
           deviceModelId: DeviceModelId.NANO_X,
           isSecureConnectionAllowed: false,
         });
+        // A non-onboarded device sits on the dashboard (BOLOS), so the app check
+        // succeeds and the OS version reveals the onboarding status.
+        getAppAndVersionMock.mockResolvedValue(
+          appAndVersionResult("BOLOS", "1.0.0"),
+        );
         getOsVersionMock.mockResolvedValue(
           osVersionCommandResult({
             secureElementFlags: {
@@ -569,7 +596,7 @@ describe("GetDeviceStatusDeviceAction", () => {
         ).mockReturnValue(extractDependenciesMock());
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
-          onboardCheckPendingState(),
+          ...onboardCheckPendingStatesWithOsVersionFetch(),
           {
             error: new DeviceNotOnboardedError(),
             status: DeviceActionStatus.Error,
@@ -613,6 +640,10 @@ describe("GetDeviceStatusDeviceAction", () => {
           },
         });
 
+        getAppAndVersionMock.mockResolvedValue(
+          appAndVersionResult("BOLOS", "1.0.0"),
+        );
+
         const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
           input: { unlockTimeout: 500 },
         });
@@ -623,6 +654,7 @@ describe("GetDeviceStatusDeviceAction", () => {
         ).mockReturnValue(extractDependenciesMock());
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
+          onboardCheckPendingState(),
           {
             error: new DeviceNotOnboardedError(),
             status: DeviceActionStatus.Error,
@@ -651,13 +683,13 @@ describe("GetDeviceStatusDeviceAction", () => {
           currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
         });
 
-        getAppAndVersionMock.mockResolvedValue(
-          CommandResultFactory({
-            error: new GlobalCommandError({
-              ...GLOBAL_ERRORS["5515"],
-              errorCode: "5515",
+        getAppAndVersionMock.mockResolvedValue(lockedErrorResult());
+
+        waitForDeviceUnlockMock.mockImplementation(
+          () =>
+            new Observable((o) => {
+              o.error(new DeviceLockedError("Device locked."));
             }),
-          }),
         );
 
         apiGetDeviceSessionStateObservableMock.mockImplementation(
@@ -693,14 +725,8 @@ describe("GetDeviceStatusDeviceAction", () => {
         ).mockReturnValue(extractDependenciesMock());
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
-          ...onboardCheckPendingStatesWithOsVersionFetch(),
-          {
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.UnlockDevice,
-              step: getDeviceStatusDAStateStep.UNLOCK_DEVICE,
-            },
-            status: DeviceActionStatus.Pending,
-          },
+          onboardCheckPendingState(),
+          unlockRequestedPendingState(),
           {
             error: new DeviceLockedError("Device locked."),
             status: DeviceActionStatus.Error,
@@ -736,36 +762,7 @@ describe("GetDeviceStatusDeviceAction", () => {
         waitForDeviceUnlockMock.mockImplementation(
           () =>
             new Observable((o) => {
-              const inner = interval(50).subscribe({
-                next: (i) => {
-                  if (i > 2) {
-                    o.next({
-                      sessionStateType:
-                        DeviceSessionStateType.ReadyWithoutSecureChannel,
-                      deviceStatus: DeviceStatus.CONNECTED,
-                      currentApp: {
-                        name: "mockedCurrentApp",
-                        version: "1.0.0",
-                      },
-                    });
-                    o.complete();
-                  } else {
-                    o.next({
-                      sessionStateType:
-                        DeviceSessionStateType.ReadyWithoutSecureChannel,
-                      deviceStatus: DeviceStatus.LOCKED,
-                      currentApp: {
-                        name: "mockedCurrentApp",
-                        version: "1.0.0",
-                      },
-                    });
-                  }
-                },
-              });
-
-              return () => {
-                inner.unsubscribe();
-              };
+              o.complete();
             }),
         );
 
@@ -779,7 +776,7 @@ describe("GetDeviceStatusDeviceAction", () => {
         ).mockReturnValue(extractDependenciesMock());
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
-          ...onboardCheckPendingStatesWithOsVersionFetch(),
+          onboardCheckPendingState(),
           {
             error,
             status: DeviceActionStatus.Error,
@@ -826,7 +823,7 @@ describe("GetDeviceStatusDeviceAction", () => {
         ).mockReturnValue(extractDependenciesMock());
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
-          ...onboardCheckPendingStatesWithOsVersionFetch(),
+          onboardCheckPendingState(),
           {
             error: new UnknownDAError("error"),
             status: DeviceActionStatus.Error,
@@ -856,16 +853,11 @@ describe("GetDeviceStatusDeviceAction", () => {
         isSecureConnectionAllowed: false,
       });
 
-      sendCommandMock
-        .mockResolvedValueOnce(osVersionCommandResult())
-        .mockResolvedValue(
-          CommandResultFactory({
-            data: {
-              name: "BOLOS",
-              version: "1.0.0",
-            },
-          }),
-        );
+      sendCommandMock.mockImplementation((command) =>
+        command.name === "getOsVersion"
+          ? Promise.resolve(osVersionCommandResult())
+          : Promise.resolve(appAndVersionResult("BOLOS", "1.0.0")),
+      );
 
       const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
         input: { unlockTimeout: 500 },

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.ts
@@ -119,7 +119,7 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
 
     const updateSessionFromOsVersion = (data: GetOsVersionResponse) => {
       const currentState = getDeviceSessionState();
-      if (!("firmwareVersion" in currentState)) {
+      if (currentState.sessionStateType === DeviceSessionStateType.Connected) {
         return;
       }
       setDeviceSessionState({
@@ -162,7 +162,8 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
             metadata !== undefined && !metadata.secureElementFlags.isOnboarded
           );
         },
-        needsOsVersionFetch: () => getCachedOnboardingMetadata() === undefined,
+        isCurrentAppBolos: ({ context }) =>
+          context._internalState.currentApp === "BOLOS",
         isOnboardedFromOsVersion: ({ context }) =>
           context._internalState.osVersionMetadata?.secureElementFlags
             .isOnboarded === true,
@@ -240,108 +241,14 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
       states: {
         DeviceReady: {
           always: {
-            target: "OnboardingCheck",
-          },
-        },
-        OnboardingCheck: {
-          always: [
-            {
-              guard: "isOnboardedFromCachedMetadata",
-              target: "AppAndVersionCheck",
-              actions: assign({
-                _internalState: (_) => ({
-                  ..._.context._internalState,
-                  onboarded: true,
-                }),
-              }),
-            },
-            {
-              guard: "isNotOnboardedFromCachedMetadata",
-              target: "Error",
-              actions: "assignErrorDeviceNotOnboarded",
-            },
-            {
-              guard: "needsOsVersionFetch",
-              target: "GetOsVersion",
-            },
-          ],
-        },
-        GetOsVersion: {
-          invoke: {
-            src: "getOsVersion",
-            onDone: {
-              target: "OnboardingResultCheck",
-              actions: assign({
-                _internalState: (_) => {
-                  if (isSuccessCommandResult(_.event.output)) {
-                    updateSessionFromOsVersion(_.event.output.data);
-                    return {
-                      ..._.context._internalState,
-                      osVersionMetadata: _.event.output.data,
-                    };
-                  }
-                  return {
-                    ..._.context._internalState,
-                    error: _.event.output.error,
-                  };
-                },
-              }),
-            },
-            onError: {
-              target: "Error",
-              actions: "assignErrorFromEvent",
-            },
-          },
-        },
-        OnboardingResultCheck: {
-          always: [
-            {
-              guard: "hasError",
-              target: "Error",
-            },
-            {
-              guard: "isOnboardedFromOsVersion",
-              target: "AppAndVersionCheck",
-              actions: assign({
-                _internalState: (_) => ({
-                  ..._.context._internalState,
-                  onboarded: true,
-                }),
-              }),
-            },
-            {
-              target: "Error",
-              actions: "assignErrorDeviceNotOnboarded",
-            },
-          ],
-        },
-        UserActionUnlockDevice: {
-          // we wait for the device to be unlocked (default timeout is 15s)
-          entry: "assignUserActionUnlockNeeded",
-          exit: "assignNoUserActionNeeded",
-          invoke: {
-            id: "UserActionUnlockDevice",
-            src: "waitForDeviceUnlock",
-            input: (_) => ({
-              unlockTimeout,
-            }),
-            onDone: {
-              target: "AppAndVersionCheck",
-              actions: assign({
-                _internalState: (_) => ({
-                  ..._.context._internalState,
-                  locked: false,
-                }),
-              }),
-            },
-            onError: {
-              target: "Error",
-              actions: "assignErrorDeviceLocked",
-            },
+            target: "AppAndVersionCheck",
           },
         },
         AppAndVersionCheck: {
-          // We check the current app and version using the getAppAndVersion command
+          // We check the current app and version using the getAppAndVersion
+          // command. This command is supported both on the dashboard (BOLOS)
+          // and inside applications, so it is used to determine the currently
+          // running app before deciding whether to read the OS version.
           invoke: {
             src: "getAppAndVersion",
             onDone: {
@@ -360,9 +267,9 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
                         currentApp: _.event.output.data,
                       });
                     } else {
-                      const osVersionMetadata =
-                        _.context._internalState.osVersionMetadata;
-                      // The device can be set to Ready if GetAppAndVersionCommand was successful
+                      // The device can be set to Ready if GetAppAndVersionCommand was successful.
+                      // The firmware version and secure connection flag are enriched later from
+                      // the OS version, which can only be read on the dashboard.
                       setDeviceSessionState({
                         deviceModelId: state.deviceModelId,
                         sessionStateType:
@@ -370,15 +277,7 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
                         deviceStatus: DeviceStatus.CONNECTED,
                         currentApp: _.event.output.data,
                         installedApps: [],
-                        isSecureConnectionAllowed:
-                          osVersionMetadata?.secureElementFlags
-                            .isSecureConnectionAllowed ?? false,
-                        ...(osVersionMetadata !== null
-                          ? {
-                              firmwareVersion:
-                                firmwareVersionFromOsVersion(osVersionMetadata),
-                            }
-                          : {}),
+                        isSecureConnectionAllowed: false,
                       });
                     }
                     return {
@@ -435,9 +334,121 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
               guard: "isDeviceLocked",
             },
             {
-              target: "Success",
+              target: "OnboardingCheck",
             },
           ],
+        },
+        OnboardingCheck: {
+          always: [
+            {
+              guard: "isOnboardedFromCachedMetadata",
+              target: "Success",
+              actions: assign({
+                _internalState: (_) => ({
+                  ..._.context._internalState,
+                  onboarded: true,
+                }),
+              }),
+            },
+            {
+              guard: "isNotOnboardedFromCachedMetadata",
+              target: "Error",
+              actions: "assignErrorDeviceNotOnboarded",
+            },
+            {
+              // The OS version (and thus the onboarding flag) can only be read
+              // on the dashboard. If we are inside an application, fetching it
+              // would fail, so we only fetch it when the current app is BOLOS.
+              guard: "isCurrentAppBolos",
+              target: "GetOsVersion",
+            },
+            {
+              // A non-BOLOS application can only run on an onboarded device, so
+              // if an app is open we can safely consider the device onboarded
+              // without reading the OS version.
+              target: "Success",
+              actions: assign({
+                _internalState: (_) => ({
+                  ..._.context._internalState,
+                  onboarded: true,
+                }),
+              }),
+            },
+          ],
+        },
+        GetOsVersion: {
+          invoke: {
+            src: "getOsVersion",
+            onDone: {
+              target: "OnboardingResultCheck",
+              actions: assign({
+                _internalState: (_) => {
+                  if (isSuccessCommandResult(_.event.output)) {
+                    updateSessionFromOsVersion(_.event.output.data);
+                    return {
+                      ..._.context._internalState,
+                      osVersionMetadata: _.event.output.data,
+                    };
+                  }
+                  return {
+                    ..._.context._internalState,
+                    error: _.event.output.error,
+                  };
+                },
+              }),
+            },
+            onError: {
+              target: "Error",
+              actions: "assignErrorFromEvent",
+            },
+          },
+        },
+        OnboardingResultCheck: {
+          always: [
+            {
+              guard: "hasError",
+              target: "Error",
+            },
+            {
+              guard: "isOnboardedFromOsVersion",
+              target: "Success",
+              actions: assign({
+                _internalState: (_) => ({
+                  ..._.context._internalState,
+                  onboarded: true,
+                }),
+              }),
+            },
+            {
+              target: "Error",
+              actions: "assignErrorDeviceNotOnboarded",
+            },
+          ],
+        },
+        UserActionUnlockDevice: {
+          // we wait for the device to be unlocked (default timeout is 15s)
+          entry: "assignUserActionUnlockNeeded",
+          exit: "assignNoUserActionNeeded",
+          invoke: {
+            id: "UserActionUnlockDevice",
+            src: "waitForDeviceUnlock",
+            input: (_) => ({
+              unlockTimeout,
+            }),
+            onDone: {
+              target: "AppAndVersionCheck",
+              actions: assign({
+                _internalState: (_) => ({
+                  ..._.context._internalState,
+                  locked: false,
+                }),
+              }),
+            },
+            onError: {
+              target: "Error",
+              actions: "assignErrorDeviceLocked",
+            },
+          },
         },
         Success: {
           type: "final",

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.ts
@@ -130,14 +130,6 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
       });
     };
 
-    const getCachedOnboardingMetadata = () => {
-      const state = getDeviceSessionState();
-      if (!("firmwareVersion" in state)) {
-        return undefined;
-      }
-      return state.firmwareVersion?.metadata;
-    };
-
     return setup({
       types: {
         input: {
@@ -152,16 +144,6 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
         waitForDeviceUnlock: fromObservable(waitForDeviceUnlock),
       },
       guards: {
-        isOnboardedFromCachedMetadata: () => {
-          const metadata = getCachedOnboardingMetadata();
-          return metadata?.secureElementFlags.isOnboarded === true;
-        },
-        isNotOnboardedFromCachedMetadata: () => {
-          const metadata = getCachedOnboardingMetadata();
-          return (
-            metadata !== undefined && !metadata.secureElementFlags.isOnboarded
-          );
-        },
         isCurrentAppBolos: ({ context }) =>
           context._internalState.currentApp === "BOLOS",
         isOnboardedFromOsVersion: ({ context }) =>
@@ -340,21 +322,6 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
         },
         OnboardingCheck: {
           always: [
-            {
-              guard: "isOnboardedFromCachedMetadata",
-              target: "Success",
-              actions: assign({
-                _internalState: (_) => ({
-                  ..._.context._internalState,
-                  onboarded: true,
-                }),
-              }),
-            },
-            {
-              guard: "isNotOnboardedFromCachedMetadata",
-              target: "Error",
-              actions: "assignErrorDeviceNotOnboarded",
-            },
             {
               // The OS version (and thus the onboarding flag) can only be read
               // on the dashboard. If we are inside an application, fetching it


### PR DESCRIPTION
### 📝 Description

`GetDeviceStatusDeviceAction` was calling `GetOsVersionCommand` (APDU `e0 01`, a BOLOS / dashboard-only command) on every fresh connection to read the onboarding flag. When a non-BOLOS application was already open on the device, that APDU is handled by the app and fails, so the whole `GetDeviceStatus` flow (and `OpenAppDeviceAction`, which now depends on it) ended in `Left(error)`.

**Previous behavior**: connecting while an app was open broke device status / onboarding detection.

**Fix**: the state machine now determines the current app first via `GetAppAndVersionCommand` (`b0 01`, supported both on the dashboard and inside apps), then:
- if the current app is not `BOLOS` → the device is necessarily onboarded (an app can only run on an onboarded device), so `GetOsVersion` is skipped;
- if the current app is `BOLOS` → `GetOsVersion` is fetched and `secureElementFlags.isOnboarded` is checked.

The `firmwareVersion` / `isSecureConnectionAllowed` session enrichment now happens on the dashboard path via `updateSessionFromOsVersion`.

<img width="653" height="417" alt="image" src="https://github.com/user-attachments/assets/5ffa66c8-3a0e-4d03-80fc-8abe942459c7" />

<img width="848" height="600" alt="image" src="https://github.com/user-attachments/assets/2e90216f-a9ed-4b61-a740-1bc8d2a914f7" />

<img width="817" height="880" alt="image" src="https://github.com/user-attachments/assets/69aa1213-91d7-4f49-8912-d2580127a678" />

