### PR TITLE
👷 (ci) [DSDK-1217]: Add SonarCloud coverage workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -124,6 +124,8 @@ jobs:
     runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@develop
 
@@ -134,8 +136,8 @@ jobs:
       - uses: sonarsource/sonarqube-scan-action@v7
         if: ${{ steps.unit-tests.conclusion == 'success' && github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
         env:
-          SONAR_TOKEN: ${{ secrets.PUBLIC_GREEN_SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ vars.PUBLIC_SONAR_HOST_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_LEDGER_DMK_PROJECT }}
 
   cs-tester:
     needs: [build-libraries, detect-changes]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,5 @@
-sonar.projectKey=LedgerHQ_device-sdk-ts_AY3G5or9RLDSln8Rix8q
+sonar.projectKey=LedgerHQ_device-sdk-ts
+sonar.organization=ledger
 sonar.typescript.tsconfigPaths=tsconfig.json
 sonar.javascript.lcov.reportPaths=**/coverage/lcov.info
 sonar.exclusions=**/node_modules/**,**/coverage/**,**/.next,**/pocs/**,**/.turbo/**,**/lib/**,**/danger/**,**/scripts/**,**/_templates/**,./packages/tools/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,4 +2,4 @@ sonar.projectKey=LedgerHQ_device-sdk-ts
 sonar.organization=ledger
 sonar.typescript.tsconfigPaths=tsconfig.json
 sonar.javascript.lcov.reportPaths=**/coverage/lcov.info
-sonar.exclusions=**/node_modules/**,**/coverage/**,**/.next,**/pocs/**,**/.turbo/**,**/lib/**,**/danger/**,**/scripts/**,**/_templates/**,./packages/tools/**
+sonar.exclusions=**/node_modules/**,**/coverage/**,**/.next,**/pocs/**,**/.turbo/**,**/lib/**,**/danger/**,**/scripts/**,**/_templates/**,./packages/tools/**,./apps/**,./agent-files/**


### PR DESCRIPTION
### 📝 Description

Change Sonarqube config for Sonarcloud with coverage reporting

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1217](https://ledgerhq.atlassian.net/browse/DSDK-1217)

### ✅ Checklist

- [x] **Covered by automatic tests** <!-- CI/workflow-only change; validated by the Sonar scan running green on this PR -->
- [ ] **Changeset is provided** — _No changeset needed: changes only affect CI workflow and Sonar config, no published packages._
- [x] **Documentation is up-to-date**
- [ ] **Impact of the changes:**
  - Code quality and coverage are now reported to SonarCloud instead of the self-hosted SonarQube server.
  - QA focus: confirm the Sonar scan step succeeds on PRs and that coverage/quality data appears on the SonarCloud project.

Made with [Cursor](https://cursor.com)

[DSDK-1217]: https://ledgerhq.atlassian.net/browse/DSDK-1217