### PR TITLE
🔧 (ci) [NO-ISSUE]: Use SONAR_TOKEN secret for SonarCloud scan

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -137,7 +137,7 @@ jobs:
         if: ${{ steps.unit-tests.conclusion == 'success' && github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_LEDGER_DMK_PROJECT }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   cs-tester:
     needs: [build-libraries, detect-changes]


### PR DESCRIPTION
### 📝 Description

Switch the SonarCloud scan step in the `pull_request` workflow to use the `SONAR_TOKEN` repository secret instead of `SONAR_TOKEN_LEDGER_DMK_PROJECT`.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Align the SonarCloud scan with the latest `SONAR_TOKEN` secret.

### ✅ Checklist

- [x] **Covered by automatic tests** — N/A, CI configuration change only.
- [ ] **Changeset is provided** — No changeset needed; change only affects CI configuration, not a published package.
- [x] **Documentation is up-to-date**
- [ ] **Impact of the changes:**
  - SonarCloud scan now authenticates using the `SONAR_TOKEN` secret.

Made with [Cursor](https://cursor.com)