### PR TITLE
✨ (signer-polkadot) [LIVE-30995]: Implement APDU commands for the Polkadot signer

### DIFF
--- a/.changeset/bittensor-apdu-commands.md
+++ b/.changeset/bittensor-apdu-commands.md
@@ -1,5 +1,0 @@
----
-"@ledgerhq/device-signer-kit-polkadot": minor
----
-
-Implement APDU commands for Bittensor support: GetAddressCommand with SS58 prefix, multi-chunk SignTransactionCommand (INIT/ADD/LAST), Polkadot application error codes, EncodeDerivationPath utility, and SignTransactionTask with blob+metadata chunking

--- a/.changeset/bittensor-apdu-commands.md
+++ b/.changeset/bittensor-apdu-commands.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-polkadot": minor
+---
+
+Implement APDU commands for Bittensor support: GetAddressCommand with SS58 prefix, multi-chunk SignTransactionCommand (INIT/ADD/LAST), Polkadot application error codes, EncodeDerivationPath utility, and SignTransactionTask with blob+metadata chunking

--- a/.changeset/polkadot-signer-apdu-commands.md
+++ b/.changeset/polkadot-signer-apdu-commands.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-polkadot": minor
+---
+
+Implement the Polkadot-family signer APDU layer: GetAddressCommand (with SS58 prefix), multi-chunk SignTransactionCommand (INIT/ADD/LAST), Polkadot application error codes, derivation-path encoding, and SignTransactionTask with blob+metadata chunking

--- a/apps/sample/src/components/SignerPolkadotView/index.tsx
+++ b/apps/sample/src/components/SignerPolkadotView/index.tsx
@@ -45,7 +45,7 @@ export const SignerPolkadotView: React.FC<{ sessionId: string }> = ({
           });
         },
         initialValues: {
-          derivationPath: "44'/0'/0'/0/0",
+          derivationPath: "44'/354'/0'/0'/0'",
           ss58Prefix: "0",
           checkOnDevice: false,
           skipOpenApp: false,
@@ -82,7 +82,7 @@ export const SignerPolkadotView: React.FC<{ sessionId: string }> = ({
           });
         },
         initialValues: {
-          derivationPath: "44'/0'/0'/0/0",
+          derivationPath: "44'/354'/0'/0'/0'",
           transaction: "",
           metadata: "",
           skipOpenApp: false,

--- a/packages/signer/signer-polkadot/README.md
+++ b/packages/signer/signer-polkadot/README.md
@@ -10,17 +10,26 @@ pnpm add @ledgerhq/device-signer-kit-polkadot
 
 ## Usage
 
+Each method returns an object holding an `observable` and a `cancel` method — it is
+not a promise.
+
+The derivation path is passed without an `m/` prefix, and the device only accepts
+paths under `44'/354'` (the Polkadot-family coin type). Anything else is refused
+with `Data is invalid`.
+
 ```typescript
 import { SignerPolkadotBuilder } from "@ledgerhq/device-signer-kit-polkadot";
 
 const signer = new SignerPolkadotBuilder({ dmk, sessionId }).build();
 
-// Get address
-const address = await signer.getAddress("m/44'/0'/0'/0/0", 42);
+// Get address — 42 is the SS58 prefix (0 for Polkadot, 42 for generic Substrate)
+const { observable, cancel } = signer.getAddress("44'/354'/0'/0'/0'", 42);
 
-// Sign transaction
-const signature = await signer.signTransaction(
-  "m/44'/0'/0'/0/0",
+// Sign transaction — `blob` is the payload to sign, `metadata` the proof used for
+// clear signing. The returned signature is 65 bytes: a 1-byte MultiSignature
+// discriminant followed by the 64-byte Ed25519 signature.
+const { observable: signObservable } = signer.signTransaction(
+  "44'/354'/0'/0'/0'",
   blob,
   metadata,
 );

--- a/packages/signer/signer-polkadot/src/api/SignerPolkadotBuilder.test.ts
+++ b/packages/signer/signer-polkadot/src/api/SignerPolkadotBuilder.test.ts
@@ -1,7 +1,7 @@
 import { type DeviceManagementKit } from "@ledgerhq/device-management-kit";
 
 import { SignerPolkadotBuilder } from "@api/SignerPolkadotBuilder";
-import { APP_NAME, INS, LEDGER_CLA } from "@internal/app-binder/constants";
+import { APP_NAME, LEDGER_CLA } from "@internal/app-binder/constants";
 import { DefaultSignerPolkadot } from "@internal/DefaultSignerPolkadot";
 
 describe("SignerPolkadotBuilder", () => {
@@ -30,11 +30,5 @@ describe("Polkadot APDU constants", () => {
 
   test("LEDGER_CLA should be 0xF9", () => {
     expect(LEDGER_CLA).toBe(0xf9);
-  });
-
-  test("INS values should match the Polkadot app protocol", () => {
-    expect(INS.GET_ADDRESS).toBe(0x01);
-    expect(INS.SIGN_TRANSACTION).toBe(0x02);
-    expect(INS.SIGN_RAW).toBe(0x03);
   });
 });

--- a/packages/signer/signer-polkadot/src/api/model/Signature.ts
+++ b/packages/signer/signer-polkadot/src/api/model/Signature.ts
@@ -1,1 +1,10 @@
+/**
+ * A signature as returned by the device: 65 bytes made of a 1-byte
+ * MultiSignature discriminant (0x00 for Ed25519) followed by the 64-byte
+ * Ed25519 signature.
+ *
+ * The discriminant is part of the value, so it is already SCALE-compatible
+ * with Substrate's `MultiSignature` enum. Consumers that expect a bare
+ * 64-byte signature must drop the first byte.
+ */
 export type Signature = Uint8Array;

--- a/packages/signer/signer-polkadot/src/internal/DefaultSignerPolkadot.test.ts
+++ b/packages/signer/signer-polkadot/src/internal/DefaultSignerPolkadot.test.ts
@@ -1,0 +1,94 @@
+import {
+  DeviceActionStatus,
+  type DeviceManagementKit,
+  type DeviceSessionId,
+  type ExecuteDeviceActionReturnType,
+} from "@ledgerhq/device-management-kit";
+import { from } from "rxjs";
+import { vi } from "vitest";
+
+import {
+  type GetAddressDAError,
+  type GetAddressDAIntermediateValue,
+  type GetAddressDAOutput,
+} from "@api/app-binder/GetAddressDeviceActionTypes";
+import {
+  type SignTransactionDAError,
+  type SignTransactionDAIntermediateValue,
+  type SignTransactionDAOutput,
+} from "@api/app-binder/SignTransactionDeviceActionTypes";
+
+import { DefaultSignerPolkadot } from "./DefaultSignerPolkadot";
+
+describe("DefaultSignerPolkadot", () => {
+  const sessionId = "test-session-id" as DeviceSessionId;
+  const derivationPath = "44'/354'/0'/0'/0'";
+  const ss58Prefix = 42;
+  const mockLoggerFactory = () => ({});
+
+  const makeDmkMock = (expectedResult: unknown) => {
+    const executeDeviceActionMock = vi.fn().mockReturnValue(expectedResult);
+    const dmkMock = {
+      executeDeviceAction: executeDeviceActionMock,
+      getLoggerFactory: vi.fn().mockReturnValue(mockLoggerFactory),
+    } as unknown as DeviceManagementKit;
+    return { executeDeviceActionMock, dmkMock };
+  };
+
+  it("getAddress should return the result from getAddressUseCase", () => {
+    // ARRANGE
+    const expectedResult: ExecuteDeviceActionReturnType<
+      GetAddressDAOutput,
+      GetAddressDAError,
+      GetAddressDAIntermediateValue
+    > = {
+      observable: from([
+        {
+          status: DeviceActionStatus.Completed as const,
+          output: {
+            publicKey: new Uint8Array([0x01, 0x02]),
+            address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+          },
+        },
+      ]),
+      cancel: vi.fn(),
+    };
+    const { executeDeviceActionMock, dmkMock } = makeDmkMock(expectedResult);
+    const signer = new DefaultSignerPolkadot({ dmk: dmkMock, sessionId });
+
+    // ACT
+    const result = signer.getAddress(derivationPath, ss58Prefix);
+
+    // ASSERT
+    expect(executeDeviceActionMock).toHaveBeenCalledTimes(1);
+    expect(result).toBe(expectedResult);
+  });
+
+  it("signTransaction should return the result from signTransactionUseCase", () => {
+    // ARRANGE
+    const blob = new Uint8Array([0x01, 0x02]);
+    const metadata = new Uint8Array([0x03, 0x04]);
+    const expectedResult: ExecuteDeviceActionReturnType<
+      SignTransactionDAOutput,
+      SignTransactionDAError,
+      SignTransactionDAIntermediateValue
+    > = {
+      observable: from([
+        {
+          status: DeviceActionStatus.Completed as const,
+          output: new Uint8Array([0x05, 0x06]),
+        },
+      ]),
+      cancel: vi.fn(),
+    };
+    const { executeDeviceActionMock, dmkMock } = makeDmkMock(expectedResult);
+    const signer = new DefaultSignerPolkadot({ dmk: dmkMock, sessionId });
+
+    // ACT
+    const result = signer.signTransaction(derivationPath, blob, metadata);
+
+    // ASSERT
+    expect(executeDeviceActionMock).toHaveBeenCalledTimes(1);
+    expect(result).toBe(expectedResult);
+  });
+});

--- a/packages/signer/signer-polkadot/src/internal/app-binder/PolkadotAppBinder.test.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/PolkadotAppBinder.test.ts
@@ -1,0 +1,160 @@
+import {
+  type DeviceManagementKit,
+  type DeviceSessionId,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+import { describe, expect, it, vi } from "vitest";
+
+import { GetAddressCommand } from "@internal/app-binder/command/GetAddressCommand";
+import { APP_NAME } from "@internal/app-binder/constants";
+
+import { PolkadotAppBinder } from "./PolkadotAppBinder";
+
+const mockLoggerFactory = () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  subscribers: [],
+});
+
+describe("PolkadotAppBinder", () => {
+  const sessionId = "test-session-id" as DeviceSessionId;
+  const mockedDmk = {
+    executeDeviceAction: vi.fn(),
+  } as unknown as DeviceManagementKit;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should be defined", () => {
+    const binder = new PolkadotAppBinder(
+      mockedDmk,
+      sessionId,
+      mockLoggerFactory,
+    );
+    expect(binder).toBeDefined();
+  });
+
+  describe("getAddress", () => {
+    it("should call executeDeviceAction with VerifyAddress when checkOnDevice is true", () => {
+      // ARRANGE
+      const args = {
+        derivationPath: "44'/354'/0'/0'/0'",
+        ss58Prefix: 13116,
+        checkOnDevice: true,
+        skipOpenApp: false,
+      };
+      const binder = new PolkadotAppBinder(
+        mockedDmk,
+        sessionId,
+        mockLoggerFactory,
+      );
+      // ACT
+      binder.getAddress(args);
+      // ASSERT
+      expect(mockedDmk.executeDeviceAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId,
+          deviceAction: expect.objectContaining({
+            input: {
+              command: new GetAddressCommand(args),
+              appName: APP_NAME,
+              requiredUserInteraction: UserInteractionRequired.VerifyAddress,
+              skipOpenApp: false,
+            },
+          }),
+        }),
+      );
+    });
+
+    it("should call executeDeviceAction with None when checkOnDevice is false", () => {
+      // ARRANGE
+      const args = {
+        derivationPath: "44'/354'/0'/0'/0'",
+        ss58Prefix: 0,
+        checkOnDevice: false,
+        skipOpenApp: true,
+      };
+      const binder = new PolkadotAppBinder(
+        mockedDmk,
+        sessionId,
+        mockLoggerFactory,
+      );
+      // ACT
+      binder.getAddress(args);
+      // ASSERT
+      expect(mockedDmk.executeDeviceAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId,
+          deviceAction: expect.objectContaining({
+            input: {
+              command: new GetAddressCommand(args),
+              appName: APP_NAME,
+              requiredUserInteraction: UserInteractionRequired.None,
+              skipOpenApp: true,
+            },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("signTransaction", () => {
+    it("should call executeDeviceAction with SignTransaction interaction", () => {
+      // ARRANGE
+      const binder = new PolkadotAppBinder(
+        mockedDmk,
+        sessionId,
+        mockLoggerFactory,
+      );
+      // ACT
+      binder.signTransaction({
+        derivationPath: "44'/354'/0'/0'/0'",
+        blob: new Uint8Array([0x01, 0x02]),
+        metadata: new Uint8Array([0x03]),
+        skipOpenApp: false,
+      });
+      // ASSERT
+      expect(mockedDmk.executeDeviceAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId,
+          deviceAction: expect.objectContaining({
+            input: expect.objectContaining({
+              appName: APP_NAME,
+              requiredUserInteraction: UserInteractionRequired.SignTransaction,
+              skipOpenApp: false,
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("should default skipOpenApp to false when not provided", () => {
+      // ARRANGE
+      const binder = new PolkadotAppBinder(
+        mockedDmk,
+        sessionId,
+        mockLoggerFactory,
+      );
+      // ACT
+      binder.signTransaction({
+        derivationPath: "44'/354'/0'/0'/0'",
+        blob: new Uint8Array([0x01]),
+        metadata: new Uint8Array([0x02]),
+      });
+      // ASSERT
+      expect(mockedDmk.executeDeviceAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId,
+          deviceAction: expect.objectContaining({
+            input: expect.objectContaining({
+              skipOpenApp: false,
+            }),
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/packages/signer/signer-polkadot/src/internal/app-binder/PolkadotAppBinder.test.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/PolkadotAppBinder.test.ts
@@ -1,0 +1,163 @@
+import {
+  type DeviceManagementKit,
+  type DeviceSessionId,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GetAddressCommand } from "@internal/app-binder/command/GetAddressCommand";
+import { APP_NAME } from "@internal/app-binder/constants";
+
+import { PolkadotAppBinder } from "./PolkadotAppBinder";
+
+const containing = (value: Record<string, unknown>): unknown =>
+  expect.objectContaining(value);
+
+const mockLoggerFactory = () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  subscribers: [],
+});
+
+describe("PolkadotAppBinder", () => {
+  const sessionId = "test-session-id" as DeviceSessionId;
+  const mockedDmk = {
+    executeDeviceAction: vi.fn(),
+  } as unknown as DeviceManagementKit;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should be defined", () => {
+    const binder = new PolkadotAppBinder(
+      mockedDmk,
+      sessionId,
+      mockLoggerFactory,
+    );
+    expect(binder).toBeDefined();
+  });
+
+  describe("getAddress", () => {
+    it("should call executeDeviceAction with VerifyAddress when checkOnDevice is true", () => {
+      // ARRANGE
+      const args = {
+        derivationPath: "44'/354'/0'/0'/0'",
+        ss58Prefix: 13116,
+        checkOnDevice: true,
+        skipOpenApp: false,
+      };
+      const binder = new PolkadotAppBinder(
+        mockedDmk,
+        sessionId,
+        mockLoggerFactory,
+      );
+      // ACT
+      binder.getAddress(args);
+      // ASSERT
+      expect(mockedDmk.executeDeviceAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId,
+          deviceAction: containing({
+            input: {
+              command: new GetAddressCommand(args),
+              appName: APP_NAME,
+              requiredUserInteraction: UserInteractionRequired.VerifyAddress,
+              skipOpenApp: false,
+            },
+          }),
+        }),
+      );
+    });
+
+    it("should call executeDeviceAction with None when checkOnDevice is false", () => {
+      // ARRANGE
+      const args = {
+        derivationPath: "44'/354'/0'/0'/0'",
+        ss58Prefix: 0,
+        checkOnDevice: false,
+        skipOpenApp: true,
+      };
+      const binder = new PolkadotAppBinder(
+        mockedDmk,
+        sessionId,
+        mockLoggerFactory,
+      );
+      // ACT
+      binder.getAddress(args);
+      // ASSERT
+      expect(mockedDmk.executeDeviceAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId,
+          deviceAction: containing({
+            input: {
+              command: new GetAddressCommand(args),
+              appName: APP_NAME,
+              requiredUserInteraction: UserInteractionRequired.None,
+              skipOpenApp: true,
+            },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("signTransaction", () => {
+    it("should call executeDeviceAction with SignTransaction interaction", () => {
+      // ARRANGE
+      const binder = new PolkadotAppBinder(
+        mockedDmk,
+        sessionId,
+        mockLoggerFactory,
+      );
+      // ACT
+      binder.signTransaction({
+        derivationPath: "44'/354'/0'/0'/0'",
+        blob: new Uint8Array([0x01, 0x02]),
+        metadata: new Uint8Array([0x03]),
+        skipOpenApp: false,
+      });
+      // ASSERT
+      expect(mockedDmk.executeDeviceAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId,
+          deviceAction: containing({
+            input: containing({
+              appName: APP_NAME,
+              requiredUserInteraction: UserInteractionRequired.SignTransaction,
+              skipOpenApp: false,
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("should default skipOpenApp to false when not provided", () => {
+      // ARRANGE
+      const binder = new PolkadotAppBinder(
+        mockedDmk,
+        sessionId,
+        mockLoggerFactory,
+      );
+      // ACT
+      binder.signTransaction({
+        derivationPath: "44'/354'/0'/0'/0'",
+        blob: new Uint8Array([0x01]),
+        metadata: new Uint8Array([0x02]),
+      });
+      // ASSERT
+      expect(mockedDmk.executeDeviceAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId,
+          deviceAction: containing({
+            input: containing({
+              skipOpenApp: false,
+            }),
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/packages/signer/signer-polkadot/src/internal/app-binder/PolkadotAppBinder.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/PolkadotAppBinder.ts
@@ -2,6 +2,7 @@ import {
   CallTaskInAppDeviceAction,
   type DeviceManagementKit,
   type DeviceSessionId,
+  LoggerPublisherService,
   SendCommandInAppDeviceAction,
   UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
@@ -20,6 +21,8 @@ export class PolkadotAppBinder {
   constructor(
     @inject(externalTypes.Dmk) private dmk: DeviceManagementKit,
     @inject(externalTypes.SessionId) private sessionId: DeviceSessionId,
+    @inject(externalTypes.DmkLoggerFactory)
+    private dmkLoggerFactory: (tag: string) => LoggerPublisherService,
   ) {}
 
   getAddress(args: {
@@ -39,6 +42,7 @@ export class PolkadotAppBinder {
             : UserInteractionRequired.None,
           skipOpenApp: args.skipOpenApp,
         },
+        logger: this.dmkLoggerFactory("GetAddressCommand"),
       }),
     });
   }
@@ -54,11 +58,16 @@ export class PolkadotAppBinder {
       deviceAction: new CallTaskInAppDeviceAction({
         input: {
           task: async (internalApi) =>
-            new SignTransactionTask(internalApi, args).run(),
+            new SignTransactionTask(
+              internalApi,
+              args,
+              this.dmkLoggerFactory("SignTransactionTask"),
+            ).run(),
           appName: APP_NAME,
           requiredUserInteraction: UserInteractionRequired.SignTransaction,
           skipOpenApp: args.skipOpenApp ?? false,
         },
+        logger: this.dmkLoggerFactory("SignTransactionCommand"),
       }),
     });
   }

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/GetAddressCommand.test.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/GetAddressCommand.test.ts
@@ -1,0 +1,198 @@
+import {
+  ApduBuilder,
+  ApduResponse,
+  type InvalidStatusWordError,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { DerivationPathUtils } from "@ledgerhq/signer-utils";
+import { describe, expect, it } from "vitest";
+
+import {
+  GetAddressCommand,
+  P1_CONFIRM,
+  P1_NO_CONFIRM,
+  polkadotGetAddressApduHeader,
+} from "@internal/app-binder/command/GetAddressCommand";
+import {
+  PolkadotAppCommandError,
+  PolkadotErrorCodes,
+} from "@internal/app-binder/command/utils/polkadotApplicationErrors";
+
+const BITTENSOR_PATH = "44'/1005'/0'/0'/0'";
+const SS58_PREFIX = 42;
+
+/**
+ * Encodes a derivation path to the Polkadot 20-byte LE format.
+ * Passthrough — all elements written as-is (hardened flag preserved).
+ */
+const pathToBuffer = (derivationPath: string): Uint8Array => {
+  const paths = DerivationPathUtils.splitPath(derivationPath);
+  const view = new DataView(new ArrayBuffer(20));
+  for (let i = 0; i < paths.length; i++) {
+    view.setUint32(i * 4, paths[i]! >>> 0, true);
+  }
+  return new Uint8Array(view.buffer);
+};
+
+const ss58ToBuffer = (prefix: number): Uint8Array => {
+  const buf = new Uint8Array(2);
+  new DataView(buf.buffer).setUint16(0, prefix, true);
+  return buf;
+};
+
+describe("GetAddressCommand", () => {
+  describe("name", () => {
+    it("should be 'GetAddress'", () => {
+      // ARRANGE
+      const command = new GetAddressCommand({
+        derivationPath: BITTENSOR_PATH,
+        ss58Prefix: SS58_PREFIX,
+        checkOnDevice: false,
+      });
+      // ASSERT
+      expect(command.name).toBe("GetAddress");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("should return APDU with P1=0x00 when checkOnDevice is false", () => {
+      // ARRANGE
+      const command = new GetAddressCommand({
+        derivationPath: BITTENSOR_PATH,
+        ss58Prefix: SS58_PREFIX,
+        checkOnDevice: false,
+      });
+      const expected = new ApduBuilder(
+        polkadotGetAddressApduHeader(P1_NO_CONFIRM),
+      )
+        .addBufferToData(pathToBuffer(BITTENSOR_PATH))
+        .addBufferToData(ss58ToBuffer(SS58_PREFIX));
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.build().getRawApdu());
+    });
+
+    it("should return APDU with P1=0x01 when checkOnDevice is true", () => {
+      // ARRANGE
+      const command = new GetAddressCommand({
+        derivationPath: BITTENSOR_PATH,
+        ss58Prefix: SS58_PREFIX,
+        checkOnDevice: true,
+      });
+      const expected = new ApduBuilder(polkadotGetAddressApduHeader(P1_CONFIRM))
+        .addBufferToData(pathToBuffer(BITTENSOR_PATH))
+        .addBufferToData(ss58ToBuffer(SS58_PREFIX));
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.build().getRawApdu());
+    });
+
+    it("should encode SS58 prefix as 2-byte little-endian", () => {
+      // ARRANGE — SS58=42 (0x002A): LE bytes = [0x2A, 0x00]
+      const command = new GetAddressCommand({
+        derivationPath: BITTENSOR_PATH,
+        ss58Prefix: 42,
+        checkOnDevice: false,
+      });
+      // ACT
+      const apdu = command.getApdu();
+      const raw = apdu.getRawApdu();
+      // The payload starts at byte 5 (CLA INS P1 P2 Lc), path is 20 bytes, then SS58 at offset 25+5=25
+      // raw[0..4] = header, raw[5] = Lc, raw[6..25] = path (20 bytes), raw[26..27] = SS58
+      // Actually ApduBuilder format: CLA(1) INS(1) P1(1) P2(1) Lc(1) data...
+      const dataOffset = 5; // after CLA INS P1 P2 Lc
+      const ss58Offset = dataOffset + 20; // after path
+      expect(raw[ss58Offset]).toBe(0x2a); // 42 LSB
+      expect(raw[ss58Offset + 1]).toBe(0x00); // 42 MSB
+    });
+
+    it("should throw when derivation path does not have 5 elements", () => {
+      // ARRANGE
+      const command = new GetAddressCommand({
+        derivationPath: "44'/1005'/0'",
+        ss58Prefix: SS58_PREFIX,
+        checkOnDevice: false,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "GetAddressCommand: expected 5 path elements, got 3",
+      );
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("should return publicKey and address on success (0x9000)", () => {
+      // ARRANGE
+      const publicKey = new Uint8Array(32).fill(0x02);
+      const addressStr = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+      const addressBytes = new TextEncoder().encode(addressStr);
+      const data = new Uint8Array(32 + addressBytes.length);
+      data.set(publicKey, 0);
+      data.set(addressBytes, 32);
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data,
+      });
+      const command = new GetAddressCommand({
+        derivationPath: BITTENSOR_PATH,
+        ss58Prefix: SS58_PREFIX,
+        checkOnDevice: false,
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data.publicKey).toStrictEqual(publicKey);
+        expect(result.data.address).toBe(addressStr);
+      }
+    });
+
+    it("should return PolkadotAppCommandError when device returns DATA_INVALID (0x6984)", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x69, 0x84]),
+        data: new Uint8Array(0),
+      });
+      const command = new GetAddressCommand({
+        derivationPath: BITTENSOR_PATH,
+        ss58Prefix: SS58_PREFIX,
+        checkOnDevice: false,
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(PolkadotAppCommandError);
+        const err = result.error as PolkadotAppCommandError;
+        expect(err.errorCode).toBe(PolkadotErrorCodes.DATA_INVALID);
+      }
+    });
+
+    it("should return InvalidStatusWordError when public key is missing from response", () => {
+      // ARRANGE — success status but empty data
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: new Uint8Array(0),
+      });
+      const command = new GetAddressCommand({
+        derivationPath: BITTENSOR_PATH,
+        ss58Prefix: SS58_PREFIX,
+        checkOnDevice: false,
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidStatusWordError;
+        expect((err.originalError as { message: string }).message).toBe(
+          "Public key is missing",
+        );
+      }
+    });
+  });
+});

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/GetAddressCommand.test.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/GetAddressCommand.test.ts
@@ -18,7 +18,7 @@ import {
   PolkadotErrorCodes,
 } from "@internal/app-binder/command/utils/polkadotApplicationErrors";
 
-const BITTENSOR_PATH = "44'/1005'/0'/0'/0'";
+const POLKADOT_PATH = "44'/354'/0'/0'/0'";
 const SS58_PREFIX = 42;
 
 /**
@@ -45,7 +45,7 @@ describe("GetAddressCommand", () => {
     it("should be 'GetAddress'", () => {
       // ARRANGE
       const command = new GetAddressCommand({
-        derivationPath: BITTENSOR_PATH,
+        derivationPath: POLKADOT_PATH,
         ss58Prefix: SS58_PREFIX,
         checkOnDevice: false,
       });
@@ -58,14 +58,14 @@ describe("GetAddressCommand", () => {
     it("should return APDU with P1=0x00 when checkOnDevice is false", () => {
       // ARRANGE
       const command = new GetAddressCommand({
-        derivationPath: BITTENSOR_PATH,
+        derivationPath: POLKADOT_PATH,
         ss58Prefix: SS58_PREFIX,
         checkOnDevice: false,
       });
       const expected = new ApduBuilder(
         polkadotGetAddressApduHeader(P1_NO_CONFIRM),
       )
-        .addBufferToData(pathToBuffer(BITTENSOR_PATH))
+        .addBufferToData(pathToBuffer(POLKADOT_PATH))
         .addBufferToData(ss58ToBuffer(SS58_PREFIX));
       // ACT
       const apdu = command.getApdu();
@@ -76,12 +76,12 @@ describe("GetAddressCommand", () => {
     it("should return APDU with P1=0x01 when checkOnDevice is true", () => {
       // ARRANGE
       const command = new GetAddressCommand({
-        derivationPath: BITTENSOR_PATH,
+        derivationPath: POLKADOT_PATH,
         ss58Prefix: SS58_PREFIX,
         checkOnDevice: true,
       });
       const expected = new ApduBuilder(polkadotGetAddressApduHeader(P1_CONFIRM))
-        .addBufferToData(pathToBuffer(BITTENSOR_PATH))
+        .addBufferToData(pathToBuffer(POLKADOT_PATH))
         .addBufferToData(ss58ToBuffer(SS58_PREFIX));
       // ACT
       const apdu = command.getApdu();
@@ -92,7 +92,7 @@ describe("GetAddressCommand", () => {
     it("should encode SS58 prefix as 2-byte little-endian", () => {
       // ARRANGE — SS58=42 (0x002A): LE bytes = [0x2A, 0x00]
       const command = new GetAddressCommand({
-        derivationPath: BITTENSOR_PATH,
+        derivationPath: POLKADOT_PATH,
         ss58Prefix: 42,
         checkOnDevice: false,
       });
@@ -111,13 +111,26 @@ describe("GetAddressCommand", () => {
     it("should throw when derivation path does not have 5 elements", () => {
       // ARRANGE
       const command = new GetAddressCommand({
-        derivationPath: "44'/1005'/0'",
+        derivationPath: "44'/354'/0'",
         ss58Prefix: SS58_PREFIX,
         checkOnDevice: false,
       });
       // ACT & ASSERT
       expect(() => command.getApdu()).toThrow(
         "GetAddressCommand: expected 5 path elements, got 3",
+      );
+    });
+
+    it("should throw when ss58Prefix exceeds the uint16 range", () => {
+      // ARRANGE
+      const command = new GetAddressCommand({
+        derivationPath: POLKADOT_PATH,
+        ss58Prefix: 0x10000,
+        checkOnDevice: false,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "GetAddressCommand: ss58Prefix must be a uint16",
       );
     });
   });
@@ -136,7 +149,7 @@ describe("GetAddressCommand", () => {
         data,
       });
       const command = new GetAddressCommand({
-        derivationPath: BITTENSOR_PATH,
+        derivationPath: POLKADOT_PATH,
         ss58Prefix: SS58_PREFIX,
         checkOnDevice: false,
       });
@@ -157,7 +170,7 @@ describe("GetAddressCommand", () => {
         data: new Uint8Array(0),
       });
       const command = new GetAddressCommand({
-        derivationPath: BITTENSOR_PATH,
+        derivationPath: POLKADOT_PATH,
         ss58Prefix: SS58_PREFIX,
         checkOnDevice: false,
       });
@@ -179,7 +192,7 @@ describe("GetAddressCommand", () => {
         data: new Uint8Array(0),
       });
       const command = new GetAddressCommand({
-        derivationPath: BITTENSOR_PATH,
+        derivationPath: POLKADOT_PATH,
         ss58Prefix: SS58_PREFIX,
         checkOnDevice: false,
       });

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/GetAddressCommand.test.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/GetAddressCommand.test.ts
@@ -1,0 +1,245 @@
+import {
+  ApduBuilder,
+  ApduResponse,
+  type InvalidStatusWordError,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { DerivationPathUtils } from "@ledgerhq/signer-utils";
+import { describe, expect, it } from "vitest";
+
+import {
+  GetAddressCommand,
+  P1_CONFIRM,
+  P1_NO_CONFIRM,
+  polkadotGetAddressApduHeader,
+} from "@internal/app-binder/command/GetAddressCommand";
+import {
+  PolkadotAppCommandError,
+  PolkadotErrorCodes,
+} from "@internal/app-binder/command/utils/polkadotApplicationErrors";
+
+const POLKADOT_PATH = "44'/354'/0'/0'/0'";
+const SS58_PREFIX = 42;
+
+/**
+ * Encodes a derivation path to the Polkadot 20-byte LE format.
+ * Passthrough — all elements written as-is (hardened flag preserved).
+ */
+const pathToBuffer = (derivationPath: string): Uint8Array => {
+  const paths = DerivationPathUtils.splitPath(derivationPath);
+  const view = new DataView(new ArrayBuffer(20));
+  for (let i = 0; i < paths.length; i++) {
+    view.setUint32(i * 4, paths[i]! >>> 0, true);
+  }
+  return new Uint8Array(view.buffer);
+};
+
+const ss58ToBuffer = (prefix: number): Uint8Array => {
+  const buf = new Uint8Array(2);
+  new DataView(buf.buffer).setUint16(0, prefix, true);
+  return buf;
+};
+
+describe("GetAddressCommand", () => {
+  describe("name", () => {
+    it("should be 'GetAddress'", () => {
+      // ARRANGE
+      const command = new GetAddressCommand({
+        derivationPath: POLKADOT_PATH,
+        ss58Prefix: SS58_PREFIX,
+        checkOnDevice: false,
+      });
+      // ASSERT
+      expect(command.name).toBe("GetAddress");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("should return APDU with P1=0x00 when checkOnDevice is false", () => {
+      // ARRANGE
+      const command = new GetAddressCommand({
+        derivationPath: POLKADOT_PATH,
+        ss58Prefix: SS58_PREFIX,
+        checkOnDevice: false,
+      });
+      const expected = new ApduBuilder(
+        polkadotGetAddressApduHeader(P1_NO_CONFIRM),
+      )
+        .addBufferToData(pathToBuffer(POLKADOT_PATH))
+        .addBufferToData(ss58ToBuffer(SS58_PREFIX));
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.build().getRawApdu());
+    });
+
+    it("should return APDU with P1=0x01 when checkOnDevice is true", () => {
+      // ARRANGE
+      const command = new GetAddressCommand({
+        derivationPath: POLKADOT_PATH,
+        ss58Prefix: SS58_PREFIX,
+        checkOnDevice: true,
+      });
+      const expected = new ApduBuilder(polkadotGetAddressApduHeader(P1_CONFIRM))
+        .addBufferToData(pathToBuffer(POLKADOT_PATH))
+        .addBufferToData(ss58ToBuffer(SS58_PREFIX));
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.build().getRawApdu());
+    });
+
+    it("should encode SS58 prefix as 2-byte little-endian", () => {
+      // ARRANGE — SS58=42 (0x002A): LE bytes = [0x2A, 0x00]
+      const command = new GetAddressCommand({
+        derivationPath: POLKADOT_PATH,
+        ss58Prefix: 42,
+        checkOnDevice: false,
+      });
+      // ACT
+      const apdu = command.getApdu();
+      const raw = apdu.getRawApdu();
+      // The payload starts at byte 5 (CLA INS P1 P2 Lc), path is 20 bytes, then SS58 at offset 25+5=25
+      // raw[0..4] = header, raw[5] = Lc, raw[6..25] = path (20 bytes), raw[26..27] = SS58
+      // Actually ApduBuilder format: CLA(1) INS(1) P1(1) P2(1) Lc(1) data...
+      const dataOffset = 5; // after CLA INS P1 P2 Lc
+      const ss58Offset = dataOffset + 20; // after path
+      expect(raw[ss58Offset]).toBe(0x2a); // 42 LSB
+      expect(raw[ss58Offset + 1]).toBe(0x00); // 42 MSB
+    });
+
+    it("should throw when derivation path does not have 5 elements", () => {
+      // ARRANGE
+      const command = new GetAddressCommand({
+        derivationPath: "44'/354'/0'",
+        ss58Prefix: SS58_PREFIX,
+        checkOnDevice: false,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "GetAddressCommand: expected 5 path elements, got 3",
+      );
+    });
+
+    it("should throw when ss58Prefix exceeds the range the device encodes", () => {
+      // ARRANGE — 16384 is the first value crypto_SS58CalculatePrefix refuses
+      const command = new GetAddressCommand({
+        derivationPath: POLKADOT_PATH,
+        ss58Prefix: 16384,
+        checkOnDevice: false,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "GetAddressCommand: ss58Prefix must be in 0..16383",
+      );
+    });
+
+    it("should accept the highest ss58Prefix the device encodes", () => {
+      // ARRANGE
+      const command = new GetAddressCommand({
+        derivationPath: POLKADOT_PATH,
+        ss58Prefix: 16383,
+        checkOnDevice: false,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).not.toThrow();
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("should return publicKey and address on success (0x9000)", () => {
+      // ARRANGE
+      const publicKey = new Uint8Array(32).fill(0x02);
+      const addressStr = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+      const addressBytes = new TextEncoder().encode(addressStr);
+      const data = new Uint8Array(32 + addressBytes.length);
+      data.set(publicKey, 0);
+      data.set(addressBytes, 32);
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data,
+      });
+      const command = new GetAddressCommand({
+        derivationPath: POLKADOT_PATH,
+        ss58Prefix: SS58_PREFIX,
+        checkOnDevice: false,
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data.publicKey).toStrictEqual(publicKey);
+        expect(result.data.address).toBe(addressStr);
+      }
+    });
+
+    it("should return PolkadotAppCommandError when device returns DATA_INVALID (0x6984)", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x69, 0x84]),
+        data: new Uint8Array(0),
+      });
+      const command = new GetAddressCommand({
+        derivationPath: POLKADOT_PATH,
+        ss58Prefix: SS58_PREFIX,
+        checkOnDevice: false,
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(PolkadotAppCommandError);
+        const err = result.error as PolkadotAppCommandError;
+        expect(err.errorCode).toBe(PolkadotErrorCodes.DATA_INVALID);
+      }
+    });
+
+    it("should return InvalidStatusWordError when the address is missing from response", () => {
+      // ARRANGE — success status carrying the public key only
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: new Uint8Array(32).fill(0x02),
+      });
+      const command = new GetAddressCommand({
+        derivationPath: POLKADOT_PATH,
+        ss58Prefix: SS58_PREFIX,
+        checkOnDevice: false,
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidStatusWordError;
+        expect((err.originalError as { message: string }).message).toBe(
+          "Address is missing",
+        );
+      }
+    });
+
+    it("should return InvalidStatusWordError when public key is missing from response", () => {
+      // ARRANGE — success status but empty data
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: new Uint8Array(0),
+      });
+      const command = new GetAddressCommand({
+        derivationPath: POLKADOT_PATH,
+        ss58Prefix: SS58_PREFIX,
+        checkOnDevice: false,
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidStatusWordError;
+        expect((err.originalError as { message: string }).message).toBe(
+          "Public key is missing",
+        );
+      }
+    });
+  });
+});

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/GetAddressCommand.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/GetAddressCommand.ts
@@ -1,11 +1,27 @@
 import {
   type Apdu,
+  ApduBuilder,
+  ApduParser,
   type ApduResponse,
   type Command,
   type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
 } from "@ledgerhq/device-management-kit";
+import {
+  CommandErrorHelper,
+  DerivationPathUtils,
+} from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
 
-import { type PolkadotErrorCodes } from "./utils/polkadotApplicationErrors";
+import {
+  POLKADOT_APP_ERRORS,
+  PolkadotAppCommandErrorFactory,
+  type PolkadotErrorCodes,
+} from "@internal/app-binder/command/utils/polkadotApplicationErrors";
+import { INS, LEDGER_CLA, P2 } from "@internal/app-binder/constants";
+
+import { encodeDerivationPath } from "./utils/EncodeDerivationPath";
 
 export type GetAddressCommandArgs = {
   readonly derivationPath: string;
@@ -15,8 +31,21 @@ export type GetAddressCommandArgs = {
 
 export type GetAddressCommandResponse = {
   readonly publicKey: Uint8Array;
-  readonly chainCode?: Uint8Array;
+  readonly address: string;
 };
+
+export const polkadotGetAddressApduHeader = (p1: number) => ({
+  cla: LEDGER_CLA,
+  ins: INS.GET_ADDRESS,
+  p1,
+  p2: P2.ED25519,
+});
+
+export const P1_CONFIRM = 0x01;
+export const P1_NO_CONFIRM = 0x00;
+
+const DERIVATION_PATH_LENGTH = 5;
+const PUBLIC_KEY_LENGTH = 32;
 
 export class GetAddressCommand
   implements
@@ -28,26 +57,71 @@ export class GetAddressCommand
 {
   readonly name = "GetAddress";
 
-  private readonly _args: GetAddressCommandArgs;
+  private readonly args: GetAddressCommandArgs;
+
+  private readonly errorHelper = new CommandErrorHelper<
+    GetAddressCommandResponse,
+    PolkadotErrorCodes
+  >(POLKADOT_APP_ERRORS, PolkadotAppCommandErrorFactory);
 
   constructor(args: GetAddressCommandArgs) {
-    this._args = args;
-  }
-
-  get args(): GetAddressCommandArgs {
-    return this._args;
+    this.args = args;
   }
 
   getApdu(): Apdu {
-    // TODO: Implement APDU construction using this._args
-    throw new Error("GetAddressCommand.getApdu() not implemented");
+    const apduBuilder = new ApduBuilder(
+      polkadotGetAddressApduHeader(
+        this.args.checkOnDevice ? P1_CONFIRM : P1_NO_CONFIRM,
+      ),
+    );
+
+    const derivationPath = DerivationPathUtils.splitPath(
+      this.args.derivationPath,
+    );
+
+    if (derivationPath.length !== DERIVATION_PATH_LENGTH) {
+      throw new Error(
+        `GetAddressCommand: expected ${DERIVATION_PATH_LENGTH} path elements, got ${derivationPath.length}`,
+      );
+    }
+
+    const encodedDerivationPath = encodeDerivationPath(derivationPath);
+    apduBuilder.addBufferToData(encodedDerivationPath);
+
+    // SS58 prefix: 2 bytes little-endian (firmware reads sizeof(uint16_t) via memcpy on ARM LE)
+    const ss58Buf = new Uint8Array(2);
+    new DataView(ss58Buf.buffer).setUint16(0, this.args.ss58Prefix, true);
+    apduBuilder.addBufferToData(ss58Buf);
+
+    return apduBuilder.build();
   }
 
   parseResponse(
-    _apduResponse: ApduResponse,
+    apduResponse: ApduResponse,
   ): CommandResult<GetAddressCommandResponse, PolkadotErrorCodes> {
-    // TODO: Implement response parsing based on your blockchain's protocol
-    // return CommandResultFactory({ data: { ... } });
-    throw new Error("GetAddressCommand.parseResponse() not implemented");
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      const apduParser = new ApduParser(apduResponse);
+      const publicKey = apduParser.extractFieldByLength(PUBLIC_KEY_LENGTH);
+      const remaining = apduParser.getUnparsedRemainingLength();
+      const address = apduParser.extractFieldByLength(remaining);
+
+      if (publicKey === undefined || address === undefined) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Public key is missing"),
+        });
+      }
+
+      // Address is variable-length ASCII, no null padding (unlike Cosmos)
+      const addressStr = apduParser.encodeToString(address);
+
+      return CommandResultFactory({
+        data: {
+          publicKey,
+          address: addressStr,
+        },
+      });
+    });
   }
 }

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/GetAddressCommand.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/GetAddressCommand.ts
@@ -19,9 +19,14 @@ import {
   PolkadotAppCommandErrorFactory,
   type PolkadotErrorCodes,
 } from "@internal/app-binder/command/utils/polkadotApplicationErrors";
-import { INS, LEDGER_CLA, P2 } from "@internal/app-binder/constants";
+import { LEDGER_CLA } from "@internal/app-binder/constants";
 
 import { encodeDerivationPath } from "./utils/EncodeDerivationPath";
+
+// INS/P2 are specific to this command (the Ledger Polkadot app supports
+// ed25519/secp256k1 only; addresses/signatures use ed25519 = 0x00).
+const INS_GET_ADDRESS = 0x01;
+const P2_ED25519 = 0x00;
 
 export type GetAddressCommandArgs = {
   readonly derivationPath: string;
@@ -36,9 +41,9 @@ export type GetAddressCommandResponse = {
 
 export const polkadotGetAddressApduHeader = (p1: number) => ({
   cla: LEDGER_CLA,
-  ins: INS.GET_ADDRESS,
+  ins: INS_GET_ADDRESS,
   p1,
-  p2: P2.ED25519,
+  p2: P2_ED25519,
 });
 
 export const P1_CONFIRM = 0x01;
@@ -46,6 +51,7 @@ export const P1_NO_CONFIRM = 0x00;
 
 const DERIVATION_PATH_LENGTH = 5;
 const PUBLIC_KEY_LENGTH = 32;
+const SS58_PREFIX_MAX = 0xffff;
 
 export class GetAddressCommand
   implements
@@ -87,6 +93,16 @@ export class GetAddressCommand
 
     const encodedDerivationPath = encodeDerivationPath(derivationPath);
     apduBuilder.addBufferToData(encodedDerivationPath);
+
+    if (
+      !Number.isInteger(this.args.ss58Prefix) ||
+      this.args.ss58Prefix < 0 ||
+      this.args.ss58Prefix > SS58_PREFIX_MAX
+    ) {
+      throw new Error(
+        `GetAddressCommand: ss58Prefix must be a uint16 (0..${SS58_PREFIX_MAX}), got ${this.args.ss58Prefix}`,
+      );
+    }
 
     // SS58 prefix: 2 bytes little-endian (firmware reads sizeof(uint16_t) via memcpy on ARM LE)
     const ss58Buf = new Uint8Array(2);

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/GetAddressCommand.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/GetAddressCommand.ts
@@ -1,11 +1,32 @@
 import {
   type Apdu,
+  ApduBuilder,
+  ApduParser,
   type ApduResponse,
   type Command,
   type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
 } from "@ledgerhq/device-management-kit";
+import {
+  CommandErrorHelper,
+  DerivationPathUtils,
+} from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
 
-import { type PolkadotErrorCodes } from "./utils/polkadotApplicationErrors";
+import {
+  POLKADOT_APP_ERRORS,
+  PolkadotAppCommandErrorFactory,
+  type PolkadotErrorCodes,
+} from "@internal/app-binder/command/utils/polkadotApplicationErrors";
+import { LEDGER_CLA } from "@internal/app-binder/constants";
+
+import { encodeDerivationPath } from "./utils/EncodeDerivationPath";
+
+// INS/P2 are specific to this command (the Ledger Polkadot app supports
+// ed25519/secp256k1 only; addresses/signatures use ed25519 = 0x00).
+const INS_GET_ADDRESS = 0x01;
+const P2_ED25519 = 0x00;
 
 export type GetAddressCommandArgs = {
   readonly derivationPath: string;
@@ -15,8 +36,24 @@ export type GetAddressCommandArgs = {
 
 export type GetAddressCommandResponse = {
   readonly publicKey: Uint8Array;
-  readonly chainCode?: Uint8Array;
+  readonly address: string;
 };
+
+export const polkadotGetAddressApduHeader = (p1: number) => ({
+  cla: LEDGER_CLA,
+  ins: INS_GET_ADDRESS,
+  p1,
+  p2: P2_ED25519,
+});
+
+export const P1_CONFIRM = 0x01;
+export const P1_NO_CONFIRM = 0x00;
+
+const DERIVATION_PATH_LENGTH = 5;
+const PUBLIC_KEY_LENGTH = 32;
+// The prefix travels as a uint16, but the device only encodes SS58 address types
+// up to 16383 — a larger value is refused with DATA_INVALID after a full round-trip.
+const SS58_PREFIX_MAX = 16383;
 
 export class GetAddressCommand
   implements
@@ -28,26 +65,91 @@ export class GetAddressCommand
 {
   readonly name = "GetAddress";
 
-  private readonly _args: GetAddressCommandArgs;
+  private readonly args: GetAddressCommandArgs;
+
+  private readonly errorHelper = new CommandErrorHelper<
+    GetAddressCommandResponse,
+    PolkadotErrorCodes
+  >(POLKADOT_APP_ERRORS, PolkadotAppCommandErrorFactory);
 
   constructor(args: GetAddressCommandArgs) {
-    this._args = args;
-  }
-
-  get args(): GetAddressCommandArgs {
-    return this._args;
+    this.args = args;
   }
 
   getApdu(): Apdu {
-    // TODO: Implement APDU construction using this._args
-    throw new Error("GetAddressCommand.getApdu() not implemented");
+    const apduBuilder = new ApduBuilder(
+      polkadotGetAddressApduHeader(
+        this.args.checkOnDevice ? P1_CONFIRM : P1_NO_CONFIRM,
+      ),
+    );
+
+    const derivationPath = DerivationPathUtils.splitPath(
+      this.args.derivationPath,
+    );
+
+    if (derivationPath.length !== DERIVATION_PATH_LENGTH) {
+      throw new Error(
+        `GetAddressCommand: expected ${DERIVATION_PATH_LENGTH} path elements, got ${derivationPath.length}`,
+      );
+    }
+
+    const encodedDerivationPath = encodeDerivationPath(derivationPath);
+    apduBuilder.addBufferToData(encodedDerivationPath);
+
+    if (
+      !Number.isInteger(this.args.ss58Prefix) ||
+      this.args.ss58Prefix < 0 ||
+      this.args.ss58Prefix > SS58_PREFIX_MAX
+    ) {
+      throw new Error(
+        `GetAddressCommand: ss58Prefix must be in 0..${SS58_PREFIX_MAX}, got ${this.args.ss58Prefix}`,
+      );
+    }
+
+    // SS58 prefix: 2 bytes little-endian (firmware reads sizeof(uint16_t) via memcpy on ARM LE)
+    const ss58Buf = new Uint8Array(2);
+    new DataView(ss58Buf.buffer).setUint16(0, this.args.ss58Prefix, true);
+    apduBuilder.addBufferToData(ss58Buf);
+
+    return apduBuilder.build();
   }
 
   parseResponse(
-    _apduResponse: ApduResponse,
+    apduResponse: ApduResponse,
   ): CommandResult<GetAddressCommandResponse, PolkadotErrorCodes> {
-    // TODO: Implement response parsing based on your blockchain's protocol
-    // return CommandResultFactory({ data: { ... } });
-    throw new Error("GetAddressCommand.parseResponse() not implemented");
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      const apduParser = new ApduParser(apduResponse);
+      const publicKey = apduParser.extractFieldByLength(PUBLIC_KEY_LENGTH);
+
+      if (publicKey === undefined) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Public key is missing"),
+        });
+      }
+
+      // A body holding only the public key leaves nothing to extract: guard on the
+      // length, as extractFieldByLength(0) returns an empty array, not undefined.
+      const remaining = apduParser.getUnparsedRemainingLength();
+      const address =
+        apduParser.extractFieldByLength(remaining) ?? new Uint8Array();
+
+      if (address.length === 0) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Address is missing"),
+        });
+      }
+
+      // Address is variable-length ASCII, no null padding (unlike Cosmos)
+      const addressStr = apduParser.encodeToString(address);
+
+      return CommandResultFactory({
+        data: {
+          publicKey,
+          address: addressStr,
+        },
+      });
+    });
   }
 }

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/SignTransactionCommand.test.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/SignTransactionCommand.test.ts
@@ -20,7 +20,7 @@ import {
   PolkadotErrorCodes,
 } from "@internal/app-binder/command/utils/polkadotApplicationErrors";
 
-const BITTENSOR_PATH = "44'/1005'/0'/0'/0'";
+const POLKADOT_PATH = "44'/354'/0'/0'/0'";
 
 /**
  * Encodes a derivation path to the Polkadot 20-byte LE format.
@@ -47,7 +47,7 @@ describe("SignTransactionCommand", () => {
       // ARRANGE
       const command = new SignTransactionCommand({
         phase: SignPhase.INIT,
-        derivationPath: BITTENSOR_PATH,
+        derivationPath: POLKADOT_PATH,
         blobLength: 100,
       });
       // ASSERT
@@ -61,13 +61,13 @@ describe("SignTransactionCommand", () => {
       const blobLength = 150;
       const command = new SignTransactionCommand({
         phase: SignPhase.INIT,
-        derivationPath: BITTENSOR_PATH,
+        derivationPath: POLKADOT_PATH,
         blobLength,
       });
       const expected = new ApduBuilder(
         polkadotSignTransactionApduHeader(P1_INIT),
       )
-        .addBufferToData(pathToBuffer(BITTENSOR_PATH))
+        .addBufferToData(pathToBuffer(POLKADOT_PATH))
         .addBufferToData(blobLenToBuffer(blobLength));
       // ACT
       const apdu = command.getApdu();
@@ -79,7 +79,7 @@ describe("SignTransactionCommand", () => {
       // ARRANGE — blobLength=300 (0x012C): LE bytes = [0x2C, 0x01]
       const command = new SignTransactionCommand({
         phase: SignPhase.INIT,
-        derivationPath: BITTENSOR_PATH,
+        derivationPath: POLKADOT_PATH,
         blobLength: 300,
       });
       // ACT
@@ -139,7 +139,7 @@ describe("SignTransactionCommand", () => {
       // ARRANGE
       const command = new SignTransactionCommand({
         phase: SignPhase.INIT,
-        derivationPath: BITTENSOR_PATH,
+        derivationPath: POLKADOT_PATH,
       });
       // ACT & ASSERT
       expect(() => command.getApdu()).toThrow(
@@ -151,12 +151,25 @@ describe("SignTransactionCommand", () => {
       // ARRANGE
       const command = new SignTransactionCommand({
         phase: SignPhase.INIT,
-        derivationPath: "44'/1005'/0'",
+        derivationPath: "44'/354'/0'",
         blobLength: 100,
       });
       // ACT & ASSERT
       expect(() => command.getApdu()).toThrow(
         "SignTransactionCommand: expected 5 path elements, got 3",
+      );
+    });
+
+    it("should throw when phase is INIT and blobLength exceeds the uint16 range", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath: POLKADOT_PATH,
+        blobLength: 0x10000,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "SignTransactionCommand: blobLength must be a uint16",
       );
     });
 

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/SignTransactionCommand.test.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/SignTransactionCommand.test.ts
@@ -1,0 +1,226 @@
+import {
+  ApduBuilder,
+  ApduResponse,
+  CommandResultFactory,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { DerivationPathUtils } from "@ledgerhq/signer-utils";
+import { describe, expect, it } from "vitest";
+
+import {
+  P1_ADD,
+  P1_INIT,
+  P1_LAST,
+  polkadotSignTransactionApduHeader,
+  SignPhase,
+  SignTransactionCommand,
+} from "@internal/app-binder/command/SignTransactionCommand";
+import {
+  PolkadotAppCommandError,
+  PolkadotErrorCodes,
+} from "@internal/app-binder/command/utils/polkadotApplicationErrors";
+
+const BITTENSOR_PATH = "44'/1005'/0'/0'/0'";
+
+/**
+ * Encodes a derivation path to the Polkadot 20-byte LE format.
+ * Passthrough — all elements written as-is (hardened flag preserved).
+ */
+const pathToBuffer = (derivationPath: string): Uint8Array => {
+  const paths = DerivationPathUtils.splitPath(derivationPath);
+  const view = new DataView(new ArrayBuffer(20));
+  for (let i = 0; i < paths.length; i++) {
+    view.setUint32(i * 4, paths[i]! >>> 0, true);
+  }
+  return new Uint8Array(view.buffer);
+};
+
+const blobLenToBuffer = (blobLength: number): Uint8Array => {
+  const buf = new Uint8Array(2);
+  new DataView(buf.buffer).setUint16(0, blobLength, true);
+  return buf;
+};
+
+describe("SignTransactionCommand", () => {
+  describe("name", () => {
+    it("should be 'SignTransaction'", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath: BITTENSOR_PATH,
+        blobLength: 100,
+      });
+      // ASSERT
+      expect(command.name).toBe("SignTransaction");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("should return INIT packet (P1=0x00) with path and blobLength", () => {
+      // ARRANGE
+      const blobLength = 150;
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath: BITTENSOR_PATH,
+        blobLength,
+      });
+      const expected = new ApduBuilder(
+        polkadotSignTransactionApduHeader(P1_INIT),
+      )
+        .addBufferToData(pathToBuffer(BITTENSOR_PATH))
+        .addBufferToData(blobLenToBuffer(blobLength));
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.build().getRawApdu());
+    });
+
+    it("should encode blobLength as 2-byte little-endian in INIT packet", () => {
+      // ARRANGE — blobLength=300 (0x012C): LE bytes = [0x2C, 0x01]
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath: BITTENSOR_PATH,
+        blobLength: 300,
+      });
+      // ACT
+      const apdu = command.getApdu();
+      const raw = apdu.getRawApdu();
+      // header(5) + path(20) + blobLen(2): blobLen at offset 25
+      const blobLenOffset = 5 + 20;
+      expect(raw[blobLenOffset]).toBe(0x2c); // 300 & 0xFF
+      expect(raw[blobLenOffset + 1]).toBe(0x01); // 300 >> 8
+    });
+
+    it("should return ADD packet (P1=0x01) with transaction chunk", () => {
+      // ARRANGE
+      const chunk = new Uint8Array(100).fill(0xab);
+      const command = new SignTransactionCommand({
+        phase: SignPhase.ADD,
+        transactionChunk: chunk,
+      });
+      const expected = new ApduBuilder(
+        polkadotSignTransactionApduHeader(P1_ADD),
+      ).addBufferToData(chunk);
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.build().getRawApdu());
+    });
+
+    it("should return LAST packet (P1=0x02) with transaction chunk", () => {
+      // ARRANGE
+      const chunk = new Uint8Array(50).fill(0xcd);
+      const command = new SignTransactionCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: chunk,
+      });
+      const expected = new ApduBuilder(
+        polkadotSignTransactionApduHeader(P1_LAST),
+      ).addBufferToData(chunk);
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.build().getRawApdu());
+    });
+
+    it("should throw when phase is INIT and derivationPath is missing", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        blobLength: 100,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "SignTransactionCommand: derivation path and blob length are required for 'init' phase.",
+      );
+    });
+
+    it("should throw when phase is INIT and blobLength is undefined", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath: BITTENSOR_PATH,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "SignTransactionCommand: derivation path and blob length are required for 'init' phase.",
+      );
+    });
+
+    it("should throw when phase is INIT and derivation path does not have 5 elements", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath: "44'/1005'/0'",
+        blobLength: 100,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "SignTransactionCommand: expected 5 path elements, got 3",
+      );
+    });
+
+    it("should throw when phase is ADD and transactionChunk is missing", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.ADD,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "SignTransactionCommand: transaction chunk is required for 'add' and 'last' phases.",
+      );
+    });
+
+    it("should throw when phase is LAST and transactionChunk is missing", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.LAST,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "SignTransactionCommand: transaction chunk is required for 'add' and 'last' phases.",
+      );
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("should return raw signature bytes on success (0x9000)", () => {
+      // ARRANGE
+      const signature = new Uint8Array(65).fill(0xee);
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: signature,
+      });
+      const command = new SignTransactionCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(result).toStrictEqual(CommandResultFactory({ data: signature }));
+      expect(isSuccessCommandResult(result)).toBe(true);
+    });
+
+    it("should return PolkadotAppCommandError with DATA_INVALID when status is 0x6984", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x69, 0x84]),
+        data: new Uint8Array(0),
+      });
+      const command = new SignTransactionCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(PolkadotAppCommandError);
+        const err = result.error as PolkadotAppCommandError;
+        expect(err.errorCode).toBe(PolkadotErrorCodes.DATA_INVALID);
+      }
+    });
+  });
+});

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/SignTransactionCommand.test.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/SignTransactionCommand.test.ts
@@ -1,0 +1,353 @@
+import {
+  ApduBuilder,
+  ApduResponse,
+  CommandResultFactory,
+  InvalidStatusWordError,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { DerivationPathUtils } from "@ledgerhq/signer-utils";
+import { describe, expect, it } from "vitest";
+
+import {
+  P1_ADD,
+  P1_INIT,
+  P1_LAST,
+  polkadotSignTransactionApduHeader,
+  SignPhase,
+  SignTransactionCommand,
+} from "@internal/app-binder/command/SignTransactionCommand";
+import {
+  PolkadotAppCommandError,
+  PolkadotErrorCodes,
+} from "@internal/app-binder/command/utils/polkadotApplicationErrors";
+
+const POLKADOT_PATH = "44'/354'/0'/0'/0'";
+
+/**
+ * Encodes a derivation path to the Polkadot 20-byte LE format.
+ * Passthrough — all elements written as-is (hardened flag preserved).
+ */
+const pathToBuffer = (derivationPath: string): Uint8Array => {
+  const paths = DerivationPathUtils.splitPath(derivationPath);
+  const view = new DataView(new ArrayBuffer(20));
+  for (let i = 0; i < paths.length; i++) {
+    view.setUint32(i * 4, paths[i]! >>> 0, true);
+  }
+  return new Uint8Array(view.buffer);
+};
+
+const blobLenToBuffer = (blobLength: number): Uint8Array => {
+  const buf = new Uint8Array(2);
+  new DataView(buf.buffer).setUint16(0, blobLength, true);
+  return buf;
+};
+
+describe("SignTransactionCommand", () => {
+  describe("name", () => {
+    it("should be 'SignTransaction'", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath: POLKADOT_PATH,
+        blobLength: 100,
+      });
+      // ASSERT
+      expect(command.name).toBe("SignTransaction");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("should return INIT packet (P1=0x00) with path and blobLength", () => {
+      // ARRANGE
+      const blobLength = 150;
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath: POLKADOT_PATH,
+        blobLength,
+      });
+      const expected = new ApduBuilder(
+        polkadotSignTransactionApduHeader(P1_INIT),
+      )
+        .addBufferToData(pathToBuffer(POLKADOT_PATH))
+        .addBufferToData(blobLenToBuffer(blobLength));
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.build().getRawApdu());
+    });
+
+    it("should encode blobLength as 2-byte little-endian in INIT packet", () => {
+      // ARRANGE — blobLength=300 (0x012C): LE bytes = [0x2C, 0x01]
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath: POLKADOT_PATH,
+        blobLength: 300,
+      });
+      // ACT
+      const apdu = command.getApdu();
+      const raw = apdu.getRawApdu();
+      // header(5) + path(20) + blobLen(2): blobLen at offset 25
+      const blobLenOffset = 5 + 20;
+      expect(raw[blobLenOffset]).toBe(0x2c); // 300 & 0xFF
+      expect(raw[blobLenOffset + 1]).toBe(0x01); // 300 >> 8
+    });
+
+    it("should return ADD packet (P1=0x01) with transaction chunk", () => {
+      // ARRANGE
+      const chunk = new Uint8Array(100).fill(0xab);
+      const command = new SignTransactionCommand({
+        phase: SignPhase.ADD,
+        transactionChunk: chunk,
+      });
+      const expected = new ApduBuilder(
+        polkadotSignTransactionApduHeader(P1_ADD),
+      ).addBufferToData(chunk);
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.build().getRawApdu());
+    });
+
+    it("should return LAST packet (P1=0x02) with transaction chunk", () => {
+      // ARRANGE
+      const chunk = new Uint8Array(50).fill(0xcd);
+      const command = new SignTransactionCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: chunk,
+      });
+      const expected = new ApduBuilder(
+        polkadotSignTransactionApduHeader(P1_LAST),
+      ).addBufferToData(chunk);
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.build().getRawApdu());
+    });
+
+    it("should throw when phase is INIT and derivationPath is missing", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        blobLength: 100,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "SignTransactionCommand: derivation path and blob length are required for 'init' phase.",
+      );
+    });
+
+    it("should throw when phase is INIT and blobLength is undefined", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath: POLKADOT_PATH,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "SignTransactionCommand: derivation path and blob length are required for 'init' phase.",
+      );
+    });
+
+    it("should throw when phase is INIT and derivation path does not have 5 elements", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath: "44'/354'/0'",
+        blobLength: 100,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "SignTransactionCommand: expected 5 path elements, got 3",
+      );
+    });
+
+    it("should throw when phase is INIT and blobLength exceeds the uint16 range", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath: POLKADOT_PATH,
+        blobLength: 0x10000,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "SignTransactionCommand: blobLength must be a uint16",
+      );
+    });
+
+    it("should throw when phase is ADD and transactionChunk is missing", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.ADD,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "SignTransactionCommand: transaction chunk is required for 'add' and 'last' phases.",
+      );
+    });
+
+    it("should throw when phase is LAST and transactionChunk is missing", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.LAST,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "SignTransactionCommand: transaction chunk is required for 'add' and 'last' phases.",
+      );
+    });
+
+    it("should build the same INIT packet when called twice", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath: POLKADOT_PATH,
+        blobLength: 150,
+      });
+      // ACT
+      const first = command.getApdu().getRawApdu();
+      const second = command.getApdu().getRawApdu();
+      // ASSERT — no data accumulated across calls
+      expect(second).toStrictEqual(first);
+    });
+
+    it("should build the same ADD packet when called twice", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.ADD,
+        transactionChunk: new Uint8Array(100).fill(0xab),
+      });
+      // ACT
+      const first = command.getApdu().getRawApdu();
+      const second = command.getApdu().getRawApdu();
+      // ASSERT — no data accumulated across calls
+      expect(second).toStrictEqual(first);
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("should return raw signature bytes on success (0x9000)", () => {
+      // ARRANGE
+      const signature = new Uint8Array(65).fill(0xee);
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: signature,
+      });
+      const command = new SignTransactionCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(result).toStrictEqual(CommandResultFactory({ data: signature }));
+      expect(isSuccessCommandResult(result)).toBe(true);
+    });
+
+    it("should return an empty body on success for the INIT and ADD phases", () => {
+      // ARRANGE — the device acknowledges INIT/ADD with 0x9000 and no data
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: new Uint8Array(0),
+      });
+      const command = new SignTransactionCommand({
+        phase: SignPhase.ADD,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data).toStrictEqual(new Uint8Array(0));
+      }
+    });
+
+    it("should surface the device reason carried by a DATA_INVALID response", () => {
+      // ARRANGE — the app writes a human-readable reason before returning 0x6984
+      const reason = "Unexpected value";
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x69, 0x84]),
+        data: new TextEncoder().encode(reason),
+      });
+      const command = new SignTransactionCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as PolkadotAppCommandError;
+        expect(err.errorCode).toBe(PolkadotErrorCodes.DATA_INVALID);
+        expect(err.message).toContain(reason);
+      }
+    });
+
+    it("should return InvalidStatusWordError when the LAST phase returns a truncated signature", () => {
+      // ARRANGE — the device always answers with exactly 65 bytes
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: new Uint8Array(64).fill(0xee),
+      });
+      const command = new SignTransactionCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidStatusWordError;
+        expect(err.originalError?.message).toBe(
+          "Expected a 65-byte signature, got 64",
+        );
+      }
+    });
+
+    it("should return InvalidStatusWordError when the LAST phase returns no signature", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: new Uint8Array(0),
+      });
+      const command = new SignTransactionCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidStatusWordError;
+        expect(err).toBeInstanceOf(InvalidStatusWordError);
+        expect(err.originalError?.message).toBe(
+          "Expected a 65-byte signature, got 0",
+        );
+      }
+    });
+
+    it("should return PolkadotAppCommandError with DATA_INVALID when status is 0x6984", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x69, 0x84]),
+        data: new Uint8Array(0),
+      });
+      const command = new SignTransactionCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(PolkadotAppCommandError);
+        const err = result.error as PolkadotAppCommandError;
+        expect(err.errorCode).toBe(PolkadotErrorCodes.DATA_INVALID);
+      }
+    });
+  });
+});

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/SignTransactionCommand.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/SignTransactionCommand.ts
@@ -1,19 +1,54 @@
 import {
   type Apdu,
+  ApduBuilder,
+  ApduParser,
   type ApduResponse,
   type Command,
   type CommandResult,
+  CommandResultFactory,
 } from "@ledgerhq/device-management-kit";
+import {
+  CommandErrorHelper,
+  DerivationPathUtils,
+} from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
 
-import { type PolkadotErrorCodes } from "./utils/polkadotApplicationErrors";
+import { type Signature } from "@api/model/Signature";
+import { encodeDerivationPath } from "@internal/app-binder/command/utils/EncodeDerivationPath";
+import {
+  POLKADOT_APP_ERRORS,
+  PolkadotAppCommandErrorFactory,
+  type PolkadotErrorCodes,
+} from "@internal/app-binder/command/utils/polkadotApplicationErrors";
+import { INS, LEDGER_CLA, P2 } from "@internal/app-binder/constants";
+
+export const polkadotSignTransactionApduHeader = (p1: number) => ({
+  cla: LEDGER_CLA,
+  ins: INS.SIGN_TRANSACTION,
+  p1,
+  p2: P2.ED25519,
+});
+
+export const P1_INIT = 0x00;
+export const P1_ADD = 0x01;
+export const P1_LAST = 0x02;
+
+const DERIVATION_PATH_LENGTH = 5;
+
+export enum SignPhase {
+  INIT = "init",
+  ADD = "add",
+  LAST = "last",
+}
 
 export type SignTransactionCommandArgs = {
-  derivationPath: string;
-  blob: Uint8Array;
-  metadata: Uint8Array;
+  phase: SignPhase;
+  derivationPath?: string;
+  blobLength?: number;
+  transactionChunk?: Uint8Array;
 };
 
-export type SignTransactionCommandResponse = Uint8Array;
+export type SignTransactionCommandResponse = Signature;
 
 export class SignTransactionCommand
   implements
@@ -25,26 +60,93 @@ export class SignTransactionCommand
 {
   readonly name = "SignTransaction";
 
-  private readonly _args: SignTransactionCommandArgs;
+  private readonly args: SignTransactionCommandArgs;
+
+  private readonly apduBuilder: ApduBuilder;
+
+  private readonly errorHelper = new CommandErrorHelper<
+    SignTransactionCommandResponse,
+    PolkadotErrorCodes
+  >(POLKADOT_APP_ERRORS, PolkadotAppCommandErrorFactory);
 
   constructor(args: SignTransactionCommandArgs) {
-    this._args = args;
+    this.args = args;
+    this.apduBuilder = new ApduBuilder(
+      polkadotSignTransactionApduHeader(this.p1()),
+    );
   }
 
-  get args(): SignTransactionCommandArgs {
-    return this._args;
+  public getApdu(): Apdu {
+    return this.isFirstChunk() ? this.firstChunk() : this.nextChunk();
   }
 
-  getApdu(): Apdu {
-    // TODO: Implement APDU construction using this._args
-    throw new Error("SignTransactionCommand.getApdu() not implemented");
-  }
-
-  parseResponse(
-    _apduResponse: ApduResponse,
+  public parseResponse(
+    apduResponse: ApduResponse,
   ): CommandResult<SignTransactionCommandResponse, PolkadotErrorCodes> {
-    // TODO: Implement response parsing based on your blockchain's protocol
-    // return CommandResultFactory({ data: { ... } });
-    throw new Error("SignTransactionCommand.parseResponse() not implemented");
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      const apduParser = new ApduParser(apduResponse);
+      const remaining = apduParser.getUnparsedRemainingLength();
+      const signature = apduParser.extractFieldByLength(remaining);
+
+      return CommandResultFactory({
+        data: signature as Signature,
+      });
+    });
+  }
+
+  private p1(): number {
+    switch (this.args.phase) {
+      case SignPhase.INIT:
+        return P1_INIT;
+      case SignPhase.ADD:
+        return P1_ADD;
+      case SignPhase.LAST:
+        return P1_LAST;
+    }
+  }
+
+  private isFirstChunk(): boolean {
+    return this.args.phase === SignPhase.INIT;
+  }
+
+  private firstChunk(): Apdu {
+    const { derivationPath, blobLength } = this.args;
+
+    if (!derivationPath || blobLength === undefined) {
+      throw new Error(
+        "SignTransactionCommand: derivation path and blob length are required for 'init' phase.",
+      );
+    }
+
+    const paths = DerivationPathUtils.splitPath(derivationPath);
+
+    if (paths.length !== DERIVATION_PATH_LENGTH) {
+      throw new Error(
+        `SignTransactionCommand: expected ${DERIVATION_PATH_LENGTH} path elements, got ${paths.length}`,
+      );
+    }
+
+    const encodedDerivationPath = encodeDerivationPath(paths);
+    this.apduBuilder.addBufferToData(encodedDerivationPath);
+
+    // blobLength: 2 bytes little-endian (firmware reads sizeof(uint16_t) via memcpy on ARM LE)
+    const blobLenBuf = new Uint8Array(2);
+    new DataView(blobLenBuf.buffer).setUint16(0, blobLength, true);
+    this.apduBuilder.addBufferToData(blobLenBuf);
+
+    return this.apduBuilder.build();
+  }
+
+  private nextChunk(): Apdu {
+    if (!this.args.transactionChunk) {
+      throw new Error(
+        "SignTransactionCommand: transaction chunk is required for 'add' and 'last' phases.",
+      );
+    }
+
+    this.apduBuilder.addBufferToData(this.args.transactionChunk);
+    return this.apduBuilder.build();
   }
 }

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/SignTransactionCommand.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/SignTransactionCommand.ts
@@ -20,13 +20,18 @@ import {
   PolkadotAppCommandErrorFactory,
   type PolkadotErrorCodes,
 } from "@internal/app-binder/command/utils/polkadotApplicationErrors";
-import { INS, LEDGER_CLA, P2 } from "@internal/app-binder/constants";
+import { LEDGER_CLA } from "@internal/app-binder/constants";
+
+// INS/P2 are specific to this command (the Ledger Polkadot app supports
+// ed25519/secp256k1 only; signatures use ed25519 = 0x00).
+const INS_SIGN_TRANSACTION = 0x02;
+const P2_ED25519 = 0x00;
 
 export const polkadotSignTransactionApduHeader = (p1: number) => ({
   cla: LEDGER_CLA,
-  ins: INS.SIGN_TRANSACTION,
+  ins: INS_SIGN_TRANSACTION,
   p1,
-  p2: P2.ED25519,
+  p2: P2_ED25519,
 });
 
 export const P1_INIT = 0x00;
@@ -34,6 +39,7 @@ export const P1_ADD = 0x01;
 export const P1_LAST = 0x02;
 
 const DERIVATION_PATH_LENGTH = 5;
+const BLOB_LENGTH_MAX = 0xffff;
 
 export enum SignPhase {
   INIT = "init",
@@ -125,6 +131,16 @@ export class SignTransactionCommand
     if (paths.length !== DERIVATION_PATH_LENGTH) {
       throw new Error(
         `SignTransactionCommand: expected ${DERIVATION_PATH_LENGTH} path elements, got ${paths.length}`,
+      );
+    }
+
+    if (
+      !Number.isInteger(blobLength) ||
+      blobLength < 0 ||
+      blobLength > BLOB_LENGTH_MAX
+    ) {
+      throw new Error(
+        `SignTransactionCommand: blobLength must be a uint16 (0..${BLOB_LENGTH_MAX}), got ${blobLength}`,
       );
     }
 

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/SignTransactionCommand.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/SignTransactionCommand.ts
@@ -1,19 +1,64 @@
 import {
   type Apdu,
+  ApduBuilder,
+  ApduParser,
   type ApduResponse,
   type Command,
   type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
 } from "@ledgerhq/device-management-kit";
+import {
+  CommandErrorHelper,
+  DerivationPathUtils,
+} from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
 
-import { type PolkadotErrorCodes } from "./utils/polkadotApplicationErrors";
+import { type Signature } from "@api/model/Signature";
+import { encodeDerivationPath } from "@internal/app-binder/command/utils/EncodeDerivationPath";
+import {
+  POLKADOT_APP_ERRORS,
+  PolkadotAppCommandErrorFactory,
+  PolkadotErrorCodes,
+} from "@internal/app-binder/command/utils/polkadotApplicationErrors";
+import { LEDGER_CLA } from "@internal/app-binder/constants";
+
+// INS/P2 are specific to this command (the Ledger Polkadot app supports
+// ed25519/secp256k1 only; signatures use ed25519 = 0x00).
+const INS_SIGN_TRANSACTION = 0x02;
+const P2_ED25519 = 0x00;
+
+export const polkadotSignTransactionApduHeader = (p1: number) => ({
+  cla: LEDGER_CLA,
+  ins: INS_SIGN_TRANSACTION,
+  p1,
+  p2: P2_ED25519,
+});
+
+export const P1_INIT = 0x00;
+export const P1_ADD = 0x01;
+export const P1_LAST = 0x02;
+
+const DERIVATION_PATH_LENGTH = 5;
+const BLOB_LENGTH_MAX = 0xffff;
+// The device always replies with a 1-byte MultiSignature discriminant followed by
+// the 64-byte Ed25519 signature.
+const SIGNATURE_LENGTH = 65;
+
+export enum SignPhase {
+  INIT = "init",
+  ADD = "add",
+  LAST = "last",
+}
 
 export type SignTransactionCommandArgs = {
-  derivationPath: string;
-  blob: Uint8Array;
-  metadata: Uint8Array;
+  phase: SignPhase;
+  derivationPath?: string;
+  blobLength?: number;
+  transactionChunk?: Uint8Array;
 };
 
-export type SignTransactionCommandResponse = Uint8Array;
+export type SignTransactionCommandResponse = Signature;
 
 export class SignTransactionCommand
   implements
@@ -25,26 +70,147 @@ export class SignTransactionCommand
 {
   readonly name = "SignTransaction";
 
-  private readonly _args: SignTransactionCommandArgs;
+  private readonly args: SignTransactionCommandArgs;
+
+  private readonly errorHelper = new CommandErrorHelper<
+    SignTransactionCommandResponse,
+    PolkadotErrorCodes
+  >(POLKADOT_APP_ERRORS, PolkadotAppCommandErrorFactory);
 
   constructor(args: SignTransactionCommandArgs) {
-    this._args = args;
+    this.args = args;
   }
 
-  get args(): SignTransactionCommandArgs {
-    return this._args;
+  public getApdu(): Apdu {
+    const apduBuilder = new ApduBuilder(
+      polkadotSignTransactionApduHeader(this.p1()),
+    );
+
+    return this.isFirstChunk()
+      ? this.firstChunk(apduBuilder)
+      : this.nextChunk(apduBuilder);
   }
 
-  getApdu(): Apdu {
-    // TODO: Implement APDU construction using this._args
-    throw new Error("SignTransactionCommand.getApdu() not implemented");
-  }
-
-  parseResponse(
-    _apduResponse: ApduResponse,
+  public parseResponse(
+    apduResponse: ApduResponse,
   ): CommandResult<SignTransactionCommandResponse, PolkadotErrorCodes> {
-    // TODO: Implement response parsing based on your blockchain's protocol
-    // return CommandResultFactory({ data: { ... } });
-    throw new Error("SignTransactionCommand.parseResponse() not implemented");
+    return Maybe.fromNullable(this.parsingFailure(apduResponse))
+      .alt(Maybe.fromNullable(this.errorHelper.getError(apduResponse)))
+      .orDefaultLazy(() => {
+        const apduParser = new ApduParser(apduResponse);
+        const remaining = apduParser.getUnparsedRemainingLength();
+        const signature =
+          apduParser.extractFieldByLength(remaining) ?? new Uint8Array();
+
+        // Only the LAST packet carries the signature: INIT and ADD answer with an empty body.
+        if (
+          this.args.phase === SignPhase.LAST &&
+          signature.length !== SIGNATURE_LENGTH
+        ) {
+          return CommandResultFactory({
+            error: new InvalidStatusWordError(
+              `Expected a ${SIGNATURE_LENGTH}-byte signature, got ${signature.length}`,
+            ),
+          });
+        }
+
+        return CommandResultFactory({
+          data: signature,
+        });
+      });
+  }
+
+  /**
+   * When the transaction cannot be parsed, the app writes a human-readable reason
+   * in the response body before returning DATA_INVALID. Surface that reason, which
+   * names the offending field, rather than the flat status-word mapping.
+   */
+  private parsingFailure(
+    apduResponse: ApduResponse,
+  ):
+    | CommandResult<SignTransactionCommandResponse, PolkadotErrorCodes>
+    | undefined {
+    const apduParser = new ApduParser(apduResponse);
+    const statusCode = apduParser.encodeToHexaString(apduResponse.statusCode);
+
+    if (
+      statusCode !== PolkadotErrorCodes.DATA_INVALID ||
+      apduResponse.data.length === 0
+    ) {
+      return undefined;
+    }
+
+    const reason = apduParser.encodeToString(apduResponse.data);
+
+    return CommandResultFactory({
+      error: PolkadotAppCommandErrorFactory({
+        message: `${POLKADOT_APP_ERRORS[PolkadotErrorCodes.DATA_INVALID].message}: ${reason}`,
+        errorCode: PolkadotErrorCodes.DATA_INVALID,
+      }),
+    });
+  }
+
+  private p1(): number {
+    switch (this.args.phase) {
+      case SignPhase.INIT:
+        return P1_INIT;
+      case SignPhase.ADD:
+        return P1_ADD;
+      case SignPhase.LAST:
+        return P1_LAST;
+    }
+  }
+
+  private isFirstChunk(): boolean {
+    return this.args.phase === SignPhase.INIT;
+  }
+
+  private firstChunk(apduBuilder: ApduBuilder): Apdu {
+    const { derivationPath, blobLength } = this.args;
+
+    if (!derivationPath || blobLength === undefined) {
+      throw new Error(
+        "SignTransactionCommand: derivation path and blob length are required for 'init' phase.",
+      );
+    }
+
+    const paths = DerivationPathUtils.splitPath(derivationPath);
+
+    if (paths.length !== DERIVATION_PATH_LENGTH) {
+      throw new Error(
+        `SignTransactionCommand: expected ${DERIVATION_PATH_LENGTH} path elements, got ${paths.length}`,
+      );
+    }
+
+    if (
+      !Number.isInteger(blobLength) ||
+      blobLength < 0 ||
+      blobLength > BLOB_LENGTH_MAX
+    ) {
+      throw new Error(
+        `SignTransactionCommand: blobLength must be a uint16 (0..${BLOB_LENGTH_MAX}), got ${blobLength}`,
+      );
+    }
+
+    const encodedDerivationPath = encodeDerivationPath(paths);
+    apduBuilder.addBufferToData(encodedDerivationPath);
+
+    // blobLength: 2 bytes little-endian (firmware reads sizeof(uint16_t) via memcpy on ARM LE)
+    const blobLenBuf = new Uint8Array(2);
+    new DataView(blobLenBuf.buffer).setUint16(0, blobLength, true);
+    apduBuilder.addBufferToData(blobLenBuf);
+
+    return apduBuilder.build();
+  }
+
+  private nextChunk(apduBuilder: ApduBuilder): Apdu {
+    if (!this.args.transactionChunk) {
+      throw new Error(
+        "SignTransactionCommand: transaction chunk is required for 'add' and 'last' phases.",
+      );
+    }
+
+    apduBuilder.addBufferToData(this.args.transactionChunk);
+    return apduBuilder.build();
   }
 }

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/EncodeDerivationPath.test.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/EncodeDerivationPath.test.ts
@@ -1,0 +1,104 @@
+import { DerivationPathUtils } from "@ledgerhq/signer-utils";
+import { describe, expect, it } from "vitest";
+
+import { encodeDerivationPath } from "./EncodeDerivationPath";
+
+describe("encodeDerivationPath", () => {
+  describe("Given a 5-level Polkadot-family derivation path (44'/354'/0'/0'/0')", () => {
+    it("should return a 20-byte Uint8Array", () => {
+      // ARRANGE
+      const paths = DerivationPathUtils.splitPath("44'/354'/0'/0'/0'");
+      // ACT
+      const result = encodeDerivationPath(paths);
+      // ASSERT
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.length).toBe(20);
+    });
+
+    it("should encode each element as little-endian uint32 with hardened flag preserved", () => {
+      // ARRANGE
+      // 44' = 0x80000000 | 44 = 0x8000002C
+      // 354' = 0x80000000 | 354 = 0x80000162
+      // 0' = 0x80000000 | 0 = 0x80000000 (three times)
+      const paths = DerivationPathUtils.splitPath("44'/354'/0'/0'/0'");
+      // ACT
+      const result = encodeDerivationPath(paths);
+      // ASSERT
+      const expected = new Uint8Array([
+        0x2c,
+        0x00,
+        0x00,
+        0x80, // 44' = 0x8000002C LE
+        0x62,
+        0x01,
+        0x00,
+        0x80, // 354' = 0x80000162 LE
+        0x00,
+        0x00,
+        0x00,
+        0x80, // 0' = 0x80000000 LE
+        0x00,
+        0x00,
+        0x00,
+        0x80, // 0' = 0x80000000 LE
+        0x00,
+        0x00,
+        0x00,
+        0x80, // 0' = 0x80000000 LE
+      ]);
+      expect(result).toStrictEqual(expected);
+    });
+
+    it("should preserve the hardened flag for all elements without stripping and re-applying", () => {
+      // ARRANGE
+      const paths = DerivationPathUtils.splitPath("44'/354'/0'/0'/0'");
+      // ACT
+      const result = encodeDerivationPath(paths);
+      const dataView = new DataView(result.buffer);
+      // ASSERT — all 5 elements must have bit 31 set
+      for (let i = 0; i < 5; i++) {
+        expect(dataView.getUint32(i * 4, true) >>> 31).toBe(1);
+      }
+    });
+
+    it("should encode elements as little-endian (first byte is LSB)", () => {
+      // ARRANGE
+      // 44' = 0x8000002C: bytes LE = [0x2C, 0x00, 0x00, 0x80]
+      const paths = DerivationPathUtils.splitPath("44'/354'/0'/0'/0'");
+      // ACT
+      const result = encodeDerivationPath(paths);
+      // ASSERT
+      expect(result[0]).toBe(0x2c); // LSB of 0x8000002C
+      expect(result[3]).toBe(0x80); // MSB of 0x8000002C
+    });
+  });
+
+  describe("Given a path with fewer than 5 elements", () => {
+    it("should throw an error", () => {
+      // ARRANGE
+      const paths = [0x80000000 | 44, 0x80000000 | 354, 0x80000000 | 0];
+      // ACT & ASSERT
+      expect(() => encodeDerivationPath(paths)).toThrow(
+        "Expected 5 path elements, got 3",
+      );
+    });
+  });
+
+  describe("Given a path with more than 5 elements", () => {
+    it("should throw an error", () => {
+      // ARRANGE
+      const paths = [
+        0x80000000 | 44,
+        0x80000000 | 354,
+        0x80000000 | 0,
+        0x80000000 | 0,
+        0x80000000 | 0,
+        0x80000000 | 0,
+      ];
+      // ACT & ASSERT
+      expect(() => encodeDerivationPath(paths)).toThrow(
+        "Expected 5 path elements, got 6",
+      );
+    });
+  });
+});

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/EncodeDerivationPath.test.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/EncodeDerivationPath.test.ts
@@ -4,10 +4,10 @@ import { describe, expect, it } from "vitest";
 import { encodeDerivationPath } from "./EncodeDerivationPath";
 
 describe("encodeDerivationPath", () => {
-  describe("Given a 5-level Bittensor derivation path (44'/1005'/0'/0'/0')", () => {
+  describe("Given a 5-level Polkadot-family derivation path (44'/354'/0'/0'/0')", () => {
     it("should return a 20-byte Uint8Array", () => {
       // ARRANGE
-      const paths = DerivationPathUtils.splitPath("44'/1005'/0'/0'/0'");
+      const paths = DerivationPathUtils.splitPath("44'/354'/0'/0'/0'");
       // ACT
       const result = encodeDerivationPath(paths);
       // ASSERT
@@ -18,9 +18,9 @@ describe("encodeDerivationPath", () => {
     it("should encode each element as little-endian uint32 with hardened flag preserved", () => {
       // ARRANGE
       // 44' = 0x80000000 | 44 = 0x8000002C
-      // 1005' = 0x80000000 | 1005 = 0x800003ED
+      // 354' = 0x80000000 | 354 = 0x80000162
       // 0' = 0x80000000 | 0 = 0x80000000 (three times)
-      const paths = DerivationPathUtils.splitPath("44'/1005'/0'/0'/0'");
+      const paths = DerivationPathUtils.splitPath("44'/354'/0'/0'/0'");
       // ACT
       const result = encodeDerivationPath(paths);
       // ASSERT
@@ -29,10 +29,10 @@ describe("encodeDerivationPath", () => {
         0x00,
         0x00,
         0x80, // 44' = 0x8000002C LE
-        0xed,
-        0x03,
+        0x62,
+        0x01,
         0x00,
-        0x80, // 1005' = 0x800003ED LE
+        0x80, // 354' = 0x80000162 LE
         0x00,
         0x00,
         0x00,
@@ -51,7 +51,7 @@ describe("encodeDerivationPath", () => {
 
     it("should preserve the hardened flag for all elements without stripping and re-applying", () => {
       // ARRANGE
-      const paths = DerivationPathUtils.splitPath("44'/1005'/0'/0'/0'");
+      const paths = DerivationPathUtils.splitPath("44'/354'/0'/0'/0'");
       // ACT
       const result = encodeDerivationPath(paths);
       const dataView = new DataView(result.buffer);
@@ -64,7 +64,7 @@ describe("encodeDerivationPath", () => {
     it("should encode elements as little-endian (first byte is LSB)", () => {
       // ARRANGE
       // 44' = 0x8000002C: bytes LE = [0x2C, 0x00, 0x00, 0x80]
-      const paths = DerivationPathUtils.splitPath("44'/1005'/0'/0'/0'");
+      const paths = DerivationPathUtils.splitPath("44'/354'/0'/0'/0'");
       // ACT
       const result = encodeDerivationPath(paths);
       // ASSERT
@@ -76,7 +76,7 @@ describe("encodeDerivationPath", () => {
   describe("Given a path with fewer than 5 elements", () => {
     it("should throw an error", () => {
       // ARRANGE
-      const paths = [0x80000000 | 44, 0x80000000 | 1005, 0x80000000 | 0];
+      const paths = [0x80000000 | 44, 0x80000000 | 354, 0x80000000 | 0];
       // ACT & ASSERT
       expect(() => encodeDerivationPath(paths)).toThrow(
         "Expected 5 path elements, got 3",
@@ -89,7 +89,7 @@ describe("encodeDerivationPath", () => {
       // ARRANGE
       const paths = [
         0x80000000 | 44,
-        0x80000000 | 1005,
+        0x80000000 | 354,
         0x80000000 | 0,
         0x80000000 | 0,
         0x80000000 | 0,

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/EncodeDerivationPath.test.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/EncodeDerivationPath.test.ts
@@ -1,0 +1,104 @@
+import { DerivationPathUtils } from "@ledgerhq/signer-utils";
+import { describe, expect, it } from "vitest";
+
+import { encodeDerivationPath } from "./EncodeDerivationPath";
+
+describe("encodeDerivationPath", () => {
+  describe("Given a 5-level Bittensor derivation path (44'/1005'/0'/0'/0')", () => {
+    it("should return a 20-byte Uint8Array", () => {
+      // ARRANGE
+      const paths = DerivationPathUtils.splitPath("44'/1005'/0'/0'/0'");
+      // ACT
+      const result = encodeDerivationPath(paths);
+      // ASSERT
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.length).toBe(20);
+    });
+
+    it("should encode each element as little-endian uint32 with hardened flag preserved", () => {
+      // ARRANGE
+      // 44' = 0x80000000 | 44 = 0x8000002C
+      // 1005' = 0x80000000 | 1005 = 0x800003ED
+      // 0' = 0x80000000 | 0 = 0x80000000 (three times)
+      const paths = DerivationPathUtils.splitPath("44'/1005'/0'/0'/0'");
+      // ACT
+      const result = encodeDerivationPath(paths);
+      // ASSERT
+      const expected = new Uint8Array([
+        0x2c,
+        0x00,
+        0x00,
+        0x80, // 44' = 0x8000002C LE
+        0xed,
+        0x03,
+        0x00,
+        0x80, // 1005' = 0x800003ED LE
+        0x00,
+        0x00,
+        0x00,
+        0x80, // 0' = 0x80000000 LE
+        0x00,
+        0x00,
+        0x00,
+        0x80, // 0' = 0x80000000 LE
+        0x00,
+        0x00,
+        0x00,
+        0x80, // 0' = 0x80000000 LE
+      ]);
+      expect(result).toStrictEqual(expected);
+    });
+
+    it("should preserve the hardened flag for all elements without stripping and re-applying", () => {
+      // ARRANGE
+      const paths = DerivationPathUtils.splitPath("44'/1005'/0'/0'/0'");
+      // ACT
+      const result = encodeDerivationPath(paths);
+      const dataView = new DataView(result.buffer);
+      // ASSERT — all 5 elements must have bit 31 set
+      for (let i = 0; i < 5; i++) {
+        expect(dataView.getUint32(i * 4, true) >>> 31).toBe(1);
+      }
+    });
+
+    it("should encode elements as little-endian (first byte is LSB)", () => {
+      // ARRANGE
+      // 44' = 0x8000002C: bytes LE = [0x2C, 0x00, 0x00, 0x80]
+      const paths = DerivationPathUtils.splitPath("44'/1005'/0'/0'/0'");
+      // ACT
+      const result = encodeDerivationPath(paths);
+      // ASSERT
+      expect(result[0]).toBe(0x2c); // LSB of 0x8000002C
+      expect(result[3]).toBe(0x80); // MSB of 0x8000002C
+    });
+  });
+
+  describe("Given a path with fewer than 5 elements", () => {
+    it("should throw an error", () => {
+      // ARRANGE
+      const paths = [0x80000000 | 44, 0x80000000 | 1005, 0x80000000 | 0];
+      // ACT & ASSERT
+      expect(() => encodeDerivationPath(paths)).toThrow(
+        "Expected 5 path elements, got 3",
+      );
+    });
+  });
+
+  describe("Given a path with more than 5 elements", () => {
+    it("should throw an error", () => {
+      // ARRANGE
+      const paths = [
+        0x80000000 | 44,
+        0x80000000 | 1005,
+        0x80000000 | 0,
+        0x80000000 | 0,
+        0x80000000 | 0,
+        0x80000000 | 0,
+      ];
+      // ACT & ASSERT
+      expect(() => encodeDerivationPath(paths)).toThrow(
+        "Expected 5 path elements, got 6",
+      );
+    });
+  });
+});

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/EncodeDerivationPath.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/EncodeDerivationPath.ts
@@ -1,0 +1,29 @@
+const DERIVATION_PATH_LENGTH = 5;
+const BYTES_PER_ELEMENT = 4;
+
+/**
+ * Encodes a parsed derivation path into a 20-byte little-endian buffer.
+ *
+ * The Polkadot app reads the derivation path via memcpy into uint32_t[] on
+ * ARM (little-endian). All path elements are passed through as-is from
+ * DerivationPathUtils.splitPath() — the hardened flag (0x80000000) is
+ * preserved without stripping or re-applying.
+ *
+ * This differs from the Cosmos encoder which strips and re-applies the hardened
+ * flag for only the first 3 elements. Polkadot/Bittensor paths are fully
+ * hardened (44'/1005'/0'/0'/0'), so all elements already carry the flag.
+ */
+export const encodeDerivationPath = (paths: number[]): Uint8Array => {
+  if (paths.length !== DERIVATION_PATH_LENGTH) {
+    throw new Error(
+      `Expected ${DERIVATION_PATH_LENGTH} path elements, got ${paths.length}`,
+    );
+  }
+  const dataView = new DataView(
+    new ArrayBuffer(DERIVATION_PATH_LENGTH * BYTES_PER_ELEMENT),
+  );
+  for (let i = 0; i < paths.length; i++) {
+    dataView.setUint32(i * BYTES_PER_ELEMENT, paths[i]! >>> 0, true); // little-endian
+  }
+  return new Uint8Array(dataView.buffer);
+};

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/EncodeDerivationPath.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/EncodeDerivationPath.ts
@@ -1,0 +1,29 @@
+const DERIVATION_PATH_LENGTH = 5;
+const BYTES_PER_ELEMENT = 4;
+
+/**
+ * Encodes a parsed derivation path into a 20-byte little-endian buffer.
+ *
+ * The Polkadot app reads the derivation path via memcpy into uint32_t[] on
+ * ARM (little-endian). All path elements are passed through as-is from
+ * DerivationPathUtils.splitPath() — the hardened flag (0x80000000) is
+ * preserved without stripping or re-applying.
+ *
+ * This differs from the Cosmos encoder which strips and re-applies the hardened
+ * flag for only the first 3 elements. Polkadot-family paths are fully
+ * hardened (e.g. 44'/354'/0'/0'/0'), so all elements already carry the flag.
+ */
+export const encodeDerivationPath = (paths: number[]): Uint8Array => {
+  if (paths.length !== DERIVATION_PATH_LENGTH) {
+    throw new Error(
+      `Expected ${DERIVATION_PATH_LENGTH} path elements, got ${paths.length}`,
+    );
+  }
+  const dataView = new DataView(
+    new ArrayBuffer(DERIVATION_PATH_LENGTH * BYTES_PER_ELEMENT),
+  );
+  for (let i = 0; i < paths.length; i++) {
+    dataView.setUint32(i * BYTES_PER_ELEMENT, paths[i]! >>> 0, true); // little-endian
+  }
+  return new Uint8Array(dataView.buffer);
+};

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/EncodeDerivationPath.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/EncodeDerivationPath.ts
@@ -10,8 +10,8 @@ const BYTES_PER_ELEMENT = 4;
  * preserved without stripping or re-applying.
  *
  * This differs from the Cosmos encoder which strips and re-applies the hardened
- * flag for only the first 3 elements. Polkadot/Bittensor paths are fully
- * hardened (44'/1005'/0'/0'/0'), so all elements already carry the flag.
+ * flag for only the first 3 elements. Polkadot-family paths are fully
+ * hardened (e.g. 44'/354'/0'/0'/0'), so all elements already carry the flag.
  */
 export const encodeDerivationPath = (paths: number[]): Uint8Array => {
   if (paths.length !== DERIVATION_PATH_LENGTH) {

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/PolkadotApplicationErrors.test.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/PolkadotApplicationErrors.test.ts
@@ -1,0 +1,109 @@
+import { DeviceExchangeError } from "@ledgerhq/device-management-kit";
+import { describe, expect, it } from "vitest";
+
+import {
+  POLKADOT_APP_ERRORS,
+  PolkadotAppCommandError,
+  PolkadotAppCommandErrorFactory,
+  PolkadotErrorCodes,
+} from "./polkadotApplicationErrors";
+
+describe("PolkadotAppCommandError", () => {
+  it('should have tag "PolkadotAppCommandError"', () => {
+    // ARRANGE
+    const error = new PolkadotAppCommandError({
+      message: "Test error",
+      errorCode: PolkadotErrorCodes.EXECUTION_ERROR,
+    });
+    // ASSERT
+    expect(error._tag).toBe("PolkadotAppCommandError");
+  });
+
+  it("should be an instance of DeviceExchangeError", () => {
+    // ARRANGE
+    const error = new PolkadotAppCommandError({
+      message: "Test error",
+      errorCode: PolkadotErrorCodes.EXECUTION_ERROR,
+    });
+    // ASSERT
+    expect(error).toBeInstanceOf(DeviceExchangeError);
+  });
+
+  it.each([
+    {
+      errorCode: PolkadotErrorCodes.EXECUTION_ERROR,
+      message: "Execution Error",
+    },
+    {
+      errorCode: PolkadotErrorCodes.WRONG_BUFFER_LENGTH,
+      message: "Wrong buffer length",
+    },
+    { errorCode: PolkadotErrorCodes.EMPTY_BUFFER, message: "Empty buffer" },
+    {
+      errorCode: PolkadotErrorCodes.OUTPUT_BUFFER_TOO_SMALL,
+      message: "Output buffer too small",
+    },
+    { errorCode: PolkadotErrorCodes.DATA_INVALID, message: "Data is invalid" },
+    {
+      errorCode: PolkadotErrorCodes.COMMAND_NOT_ALLOWED,
+      message: "Command not allowed",
+    },
+    {
+      errorCode: PolkadotErrorCodes.TX_NOT_INITIALIZED,
+      message: "Tx is not initialized",
+    },
+    {
+      errorCode: PolkadotErrorCodes.P1_P2_INVALID,
+      message: "P1/P2 are invalid",
+    },
+    {
+      errorCode: PolkadotErrorCodes.INS_NOT_SUPPORTED,
+      message: "INS not supported",
+    },
+    {
+      errorCode: PolkadotErrorCodes.CLA_NOT_SUPPORTED,
+      message: "CLA not supported",
+    },
+    { errorCode: PolkadotErrorCodes.UNKNOWN_ERROR, message: "Unknown error" },
+    {
+      errorCode: PolkadotErrorCodes.SIGN_VERIFY_ERROR,
+      message: "Sign / verify error",
+    },
+  ])(
+    "should have correct errorCode and message for $errorCode",
+    ({ errorCode, message }) => {
+      // ARRANGE
+      const error = new PolkadotAppCommandError({ errorCode, message });
+      // ASSERT
+      expect(error.errorCode).toBe(errorCode);
+      expect(error.message).toBe(message);
+    },
+  );
+});
+
+describe("PolkadotAppCommandErrorFactory", () => {
+  it("should produce PolkadotAppCommandError instances", () => {
+    // ARRANGE
+    const error = PolkadotAppCommandErrorFactory({
+      message: "Data is invalid",
+      errorCode: PolkadotErrorCodes.DATA_INVALID,
+    });
+    // ASSERT
+    expect(error).toBeInstanceOf(PolkadotAppCommandError);
+    expect(error).toBeInstanceOf(DeviceExchangeError);
+    expect(error.errorCode).toBe(PolkadotErrorCodes.DATA_INVALID);
+  });
+});
+
+describe("POLKADOT_APP_ERRORS", () => {
+  it("should have entries for all 12 Polkadot error codes", () => {
+    // ARRANGE
+    const expectedCodes = Object.values(PolkadotErrorCodes);
+    // ASSERT
+    expect(expectedCodes).toHaveLength(12);
+    for (const code of expectedCodes) {
+      expect(POLKADOT_APP_ERRORS).toHaveProperty(code);
+      expect(typeof POLKADOT_APP_ERRORS[code].message).toBe("string");
+    }
+  });
+});

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/polkadotApplicationErrors.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/polkadotApplicationErrors.ts
@@ -1,1 +1,45 @@
-export enum PolkadotErrorCodes {}
+import {
+  type CommandErrorArgs,
+  type CommandErrors,
+  DeviceExchangeError,
+} from "@ledgerhq/device-management-kit";
+
+export enum PolkadotErrorCodes {
+  EXECUTION_ERROR = "6400",
+  WRONG_BUFFER_LENGTH = "6700",
+  EMPTY_BUFFER = "6982",
+  OUTPUT_BUFFER_TOO_SMALL = "6983",
+  DATA_INVALID = "6984",
+  COMMAND_NOT_ALLOWED = "6986",
+  TX_NOT_INITIALIZED = "6987",
+  P1_P2_INVALID = "6b00",
+  INS_NOT_SUPPORTED = "6d00",
+  CLA_NOT_SUPPORTED = "6e00",
+  UNKNOWN_ERROR = "6f00",
+  SIGN_VERIFY_ERROR = "6f01",
+}
+
+export const POLKADOT_APP_ERRORS: CommandErrors<PolkadotErrorCodes> = {
+  "6400": { message: "Execution Error" },
+  "6700": { message: "Wrong buffer length" },
+  "6982": { message: "Empty buffer" },
+  "6983": { message: "Output buffer too small" },
+  "6984": { message: "Data is invalid" },
+  "6986": { message: "Command not allowed" },
+  "6987": { message: "Tx is not initialized" },
+  "6b00": { message: "P1/P2 are invalid" },
+  "6d00": { message: "INS not supported" },
+  "6e00": { message: "CLA not supported" },
+  "6f00": { message: "Unknown error" },
+  "6f01": { message: "Sign / verify error" },
+};
+
+export class PolkadotAppCommandError extends DeviceExchangeError<PolkadotErrorCodes> {
+  constructor(args: CommandErrorArgs<PolkadotErrorCodes>) {
+    super({ tag: "PolkadotAppCommandError", ...args });
+  }
+}
+
+export const PolkadotAppCommandErrorFactory = (
+  args: CommandErrorArgs<PolkadotErrorCodes>,
+) => new PolkadotAppCommandError(args);

--- a/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/polkadotApplicationErrors.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/command/utils/polkadotApplicationErrors.ts
@@ -1,1 +1,50 @@
-export enum PolkadotErrorCodes {}
+import {
+  type CommandErrorArgs,
+  type CommandErrors,
+  DeviceExchangeError,
+} from "@ledgerhq/device-management-kit";
+
+export enum PolkadotErrorCodes {
+  EXECUTION_ERROR = "6400",
+  WRONG_BUFFER_LENGTH = "6700",
+  EMPTY_BUFFER = "6982",
+  OUTPUT_BUFFER_TOO_SMALL = "6983",
+  DATA_INVALID = "6984",
+  COMMAND_NOT_ALLOWED = "6986",
+  TX_NOT_INITIALIZED = "6987",
+  P1_P2_INVALID = "6b00",
+  INS_NOT_SUPPORTED = "6d00",
+  CLA_NOT_SUPPORTED = "6e00",
+  UNKNOWN_ERROR = "6f00",
+  SIGN_VERIFY_ERROR = "6f01",
+}
+
+export const POLKADOT_APP_ERRORS: CommandErrors<PolkadotErrorCodes> = {
+  "6400": { message: "Execution Error" },
+  "6700": { message: "Wrong buffer length" },
+  "6982": { message: "Empty buffer" },
+  "6983": { message: "Output buffer too small" },
+  "6984": { message: "Data is invalid" },
+  // The app returns this both when the user declines on device and when it cannot
+  // serve the command (locked device, review already pending) — the status word
+  // alone does not tell them apart.
+  "6986": {
+    message: "Rejected by the user, or device not ready (locked or busy)",
+  },
+  "6987": { message: "Tx is not initialized" },
+  "6b00": { message: "P1/P2 are invalid" },
+  "6d00": { message: "INS not supported" },
+  "6e00": { message: "CLA not supported" },
+  "6f00": { message: "Unknown error" },
+  "6f01": { message: "Sign / verify error" },
+};
+
+export class PolkadotAppCommandError extends DeviceExchangeError<PolkadotErrorCodes> {
+  constructor(args: CommandErrorArgs<PolkadotErrorCodes>) {
+    super({ tag: "PolkadotAppCommandError", ...args });
+  }
+}
+
+export const PolkadotAppCommandErrorFactory = (
+  args: CommandErrorArgs<PolkadotErrorCodes>,
+) => new PolkadotAppCommandError(args);

--- a/packages/signer/signer-polkadot/src/internal/app-binder/constants.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/constants.ts
@@ -1,9 +1,5 @@
 export const APP_NAME = "Polkadot";
 
+// CLA is app-wide. INS and P2 are command-specific and live in each command
+// (GetAddressCommand, SignTransactionCommand).
 export const LEDGER_CLA = 0xf9;
-
-export const INS = {
-  GET_ADDRESS: 0x01,
-  SIGN_TRANSACTION: 0x02,
-  SIGN_RAW: 0x03,
-} as const;

--- a/packages/signer/signer-polkadot/src/internal/app-binder/constants.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/constants.ts
@@ -7,3 +7,8 @@ export const INS = {
   SIGN_TRANSACTION: 0x02,
   SIGN_RAW: 0x03,
 } as const;
+
+export const P2 = {
+  ED25519: 0x00,
+  ECDSA: 0x02,
+} as const;

--- a/packages/signer/signer-polkadot/src/internal/app-binder/constants.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/constants.ts
@@ -1,14 +1,5 @@
 export const APP_NAME = "Polkadot";
 
+// CLA is app-wide. INS and P2 are command-specific and live in each command
+// (GetAddressCommand, SignTransactionCommand).
 export const LEDGER_CLA = 0xf9;
-
-export const INS = {
-  GET_ADDRESS: 0x01,
-  SIGN_TRANSACTION: 0x02,
-  SIGN_RAW: 0x03,
-} as const;
-
-export const P2 = {
-  ED25519: 0x00,
-  ECDSA: 0x02,
-} as const;

--- a/packages/signer/signer-polkadot/src/internal/app-binder/task/SignTransactionTask.test.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/task/SignTransactionTask.test.ts
@@ -1,0 +1,282 @@
+import {
+  CommandResultFactory,
+  CommandResultStatus,
+  type InternalApi,
+  InvalidStatusWordError,
+  isSuccessCommandResult,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  PolkadotAppCommandError,
+  PolkadotErrorCodes,
+} from "@internal/app-binder/command/utils/polkadotApplicationErrors";
+import { SignTransactionTask } from "@internal/app-binder/task/SignTransactionTask";
+
+const BITTENSOR_PATH = "44'/1005'/0'/0'/0'";
+
+describe("SignTransactionTask", () => {
+  let sendCommandMock: ReturnType<typeof vi.fn>;
+  let apiMock: InternalApi;
+  let loggerMock: LoggerPublisherService;
+
+  beforeEach(() => {
+    sendCommandMock = vi.fn();
+    apiMock = {
+      sendCommand: sendCommandMock,
+    } as unknown as InternalApi;
+    loggerMock = {
+      debug: vi.fn(),
+    } as unknown as LoggerPublisherService;
+  });
+
+  describe("run", () => {
+    it("should send INIT + LAST for small payload (blob + metadata < 255 bytes) and return signature", async () => {
+      // ARRANGE
+      const blob = new Uint8Array(50).fill(0x01);
+      const metadata = new Uint8Array(40).fill(0x02);
+      const signature = new Uint8Array(65).fill(0xee);
+
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(CommandResultFactory({ data: signature })); // LAST
+
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: BITTENSOR_PATH, blob, metadata },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(sendCommandMock).toHaveBeenCalledTimes(2);
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data).toStrictEqual(signature);
+      }
+    });
+
+    it("should use blobLength equal to blob.length in INIT command", async () => {
+      // ARRANGE
+      const blob = new Uint8Array(120).fill(0x01);
+      const metadata = new Uint8Array(30).fill(0x02);
+      const signature = new Uint8Array(65).fill(0xee);
+
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(CommandResultFactory({ data: signature })); // LAST
+
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: BITTENSOR_PATH, blob, metadata },
+        loggerMock,
+      );
+
+      // ACT
+      await task.run();
+
+      // ASSERT — first call is INIT, inspect args
+      const initCommandArg = sendCommandMock.mock.calls[0]?.[0] as
+        | { args: { blobLength: number } }
+        | undefined;
+      expect(initCommandArg).toBeDefined();
+      // The INIT command's args.blobLength should equal blob.length
+      expect(initCommandArg?.args.blobLength).toBe(blob.length);
+    });
+
+    it("should send INIT + ADD + LAST for payloads between 255 and 510 bytes", async () => {
+      // ARRANGE
+      const blob = new Uint8Array(200).fill(0x03);
+      const metadata = new Uint8Array(200).fill(0x04); // total = 400 bytes → 2 data chunks
+      const signature = new Uint8Array(65).fill(0xff);
+
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(
+          CommandResultFactory({ data: new Uint8Array(0) }),
+        ) // ADD
+        .mockResolvedValueOnce(CommandResultFactory({ data: signature })); // LAST
+
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: BITTENSOR_PATH, blob, metadata },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(sendCommandMock).toHaveBeenCalledTimes(3); // INIT + ADD + LAST
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data).toStrictEqual(signature);
+      }
+    });
+
+    it("should send INIT + multiple ADD + LAST for large payloads (>510 bytes)", async () => {
+      // ARRANGE
+      const blob = new Uint8Array(400).fill(0x05);
+      const metadata = new Uint8Array(400).fill(0x06); // total = 800 bytes → 4 data chunks
+      const signature = new Uint8Array(65).fill(0xaa);
+
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(
+          CommandResultFactory({ data: new Uint8Array(0) }),
+        ) // ADD 1
+        .mockResolvedValueOnce(
+          CommandResultFactory({ data: new Uint8Array(0) }),
+        ) // ADD 2
+        .mockResolvedValueOnce(
+          CommandResultFactory({ data: new Uint8Array(0) }),
+        ) // ADD 3
+        .mockResolvedValueOnce(CommandResultFactory({ data: signature })); // LAST
+
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: BITTENSOR_PATH, blob, metadata },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(sendCommandMock).toHaveBeenCalledTimes(5); // INIT + 3 ADD + LAST
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data).toStrictEqual(signature);
+      }
+    });
+
+    it("should correctly concatenate blob + metadata before chunking", async () => {
+      // ARRANGE — use distinctive byte values to verify concatenation
+      const blob = new Uint8Array(10).fill(0xaa);
+      const metadata = new Uint8Array(10).fill(0xbb);
+      const signature = new Uint8Array(65).fill(0xee);
+
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(CommandResultFactory({ data: signature })); // LAST
+
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: BITTENSOR_PATH, blob, metadata },
+        loggerMock,
+      );
+
+      // ACT
+      await task.run();
+
+      // ASSERT — the LAST chunk should contain [0xaa * 10, 0xbb * 10]
+      const lastCommandArg = sendCommandMock.mock.calls[1]?.[0] as
+        | { args: { transactionChunk: Uint8Array } }
+        | undefined;
+      const chunk = lastCommandArg?.args.transactionChunk;
+      expect(chunk).toBeDefined();
+      if (chunk) {
+        expect(chunk.length).toBe(20);
+        expect(Array.from(chunk.slice(0, 10))).toStrictEqual(
+          Array(10).fill(0xaa),
+        );
+        expect(Array.from(chunk.slice(10, 20))).toStrictEqual(
+          Array(10).fill(0xbb),
+        );
+      }
+    });
+
+    it("should return InvalidStatusWordError when INIT command fails", async () => {
+      // ARRANGE
+      sendCommandMock.mockResolvedValueOnce({
+        status: CommandResultStatus.Error,
+      });
+
+      const task = new SignTransactionTask(
+        apiMock,
+        {
+          derivationPath: BITTENSOR_PATH,
+          blob: new Uint8Array(10),
+          metadata: new Uint8Array(5),
+        },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidStatusWordError;
+        expect(err).toBeInstanceOf(InvalidStatusWordError);
+        expect(err.originalError?.message).toBe("Failed to sign transaction");
+      }
+    });
+
+    it("should return error when a data chunk command fails mid-stream", async () => {
+      // ARRANGE
+      const blob = new Uint8Array(200).fill(0x07);
+      const metadata = new Uint8Array(200).fill(0x08); // total 400 bytes
+      const commandError = CommandResultFactory({
+        error: new PolkadotAppCommandError({
+          message: "Data is invalid",
+          errorCode: PolkadotErrorCodes.DATA_INVALID,
+        }),
+      });
+
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(commandError); // ADD fails
+
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: BITTENSOR_PATH, blob, metadata },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(PolkadotAppCommandError);
+        expect((result.error as PolkadotAppCommandError).errorCode).toBe(
+          PolkadotErrorCodes.DATA_INVALID,
+        );
+      }
+    });
+
+    it("should return InvalidStatusWordError when loop exits without producing a signature", async () => {
+      // ARRANGE — empty payload (blob=0, metadata=0), loop does not iterate
+      sendCommandMock.mockResolvedValueOnce({
+        status: CommandResultStatus.Success,
+      });
+
+      const task = new SignTransactionTask(
+        apiMock,
+        {
+          derivationPath: BITTENSOR_PATH,
+          blob: new Uint8Array(0),
+          metadata: new Uint8Array(0),
+        },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidStatusWordError;
+        expect(err).toBeInstanceOf(InvalidStatusWordError);
+        expect(err.originalError?.message).toBe("No signature returned");
+      }
+    });
+  });
+});

--- a/packages/signer/signer-polkadot/src/internal/app-binder/task/SignTransactionTask.test.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/task/SignTransactionTask.test.ts
@@ -14,7 +14,7 @@ import {
 } from "@internal/app-binder/command/utils/polkadotApplicationErrors";
 import { SignTransactionTask } from "@internal/app-binder/task/SignTransactionTask";
 
-const BITTENSOR_PATH = "44'/1005'/0'/0'/0'";
+const POLKADOT_PATH = "44'/354'/0'/0'/0'";
 
 describe("SignTransactionTask", () => {
   let sendCommandMock: ReturnType<typeof vi.fn>;
@@ -44,7 +44,7 @@ describe("SignTransactionTask", () => {
 
       const task = new SignTransactionTask(
         apiMock,
-        { derivationPath: BITTENSOR_PATH, blob, metadata },
+        { derivationPath: POLKADOT_PATH, blob, metadata },
         loggerMock,
       );
 
@@ -71,7 +71,7 @@ describe("SignTransactionTask", () => {
 
       const task = new SignTransactionTask(
         apiMock,
-        { derivationPath: BITTENSOR_PATH, blob, metadata },
+        { derivationPath: POLKADOT_PATH, blob, metadata },
         loggerMock,
       );
 
@@ -102,7 +102,7 @@ describe("SignTransactionTask", () => {
 
       const task = new SignTransactionTask(
         apiMock,
-        { derivationPath: BITTENSOR_PATH, blob, metadata },
+        { derivationPath: POLKADOT_PATH, blob, metadata },
         loggerMock,
       );
 
@@ -138,7 +138,7 @@ describe("SignTransactionTask", () => {
 
       const task = new SignTransactionTask(
         apiMock,
-        { derivationPath: BITTENSOR_PATH, blob, metadata },
+        { derivationPath: POLKADOT_PATH, blob, metadata },
         loggerMock,
       );
 
@@ -165,7 +165,7 @@ describe("SignTransactionTask", () => {
 
       const task = new SignTransactionTask(
         apiMock,
-        { derivationPath: BITTENSOR_PATH, blob, metadata },
+        { derivationPath: POLKADOT_PATH, blob, metadata },
         loggerMock,
       );
 
@@ -198,7 +198,7 @@ describe("SignTransactionTask", () => {
       const task = new SignTransactionTask(
         apiMock,
         {
-          derivationPath: BITTENSOR_PATH,
+          derivationPath: POLKADOT_PATH,
           blob: new Uint8Array(10),
           metadata: new Uint8Array(5),
         },
@@ -234,7 +234,7 @@ describe("SignTransactionTask", () => {
 
       const task = new SignTransactionTask(
         apiMock,
-        { derivationPath: BITTENSOR_PATH, blob, metadata },
+        { derivationPath: POLKADOT_PATH, blob, metadata },
         loggerMock,
       );
 
@@ -260,7 +260,7 @@ describe("SignTransactionTask", () => {
       const task = new SignTransactionTask(
         apiMock,
         {
-          derivationPath: BITTENSOR_PATH,
+          derivationPath: POLKADOT_PATH,
           blob: new Uint8Array(0),
           metadata: new Uint8Array(0),
         },

--- a/packages/signer/signer-polkadot/src/internal/app-binder/task/SignTransactionTask.test.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/task/SignTransactionTask.test.ts
@@ -1,0 +1,283 @@
+import {
+  CommandResultFactory,
+  CommandResultStatus,
+  type InternalApi,
+  InvalidArgumentError,
+  isSuccessCommandResult,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  PolkadotAppCommandError,
+  PolkadotErrorCodes,
+} from "@internal/app-binder/command/utils/polkadotApplicationErrors";
+import { SignTransactionTask } from "@internal/app-binder/task/SignTransactionTask";
+
+const POLKADOT_PATH = "44'/354'/0'/0'/0'";
+
+describe("SignTransactionTask", () => {
+  let sendCommandMock: ReturnType<typeof vi.fn>;
+  let apiMock: InternalApi;
+  let loggerMock: LoggerPublisherService;
+
+  beforeEach(() => {
+    sendCommandMock = vi.fn();
+    apiMock = {
+      sendCommand: sendCommandMock,
+    } as unknown as InternalApi;
+    loggerMock = {
+      debug: vi.fn(),
+    } as unknown as LoggerPublisherService;
+  });
+
+  describe("run", () => {
+    it("should send INIT + LAST for small payload (blob + metadata < 255 bytes) and return signature", async () => {
+      // ARRANGE
+      const blob = new Uint8Array(50).fill(0x01);
+      const metadata = new Uint8Array(40).fill(0x02);
+      const signature = new Uint8Array(65).fill(0xee);
+
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(CommandResultFactory({ data: signature })); // LAST
+
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: POLKADOT_PATH, blob, metadata },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(sendCommandMock).toHaveBeenCalledTimes(2);
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data).toStrictEqual(signature);
+      }
+    });
+
+    it("should use blobLength equal to blob.length in INIT command", async () => {
+      // ARRANGE
+      const blob = new Uint8Array(120).fill(0x01);
+      const metadata = new Uint8Array(30).fill(0x02);
+      const signature = new Uint8Array(65).fill(0xee);
+
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(CommandResultFactory({ data: signature })); // LAST
+
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: POLKADOT_PATH, blob, metadata },
+        loggerMock,
+      );
+
+      // ACT
+      await task.run();
+
+      // ASSERT — first call is INIT, inspect args
+      const initCommandArg = sendCommandMock.mock.calls[0]?.[0] as
+        | { args: { blobLength: number } }
+        | undefined;
+      expect(initCommandArg).toBeDefined();
+      // The INIT command's args.blobLength should equal blob.length
+      expect(initCommandArg?.args.blobLength).toBe(blob.length);
+    });
+
+    it("should send INIT + ADD + LAST for payloads between 255 and 510 bytes", async () => {
+      // ARRANGE
+      const blob = new Uint8Array(200).fill(0x03);
+      const metadata = new Uint8Array(200).fill(0x04); // total = 400 bytes → 2 data chunks
+      const signature = new Uint8Array(65).fill(0xff);
+
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(
+          CommandResultFactory({ data: new Uint8Array(0) }),
+        ) // ADD
+        .mockResolvedValueOnce(CommandResultFactory({ data: signature })); // LAST
+
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: POLKADOT_PATH, blob, metadata },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(sendCommandMock).toHaveBeenCalledTimes(3); // INIT + ADD + LAST
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data).toStrictEqual(signature);
+      }
+    });
+
+    it("should send INIT + multiple ADD + LAST for large payloads (>510 bytes)", async () => {
+      // ARRANGE
+      const blob = new Uint8Array(400).fill(0x05);
+      const metadata = new Uint8Array(400).fill(0x06); // total = 800 bytes → 4 data chunks
+      const signature = new Uint8Array(65).fill(0xaa);
+
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(
+          CommandResultFactory({ data: new Uint8Array(0) }),
+        ) // ADD 1
+        .mockResolvedValueOnce(
+          CommandResultFactory({ data: new Uint8Array(0) }),
+        ) // ADD 2
+        .mockResolvedValueOnce(
+          CommandResultFactory({ data: new Uint8Array(0) }),
+        ) // ADD 3
+        .mockResolvedValueOnce(CommandResultFactory({ data: signature })); // LAST
+
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: POLKADOT_PATH, blob, metadata },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(sendCommandMock).toHaveBeenCalledTimes(5); // INIT + 3 ADD + LAST
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data).toStrictEqual(signature);
+      }
+    });
+
+    it("should correctly concatenate blob + metadata before chunking", async () => {
+      // ARRANGE — use distinctive byte values to verify concatenation
+      const blob = new Uint8Array(10).fill(0xaa);
+      const metadata = new Uint8Array(10).fill(0xbb);
+      const signature = new Uint8Array(65).fill(0xee);
+
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(CommandResultFactory({ data: signature })); // LAST
+
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: POLKADOT_PATH, blob, metadata },
+        loggerMock,
+      );
+
+      // ACT
+      await task.run();
+
+      // ASSERT — the LAST chunk should contain [0xaa * 10, 0xbb * 10]
+      const lastCommandArg = sendCommandMock.mock.calls[1]?.[0] as
+        | { args: { transactionChunk: Uint8Array } }
+        | undefined;
+      const chunk = lastCommandArg?.args.transactionChunk;
+      expect(chunk).toBeDefined();
+      if (chunk) {
+        expect(chunk.length).toBe(20);
+        expect(Array.from(chunk.slice(0, 10))).toStrictEqual(
+          Array(10).fill(0xaa),
+        );
+        expect(Array.from(chunk.slice(10, 20))).toStrictEqual(
+          Array(10).fill(0xbb),
+        );
+      }
+    });
+
+    it("should propagate the device error when INIT command fails", async () => {
+      // ARRANGE
+      const commandError = CommandResultFactory({
+        error: new PolkadotAppCommandError({
+          message: "Data is invalid",
+          errorCode: PolkadotErrorCodes.DATA_INVALID,
+        }),
+      });
+      sendCommandMock.mockResolvedValueOnce(commandError);
+
+      const task = new SignTransactionTask(
+        apiMock,
+        {
+          derivationPath: POLKADOT_PATH,
+          blob: new Uint8Array(10),
+          metadata: new Uint8Array(5),
+        },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT — same propagation as a failing data chunk (no error rewriting)
+      expect(sendCommandMock).toHaveBeenCalledTimes(1);
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(PolkadotAppCommandError);
+        expect((result.error as PolkadotAppCommandError).errorCode).toBe(
+          PolkadotErrorCodes.DATA_INVALID,
+        );
+      }
+    });
+
+    it("should return error when a data chunk command fails mid-stream", async () => {
+      // ARRANGE
+      const blob = new Uint8Array(200).fill(0x07);
+      const metadata = new Uint8Array(200).fill(0x08); // total 400 bytes
+      const commandError = CommandResultFactory({
+        error: new PolkadotAppCommandError({
+          message: "Data is invalid",
+          errorCode: PolkadotErrorCodes.DATA_INVALID,
+        }),
+      });
+
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(commandError); // ADD fails
+
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: POLKADOT_PATH, blob, metadata },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(PolkadotAppCommandError);
+        expect((result.error as PolkadotAppCommandError).errorCode).toBe(
+          PolkadotErrorCodes.DATA_INVALID,
+        );
+      }
+    });
+
+    it("should reject an empty blob without sending any command", async () => {
+      // ARRANGE
+      const task = new SignTransactionTask(
+        apiMock,
+        {
+          derivationPath: POLKADOT_PATH,
+          blob: new Uint8Array(0),
+          metadata: new Uint8Array(0),
+        },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT — no INIT is sent, so no transaction is left open on the device
+      expect(sendCommandMock).not.toHaveBeenCalled();
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(InvalidArgumentError);
+      }
+    });
+  });
+});

--- a/packages/signer/signer-polkadot/src/internal/app-binder/task/SignTransactionTask.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/task/SignTransactionTask.ts
@@ -1,12 +1,19 @@
 import {
+  APDU_MAX_PAYLOAD,
   type CommandResult,
   CommandResultFactory,
   type InternalApi,
+  InvalidStatusWordError,
   isSuccessCommandResult,
+  type LoggerPublisherService,
 } from "@ledgerhq/device-management-kit";
 
 import { type Signature } from "@api/model/Signature";
-import { SignTransactionCommand } from "@internal/app-binder/command/SignTransactionCommand";
+import {
+  SignPhase,
+  SignTransactionCommand,
+  type SignTransactionCommandResponse,
+} from "@internal/app-binder/command/SignTransactionCommand";
 import { type PolkadotErrorCodes } from "@internal/app-binder/command/utils/polkadotApplicationErrors";
 
 type SignTransactionTaskArgs = {
@@ -19,29 +26,84 @@ export class SignTransactionTask {
   constructor(
     private api: InternalApi,
     private args: SignTransactionTaskArgs,
+    private logger: LoggerPublisherService,
   ) {}
 
-  async run(): Promise<CommandResult<Signature, PolkadotErrorCodes>> {
-    // TODO: Adapt this implementation to your blockchain's signing protocol
-    // For transactions larger than a single APDU, you may need to:
-    // 1. Split the transaction into chunks
-    // 2. Send each chunk with appropriate first/continue flags
-    // 3. Collect the final signature from the last response
+  async run(): Promise<
+    CommandResult<SignTransactionCommandResponse, PolkadotErrorCodes>
+  > {
+    const { derivationPath, blob, metadata } = this.args;
+    const blobLength = blob.length;
 
-    const result = await this.api.sendCommand(
+    // Concatenate blob + metadata into the full payload
+    const payload = new Uint8Array(blob.length + metadata.length);
+    payload.set(blob, 0);
+    payload.set(metadata, blob.length);
+
+    this.logger.debug("[run] Starting SignTransactionTask", {
+      data: {
+        derivationPath,
+        blobLength,
+        metadataLength: metadata.length,
+        payloadLength: payload.length,
+      },
+    });
+
+    // Send INIT command with derivation path and blobLength
+    const initResult = await this.api.sendCommand(
       new SignTransactionCommand({
-        derivationPath: this.args.derivationPath,
-        blob: this.args.blob,
-        metadata: this.args.metadata,
+        phase: SignPhase.INIT,
+        derivationPath,
+        blobLength,
       }),
     );
 
-    if (!isSuccessCommandResult(result)) {
-      return result;
+    if (!isSuccessCommandResult(initResult)) {
+      this.logger.debug("[run] Failed to sign transaction", {
+        data: { error: initResult.error },
+      });
+      return CommandResultFactory({
+        error: new InvalidStatusWordError("Failed to sign transaction"),
+      });
+    }
+
+    // Loop through payload in APDU_MAX_PAYLOAD chunks
+    for (let offset = 0; offset < payload.length; offset += APDU_MAX_PAYLOAD) {
+      const isLastChunk = offset + APDU_MAX_PAYLOAD >= payload.length;
+      const phase = isLastChunk ? SignPhase.LAST : SignPhase.ADD;
+      const transactionChunk = payload.slice(offset, offset + APDU_MAX_PAYLOAD);
+
+      const result = await this.api.sendCommand(
+        new SignTransactionCommand({
+          phase,
+          transactionChunk,
+        }),
+      );
+
+      if (!isSuccessCommandResult(result)) {
+        this.logger.debug("[run] Failed to sign transaction", {
+          data: {
+            chunkIndex: offset,
+            error: result.error,
+          },
+        });
+        return result;
+      }
+
+      if (isLastChunk) {
+        this.logger.debug("[run] Transaction signed successfully", {
+          data: {
+            signature: result.data,
+          },
+        });
+        return CommandResultFactory({
+          data: result.data as Signature,
+        });
+      }
     }
 
     return CommandResultFactory({
-      data: result.data,
+      error: new InvalidStatusWordError("No signature returned"),
     });
   }
 }

--- a/packages/signer/signer-polkadot/src/internal/app-binder/task/SignTransactionTask.ts
+++ b/packages/signer/signer-polkadot/src/internal/app-binder/task/SignTransactionTask.ts
@@ -1,12 +1,19 @@
 import {
+  APDU_MAX_PAYLOAD,
   type CommandResult,
-  CommandResultFactory,
+  DmkResultFactory,
   type InternalApi,
+  InvalidArgumentError,
+  InvalidStatusWordError,
   isSuccessCommandResult,
+  type LoggerPublisherService,
 } from "@ledgerhq/device-management-kit";
 
-import { type Signature } from "@api/model/Signature";
-import { SignTransactionCommand } from "@internal/app-binder/command/SignTransactionCommand";
+import {
+  SignPhase,
+  SignTransactionCommand,
+  type SignTransactionCommandResponse,
+} from "@internal/app-binder/command/SignTransactionCommand";
 import { type PolkadotErrorCodes } from "@internal/app-binder/command/utils/polkadotApplicationErrors";
 
 type SignTransactionTaskArgs = {
@@ -19,29 +26,90 @@ export class SignTransactionTask {
   constructor(
     private api: InternalApi,
     private args: SignTransactionTaskArgs,
+    private logger: LoggerPublisherService,
   ) {}
 
-  async run(): Promise<CommandResult<Signature, PolkadotErrorCodes>> {
-    // TODO: Adapt this implementation to your blockchain's signing protocol
-    // For transactions larger than a single APDU, you may need to:
-    // 1. Split the transaction into chunks
-    // 2. Send each chunk with appropriate first/continue flags
-    // 3. Collect the final signature from the last response
+  async run(): Promise<
+    CommandResult<SignTransactionCommandResponse, PolkadotErrorCodes>
+  > {
+    const { derivationPath, blob, metadata } = this.args;
+    const blobLength = blob.length;
 
-    const result = await this.api.sendCommand(
+    // An empty blob has nothing to sign: the device would refuse it anyway, and
+    // sending INIT alone would leave a transaction open on it.
+    if (blobLength === 0) {
+      return DmkResultFactory({
+        error: new InvalidArgumentError(
+          "Cannot sign an empty transaction blob",
+        ),
+      });
+    }
+
+    // Concatenate blob + metadata into the full payload
+    const payload = new Uint8Array(blob.length + metadata.length);
+    payload.set(blob, 0);
+    payload.set(metadata, blob.length);
+
+    this.logger.debug("[run] Starting SignTransactionTask", {
+      data: {
+        derivationPath,
+        blobLength,
+        metadataLength: metadata.length,
+        payloadLength: payload.length,
+      },
+    });
+
+    // Send INIT command with derivation path and blobLength
+    const initResult = await this.api.sendCommand(
       new SignTransactionCommand({
-        derivationPath: this.args.derivationPath,
-        blob: this.args.blob,
-        metadata: this.args.metadata,
+        phase: SignPhase.INIT,
+        derivationPath,
+        blobLength,
       }),
     );
 
-    if (!isSuccessCommandResult(result)) {
-      return result;
+    if (!isSuccessCommandResult(initResult)) {
+      this.logger.debug("[run] Failed to sign transaction", {
+        data: { error: initResult.error },
+      });
+      return initResult;
     }
 
-    return CommandResultFactory({
-      data: result.data,
+    // Loop through payload in APDU_MAX_PAYLOAD chunks
+    for (let offset = 0; offset < payload.length; offset += APDU_MAX_PAYLOAD) {
+      const isLastChunk = offset + APDU_MAX_PAYLOAD >= payload.length;
+      const phase = isLastChunk ? SignPhase.LAST : SignPhase.ADD;
+      const transactionChunk = payload.slice(offset, offset + APDU_MAX_PAYLOAD);
+
+      const result = await this.api.sendCommand(
+        new SignTransactionCommand({
+          phase,
+          transactionChunk,
+        }),
+      );
+
+      if (!isSuccessCommandResult(result)) {
+        this.logger.debug("[run] Failed to sign transaction", {
+          data: {
+            chunkIndex: offset,
+            error: result.error,
+          },
+        });
+        return result;
+      }
+
+      if (isLastChunk) {
+        this.logger.debug("[run] Transaction signed successfully", {
+          data: {
+            signature: result.data,
+          },
+        });
+        return result;
+      }
+    }
+
+    return DmkResultFactory({
+      error: new InvalidStatusWordError("No signature returned"),
     });
   }
 }

--- a/packages/signer/signer-polkadot/src/internal/di.ts
+++ b/packages/signer/signer-polkadot/src/internal/di.ts
@@ -1,6 +1,7 @@
 import {
   type DeviceManagementKit,
   type DeviceSessionId,
+  type LoggerPublisherService,
 } from "@ledgerhq/device-management-kit";
 import { Container } from "inversify";
 
@@ -21,6 +22,14 @@ export const makeContainer = ({ dmk, sessionId }: MakeContainerProps) => {
   container
     .bind<DeviceSessionId>(externalTypes.SessionId)
     .toConstantValue(sessionId);
+
+  container
+    .bind<
+      (tag: string) => LoggerPublisherService
+    >(externalTypes.DmkLoggerFactory)
+    .toConstantValue((tag: string) =>
+      dmk.getLoggerFactory()(["SignerPolkadot", tag]),
+    );
 
   container.loadSync(
     appBindingModuleFactory(),

--- a/packages/signer/signer-polkadot/src/internal/externalTypes.ts
+++ b/packages/signer/signer-polkadot/src/internal/externalTypes.ts
@@ -1,6 +1,5 @@
 export const externalTypes = {
   Dmk: Symbol.for("Dmk"),
   SessionId: Symbol.for("SessionId"),
-  // Add ContextModule if needed
-  // ContextModule: Symbol.for("ContextModule"),
+  DmkLoggerFactory: Symbol.for("DmkLoggerFactory"),
 } as const;

--- a/packages/signer/signer-polkadot/src/internal/use-cases/address/GetAddressUseCase.test.ts
+++ b/packages/signer/signer-polkadot/src/internal/use-cases/address/GetAddressUseCase.test.ts
@@ -1,0 +1,81 @@
+import {
+  DeviceActionStatus,
+  type ExecuteDeviceActionReturnType,
+} from "@ledgerhq/device-management-kit";
+import { from } from "rxjs";
+import { vi } from "vitest";
+
+import {
+  type GetAddressDAError,
+  type GetAddressDAIntermediateValue,
+  type GetAddressDAOutput,
+} from "@api/app-binder/GetAddressDeviceActionTypes";
+import { type PolkadotAppBinder } from "@internal/app-binder/PolkadotAppBinder";
+
+import { GetAddressUseCase } from "./GetAddressUseCase";
+
+describe("GetAddressUseCase", () => {
+  const derivationPath = "44'/354'/0'/0'/0'";
+  const ss58Prefix = 42;
+
+  it("should return the result from appBinder.getAddress with default options", () => {
+    // ARRANGE
+    const getAddressMock = vi.fn();
+    const appBinderMock = {
+      getAddress: getAddressMock,
+    } as unknown as PolkadotAppBinder;
+    const expectedResult: ExecuteDeviceActionReturnType<
+      GetAddressDAOutput,
+      GetAddressDAError,
+      GetAddressDAIntermediateValue
+    > = {
+      observable: from([
+        {
+          status: DeviceActionStatus.Completed as const,
+          output: {
+            publicKey: new Uint8Array([0x01, 0x02]),
+            address: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+          },
+        },
+      ]),
+      cancel: vi.fn(),
+    };
+    getAddressMock.mockReturnValue(expectedResult);
+    const getAddressUseCase = new GetAddressUseCase(appBinderMock);
+
+    // ACT
+    const result = getAddressUseCase.execute(derivationPath, ss58Prefix);
+
+    // ASSERT
+    expect(getAddressMock).toHaveBeenCalledWith({
+      derivationPath,
+      ss58Prefix,
+      checkOnDevice: false,
+      skipOpenApp: false,
+    });
+    expect(result).toEqual(expectedResult);
+  });
+
+  it("should forward the checkOnDevice and skipOpenApp options", () => {
+    // ARRANGE
+    const getAddressMock = vi.fn();
+    const appBinderMock = {
+      getAddress: getAddressMock,
+    } as unknown as PolkadotAppBinder;
+    const getAddressUseCase = new GetAddressUseCase(appBinderMock);
+
+    // ACT
+    getAddressUseCase.execute(derivationPath, ss58Prefix, {
+      checkOnDevice: true,
+      skipOpenApp: true,
+    });
+
+    // ASSERT
+    expect(getAddressMock).toHaveBeenCalledWith({
+      derivationPath,
+      ss58Prefix,
+      checkOnDevice: true,
+      skipOpenApp: true,
+    });
+  });
+});


### PR DESCRIPTION
### 📝 Description

Implement the full APDU command layer for the `signer-polkadot` DMK signer kit. The signer is generic across the Polkadot family (Polkadot, Westend, AssetHub, Bittensor, …) — chains differ only by the SS58 prefix parameter and the derivation path. Bittensor is the driving integration.

**Commands implemented:**
- **GetAddressCommand** — derives the address with a configurable SS58 prefix (0 = Polkadot, 42 = Bittensor) and optional on-device confirmation
- **SignTransactionCommand** — multi-chunk protocol (INIT/ADD/LAST) for signing transaction blobs, with the derivation path and blob length sent in the initial chunk
- **SignTransactionTask** — orchestrates blob+metadata chunking into sequential APDU calls, respecting the 255-byte payload limit

**Supporting utilities:**
- `EncodeDerivationPath` — encodes a hardened BIP44 path into the little-endian binary layout expected by the device app
- `polkadotApplicationErrors` — maps device status words to typed error codes
- Constants module with the app-wide CLA (INS/P2 live in their respective commands)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-30995](https://ledgerhq.atlassian.net/browse/LIVE-30995)
- **Feature**: Polkadot-family signer kit (APDU layer) — driven by the Bittensor integration

Depends on #1501 (scaffold, merged).

### ✅ Checklist

- [x] **Covered by automatic tests** — unit tests across the command, task, use-case and signer layers (GetAddress/SignTransaction commands, SignTransactionTask, EncodeDerivationPath, application errors, GetAddressUseCase, DefaultSignerPolkadot, builder)
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - New APDU commands in `@ledgerhq/device-signer-kit-polkadot`
  - No impact on existing packages — all changes scoped to `signer-polkadot`
  - Multi-chunk signing protocol for large Substrate extrinsics

[LIVE-30995]: https://ledgerhq.atlassian.net/browse/LIVE-30995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
