### PR TITLE
✨ (device-management-kit) [NO-ISSUE]: Add WaitAppAndVersionDeviceAction

### DIFF
--- a/.changeset/grumpy-pants-switch.md
+++ b/.changeset/grumpy-pants-switch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": minor
+---
+
+Add WaitForAppAndVersionDeviceAction

--- a/packages/device-management-kit/src/api/device-action/os/WaitForAppAndVersion/WaitForAppAndVersionDeviceAction.test.ts
+++ b/packages/device-management-kit/src/api/device-action/os/WaitForAppAndVersion/WaitForAppAndVersionDeviceAction.test.ts
@@ -1,0 +1,292 @@
+import { of, throwError } from "rxjs";
+
+import { CommandResultFactory } from "@api/command/model/CommandResult";
+import {
+  GLOBAL_ERRORS,
+  GlobalCommandError,
+} from "@api/command/utils/GlobalCommandError";
+import { makeDeviceActionInternalApiMock } from "@api/device-action/__test-utils__/makeInternalApi";
+import { testDeviceActionStates } from "@api/device-action/__test-utils__/testDeviceActionStates";
+import { DeviceActionStatus } from "@api/device-action/model/DeviceActionState";
+import { UserInteractionRequired } from "@api/device-action/model/UserInteractionRequired";
+import {
+  DeviceLockedError,
+  UnknownDAError,
+} from "@api/device-action/os/Errors";
+
+import {
+  type WaitForAppAndVersionDAState,
+  waitForAppAndVersionDAStateStep,
+} from "./types";
+import { WaitForAppAndVersionDeviceAction } from "./WaitForAppAndVersionDeviceAction";
+
+const appAndVersionResult = (name: string, version: string) =>
+  CommandResultFactory({
+    data: {
+      name,
+      version,
+    },
+  });
+
+const lockedErrorResult = () =>
+  CommandResultFactory({
+    error: new GlobalCommandError({
+      ...GLOBAL_ERRORS["5515"],
+      errorCode: "5515",
+    }),
+  });
+
+const claNotSupportedErrorResult = () =>
+  CommandResultFactory({
+    error: new GlobalCommandError({
+      ...GLOBAL_ERRORS["6e00"],
+      errorCode: "6e00",
+    }),
+  });
+
+const getAppAndVersionPendingState = (): WaitForAppAndVersionDAState => ({
+  intermediateValue: {
+    requiredUserInteraction: UserInteractionRequired.None,
+    step: waitForAppAndVersionDAStateStep.GET_APP_AND_VERSION,
+  },
+  status: DeviceActionStatus.Pending,
+});
+
+const unlockRequestedPendingState = (): WaitForAppAndVersionDAState => ({
+  intermediateValue: {
+    requiredUserInteraction: UserInteractionRequired.UnlockDevice,
+    step: waitForAppAndVersionDAStateStep.UNLOCK_DEVICE,
+  },
+  status: DeviceActionStatus.Pending,
+});
+
+describe("WaitForAppAndVersionDeviceAction", () => {
+  const getAppAndVersionMock = vi.fn();
+  const waitForDeviceUnlockMock = vi.fn();
+
+  function extractDependenciesMock() {
+    return {
+      getAppAndVersion: getAppAndVersionMock,
+      waitForDeviceUnlock: waitForDeviceUnlockMock,
+    };
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("should succeed on the first call when the device is already unlocked", () =>
+    new Promise<void>((resolve, reject) => {
+      getAppAndVersionMock.mockResolvedValue(
+        appAndVersionResult("BOLOS", "1.0.0"),
+      );
+
+      const deviceAction = new WaitForAppAndVersionDeviceAction({
+        input: { unlockTimeout: 500 },
+      });
+
+      vi.spyOn(deviceAction, "extractDependencies").mockReturnValue(
+        extractDependenciesMock(),
+      );
+
+      const expectedStates: Array<WaitForAppAndVersionDAState> = [
+        getAppAndVersionPendingState(),
+        {
+          status: DeviceActionStatus.Completed,
+          output: {
+            name: "BOLOS",
+            version: "1.0.0",
+          },
+        },
+      ];
+
+      testDeviceActionStates(
+        deviceAction,
+        expectedStates,
+        makeDeviceActionInternalApiMock(),
+        {
+          onDone: resolve,
+          onError: reject,
+        },
+      );
+    }));
+
+  it("should wait for the device to be unlocked then succeed", () =>
+    new Promise<void>((resolve, reject) => {
+      getAppAndVersionMock
+        .mockResolvedValueOnce(lockedErrorResult())
+        .mockResolvedValueOnce(appAndVersionResult("Bitcoin", "2.1.0"));
+
+      waitForDeviceUnlockMock.mockReturnValue(of(undefined));
+
+      const deviceAction = new WaitForAppAndVersionDeviceAction({
+        input: { unlockTimeout: 500 },
+      });
+
+      vi.spyOn(deviceAction, "extractDependencies").mockReturnValue(
+        extractDependenciesMock(),
+      );
+
+      const expectedStates: Array<WaitForAppAndVersionDAState> = [
+        getAppAndVersionPendingState(),
+        unlockRequestedPendingState(),
+        getAppAndVersionPendingState(),
+        {
+          status: DeviceActionStatus.Completed,
+          output: {
+            name: "Bitcoin",
+            version: "2.1.0",
+          },
+        },
+      ];
+
+      testDeviceActionStates(
+        deviceAction,
+        expectedStates,
+        makeDeviceActionInternalApiMock(),
+        {
+          onDone: resolve,
+          onError: reject,
+        },
+      );
+    }));
+
+  it("should consider the device on the dashboard of an old firmware when CLA is not supported", () =>
+    new Promise<void>((resolve, reject) => {
+      getAppAndVersionMock.mockResolvedValue(claNotSupportedErrorResult());
+
+      const deviceAction = new WaitForAppAndVersionDeviceAction({
+        input: { unlockTimeout: 500 },
+      });
+
+      vi.spyOn(deviceAction, "extractDependencies").mockReturnValue(
+        extractDependenciesMock(),
+      );
+
+      const expectedStates: Array<WaitForAppAndVersionDAState> = [
+        getAppAndVersionPendingState(),
+        {
+          status: DeviceActionStatus.Completed,
+          output: {
+            name: "BOLOS",
+            version: "0.0.0",
+          },
+        },
+      ];
+
+      testDeviceActionStates(
+        deviceAction,
+        expectedStates,
+        makeDeviceActionInternalApiMock(),
+        {
+          onDone: resolve,
+          onError: reject,
+        },
+      );
+    }));
+
+  it("should end in an error if the device stays locked until the unlock timeout", () =>
+    new Promise<void>((resolve, reject) => {
+      getAppAndVersionMock.mockResolvedValue(lockedErrorResult());
+
+      waitForDeviceUnlockMock.mockReturnValue(
+        throwError(() => new DeviceLockedError()),
+      );
+
+      const deviceAction = new WaitForAppAndVersionDeviceAction({
+        input: { unlockTimeout: 500 },
+      });
+
+      vi.spyOn(deviceAction, "extractDependencies").mockReturnValue(
+        extractDependenciesMock(),
+      );
+
+      const expectedStates: Array<WaitForAppAndVersionDAState> = [
+        getAppAndVersionPendingState(),
+        unlockRequestedPendingState(),
+        {
+          status: DeviceActionStatus.Error,
+          error: new DeviceLockedError(),
+        },
+      ];
+
+      testDeviceActionStates(
+        deviceAction,
+        expectedStates,
+        makeDeviceActionInternalApiMock(),
+        {
+          onDone: resolve,
+          onError: reject,
+        },
+      );
+    }));
+
+  it("should end in an error if the GetAppAndVersion command fails with a non-locked error", () =>
+    new Promise<void>((resolve, reject) => {
+      const error = new GlobalCommandError({
+        ...GLOBAL_ERRORS["5501"],
+        errorCode: "5501",
+      });
+
+      getAppAndVersionMock.mockResolvedValue(CommandResultFactory({ error }));
+
+      const deviceAction = new WaitForAppAndVersionDeviceAction({
+        input: { unlockTimeout: 500 },
+      });
+
+      vi.spyOn(deviceAction, "extractDependencies").mockReturnValue(
+        extractDependenciesMock(),
+      );
+
+      const expectedStates: Array<WaitForAppAndVersionDAState> = [
+        getAppAndVersionPendingState(),
+        {
+          status: DeviceActionStatus.Error,
+          error,
+        },
+      ];
+
+      testDeviceActionStates(
+        deviceAction,
+        expectedStates,
+        makeDeviceActionInternalApiMock(),
+        {
+          onDone: resolve,
+          onError: reject,
+        },
+      );
+    }));
+
+  it("should end in an error if the getAppAndVersion actor throws an error", () =>
+    new Promise<void>((resolve, reject) => {
+      getAppAndVersionMock.mockImplementation(() => {
+        throw new UnknownDAError("error");
+      });
+
+      const deviceAction = new WaitForAppAndVersionDeviceAction({
+        input: { unlockTimeout: 500 },
+      });
+
+      vi.spyOn(deviceAction, "extractDependencies").mockReturnValue(
+        extractDependenciesMock(),
+      );
+
+      const expectedStates: Array<WaitForAppAndVersionDAState> = [
+        getAppAndVersionPendingState(),
+        {
+          status: DeviceActionStatus.Error,
+          error: new UnknownDAError("error"),
+        },
+      ];
+
+      testDeviceActionStates(
+        deviceAction,
+        expectedStates,
+        makeDeviceActionInternalApiMock(),
+        {
+          onDone: resolve,
+          onError: reject,
+        },
+      );
+    }));
+});

--- a/packages/device-management-kit/src/api/device-action/os/WaitForAppAndVersion/WaitForAppAndVersionDeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/os/WaitForAppAndVersion/WaitForAppAndVersionDeviceAction.ts
@@ -1,0 +1,275 @@
+import { Left, Right } from "purify-ts";
+import { first, from, interval, map, type Observable, switchMap } from "rxjs";
+import { timeout } from "rxjs/operators";
+import { assign, fromObservable, fromPromise, setup } from "xstate";
+
+import { isSuccessCommandResult } from "@api/command/model/CommandResult";
+import {
+  GetAppAndVersionCommand,
+  type GetAppAndVersionCommandResult,
+} from "@api/command/os/GetAppAndVersionCommand";
+import { type InternalApi } from "@api/device-action/DeviceAction";
+import { UserInteractionRequired } from "@api/device-action/model/UserInteractionRequired";
+import { DEFAULT_UNLOCK_TIMEOUT_MS } from "@api/device-action/os/Const";
+import { DeviceLockedError } from "@api/device-action/os/Errors";
+import { type StateMachineTypes } from "@api/device-action/xstate-utils/StateMachineTypes";
+import {
+  type DeviceActionStateMachine,
+  XStateDeviceAction,
+} from "@api/device-action/xstate-utils/XStateDeviceAction";
+import { LEDGER_OS_NAME } from "@api/utils/AppName";
+
+import {
+  type WaitForAppAndVersionDAError,
+  type WaitForAppAndVersionDAInput,
+  type WaitForAppAndVersionDAIntermediateValue,
+  type WaitForAppAndVersionDAOutput,
+  waitForAppAndVersionDAStateStep,
+} from "./types";
+
+type WaitForAppAndVersionMachineInternalState = {
+  readonly appAndVersion: WaitForAppAndVersionDAOutput | null;
+  readonly locked: boolean;
+  readonly error: WaitForAppAndVersionDAError | null;
+};
+
+export type MachineDependencies = {
+  readonly getAppAndVersion: () => Promise<GetAppAndVersionCommandResult>;
+  readonly waitForDeviceUnlock: (args: {
+    input: { unlockTimeout: number };
+  }) => Observable<void>;
+};
+
+export type ExtractMachineDependencies = (
+  internalApi: InternalApi,
+) => MachineDependencies;
+
+const isLocked = (output: GetAppAndVersionCommandResult): boolean =>
+  !isSuccessCommandResult(output) &&
+  "errorCode" in output.error &&
+  output.error.errorCode === "5515";
+
+const isClaNotSupported = (output: GetAppAndVersionCommandResult): boolean =>
+  !isSuccessCommandResult(output) &&
+  "errorCode" in output.error &&
+  output.error.errorCode === "6e00";
+
+export class WaitForAppAndVersionDeviceAction extends XStateDeviceAction<
+  WaitForAppAndVersionDAOutput,
+  WaitForAppAndVersionDAInput,
+  WaitForAppAndVersionDAError,
+  WaitForAppAndVersionDAIntermediateValue,
+  WaitForAppAndVersionMachineInternalState
+> {
+  makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    WaitForAppAndVersionDAOutput,
+    WaitForAppAndVersionDAInput,
+    WaitForAppAndVersionDAError,
+    WaitForAppAndVersionDAIntermediateValue,
+    WaitForAppAndVersionMachineInternalState
+  > {
+    type types = StateMachineTypes<
+      WaitForAppAndVersionDAOutput,
+      WaitForAppAndVersionDAInput,
+      WaitForAppAndVersionDAError,
+      WaitForAppAndVersionDAIntermediateValue,
+      WaitForAppAndVersionMachineInternalState
+    >;
+
+    const { getAppAndVersion, waitForDeviceUnlock } =
+      this.extractDependencies(internalApi);
+
+    const unlockTimeout = this.input.unlockTimeout ?? DEFAULT_UNLOCK_TIMEOUT_MS;
+
+    return setup({
+      types: {
+        input: {
+          unlockTimeout,
+        } as types["input"],
+        context: {} as types["context"],
+        output: {} as types["output"],
+      },
+      actors: {
+        getAppAndVersion: fromPromise(getAppAndVersion),
+        waitForDeviceUnlock: fromObservable(waitForDeviceUnlock),
+      },
+      guards: {
+        isDeviceLocked: ({ context }) => context._internalState.locked,
+        hasError: ({ context }) => context._internalState.error !== null,
+      },
+      actions: {
+        assignErrorDeviceLocked: assign({
+          _internalState: (_) => ({
+            ..._.context._internalState,
+            error: new DeviceLockedError(),
+          }),
+        }),
+        assignErrorFromEvent: assign({
+          _internalState: (_) => ({
+            ..._.context._internalState,
+            error: _.event["error"], // NOTE: it should never happen, the error is not typed anymore here
+          }),
+        }),
+      },
+    }).createMachine({
+      id: "WaitForAppAndVersionDeviceAction",
+      initial: "GetAppAndVersion",
+      context: (_) => ({
+        input: {
+          unlockTimeout: _.input.unlockTimeout,
+        },
+        intermediateValue: {
+          requiredUserInteraction: UserInteractionRequired.None,
+          step: waitForAppAndVersionDAStateStep.GET_APP_AND_VERSION,
+        },
+        _internalState: {
+          appAndVersion: null,
+          locked: false,
+          error: null,
+        },
+      }),
+      states: {
+        GetAppAndVersion: {
+          entry: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              step: waitForAppAndVersionDAStateStep.GET_APP_AND_VERSION,
+              requiredUserInteraction: UserInteractionRequired.None,
+            }),
+          }),
+          invoke: {
+            src: "getAppAndVersion",
+            onDone: {
+              target: "CheckGetAppAndVersionResult",
+              actions: assign({
+                _internalState: (_) => {
+                  if (isSuccessCommandResult(_.event.output)) {
+                    return {
+                      ..._.context._internalState,
+                      locked: false,
+                      appAndVersion: _.event.output.data,
+                    };
+                  }
+                  if (isLocked(_.event.output)) {
+                    return {
+                      ..._.context._internalState,
+                      locked: true,
+                    };
+                  }
+                  if (isClaNotSupported(_.event.output)) {
+                    // GetAppAndVersion should always be supported by the firmware or any app.
+                    // But on old firmware versions, that APDU was not supported in the dashboard.
+                    // On those firmwares, it fails with CLA_NOT_SUPPORTED in BOLOS, and INS_NOT_SUPPORTED
+                    // in applications. Therefore if CLA is not supported, we can consider we're on the
+                    // dashboard on an old firmware. We should therefore return that information to
+                    // ensure the user can still update his firmware and is not blocked at this step.
+                    return {
+                      ..._.context._internalState,
+                      locked: false,
+                      appAndVersion: {
+                        name: LEDGER_OS_NAME,
+                        version: "0.0.0",
+                      },
+                    };
+                  }
+                  return {
+                    ..._.context._internalState,
+                    error: _.event.output.error,
+                  };
+                },
+              }),
+            },
+            onError: {
+              target: "Error",
+              actions: "assignErrorFromEvent",
+            },
+          },
+        },
+        CheckGetAppAndVersionResult: {
+          always: [
+            {
+              guard: "hasError",
+              target: "Error",
+            },
+            {
+              guard: "isDeviceLocked",
+              target: "AwaitingForDeviceUnlocked",
+            },
+            {
+              target: "Success",
+            },
+          ],
+        },
+        AwaitingForDeviceUnlocked: {
+          entry: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              requiredUserInteraction: UserInteractionRequired.UnlockDevice,
+              step: waitForAppAndVersionDAStateStep.UNLOCK_DEVICE,
+            }),
+          }),
+          invoke: {
+            id: "AwaitingForDeviceUnlocked",
+            src: "waitForDeviceUnlock",
+            input: (_) => ({
+              unlockTimeout,
+            }),
+            onDone: {
+              target: "GetAppAndVersion",
+              actions: assign({
+                _internalState: (_) => ({
+                  ..._.context._internalState,
+                  locked: false,
+                }),
+              }),
+            },
+            onError: {
+              target: "Error",
+              actions: "assignErrorDeviceLocked",
+            },
+          },
+        },
+        Success: {
+          type: "final",
+        },
+        Error: {
+          type: "final",
+        },
+      },
+      output: (args) => {
+        const { context } = args;
+        const { error, appAndVersion } = context._internalState;
+        if (error) {
+          return Left(error);
+        }
+        return Right<WaitForAppAndVersionDAOutput>(appAndVersion!);
+      },
+    });
+  }
+
+  extractDependencies(internalApi: InternalApi): MachineDependencies {
+    const getAppAndVersion = () =>
+      internalApi.sendCommand(new GetAppAndVersionCommand());
+
+    const waitForDeviceUnlock = ({
+      input,
+    }: {
+      input: { unlockTimeout: number };
+    }) =>
+      interval(1000).pipe(
+        switchMap(() =>
+          from(internalApi.sendCommand(new GetAppAndVersionCommand())),
+        ),
+        first((output) => !isLocked(output)),
+        map(() => undefined),
+        timeout(input.unlockTimeout),
+      );
+
+    return {
+      getAppAndVersion,
+      waitForDeviceUnlock,
+    };
+  }
+}

--- a/packages/device-management-kit/src/api/device-action/os/WaitForAppAndVersion/types.ts
+++ b/packages/device-management-kit/src/api/device-action/os/WaitForAppAndVersion/types.ts
@@ -1,0 +1,42 @@
+import { type CommandErrorResult } from "@api/command/model/CommandResult";
+import { type GetAppAndVersionResponse } from "@api/command/os/GetAppAndVersionCommand";
+import { type DeviceActionState } from "@api/device-action/model/DeviceActionState";
+import { type UserInteractionRequired } from "@api/device-action/model/UserInteractionRequired";
+import {
+  type DeviceLockedError,
+  type UnknownDAError,
+} from "@api/device-action/os/Errors";
+
+export const waitForAppAndVersionDAStateStep = Object.freeze({
+  GET_APP_AND_VERSION: "os.waitForAppAndVersion.steps.getAppAndVersion",
+  UNLOCK_DEVICE: "os.waitForAppAndVersion.steps.unlockDevice",
+} as const);
+
+export type WaitForAppAndVersionDAStateStep =
+  (typeof waitForAppAndVersionDAStateStep)[keyof typeof waitForAppAndVersionDAStateStep];
+
+export type WaitForAppAndVersionDAOutput = GetAppAndVersionResponse;
+
+export type WaitForAppAndVersionDAInput = {
+  readonly unlockTimeout?: number;
+};
+
+export type WaitForAppAndVersionDAError =
+  | DeviceLockedError
+  | UnknownDAError
+  | CommandErrorResult["error"];
+
+export type WaitForAppAndVersionDARequiredInteraction =
+  | UserInteractionRequired.None
+  | UserInteractionRequired.UnlockDevice;
+
+export type WaitForAppAndVersionDAIntermediateValue = {
+  requiredUserInteraction: WaitForAppAndVersionDARequiredInteraction;
+  step: WaitForAppAndVersionDAStateStep;
+};
+
+export type WaitForAppAndVersionDAState = DeviceActionState<
+  WaitForAppAndVersionDAOutput,
+  WaitForAppAndVersionDAError,
+  WaitForAppAndVersionDAIntermediateValue
+>;

--- a/packages/device-management-kit/src/api/index.ts
+++ b/packages/device-management-kit/src/api/index.ts
@@ -130,6 +130,15 @@ export { ListAppsWithMetadataDeviceAction } from "@api/device-action/os/ListApps
 export { OpenAppDeviceAction } from "@api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction";
 export { OpenAppWithDependenciesDeviceAction } from "@api/device-action/os/OpenAppWithDependencies/OpenAppWithDependenciesDeviceAction";
 export { SendCommandInAppDeviceAction } from "@api/device-action/os/SendCommandInAppDeviceAction/SendCommandInAppDeviceAction";
+export type {
+  WaitForAppAndVersionDAError,
+  WaitForAppAndVersionDAInput,
+  WaitForAppAndVersionDAIntermediateValue,
+  WaitForAppAndVersionDAOutput,
+  WaitForAppAndVersionDARequiredInteraction,
+  WaitForAppAndVersionDAState,
+} from "@api/device-action/os/WaitForAppAndVersion/types";
+export { WaitForAppAndVersionDeviceAction } from "@api/device-action/os/WaitForAppAndVersion/WaitForAppAndVersionDeviceAction";
 export { BackupAppStorageTask } from "@api/device-action/task/BackupAppStorageTask";
 export {
   GetApplicationsMetadataTaskError,


### PR DESCRIPTION
### 📝 Description

This PR introduces a new **`WaitForAppAndVersionDeviceAction`** in the Device Management Kit.

> **Note:** `GetDeviceStatusDeviceAction` currently reimplements this same unlock-polling logic internally. A follow-up could refactor it to reuse `WaitForAppAndVersionDeviceAction`, removing the duplicated polling code and keeping a single source of truth for the "get app & version / wait for unlock" behavior.

**The why:**

We need a device action that retrieves the currently running app **without requiring the device to be onboarded**, and that can be used as a building block to reach the dashboard for OS-level operations (e.g. the upcoming **OS update migration**, which needs to run a `GetOsVersion` command on the dashboard).

Today our only options have important constraints:

- **`GetDeviceStatusDeviceAction`** rejects non-onboarded devices: it runs an onboarding check and fails with `DeviceNotOnboardedError`. We don't want that here — **OS updates must also work on devices that are not yet onboarded.**
- **`GoToDashboardDeviceAction`** can't be used as the first step for the same reason: it relies on device-status / onboarding assumptions and will fail on a non-onboarded device.

`GetAppAndVersion` is the right primitive because it can be issued safely on any device state (onboarded or not, dashboard or app), only requiring the device to be unlocked. It lets us answer "are we on the dashboard?", then if not (if the device is not onboarded, it will), run `GoToDashboardDeviceAction` and drive the OS-update path accordingly.

<img width="2392" height="888" alt="image" src="https://github.com/user-attachments/assets/3bad2072-e989-458a-9471-12d739d15e2e" />

**Polling mechanism:**

The unlock-wait/polling logic is **inspired by `GetDeviceStatusDeviceAction`** but **extracted into a dedicated, single-purpose device action**. Rather than embedding the full device-status / onboarding flow, we reuse only the lightweight `interval` + `GetAppAndVersion` polling pattern (with a configurable `unlockTimeout`, defaulting to `DEFAULT_UNLOCK_TIMEOUT_MS`). This keeps the action reusable and free of the onboarding constraint, so it can serve as the entry point for the OS update path.
### ❓ Context

- **JIRA or GitHub link**: NO TICKET

### ✅ Checklist

- [x] **Covered by automatic tests** — `WaitForAppAndVersionDeviceAction.test.ts` covers success, locked → unlock polling, timeout, and error cases.
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - Adds a new public device action exported from `@api`.
  - QA focus: locked-device unlock polling + timeout behavior, and behavior on **non-onboarded** devices.