### PR TITLE
🔧 (ci) [NO-ISSUE]: Exclude test files from SonarCloud coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,3 +3,4 @@ sonar.organization=ledger
 sonar.typescript.tsconfigPaths=tsconfig.json
 sonar.javascript.lcov.reportPaths=**/coverage/lcov.info
 sonar.exclusions=**/node_modules/**,**/coverage/**,**/.next,**/pocs/**,**/.turbo/**,**/lib/**,**/danger/**,**/scripts/**,**/_templates/**,./packages/tools/**,./apps/**,./agent-files/**
+sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,**/*.stub.ts,**/*.stub.tsx,**/*.mock.ts,**/*.mock.tsx,**/__tests__/**,**/__mocks__/**


### PR DESCRIPTION
### 📝 Description

Test files (`*.test.ts`, `*.spec.ts`, `*.stub.ts`, etc.) were being counted in the SonarCloud "Coverage on New Code" metric. Since these files have no coverage of their own, they showed up as 0% with many uncovered lines, dragging the overall coverage figure down (e.g. 42.1% in a recent analysis).

This adds a `sonar.coverage.exclusions` setting to `sonar-project.properties` so test, stub, and mock files are still analyzed for code quality but excluded from the coverage calculation. As a result, "Coverage on New Code" will reflect only the actual source code.

Patterns excluded:
- `**/*.test.ts`, `**/*.test.tsx`
- `**/*.spec.ts`, `**/*.spec.tsx`
- `**/*.stub.ts`, `**/*.stub.tsx`
- `**/*.mock.ts`, `**/*.mock.tsx`
- `**/__tests__/**`, `**/__mocks__/**`

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Fix SonarCloud coverage reporting to exclude test files.

### ✅ Checklist

- [x] **Covered by automatic tests** — N/A, CI configuration change only.
- [ ] **Changeset is provided** — No changeset needed; this only affects CI tooling config, not a published package.
- [x] **Documentation is up-to-date**
- [ ] **Impact of the changes:**
  - SonarCloud no longer counts test/stub/mock files toward coverage metrics.
  - "Coverage on New Code" will reflect only production source files.

Made with [Cursor](https://cursor.com)