### PR TITLE
✨ (solana-signer) [DSDK-1145]: Add the Solana clear-signing IDL_TYPE_POOL decoder

### DIFF
--- a/.changeset/khaki-tips-flow.md
+++ b/.changeset/khaki-tips-flow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": minor
+---
+
+Add requirement builder

--- a/.changeset/loud-bobcats-live.md
+++ b/.changeset/loud-bobcats-live.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": minor
+---
+
+Add the Solana clear-signing IDL_TYPE_POOL walker

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/TypePoolDecoder.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/TypePoolDecoder.test.ts
@@ -1,0 +1,413 @@
+import {
+  arrayPrefixed,
+  arrayRemainder,
+  bytes,
+  bytesRemainder,
+  concat,
+  enumEntry,
+  optionDynamic,
+  optionFixed,
+  optionZeroable,
+  pool,
+  pubkey,
+  stringPrefixed,
+  struct,
+  tuple,
+  u8,
+  u16,
+  u16le,
+  u32,
+  u32le,
+  u64,
+  u64le,
+} from "./__tests__/fixtures/builders";
+import {
+  JUPITER_DATA,
+  JUPITER_IN_AMOUNT,
+  JUPITER_PLATFORM_FEE_BPS,
+  JUPITER_POOL,
+  JUPITER_QUOTED_OUT_AMOUNT,
+  JUPITER_ROOT,
+  JUPITER_SLIPPAGE_BPS,
+  JUPITER_SWAP_VARIANT_INDEX,
+} from "./__tests__/fixtures/jupiterRoute";
+import { packPath } from "./argumentPaths";
+import { type DataReader, DefaultDataReader } from "./dataReaders";
+import * as K from "./kinds";
+import { parseInlinePayload, parsePool } from "./parsePool";
+import { decode } from "./TypePoolDecoder";
+import {
+  DecodeBudgetExceededError,
+  NoProgressError,
+  PoolIndexOutOfRangeError,
+  TruncatedDataError,
+  UnsupportedKindError,
+} from "./TypePoolDecoderError";
+import {
+  type CachedVariant,
+  type LeafValue,
+  type VariantCache,
+  variantCacheKey,
+} from "./types";
+
+const EMPTY_CACHE: VariantCache = new Map();
+
+function makeCache(
+  entries: [enumId: string, index: number, variant: CachedVariant][],
+): VariantCache {
+  return new Map(entries.map(([id, idx, v]) => [variantCacheKey(id, idx), v]));
+}
+
+/** Decode a raw pool value and unwrap the Right (fails the test on Left). */
+function decodeOrThrow(
+  poolBytes: Uint8Array,
+  root: number,
+  data: Uint8Array,
+  cache = EMPTY_CACHE,
+) {
+  const result = decode(parsePool(poolBytes), root, cache, data);
+  return result.unsafeCoerce();
+}
+
+describe("TypePoolDecoder", () => {
+  describe("primitive reads", () => {
+    it("reads each integer width little-endian, 64/128-bit as bigint", () => {
+      const p = pool([struct([1, 2, 3, 4]), u8(), u16(), u32(), u64()]);
+      const data = concat(
+        bytes(0xff),
+        u16le(0x1234),
+        u32le(0xdeadbeef),
+        u64le(50_000_000_000n),
+      );
+      const { leaves, cursorEnd } = decodeOrThrow(p, 0, data);
+      expect(leaves.map((l) => l.value)).toEqual([
+        0xff,
+        0x1234,
+        0xdeadbeef,
+        50_000_000_000n,
+      ]);
+      expect(cursorEnd).toBe(data.length);
+    });
+
+    it("sign-extends signed integers", () => {
+      const p = pool([struct([1]), bytes(K.KIND_I8)]);
+      const { leaves } = decodeOrThrow(p, 0, bytes(0xff));
+      expect(leaves[0]!.value).toBe(-1);
+    });
+
+    it("decodes a PUBKEY_32 leaf as base58", () => {
+      const raw = new Uint8Array(32).fill(0); // all-zero pubkey
+      const p = pool([struct([1]), pubkey()]);
+      const { leaves } = decodeOrThrow(p, 0, raw);
+      expect(leaves[0]!.value).toBe("11111111111111111111111111111111");
+    });
+
+    it("reads a BOOL_U8 as a boolean", () => {
+      const p = pool([struct([1]), bytes(K.KIND_BOOL_U8)]);
+      expect(decodeOrThrow(p, 0, bytes(7)).leaves[0]!.value).toBe(true);
+      expect(decodeOrThrow(p, 0, bytes(0)).leaves[0]!.value).toBe(false);
+    });
+
+    it("reads a SHORT_U16 varint (1-3 bytes)", () => {
+      const p = pool([struct([1]), bytes(K.KIND_SHORT_U16)]);
+      // 300 = 0xAC 0x02 in ShortU16.
+      const { leaves, cursorEnd } = decodeOrThrow(p, 0, bytes(0xac, 0x02));
+      expect(leaves[0]!.value).toBe(300);
+      expect(cursorEnd).toBe(2);
+    });
+  });
+
+  describe("aggregates", () => {
+    it("decodes a fixed array, emitting one leaf per element with array-index paths", () => {
+      const p = pool([
+        struct([1]),
+        bytes(K.KIND_ARRAY_FIXED, 0x00, 0x03, 2),
+        u8(),
+      ]);
+      const { leaves } = decodeOrThrow(p, 0, bytes(10, 20, 30));
+      expect(leaves.map((l) => l.value)).toEqual([10, 20, 30]);
+      // path = [STRUCT field 0][ARRAY_FIXED index i] → step_count 2, struct(u8)=0, idx(u16be)
+      expect(Array.from(leaves[0]!.path)).toEqual([2, 0, 0x00, 0x00]);
+      expect(Array.from(leaves[2]!.path)).toEqual([2, 0, 0x00, 0x02]);
+    });
+
+    it("reads a length-prefixed array", () => {
+      const p = pool([struct([1]), arrayPrefixed(K.KIND_U32, 2), u8()]);
+      const { leaves } = decodeOrThrow(p, 0, concat(u32le(2), bytes(7, 8)));
+      expect(leaves.map((l) => l.value)).toEqual([7, 8]);
+    });
+
+    it("reads a remainder array until end of buffer", () => {
+      const p = pool([struct([1]), arrayRemainder(2), u8()]);
+      const { leaves, cursorEnd } = decodeOrThrow(p, 0, bytes(1, 2, 3, 4));
+      expect(leaves.map((l) => l.value)).toEqual([1, 2, 3, 4]);
+      expect(cursorEnd).toBe(4);
+    });
+
+    it("emits BYTES_REMAINDER as raw bytes", () => {
+      const p = pool([struct([1]), bytesRemainder()]);
+      const { leaves } = decodeOrThrow(p, 0, bytes(0xaa, 0xbb));
+      expect(leaves[0]!.value).toEqual(bytes(0xaa, 0xbb));
+    });
+
+    it("decodes a tuple", () => {
+      const p = pool([tuple([1, 2]), u8(), u16()]);
+      const { leaves } = decodeOrThrow(p, 0, concat(bytes(9), u16le(0x0102)));
+      expect(leaves.map((l) => l.value)).toEqual([9, 0x0102]);
+    });
+
+    it("decodes a STRING_PREFIXED leaf", () => {
+      const p = pool([struct([1]), stringPrefixed(K.KIND_U8)]);
+      const data = concat(bytes(2), bytes(0x68, 0x69)); // len 2, "hi"
+      expect(decodeOrThrow(p, 0, data).leaves[0]!.value).toBe("hi");
+    });
+  });
+
+  describe("options", () => {
+    it("OPTION_DYNAMIC decodes the inner only when the flag is set", () => {
+      const p = pool([struct([1]), optionDynamic(K.KIND_U8, 2), u32()]);
+      expect(decodeOrThrow(p, 0, bytes(0)).leaves).toHaveLength(0);
+      const some = decodeOrThrow(p, 0, concat(bytes(1), u32le(42)));
+      expect(some.leaves[0]!.value).toBe(42);
+    });
+
+    it("OPTION_FIXED always advances by size(inner) even when absent", () => {
+      const p = pool([struct([1, 2]), optionFixed(K.KIND_U8, 3), u8(), u32()]);
+      // flag=0 → skip 4 inner bytes without emitting; then trailing u8.
+      const data = concat(bytes(0), u32le(0xdeadbeef), bytes(0x77));
+      const { leaves, cursorEnd } = decodeOrThrow(p, 0, data);
+      expect(leaves.map((l) => l.value)).toEqual([0x77]);
+      expect(cursorEnd).toBe(data.length);
+    });
+
+    it("OPTION_ZEROABLE skips the sentinel, else decodes inner", () => {
+      const sentinel = bytes(0, 0, 0, 0);
+      const p = pool([struct([1]), optionZeroable(2, sentinel), u32()]);
+      expect(decodeOrThrow(p, 0, bytes(0, 0, 0, 0)).leaves).toHaveLength(0);
+      expect(decodeOrThrow(p, 0, u32le(5)).leaves[0]!.value).toBe(5);
+    });
+  });
+
+  describe("enums", () => {
+    const enumPool = pool([struct([1]), enumEntry(K.KIND_U8, 4, "action")]);
+
+    it("on a cache miss, emits the integer discriminator and stops", () => {
+      const { leaves, cursorEnd, selectedEnumVariants } = decodeOrThrow(
+        enumPool,
+        0,
+        bytes(2),
+      );
+      expect(leaves[0]!.value).toBe(2);
+      expect(cursorEnd).toBe(1);
+      expect(selectedEnumVariants).toEqual([
+        { enumId: "action", variantIndex: 2 },
+      ]);
+    });
+
+    it("on an EMPTY variant, emits the variant name and advances only the disc", () => {
+      const cache = makeCache([
+        ["action", 2, { variantName: "stake", kind: K.VARIANT_PAYLOAD_EMPTY }],
+      ]);
+      const { leaves, cursorEnd } = decode(
+        parsePool(enumPool),
+        0,
+        cache,
+        bytes(2),
+      ).unsafeCoerce();
+      expect(leaves[0]!.value).toBe("stake");
+      expect(cursorEnd).toBe(1);
+    });
+
+    it("decodes an INLINE struct payload", () => {
+      // inline payload = STRUCT { u8, u32 }
+      const inline = bytes(K.KIND_STRUCT, 2, K.KIND_U8, K.KIND_U32);
+      const cache = makeCache([
+        [
+          "action",
+          1,
+          {
+            variantName: "deposit",
+            kind: K.VARIANT_PAYLOAD_INLINE,
+            payload: parseInlinePayload(inline),
+          },
+        ],
+      ]);
+      const data = concat(bytes(1), bytes(9), u32le(1000));
+      const { leaves, cursorEnd } = decode(
+        parsePool(enumPool),
+        0,
+        cache,
+        data,
+      ).unsafeCoerce();
+      expect(leaves.map((l) => l.value)).toEqual(["deposit", 9, 1000]);
+      expect(cursorEnd).toBe(data.length);
+    });
+
+    it("skips a RAW_SIZE variant payload by its byte count", () => {
+      const cache = makeCache([
+        [
+          "action",
+          3,
+          { variantName: "raw", kind: K.VARIANT_PAYLOAD_RAW_SIZE, size: 4 },
+        ],
+      ]);
+      const data = concat(bytes(3), bytes(1, 2, 3, 4));
+      const { leaves, cursorEnd } = decode(
+        parsePool(enumPool),
+        0,
+        cache,
+        data,
+      ).unsafeCoerce();
+      expect(leaves.map((l) => l.value)).toEqual(["raw"]);
+      expect(cursorEnd).toBe(data.length);
+    });
+  });
+
+  describe("jupiter.route worked example", () => {
+    it("extracts every displayed leaf at the documented paths", () => {
+      const { leaves, cursorEnd, selectedEnumVariants } = decodeOrThrow(
+        JUPITER_POOL,
+        JUPITER_ROOT,
+        JUPITER_DATA,
+      );
+      // Fully consumes the 35-byte argument data.
+      expect(cursorEnd).toBe(JUPITER_DATA.length);
+
+      const byPath = (steps: Parameters<typeof packPath>[0]) => {
+        const target = packPath(steps);
+        return leaves.find(
+          (l) =>
+            l.path.length === target.length &&
+            l.path.every((b, i) => b === target[i]),
+        )?.value;
+      };
+
+      expect(byPath([[K.KIND_STRUCT, 2, undefined]])).toBe(JUPITER_IN_AMOUNT);
+      expect(byPath([[K.KIND_STRUCT, 3, undefined]])).toBe(
+        JUPITER_QUOTED_OUT_AMOUNT,
+      );
+      expect(byPath([[K.KIND_STRUCT, 4, undefined]])).toBe(
+        JUPITER_SLIPPAGE_BPS,
+      );
+      expect(byPath([[K.KIND_STRUCT, 5, undefined]])).toBe(
+        JUPITER_PLATFORM_FEE_BPS,
+      );
+      expect(selectedEnumVariants).toEqual([
+        { enumId: "swap", variantIndex: JUPITER_SWAP_VARIANT_INDEX },
+      ]);
+    });
+
+    it("is deterministic across repeated decodes", () => {
+      const a = decodeOrThrow(JUPITER_POOL, JUPITER_ROOT, JUPITER_DATA);
+      const b = decodeOrThrow(JUPITER_POOL, JUPITER_ROOT, JUPITER_DATA);
+      expect(a.leaves.map((l) => [Array.from(l.path), l.value])).toEqual(
+        b.leaves.map((l) => [Array.from(l.path), l.value]),
+      );
+    });
+  });
+
+  describe("defensive: malformed input returns typed errors, never throws", () => {
+    it("truncated instruction data → TruncatedDataError", () => {
+      const p = pool([struct([1]), u32()]);
+      const result = decode(parsePool(p), 0, EMPTY_CACHE, bytes(1, 2));
+      expect(result.isLeft()).toBe(true);
+      result.ifLeft((e) => expect(e).toBeInstanceOf(TruncatedDataError));
+    });
+
+    it("pool ref out of range → PoolIndexOutOfRangeError", () => {
+      const p = pool([struct([9])]); // ref 9 does not exist
+      const result = decode(parsePool(p), 0, EMPTY_CACHE, bytes(1));
+      expect(result.isLeft()).toBe(true);
+      result.ifLeft((e) => expect(e).toBeInstanceOf(PoolIndexOutOfRangeError));
+    });
+
+    it("empty pool with an out-of-range root → PoolIndexOutOfRangeError", () => {
+      const result = decode([], 0, EMPTY_CACHE, bytes());
+      expect(result.isLeft()).toBe(true);
+      result.ifLeft((e) => expect(e).toBeInstanceOf(PoolIndexOutOfRangeError));
+    });
+
+    it("recursive type-pool cycle → DecodeBudgetExceededError", () => {
+      // entry 0 is a struct that references itself.
+      const cyclic = pool([struct([0])]);
+      const result = decode(
+        parsePool(cyclic),
+        0,
+        EMPTY_CACHE,
+        bytes(1, 2, 3, 4),
+      );
+      expect(result.isLeft()).toBe(true);
+      result.ifLeft((e) => expect(e).toBeInstanceOf(DecodeBudgetExceededError));
+    });
+
+    it("oversize ARRAY_PREFIXED length → TruncatedDataError", () => {
+      const p = pool([struct([1]), arrayPrefixed(K.KIND_U32, 2), u8()]);
+      // claims 1e9 elements but provides none.
+      const result = decode(parsePool(p), 0, EMPTY_CACHE, u32le(1_000_000_000));
+      expect(result.isLeft()).toBe(true);
+      result.ifLeft((e) => expect(e).toBeInstanceOf(TruncatedDataError));
+    });
+
+    it("ARRAY_REMAINDER over a zero-width item → NoProgressError", () => {
+      // item is an OPTION_FIXED(u8 flag, empty struct) → 1-byte flag still
+      // advances; instead use a struct with no fields (zero width).
+      const p = pool([struct([1]), arrayRemainder(2), struct([])]);
+      const result = decode(parsePool(p), 0, EMPTY_CACHE, bytes(1, 2));
+      expect(result.isLeft()).toBe(true);
+      result.ifLeft((e) => expect(e).toBeInstanceOf(NoProgressError));
+    });
+
+    it("OPTION_FIXED with variable-size inner → UnsupportedKindError", () => {
+      const p = pool([
+        struct([1]),
+        optionFixed(K.KIND_U8, 2),
+        arrayRemainder(3),
+        u8(),
+      ]);
+      const result = decode(parsePool(p), 0, EMPTY_CACHE, bytes(0));
+      expect(result.isLeft()).toBe(true);
+      result.ifLeft((e) => expect(e).toBeInstanceOf(UnsupportedKindError));
+    });
+  });
+
+  describe("dependency injection", () => {
+    it("delegates scalar decoding to the injected DataReader", () => {
+      const calls: number[] = [];
+      const spyReader: DataReader = {
+        readUnsigned: (data, offset, kind) => {
+          calls.push(kind);
+          return new DefaultDataReader().readUnsigned(data, offset, kind);
+        },
+        readPrimitive: (data, offset, kind) => {
+          calls.push(kind);
+          return new DefaultDataReader().readPrimitive(data, offset, kind);
+        },
+        decodeString: (raw, encoding) =>
+          new DefaultDataReader().decodeString(raw, encoding),
+      };
+      const p = pool([struct([1]), u32()]);
+      const result = decode(parsePool(p), 0, EMPTY_CACHE, u32le(42), spyReader);
+      expect(result.unsafeCoerce().leaves[0]!.value).toBe(42);
+      expect(calls).toContain(K.KIND_U32); // the injected reader was used
+    });
+
+    it("can swap the leaf representation via a custom reader", () => {
+      const base = new DefaultDataReader();
+      const taggingReader: DataReader = {
+        readUnsigned: (data, offset, kind) =>
+          base.readUnsigned(data, offset, kind),
+        readPrimitive: (): [LeafValue, number] => ["TAGGED", 4],
+        decodeString: (raw, encoding) => base.decodeString(raw, encoding),
+      };
+      const p = pool([struct([1]), u32()]);
+      const result = decode(
+        parsePool(p),
+        0,
+        EMPTY_CACHE,
+        u32le(42),
+        taggingReader,
+      );
+      expect(result.unsafeCoerce().leaves[0]!.value).toBe("TAGGED");
+    });
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/TypePoolDecoder.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/TypePoolDecoder.ts
@@ -1,0 +1,407 @@
+import { type Either, Left, Right } from "purify-ts";
+
+import { packPath, PathPackError, type PathStep } from "./argumentPaths";
+import { type DataReader, DefaultDataReader, fixedSizeOf } from "./dataReaders";
+import * as K from "./kinds";
+import { parsePool } from "./parsePool";
+import {
+  DecodeBudgetExceededError,
+  fail,
+  MAX_DECODE_DEPTH,
+  MAX_DECODE_NODE_VISITS,
+  NoProgressError,
+  PoolIndexOutOfRangeError,
+  TruncatedDataError,
+  type TypePoolDecoderError,
+  TypePoolDecoderThrow,
+  UnsupportedKindError,
+} from "./TypePoolDecoderError";
+import {
+  type DecodeResult,
+  type Entry,
+  type Leaf,
+  type LeafValue,
+  type Ref,
+  type SelectedEnumVariant,
+  type VariantCache,
+  variantCacheKey,
+} from "./types";
+
+/** Decodes one entry, given its already-resolved {@link Entry} and path so far. */
+type KindHandler = (entry: Entry, pathSteps: readonly PathStep[]) => void;
+
+class TypePoolDecoder {
+  private cursor = 0;
+  private depth = 0;
+  private nodeVisits = 0;
+  private readonly leaves: Leaf[] = [];
+  private readonly selectedEnumVariants: SelectedEnumVariant[] = [];
+
+  /** Kind byte → per-kind decode handler. Built once per decode. */
+  private readonly handlers: ReadonlyMap<number, KindHandler>;
+
+  constructor(
+    private readonly pool: Entry[],
+    private readonly enumCache: VariantCache,
+    private readonly data: Uint8Array,
+    private readonly dataReader: DataReader = new DefaultDataReader(),
+  ) {
+    this.handlers = this.buildHandlers();
+  }
+
+  decode(rootIndex: number): DecodeResult {
+    this.decodeEntry(this.resolve(rootIndex), []);
+    return {
+      leaves: this.leaves,
+      selectedEnumVariants: this.selectedEnumVariants,
+      cursorEnd: this.cursor,
+    };
+  }
+
+  private resolve(ref: Ref): Entry {
+    if (typeof ref !== "number") return ref;
+    if (ref < 0 || ref >= this.pool.length) {
+      fail(new PoolIndexOutOfRangeError(ref, this.pool.length));
+    }
+    return this.pool[ref]!;
+  }
+
+  private emit(pathSteps: readonly PathStep[], value: LeafValue): void {
+    let packed: Uint8Array;
+    try {
+      packed = packPath(pathSteps);
+    } catch (error) {
+      if (error instanceof PathPackError) return; // unaddressable leaf — skip
+      throw error;
+    }
+    this.leaves.push({ path: packed, value });
+  }
+
+  /** Resolve `ref` and decode it with one extra path step appended. */
+  private descend(
+    ref: Ref,
+    pathSteps: readonly PathStep[],
+    parentKind: number,
+    stepValue: number,
+    discKind?: number,
+  ): void {
+    this.decodeEntry(this.resolve(ref), [
+      ...pathSteps,
+      [parentKind, stepValue, discKind],
+    ]);
+  }
+
+  private decodeEntry(entry: Entry, pathSteps: readonly PathStep[]): void {
+    this.nodeVisits += 1;
+    if (this.nodeVisits > MAX_DECODE_NODE_VISITS) {
+      fail(
+        new DecodeBudgetExceededError(
+          `exceeded ${MAX_DECODE_NODE_VISITS} node visits`,
+        ),
+      );
+    }
+    this.depth += 1;
+    if (this.depth > MAX_DECODE_DEPTH) {
+      fail(
+        new DecodeBudgetExceededError(
+          `exceeded max nesting depth ${MAX_DECODE_DEPTH} (recursive type pool?)`,
+        ),
+      );
+    }
+    try {
+      const handler = this.handlers.get(entry.kind);
+      if (handler === undefined) {
+        fail(
+          new UnsupportedKindError(
+            `decoder: unhandled kind 0x${entry.kind
+              .toString(16)
+              .padStart(2, "0")}`,
+          ),
+        );
+      }
+      handler(entry, pathSteps);
+    } finally {
+      this.depth -= 1;
+    }
+  }
+
+  // ---- per-kind handlers ------------------------------------------------
+
+  private readonly decodePrimitiveLeaf: KindHandler = (entry, steps) => {
+    const [value, next] = this.dataReader.readPrimitive(
+      this.data,
+      this.cursor,
+      entry.kind,
+    );
+    this.cursor = next;
+    this.emit(steps, value);
+  };
+
+  private readonly decodeBytesFixed: KindHandler = (entry, steps) => {
+    const size = entry.fixedSize ?? 0;
+    if (this.cursor + size > this.data.length) {
+      fail(new TruncatedDataError("truncated BYTES_FIXED leaf"));
+    }
+    const raw = this.data.subarray(this.cursor, this.cursor + size);
+    this.cursor += size;
+    // BYTES_FIXED is rendered as a hex string.
+    this.emit(steps, this.dataReader.decodeString(raw, K.ENCODING_BASE16));
+  };
+
+  private readonly decodeStringFixed: KindHandler = (entry, steps) => {
+    const size = entry.fixedSize ?? 0;
+    if (this.cursor + size > this.data.length) {
+      fail(new TruncatedDataError("truncated STRING_FIXED leaf"));
+    }
+    const raw = this.data.subarray(this.cursor, this.cursor + size);
+    this.cursor += size;
+    this.emit(steps, this.dataReader.decodeString(raw, entry.encoding));
+  };
+
+  private readonly decodeStringPrefixed: KindHandler = (entry, steps) => {
+    const [length, afterLen] = this.dataReader.readUnsigned(
+      this.data,
+      this.cursor,
+      entry.lenKind ?? K.KIND_U8,
+    );
+    this.cursor = afterLen;
+    if (this.cursor + length > this.data.length) {
+      fail(new TruncatedDataError("truncated STRING_PREFIXED leaf"));
+    }
+    const raw = this.data.subarray(this.cursor, this.cursor + length);
+    this.cursor += length;
+    this.emit(steps, this.dataReader.decodeString(raw, entry.encoding));
+  };
+
+  private readonly decodeBytesRemainder: KindHandler = (_entry, steps) => {
+    const raw = this.data.subarray(this.cursor);
+    this.cursor = this.data.length;
+    this.emit(steps, raw);
+  };
+
+  private readonly decodeAggregate: KindHandler = (entry, steps) => {
+    entry.refs.forEach((ref, subIdx) =>
+      this.descend(ref, steps, entry.kind, subIdx),
+    );
+  };
+
+  private readonly decodeArrayFixed: KindHandler = (entry, steps) => {
+    const item = this.resolve(entry.refs[0]!);
+    const count = entry.fixedSize ?? 0;
+    for (let i = 0; i < count; i++) {
+      this.decodeEntry(item, [...steps, [entry.kind, i, undefined]]);
+    }
+  };
+
+  private readonly decodeArrayPrefixed: KindHandler = (entry, steps) => {
+    const [length, afterLen] = this.dataReader.readUnsigned(
+      this.data,
+      this.cursor,
+      entry.lenKind ?? K.KIND_U32,
+    );
+    this.cursor = afterLen;
+    const item = this.resolve(entry.refs[0]!);
+    for (let i = 0; i < length; i++) {
+      this.decodeEntry(item, [...steps, [entry.kind, i, undefined]]);
+    }
+  };
+
+  private readonly decodeArrayRemainder: KindHandler = (entry, steps) => {
+    const item = this.resolve(entry.refs[0]!);
+    let i = 0;
+    while (this.cursor < this.data.length) {
+      const start = this.cursor;
+      this.decodeEntry(item, [...steps, [entry.kind, i, undefined]]);
+      if (this.cursor <= start) {
+        fail(new NoProgressError("ARRAY_REMAINDER item consumed no bytes"));
+      }
+      i += 1;
+    }
+  };
+
+  private readonly decodeOptionDynamic: KindHandler = (entry, steps) => {
+    const [flag, afterFlag] = this.dataReader.readUnsigned(
+      this.data,
+      this.cursor,
+      entry.flagKind ?? K.KIND_U8,
+    );
+    this.cursor = afterFlag;
+    if (flag !== 0) {
+      this.descend(entry.refs[0]!, steps, entry.kind, 0);
+    }
+  };
+
+  private readonly decodeOptionFixed: KindHandler = (entry, steps) => {
+    const [flag, afterFlag] = this.dataReader.readUnsigned(
+      this.data,
+      this.cursor,
+      entry.flagKind ?? K.KIND_U8,
+    );
+    this.cursor = afterFlag;
+    const inner = this.resolve(entry.refs[0]!);
+    if (flag !== 0) {
+      this.decodeEntry(inner, [...steps, [entry.kind, 0, undefined]]);
+      return;
+    }
+    const innerSize = fixedSizeOf(inner, (ref) => this.resolve(ref));
+    if (innerSize === undefined) {
+      fail(
+        new UnsupportedKindError(
+          "OPTION_FIXED with variable-size inner is not supported",
+        ),
+      );
+    }
+    if (this.cursor + innerSize > this.data.length) {
+      fail(new TruncatedDataError("truncated OPTION_FIXED skip"));
+    }
+    this.cursor += innerSize;
+  };
+
+  private readonly decodeOptionZeroable: KindHandler = (entry, steps) => {
+    const sentinel = entry.sentinel ?? new Uint8Array(0);
+    const slice = this.data.subarray(
+      this.cursor,
+      this.cursor + sentinel.length,
+    );
+    if (
+      slice.length === sentinel.length &&
+      sentinel.every((byte, index) => byte === slice[index])
+    ) {
+      this.cursor += sentinel.length;
+      return;
+    }
+    this.descend(entry.refs[0]!, steps, entry.kind, 0);
+  };
+
+  private readonly decodeOptionRemainder: KindHandler = (entry, steps) => {
+    if (this.cursor < this.data.length) {
+      this.descend(entry.refs[0]!, steps, entry.kind, 0);
+    }
+  };
+
+  private readonly decodeEnum: KindHandler = (entry, steps) => {
+    const [variantIndex, afterDiscriminator] = this.dataReader.readUnsigned(
+      this.data,
+      this.cursor,
+      entry.discKind ?? K.KIND_U8,
+    );
+    this.cursor = afterDiscriminator;
+    const enumId = entry.enumId ?? "";
+    this.selectedEnumVariants.push({ enumId, variantIndex });
+    const cached = this.enumCache.get(variantCacheKey(enumId, variantIndex));
+    if (cached === undefined) {
+      // No variant info: emit the raw discriminator and stop descending (the
+      // cursor-end check then surfaces the under-consumption).
+      this.emit(steps, variantIndex);
+      return;
+    }
+    this.emit(steps, cached.variantName);
+    const childSteps: PathStep[] = [
+      ...steps,
+      [entry.kind, variantIndex, entry.discKind],
+    ];
+    if (cached.kind === K.VARIANT_PAYLOAD_EMPTY) {
+      return;
+    }
+    if (cached.kind === K.VARIANT_PAYLOAD_INLINE) {
+      this.decodeEntry(cached.payload, childSteps);
+      return;
+    }
+    // RAW_SIZE
+    if (this.cursor + cached.size > this.data.length) {
+      fail(new TruncatedDataError("truncated RAW_SIZE variant payload"));
+    }
+    this.cursor += cached.size;
+  };
+
+  private readonly decodeHiddenPrefix: KindHandler = (entry, steps) => {
+    this.descend(entry.refs[0]!, steps, entry.kind, 1);
+    this.descend(entry.refs[1]!, steps, entry.kind, 0);
+  };
+
+  private readonly decodeHiddenSuffix: KindHandler = (entry, steps) => {
+    this.descend(entry.refs[1]!, steps, entry.kind, 0);
+    this.descend(entry.refs[0]!, steps, entry.kind, 1);
+  };
+
+  private buildHandlers(): ReadonlyMap<number, KindHandler> {
+    const handlers = new Map<number, KindHandler>();
+    for (const kind of K.PRIMITIVE_KINDS) {
+      handlers.set(kind, this.decodePrimitiveLeaf);
+    }
+    handlers.set(K.KIND_BYTES_FIXED, this.decodeBytesFixed);
+    handlers.set(K.KIND_STRING_FIXED, this.decodeStringFixed);
+    handlers.set(K.KIND_STRING_PREFIXED, this.decodeStringPrefixed);
+    handlers.set(K.KIND_BYTES_REMAINDER, this.decodeBytesRemainder);
+    handlers.set(K.KIND_STRUCT, this.decodeAggregate);
+    handlers.set(K.KIND_TUPLE, this.decodeAggregate);
+    handlers.set(K.KIND_ARRAY_FIXED, this.decodeArrayFixed);
+    handlers.set(K.KIND_ARRAY_PREFIXED, this.decodeArrayPrefixed);
+    handlers.set(K.KIND_ARRAY_REMAINDER, this.decodeArrayRemainder);
+    handlers.set(K.KIND_OPTION_DYNAMIC, this.decodeOptionDynamic);
+    handlers.set(K.KIND_OPTION_FIXED, this.decodeOptionFixed);
+    handlers.set(K.KIND_OPTION_ZEROABLE, this.decodeOptionZeroable);
+    handlers.set(K.KIND_OPTION_REMAINDER, this.decodeOptionRemainder);
+    handlers.set(K.KIND_ENUM, this.decodeEnum);
+    handlers.set(K.KIND_HIDDEN_PREFIX, this.decodeHiddenPrefix);
+    handlers.set(K.KIND_HIDDEN_SUFFIX, this.decodeHiddenSuffix);
+    return handlers;
+  }
+}
+
+function runDecode(
+  build: () => TypePoolDecoder,
+  rootIndex: number,
+): Either<TypePoolDecoderError, DecodeResult> {
+  try {
+    return Right(build().decode(rootIndex));
+  } catch (error) {
+    if (error instanceof TypePoolDecoderThrow) {
+      return Left(error.error);
+    }
+    return Left(
+      new UnsupportedKindError(
+        `internal decoder error: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      ),
+    );
+  }
+}
+
+/**
+ * Decode `data` under `pool[rootIndex]`, returning the emitted leaves, the
+ * selected enum variants, and the final cursor position. Pure and
+ * deterministic; scalar decoding is delegated to `dataReader`. Malformed input
+ * surfaces as a typed {@link TypePoolDecoderError} `Left` — never throws.
+ */
+export function decode(
+  pool: Entry[],
+  rootIndex: number,
+  enumCache: VariantCache,
+  data: Uint8Array,
+  dataReader: DataReader = new DefaultDataReader(),
+): Either<TypePoolDecoderError, DecodeResult> {
+  return runDecode(
+    () => new TypePoolDecoder(pool, enumCache, data, dataReader),
+    rootIndex,
+  );
+}
+
+/**
+ * Convenience wrapper over {@link decode} that accepts the raw `IDL_TYPE_POOL`
+ * TLV value (`u8 count || entries…`) and parses it before decoding. Parse
+ * failures surface as the same typed {@link TypePoolDecoderError} `Left`.
+ */
+export function decodePoolBytes(
+  typePool: Uint8Array,
+  rootType: number,
+  enumCache: VariantCache,
+  data: Uint8Array,
+  dataReader: DataReader = new DefaultDataReader(),
+): Either<TypePoolDecoderError, DecodeResult> {
+  return runDecode(
+    () => new TypePoolDecoder(parsePool(typePool), enumCache, data, dataReader),
+    rootType,
+  );
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/TypePoolDecoderError.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/TypePoolDecoderError.ts
@@ -1,0 +1,130 @@
+import { type DmkError } from "@ledgerhq/device-management-kit";
+
+/** Guards against recursive type-pool cycles that would overflow the stack. */
+export const MAX_DECODE_DEPTH = 64;
+
+/** Guards against adversarial length prefixes / remainder loops. */
+export const MAX_DECODE_NODE_VISITS = 100_000;
+
+/** Raised when a read or descriptor parse runs past the end of its buffer. */
+export class TruncatedDataError implements DmkError {
+  readonly _tag = "TruncatedDataError";
+  readonly originalError: Error;
+
+  constructor(message: string) {
+    this.originalError = new Error(`Truncated IDL type-pool data: ${message}`);
+  }
+}
+
+/** Raised when decoded bytes are a malformed or unrepresentable value. */
+export class MalformedDataError implements DmkError {
+  readonly _tag = "MalformedDataError";
+  readonly originalError: Error;
+
+  constructor(message: string) {
+    this.originalError = new Error(`Malformed IDL type-pool data: ${message}`);
+  }
+}
+
+/** Raised when a kind byte is not part of the supported kind table. */
+export class UnknownKindError implements DmkError {
+  readonly _tag = "UnknownKindError";
+  readonly originalError: Error;
+
+  constructor(kind: number) {
+    this.originalError = new Error(
+      `Unknown IDL type-pool kind 0x${kind.toString(16).padStart(2, "0")}.`,
+    );
+  }
+}
+
+/** Raised when a pool entry references an index outside the pool. */
+export class PoolIndexOutOfRangeError implements DmkError {
+  readonly _tag = "PoolIndexOutOfRangeError";
+  readonly originalError: Error;
+
+  constructor(index: number, poolSize: number) {
+    this.originalError = new Error(
+      `Type-pool ref ${index} out of range (pool has ${poolSize} entries).`,
+    );
+  }
+}
+
+/** Raised when the trailing bytes of a pool / inline payload are not consumed. */
+export class TrailingBytesError implements DmkError {
+  readonly _tag = "TrailingBytesError";
+  readonly originalError: Error;
+
+  constructor(remaining: number, context: string) {
+    this.originalError = new Error(
+      `${remaining} trailing byte(s) in ${context}.`,
+    );
+  }
+}
+
+/** Raised when a kind is structurally valid but unsupported in this context. */
+export class UnsupportedKindError implements DmkError {
+  readonly _tag = "UnsupportedKindError";
+  readonly originalError: Error;
+
+  constructor(message: string) {
+    this.originalError = new Error(message);
+  }
+}
+
+/** Raised when an ENUM_VARIANT payload descriptor is malformed. */
+export class InvalidVariantPayloadError implements DmkError {
+  readonly _tag = "InvalidVariantPayloadError";
+  readonly originalError: Error;
+
+  constructor(message: string) {
+    this.originalError = new Error(`Invalid ENUM_VARIANT payload: ${message}`);
+  }
+}
+
+/** Raised when an ARRAY_REMAINDER element consumes no bytes (would loop forever). */
+export class NoProgressError implements DmkError {
+  readonly _tag = "NoProgressError";
+  readonly originalError: Error;
+
+  constructor(message: string) {
+    this.originalError = new Error(message);
+  }
+}
+
+/** Raised when the decode exceeds its depth or node-visit budget. */
+export class DecodeBudgetExceededError implements DmkError {
+  readonly _tag = "DecodeBudgetExceededError";
+  readonly originalError: Error;
+
+  constructor(message: string) {
+    this.originalError = new Error(`Decode budget exceeded: ${message}`);
+  }
+}
+
+export type TypePoolDecoderError =
+  | TruncatedDataError
+  | MalformedDataError
+  | UnknownKindError
+  | PoolIndexOutOfRangeError
+  | TrailingBytesError
+  | UnsupportedKindError
+  | InvalidVariantPayloadError
+  | NoProgressError
+  | DecodeBudgetExceededError;
+
+/**
+ * Internal exception used to unwind the recursive decoder / parser; caught at
+ * the public boundary and surfaced as a `Left`. Never escapes the module.
+ */
+export class TypePoolDecoderThrow extends Error {
+  constructor(readonly error: TypePoolDecoderError) {
+    super(error.originalError.message);
+    this.name = "TypePoolDecoderThrow";
+  }
+}
+
+/** Throw a typed decoder error from inside the recursive routines. */
+export function fail(error: TypePoolDecoderError): never {
+  throw new TypePoolDecoderThrow(error);
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/__tests__/fixtures/builders.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/__tests__/fixtures/builders.ts
@@ -1,0 +1,175 @@
+/**
+ * Byte-level builders for `IDL_TYPE_POOL` entries, `ENUM_VARIANT` TLVs and raw
+ * instruction data. Deliberately dumb so the tests pin the exact on-wire bytes
+ * the device would receive.
+ */
+
+import * as K from "@internal/app-binder/clear-sign/idl-type-pool/kinds";
+
+export function bytes(...values: number[]): Uint8Array {
+  return Uint8Array.from(values);
+}
+
+export function concat(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const p of parts) {
+    out.set(p, offset);
+    offset += p.length;
+  }
+  return out;
+}
+
+const u16be = (n: number): Uint8Array => bytes((n >> 8) & 0xff, n & 0xff);
+
+// ---- pool entry builders (return the encoded bytes of one entry) ----------
+
+export const primitive = (kind: number): Uint8Array => bytes(kind);
+export const u8 = (): Uint8Array => bytes(K.KIND_U8);
+export const u16 = (): Uint8Array => bytes(K.KIND_U16);
+export const u32 = (): Uint8Array => bytes(K.KIND_U32);
+export const u64 = (): Uint8Array => bytes(K.KIND_U64);
+export const pubkey = (): Uint8Array => bytes(K.KIND_PUBKEY_32);
+export const bytesRemainder = (): Uint8Array => bytes(K.KIND_BYTES_REMAINDER);
+
+export const bytesFixed = (size: number): Uint8Array =>
+  concat(bytes(K.KIND_BYTES_FIXED), u16be(size));
+
+export const stringFixed = (
+  size: number,
+  encoding = K.ENCODING_UTF8,
+): Uint8Array =>
+  concat(bytes(K.KIND_STRING_FIXED), u16be(size), bytes(encoding));
+
+export const stringPrefixed = (
+  lenKind: number,
+  encoding = K.ENCODING_UTF8,
+): Uint8Array => bytes(K.KIND_STRING_PREFIXED, lenKind, encoding);
+
+export const struct = (refs: number[]): Uint8Array =>
+  bytes(K.KIND_STRUCT, refs.length, ...refs);
+
+export const tuple = (refs: number[]): Uint8Array =>
+  bytes(K.KIND_TUPLE, refs.length, ...refs);
+
+export const optionDynamic = (flagKind: number, innerRef: number): Uint8Array =>
+  bytes(K.KIND_OPTION_DYNAMIC, flagKind, innerRef);
+
+export const optionFixed = (flagKind: number, innerRef: number): Uint8Array =>
+  bytes(K.KIND_OPTION_FIXED, flagKind, innerRef);
+
+export const optionZeroable = (
+  innerRef: number,
+  sentinel: Uint8Array,
+): Uint8Array =>
+  concat(bytes(K.KIND_OPTION_ZEROABLE, innerRef, sentinel.length), sentinel);
+
+export const optionRemainder = (innerRef: number): Uint8Array =>
+  bytes(K.KIND_OPTION_REMAINDER, innerRef);
+
+export const arrayFixed = (count: number, itemRef: number): Uint8Array =>
+  concat(bytes(K.KIND_ARRAY_FIXED), u16be(count), bytes(itemRef));
+
+export const arrayPrefixed = (lenKind: number, itemRef: number): Uint8Array =>
+  bytes(K.KIND_ARRAY_PREFIXED, lenKind, itemRef);
+
+export const arrayRemainder = (itemRef: number): Uint8Array =>
+  bytes(K.KIND_ARRAY_REMAINDER, itemRef);
+
+export const enumEntry = (
+  discKind: number,
+  totalVariants: number,
+  enumId: string,
+): Uint8Array => {
+  const id = new TextEncoder().encode(enumId);
+  return concat(
+    bytes(K.KIND_ENUM, discKind),
+    u16be(totalVariants),
+    bytes(id.length),
+    id,
+  );
+};
+
+export const hiddenPrefix = (skipRef: number, innerRef: number): Uint8Array =>
+  bytes(K.KIND_HIDDEN_PREFIX, skipRef, innerRef);
+
+export const hiddenSuffix = (skipRef: number, innerRef: number): Uint8Array =>
+  bytes(K.KIND_HIDDEN_SUFFIX, skipRef, innerRef);
+
+/** Assemble a full `IDL_TYPE_POOL` value: `u8 count || entries…`. */
+export const pool = (entries: Uint8Array[]): Uint8Array =>
+  concat(bytes(entries.length), ...entries);
+
+// ---- ENUM_VARIANT TLV builder ---------------------------------------------
+
+const TAG_EV_ENUM_ID = 0x21;
+const TAG_EV_VARIANT_INDEX = 0x22;
+const TAG_EV_VARIANT_NAME = 0x23;
+const TAG_EV_PAYLOAD_KIND = 0x24;
+const TAG_EV_PAYLOAD = 0x25;
+
+function derLength(length: number): Uint8Array {
+  if (length < 0x80) return bytes(length);
+  if (length <= 0xff) return bytes(0x81, length);
+  return bytes(0x82, (length >> 8) & 0xff, length & 0xff);
+}
+
+function tlv(tag: number, value: Uint8Array): Uint8Array {
+  return concat(bytes(tag), derLength(value.length), value);
+}
+
+export type VariantTlvSpec = {
+  enumId: string;
+  variantIndex: number;
+  variantName: string;
+  /** EMPTY (0x00), INLINE (0x02) or RAW_SIZE (0x03). */
+  payloadKind: number;
+  /** For INLINE: the inline descriptor bytes. For RAW_SIZE: u16be size. */
+  payload?: Uint8Array;
+  /** Drop the given tag from the record (to test lenient skipping). */
+  omit?: ("enumId" | "variantIndex" | "payloadKind")[];
+};
+
+/** Build one `ENUM_VARIANT` TLV value carrying only the tags the cache reads. */
+export function enumVariantTlv(spec: VariantTlvSpec): Uint8Array {
+  const omit = new Set(spec.omit ?? []);
+  const records: Uint8Array[] = [];
+  if (!omit.has("enumId")) {
+    records.push(tlv(TAG_EV_ENUM_ID, new TextEncoder().encode(spec.enumId)));
+  }
+  if (!omit.has("variantIndex")) {
+    records.push(tlv(TAG_EV_VARIANT_INDEX, u16be(spec.variantIndex)));
+  }
+  records.push(
+    tlv(TAG_EV_VARIANT_NAME, new TextEncoder().encode(spec.variantName)),
+  );
+  if (!omit.has("payloadKind")) {
+    records.push(tlv(TAG_EV_PAYLOAD_KIND, bytes(spec.payloadKind)));
+  }
+  if (spec.payload !== undefined) {
+    records.push(tlv(TAG_EV_PAYLOAD, spec.payload));
+  }
+  return concat(...records);
+}
+
+/** Encode a RAW_SIZE payload (`u16be` byte count). */
+export const rawSizePayload = (size: number): Uint8Array => u16be(size);
+
+// ---- instruction-data builders --------------------------------------------
+
+export const u32le = (n: number): Uint8Array =>
+  bytes(n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >> 24) & 0xff);
+
+export const u16le = (n: number): Uint8Array =>
+  bytes(n & 0xff, (n >> 8) & 0xff);
+
+export const u64le = (n: bigint): Uint8Array => {
+  const out = new Uint8Array(8);
+  let v = n;
+  for (let i = 0; i < 8; i++) {
+    out[i] = Number(v & 0xffn);
+    v >>= 8n;
+  }
+  return out;
+};

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/__tests__/fixtures/jupiterRoute.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/__tests__/fixtures/jupiterRoute.ts
@@ -1,0 +1,65 @@
+/**
+ * The `jupiter.route` worked example: the smallest realistic Jupiter v6 case, a
+ * single-step `routePlanStep` whose `swap` enum field holds variant
+ * 46 = raydiumCP (empty payload).
+ */
+
+import * as K from "@internal/app-binder/clear-sign/idl-type-pool/kinds";
+
+import {
+  arrayPrefixed,
+  bytes,
+  bytesFixed,
+  concat,
+  enumEntry,
+  pool,
+  struct,
+  u8,
+  u16,
+  u16le,
+  u32le,
+  u64,
+  u64le,
+} from "./builders";
+
+// IDL_TYPE_POOL payload — 8 deduplicated entries.
+export const JUPITER_POOL = pool([
+  /* 0 */ bytesFixed(8), // discriminator slot (skip leaf)
+  /* 1 */ enumEntry(K.KIND_U8, 142, "swap"), // disc=U8 total=142 enum_id="swap"
+  /* 2 */ u8(), // reused for percent / inputIndex / outputIndex / platformFeeBps
+  /* 3 */ struct([1, 2, 2, 2]), // routePlanStep
+  /* 4 */ arrayPrefixed(K.KIND_U32, 3), // Vec<routePlanStep>
+  /* 5 */ u64(), // inAmount + quotedOutAmount
+  /* 6 */ u16(), // slippageBps
+  /* 7 */ struct([0, 4, 5, 5, 6, 2]), // pruned arg-struct of `route`
+]);
+
+export const JUPITER_ROOT = 7;
+
+// 8-byte discriminator + arg data.
+export const JUPITER_DISCRIMINATOR = bytes(
+  0xe5,
+  0x17,
+  0xcb,
+  0x97,
+  0x7a,
+  0xe3,
+  0xad,
+  0x2a,
+);
+
+export const JUPITER_IN_AMOUNT = 50_000_000_000n;
+export const JUPITER_QUOTED_OUT_AMOUNT = 555n;
+export const JUPITER_SLIPPAGE_BPS = 10_000;
+export const JUPITER_PLATFORM_FEE_BPS = 0;
+export const JUPITER_SWAP_VARIANT_INDEX = 46;
+
+export const JUPITER_DATA = concat(
+  JUPITER_DISCRIMINATOR, // field 0: BYTES_FIXED(8)
+  u32le(1), // field 1: routePlan length = 1
+  bytes(JUPITER_SWAP_VARIANT_INDEX, 100, 0, 1), // swap=46, percent=100, in=0, out=1
+  u64le(JUPITER_IN_AMOUNT), // field 2: inAmount
+  u64le(JUPITER_QUOTED_OUT_AMOUNT), // field 3: quotedOutAmount
+  u16le(JUPITER_SLIPPAGE_BPS), // field 4: slippageBps
+  bytes(JUPITER_PLATFORM_FEE_BPS), // field 5: platformFeeBps
+);

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/argumentPaths.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/argumentPaths.test.ts
@@ -1,0 +1,101 @@
+import {
+  ARRAY_ITERATE_ALL,
+  packPath,
+  packStep,
+  PathPackError,
+  pathsEqual,
+  stepWidthForParent,
+} from "./argumentPaths";
+import * as K from "./kinds";
+
+describe("argumentPaths", () => {
+  describe("stepWidthForParent", () => {
+    it("returns u8 width for STRUCT/TUPLE/OPTION parents", () => {
+      expect(stepWidthForParent(K.KIND_STRUCT)).toBe(1);
+      expect(stepWidthForParent(K.KIND_OPTION_DYNAMIC)).toBe(1);
+    });
+
+    it("returns u16 width for ARRAY parents", () => {
+      expect(stepWidthForParent(K.KIND_ARRAY_PREFIXED)).toBe(2);
+    });
+
+    it("uses the disc kind width for ENUM parents", () => {
+      expect(stepWidthForParent(K.KIND_ENUM, K.KIND_U8)).toBe(1);
+      expect(stepWidthForParent(K.KIND_ENUM, K.KIND_U32)).toBe(4);
+    });
+
+    it("throws for an ENUM parent without a disc kind", () => {
+      expect(() => stepWidthForParent(K.KIND_ENUM)).toThrow(PathPackError);
+    });
+
+    it("throws for a SHORT_U16 enum discriminator (no fixed BE width)", () => {
+      expect(() => stepWidthForParent(K.KIND_ENUM, K.KIND_SHORT_U16)).toThrow(
+        PathPackError,
+      );
+    });
+  });
+
+  describe("packStep / packPath", () => {
+    it("packs a struct step as a single byte", () => {
+      expect(Array.from(packStep(K.KIND_STRUCT, 5))).toEqual([5]);
+    });
+
+    it("packs an array step big-endian over two bytes", () => {
+      expect(Array.from(packStep(K.KIND_ARRAY_FIXED, 0x0102))).toEqual([
+        0x01, 0x02,
+      ]);
+    });
+
+    it("packs the iterate-all sentinel", () => {
+      expect(
+        Array.from(packStep(K.KIND_ARRAY_FIXED, ARRAY_ITERATE_ALL)),
+      ).toEqual([0xff, 0xff]);
+    });
+
+    it("packs a wide enum step above 2^31 without int32 corruption", () => {
+      // u64-disc ENUM step value 0x1_0000_0000 (> 2^31). `& 0xff` would
+      // corrupt this; `% 256` packs it big-endian over 8 bytes.
+      expect(
+        Array.from(packStep(K.KIND_ENUM, 0x1_0000_0000, K.KIND_U64)),
+      ).toEqual([0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]);
+    });
+
+    it("prefixes the step count", () => {
+      const packed = packPath([
+        [K.KIND_STRUCT, 1, undefined],
+        [K.KIND_ARRAY_PREFIXED, 0x0203, undefined],
+      ]);
+      expect(Array.from(packed)).toEqual([2, 0x01, 0x02, 0x03]);
+    });
+
+    it("throws on an integer that is not safely representable", () => {
+      // 2^53 is the first integer a JS number can no longer represent exactly.
+      expect(() => packStep(K.KIND_ENUM, 2 ** 53, K.KIND_U64)).toThrow(
+        PathPackError,
+      );
+    });
+
+    it("throws when an array index overflows its width", () => {
+      expect(() => packStep(K.KIND_ARRAY_FIXED, 0x1_0000)).toThrow(
+        PathPackError,
+      );
+    });
+  });
+
+  describe("pathsEqual", () => {
+    it("compares packed paths byte-for-byte", () => {
+      expect(
+        pathsEqual(
+          packPath([[K.KIND_STRUCT, 2, undefined]]),
+          Uint8Array.from([1, 2]),
+        ),
+      ).toBe(true);
+      expect(pathsEqual(Uint8Array.from([1, 2]), Uint8Array.from([1, 3]))).toBe(
+        false,
+      );
+      expect(pathsEqual(Uint8Array.from([1, 2]), Uint8Array.from([1]))).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/argumentPaths.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/argumentPaths.ts
@@ -1,0 +1,143 @@
+import * as K from "./kinds";
+
+/**
+ * An argument path is the sequence of steps the decoder takes from the root to
+ * a leaf. Each step's byte width is fixed by its parent kind (so the decoder can
+ * locate steps without an in-band length), and step values are big-endian.
+ * Wire format: `u8 step_count || <packed steps>`.
+ */
+
+/** Sentinel array index meaning "iterate every element" (`0xFFFF`). */
+export const ARRAY_ITERATE_ALL = 0xffff;
+
+/** A single packed step: `[parentKind, value, discKind | undefined]`. */
+export type PathStep = readonly [
+  parentKind: number,
+  value: number,
+  discKind: number | undefined,
+];
+
+/**
+ * Thrown when a step value cannot be packed under its parent kind (e.g. an
+ * array index exceeding `0xFFFF`, or an ENUM discriminator wider than `u64`).
+ * The decoder treats this as "leaf has no addressable path" and skips it.
+ */
+export class PathPackError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PathPackError";
+  }
+}
+
+// `parentKind -> step width in bytes` (undefined means "look up discKind").
+const PARENT_KIND_STEP_WIDTH: ReadonlyMap<number, number | undefined> = new Map(
+  [
+    [K.KIND_STRUCT, 1],
+    [K.KIND_TUPLE, 1],
+    [K.KIND_ARRAY_FIXED, 2],
+    [K.KIND_ARRAY_PREFIXED, 2],
+    [K.KIND_ARRAY_REMAINDER, 2],
+    [K.KIND_ENUM, undefined],
+    [K.KIND_OPTION_DYNAMIC, 1],
+    [K.KIND_OPTION_FIXED, 1],
+    [K.KIND_OPTION_ZEROABLE, 1],
+    [K.KIND_OPTION_REMAINDER, 1],
+    [K.KIND_HIDDEN_PREFIX, 1],
+    [K.KIND_HIDDEN_SUFFIX, 1],
+  ],
+);
+
+const DISC_KIND_BYTE_WIDTH: ReadonlyMap<number, number> = new Map([
+  [K.KIND_U8, 1],
+  [K.KIND_U16, 2],
+  [K.KIND_U32, 4],
+  [K.KIND_U64, 8],
+]);
+
+/**
+ * Return the byte width of one step under `parentKind`.
+ *
+ * For `ENUM` parents the caller must pass `discKind`. `SHORT_U16` is rejected —
+ * argument-path steps must have a fixed BE width so the decoder can locate them
+ * cursor-blind.
+ */
+export function stepWidthForParent(
+  parentKind: number,
+  discKind?: number,
+): number {
+  if (parentKind === K.KIND_ENUM) {
+    if (discKind === undefined) {
+      throw new PathPackError("ENUM parent requires discKind");
+    }
+    const width = DISC_KIND_BYTE_WIDTH.get(discKind);
+    if (width === undefined) {
+      throw new PathPackError(
+        `unsupported ENUM disc_kind 0x${discKind
+          .toString(16)
+          .padStart(2, "0")} in argument path`,
+      );
+    }
+    return width;
+  }
+  if (!PARENT_KIND_STEP_WIDTH.has(parentKind)) {
+    throw new PathPackError(
+      `argument-path step under parent kind 0x${parentKind
+        .toString(16)
+        .padStart(2, "0")} is undefined`,
+    );
+  }
+  return PARENT_KIND_STEP_WIDTH.get(parentKind)!;
+}
+
+/** Encode a single step as the parent-kind-driven number of BE bytes. */
+export function packStep(
+  parentKind: number,
+  value: number,
+  discKind?: number,
+): Uint8Array {
+  const width = stepWidthForParent(parentKind, discKind);
+  // Must be a non-negative, exactly-representable integer that fits in `width`.
+  if (!Number.isSafeInteger(value) || value < 0 || value >= 2 ** (width * 8)) {
+    throw new PathPackError(
+      `step value ${value} does not fit in width ${width} for parent kind ` +
+        `0x${parentKind.toString(16).padStart(2, "0")}`,
+    );
+  }
+  const out = new Uint8Array(width);
+  let remaining = value;
+  for (let i = width - 1; i >= 0; i--) {
+    // `% 256`, not `& 0xff`: bitwise ops coerce to int32 and would corrupt
+    // values above 2^31 (e.g. a u64 enum discriminator step).
+    out[i] = remaining % 256;
+    remaining = Math.floor(remaining / 256);
+  }
+  return out;
+}
+
+/** @throws {PathPackError} when a step value can't be packed under its parent. */
+export function packPath(steps: readonly PathStep[]): Uint8Array {
+  if (steps.length > 0xff) {
+    throw new PathPackError("argument paths cannot have more than 255 steps");
+  }
+  const chunks = steps.map(([parentKind, value, discKind]) =>
+    packStep(parentKind, value, discKind),
+  );
+  const bodyLength = chunks.reduce((total, chunk) => total + chunk.length, 0);
+  const out = new Uint8Array(1 + bodyLength);
+  out[0] = steps.length;
+  let offset = 1;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
+/** Byte-equality of two packed paths. */
+export function pathsEqual(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.length !== right.length) return false;
+  for (let i = 0; i < left.length; i++) {
+    if (left[i] !== right[i]) return false;
+  }
+  return true;
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/buildEnumCache.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/buildEnumCache.test.ts
@@ -1,0 +1,102 @@
+import {
+  bytes,
+  enumVariantTlv,
+  rawSizePayload,
+} from "./__tests__/fixtures/builders";
+import { buildEnumCache } from "./buildEnumCache";
+import * as K from "./kinds";
+import { TruncatedDataError } from "./TypePoolDecoderError";
+import { variantCacheKey } from "./types";
+
+describe("buildEnumCache", () => {
+  it("builds EMPTY / INLINE / RAW_SIZE variants from ENUM_VARIANT TLVs", () => {
+    const inline = bytes(K.KIND_STRUCT, 1, K.KIND_U8);
+    const result = buildEnumCache([
+      enumVariantTlv({
+        enumId: "swap",
+        variantIndex: 46,
+        variantName: "raydiumCP",
+        payloadKind: K.VARIANT_PAYLOAD_EMPTY,
+      }),
+      enumVariantTlv({
+        enumId: "action",
+        variantIndex: 1,
+        variantName: "deposit",
+        payloadKind: K.VARIANT_PAYLOAD_INLINE,
+        payload: inline,
+      }),
+      enumVariantTlv({
+        enumId: "action",
+        variantIndex: 2,
+        variantName: "raw",
+        payloadKind: K.VARIANT_PAYLOAD_RAW_SIZE,
+        payload: rawSizePayload(8),
+      }),
+    ]);
+
+    expect(result.isRight()).toBe(true);
+    const cache = result.unsafeCoerce();
+    expect(cache.get(variantCacheKey("swap", 46))).toMatchObject({
+      variantName: "raydiumCP",
+      kind: K.VARIANT_PAYLOAD_EMPTY,
+    });
+    expect(cache.get(variantCacheKey("action", 1))).toMatchObject({
+      variantName: "deposit",
+      kind: K.VARIANT_PAYLOAD_INLINE,
+    });
+    expect(cache.get(variantCacheKey("action", 2))).toMatchObject({
+      variantName: "raw",
+      kind: K.VARIANT_PAYLOAD_RAW_SIZE,
+      size: 8,
+    });
+  });
+
+  it("skips semantically-incomplete records (missing mandatory tags)", () => {
+    const result = buildEnumCache([
+      enumVariantTlv({
+        enumId: "x",
+        variantIndex: 0,
+        variantName: "ok",
+        payloadKind: K.VARIANT_PAYLOAD_EMPTY,
+      }),
+      enumVariantTlv({
+        enumId: "x",
+        variantIndex: 1,
+        variantName: "missingKind",
+        payloadKind: K.VARIANT_PAYLOAD_EMPTY,
+        omit: ["payloadKind"],
+      }),
+    ]);
+    const cache = result.unsafeCoerce();
+    expect(cache.has(variantCacheKey("x", 0))).toBe(true);
+    expect(cache.has(variantCacheKey("x", 1))).toBe(false);
+  });
+
+  it("returns a typed error for structurally-truncated TLV framing", () => {
+    // tag present, DER length claims 5 bytes but the value is missing.
+    const truncated = bytes(0x23, 0x05, 0x68, 0x69);
+    const result = buildEnumCache([truncated]);
+    expect(result.isLeft()).toBe(true);
+    result.ifLeft((e) => expect(e).toBeInstanceOf(TruncatedDataError));
+  });
+
+  it("is deterministic: later duplicates win", () => {
+    const result = buildEnumCache([
+      enumVariantTlv({
+        enumId: "e",
+        variantIndex: 0,
+        variantName: "first",
+        payloadKind: K.VARIANT_PAYLOAD_EMPTY,
+      }),
+      enumVariantTlv({
+        enumId: "e",
+        variantIndex: 0,
+        variantName: "second",
+        payloadKind: K.VARIANT_PAYLOAD_EMPTY,
+      }),
+    ]);
+    expect(
+      result.unsafeCoerce().get(variantCacheKey("e", 0))?.variantName,
+    ).toBe("second");
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/buildEnumCache.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/buildEnumCache.ts
@@ -1,0 +1,185 @@
+import { type Either, Left, Right } from "purify-ts";
+
+import * as K from "./kinds";
+import { parseInlinePayload } from "./parsePool";
+import {
+  fail,
+  InvalidVariantPayloadError,
+  TruncatedDataError,
+  type TypePoolDecoderError,
+  TypePoolDecoderThrow,
+} from "./TypePoolDecoderError";
+import {
+  type CachedVariant,
+  type VariantCache,
+  variantCacheKey,
+} from "./types";
+
+// ENUM_VARIANT TLV tags.
+const TAG_EV_ENUM_ID = 0x21;
+const TAG_EV_VARIANT_INDEX = 0x22;
+const TAG_EV_VARIANT_NAME = 0x23;
+const TAG_EV_PAYLOAD_KIND = 0x24;
+const TAG_EV_PAYLOAD = 0x25;
+
+const textDecoder = new TextDecoder("utf-8");
+
+type TlvRecord = { tag: number; value: Uint8Array };
+
+/** Decode a DER-encoded length at `offset`. Returns `[length, newOffset]`. */
+function decodeLength(buf: Uint8Array, offset: number): [number, number] {
+  if (offset >= buf.length) {
+    fail(new TruncatedDataError("truncated TLV length byte"));
+  }
+  const head = buf[offset]!;
+  offset += 1;
+  if (head < 0x80) {
+    return [head, offset];
+  }
+  const lengthSize = head & 0x7f;
+  if (lengthSize === 0) {
+    fail(new TruncatedDataError("indefinite-length form not allowed in DER"));
+  }
+  if (offset + lengthSize > buf.length) {
+    fail(new TruncatedDataError("truncated extended TLV length"));
+  }
+  let length = 0;
+  for (let i = 0; i < lengthSize; i++) {
+    length = length * 256 + buf[offset + i]!;
+  }
+  return [length, offset + lengthSize];
+}
+
+/** Parse every `(tag, value)` record in `buf` in stream order. */
+function readTlvRecords(buf: Uint8Array): TlvRecord[] {
+  const records: TlvRecord[] = [];
+  let offset = 0;
+  while (offset < buf.length) {
+    const tag = buf[offset]!;
+    const [length, afterLen] = decodeLength(buf, offset + 1);
+    if (afterLen + length > buf.length) {
+      fail(new TruncatedDataError("truncated TLV value"));
+    }
+    records.push({ tag, value: buf.subarray(afterLen, afterLen + length) });
+    offset = afterLen + length;
+  }
+  return records;
+}
+
+function readBE(buf: Uint8Array, size: number): number {
+  let value = 0;
+  for (let i = 0; i < size; i++) {
+    value = value * 256 + (buf[i] ?? 0);
+  }
+  return value;
+}
+
+function buildOne(
+  tlv: Uint8Array,
+): { key: string; variant: CachedVariant } | null {
+  const records = readTlvRecords(tlv);
+  let enumId: string | undefined;
+  let variantIndex: number | undefined;
+  let variantName: string | undefined;
+  let payloadKind: number | undefined;
+  let payload: Uint8Array | undefined;
+
+  for (const { tag, value } of records) {
+    switch (tag) {
+      case TAG_EV_ENUM_ID:
+        enumId = textDecoder.decode(value);
+        break;
+      case TAG_EV_VARIANT_INDEX:
+        variantIndex = readBE(value, value.length);
+        break;
+      case TAG_EV_VARIANT_NAME:
+        variantName = textDecoder.decode(value);
+        break;
+      case TAG_EV_PAYLOAD_KIND:
+        payloadKind = value.length > 0 ? value[0] : undefined;
+        break;
+      case TAG_EV_PAYLOAD:
+        payload = value;
+        break;
+      default:
+        break; // ignore PROGRAM_ID, STRUCT_TYPE/VERSION, SIGNATURE, etc.
+    }
+  }
+
+  if (
+    enumId === undefined ||
+    variantIndex === undefined ||
+    payloadKind === undefined
+  ) {
+    return null; // incomplete record — skip leniently
+  }
+  const name = variantName ?? `variant_${variantIndex}`;
+  const key = variantCacheKey(enumId, variantIndex);
+
+  if (payloadKind === K.VARIANT_PAYLOAD_EMPTY) {
+    return {
+      key,
+      variant: { variantName: name, kind: K.VARIANT_PAYLOAD_EMPTY },
+    };
+  }
+  if (payloadKind === K.VARIANT_PAYLOAD_INLINE) {
+    if (payload === undefined) return null;
+    const parsed = parseInlinePayload(payload);
+    return {
+      key,
+      variant: {
+        variantName: name,
+        kind: K.VARIANT_PAYLOAD_INLINE,
+        payload: parsed,
+      },
+    };
+  }
+  if (payloadKind === K.VARIANT_PAYLOAD_RAW_SIZE) {
+    if (payload === undefined || payload.length < 2) return null;
+    return {
+      key,
+      variant: {
+        variantName: name,
+        kind: K.VARIANT_PAYLOAD_RAW_SIZE,
+        size: readBE(payload.subarray(0, 2), 2),
+      },
+    };
+  }
+  fail(
+    new InvalidVariantPayloadError(
+      `unknown payload kind 0x${payloadKind.toString(16).padStart(2, "0")}`,
+    ),
+  );
+}
+
+/**
+ * Build the decoder's {@link VariantCache} from a program's `ENUM_VARIANT`
+ * descriptors (one raw TLV per variant).
+ *
+ * Structurally-malformed TLV framing (truncated records / lengths) surfaces as
+ * a typed {@link TypePoolDecoderError} `Left`; semantically-incomplete records (missing
+ * mandatory tags) are skipped leniently. Later entries win on duplicate keys.
+ */
+export function buildEnumCache(
+  variantTlvs: readonly Uint8Array[],
+): Either<TypePoolDecoderError, VariantCache> {
+  try {
+    const cache = new Map<string, CachedVariant>();
+    for (const tlv of variantTlvs) {
+      const built = buildOne(tlv);
+      if (built !== null) {
+        cache.set(built.key, built.variant);
+      }
+    }
+    return Right(cache);
+  } catch (error) {
+    if (error instanceof TypePoolDecoderThrow) {
+      return Left(error.error);
+    }
+    return Left(
+      new InvalidVariantPayloadError(
+        error instanceof Error ? error.message : String(error),
+      ),
+    );
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/buildEnumCache.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/buildEnumCache.ts
@@ -1,5 +1,10 @@
 import { type Either, Left, Right } from "purify-ts";
 
+import {
+  readTlvEntries,
+  TlvParseError,
+} from "@internal/app-binder/clear-sign/tlv";
+
 import * as K from "./kinds";
 import { parseInlinePayload } from "./parsePool";
 import {
@@ -24,48 +29,6 @@ const TAG_EV_PAYLOAD = 0x25;
 
 const textDecoder = new TextDecoder("utf-8");
 
-type TlvRecord = { tag: number; value: Uint8Array };
-
-/** Decode a DER-encoded length at `offset`. Returns `[length, newOffset]`. */
-function decodeLength(buf: Uint8Array, offset: number): [number, number] {
-  if (offset >= buf.length) {
-    fail(new TruncatedDataError("truncated TLV length byte"));
-  }
-  const head = buf[offset]!;
-  offset += 1;
-  if (head < 0x80) {
-    return [head, offset];
-  }
-  const lengthSize = head & 0x7f;
-  if (lengthSize === 0) {
-    fail(new TruncatedDataError("indefinite-length form not allowed in DER"));
-  }
-  if (offset + lengthSize > buf.length) {
-    fail(new TruncatedDataError("truncated extended TLV length"));
-  }
-  let length = 0;
-  for (let i = 0; i < lengthSize; i++) {
-    length = length * 256 + buf[offset + i]!;
-  }
-  return [length, offset + lengthSize];
-}
-
-/** Parse every `(tag, value)` record in `buf` in stream order. */
-function readTlvRecords(buf: Uint8Array): TlvRecord[] {
-  const records: TlvRecord[] = [];
-  let offset = 0;
-  while (offset < buf.length) {
-    const tag = buf[offset]!;
-    const [length, afterLen] = decodeLength(buf, offset + 1);
-    if (afterLen + length > buf.length) {
-      fail(new TruncatedDataError("truncated TLV value"));
-    }
-    records.push({ tag, value: buf.subarray(afterLen, afterLen + length) });
-    offset = afterLen + length;
-  }
-  return records;
-}
-
 function readBE(buf: Uint8Array, size: number): number {
   let value = 0;
   for (let i = 0; i < size; i++) {
@@ -77,7 +40,7 @@ function readBE(buf: Uint8Array, size: number): number {
 function buildOne(
   tlv: Uint8Array,
 ): { key: string; variant: CachedVariant } | null {
-  const records = readTlvRecords(tlv);
+  const records = readTlvEntries(tlv);
   let enumId: string | undefined;
   let variantIndex: number | undefined;
   let variantName: string | undefined;
@@ -175,6 +138,9 @@ export function buildEnumCache(
   } catch (error) {
     if (error instanceof TypePoolDecoderThrow) {
       return Left(error.error);
+    }
+    if (error instanceof TlvParseError) {
+      return Left(new TruncatedDataError(error.message));
     }
     return Left(
       new InvalidVariantPayloadError(

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/dataReaders.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/dataReaders.test.ts
@@ -1,0 +1,173 @@
+import { bytes } from "./__tests__/fixtures/builders";
+import { DefaultDataReader, fixedSizeOf } from "./dataReaders";
+import * as K from "./kinds";
+import {
+  MalformedDataError,
+  TruncatedDataError,
+  TypePoolDecoderThrow,
+  UnsupportedKindError,
+} from "./TypePoolDecoderError";
+import { type Entry, type Ref } from "./types";
+
+const reader = new DefaultDataReader();
+
+/** Capture the TypePoolDecoderError a reader throws internally (via TypePoolDecoderThrow). */
+function caughtError(run: () => unknown): unknown {
+  try {
+    run();
+  } catch (error) {
+    if (error instanceof TypePoolDecoderThrow) return error.error;
+    throw error;
+  }
+  throw new Error("expected the reader to throw");
+}
+
+describe("DefaultDataReader", () => {
+  describe("readUnsigned", () => {
+    it("reads fixed-width unsigned integers little-endian", () => {
+      expect(reader.readUnsigned(bytes(0x2a), 0, K.KIND_U8)).toEqual([0x2a, 1]);
+      expect(reader.readUnsigned(bytes(0x34, 0x12), 0, K.KIND_U16)).toEqual([
+        0x1234, 2,
+      ]);
+    });
+
+    it("decodes a SHORT_U16 varint (1-3 bytes)", () => {
+      expect(reader.readUnsigned(bytes(0x7f), 0, K.KIND_SHORT_U16)).toEqual([
+        127, 1,
+      ]);
+      expect(
+        reader.readUnsigned(bytes(0xac, 0x02), 0, K.KIND_SHORT_U16),
+      ).toEqual([300, 2]);
+    });
+
+    it("rejects a non-unsigned kind", () => {
+      expect(
+        caughtError(() => reader.readUnsigned(bytes(0x01), 0, K.KIND_I8)),
+      ).toBeInstanceOf(UnsupportedKindError);
+    });
+
+    it("rejects a truncated read", () => {
+      expect(
+        caughtError(() => reader.readUnsigned(bytes(0x01), 0, K.KIND_U32)),
+      ).toBeInstanceOf(TruncatedDataError);
+    });
+
+    it("fails closed on an overlong SHORT_U16 (continuation bit past 3 bytes)", () => {
+      expect(
+        caughtError(() =>
+          reader.readUnsigned(bytes(0x80, 0x80, 0x80), 0, K.KIND_SHORT_U16),
+        ),
+      ).toBeInstanceOf(MalformedDataError);
+    });
+
+    it("fails closed on an unsigned value above MAX_SAFE_INTEGER", () => {
+      // u64 = 0xFFFFFFFFFFFFFFFF is not safely representable as a number.
+      const eightBytes = bytes(0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff);
+      expect(
+        caughtError(() => reader.readUnsigned(eightBytes, 0, K.KIND_U64)),
+      ).toBeInstanceOf(MalformedDataError);
+    });
+
+    it("reads the largest safely-representable unsigned value", () => {
+      // 2^53 - 1 = 0x1FFFFFFFFFFFFF, little-endian over 8 bytes.
+      const maxSafe = bytes(0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, 0x00);
+      expect(reader.readUnsigned(maxSafe, 0, K.KIND_U64)).toEqual([
+        Number.MAX_SAFE_INTEGER,
+        8,
+      ]);
+    });
+  });
+
+  describe("readPrimitive", () => {
+    it("returns 64-bit integers as bigint", () => {
+      const data = bytes(0x00, 0x74, 0x3b, 0xa4, 0x0b, 0x00, 0x00, 0x00);
+      expect(reader.readPrimitive(data, 0, K.KIND_U64)).toEqual([
+        50_000_000_000n,
+        8,
+      ]);
+    });
+
+    it("sign-extends signed integers", () => {
+      expect(reader.readPrimitive(bytes(0xff), 0, K.KIND_I8)).toEqual([-1, 1]);
+    });
+
+    it("decodes a PUBKEY_32 as base58", () => {
+      const [value] = reader.readPrimitive(
+        new Uint8Array(32),
+        0,
+        K.KIND_PUBKEY_32,
+      );
+      expect(value).toBe("11111111111111111111111111111111");
+    });
+
+    it("encodes PUBKEY_32 via the injected Bs58Encoder", () => {
+      const calls: Uint8Array[] = [];
+      const fakeEncoder = {
+        encode: (data: Uint8Array) => {
+          calls.push(data);
+          return "FAKE_PUBKEY";
+        },
+        decode: () => new Uint8Array(),
+      };
+      const injectedReader = new DefaultDataReader(fakeEncoder);
+      const [value] = injectedReader.readPrimitive(
+        new Uint8Array(32),
+        0,
+        K.KIND_PUBKEY_32,
+      );
+      expect(value).toBe("FAKE_PUBKEY");
+      expect(calls).toHaveLength(1);
+    });
+
+    it("reads booleans", () => {
+      expect(reader.readPrimitive(bytes(0), 0, K.KIND_BOOL_U8)[0]).toBe(false);
+      expect(reader.readPrimitive(bytes(9), 0, K.KIND_BOOL_U8)[0]).toBe(true);
+    });
+  });
+
+  describe("decodeString", () => {
+    it("decodes UTF-8 by default", () => {
+      expect(reader.decodeString(bytes(0x68, 0x69), K.ENCODING_UTF8)).toBe(
+        "hi",
+      );
+    });
+
+    it("renders base16 as hex", () => {
+      expect(reader.decodeString(bytes(0xde, 0xad), K.ENCODING_BASE16)).toBe(
+        "dead",
+      );
+    });
+  });
+});
+
+describe("fixedSizeOf", () => {
+  const resolve =
+    (pool: Entry[]) =>
+    (ref: Ref): Entry =>
+      typeof ref === "number" ? pool[ref]! : ref;
+
+  it("sums fixed-size struct fields", () => {
+    const pool: Entry[] = [
+      { kind: K.KIND_STRUCT, refs: [1, 2] },
+      { kind: K.KIND_U8, refs: [] },
+      { kind: K.KIND_U32, refs: [] },
+    ];
+    expect(fixedSizeOf(pool[0]!, resolve(pool))).toBe(5);
+  });
+
+  it("returns undefined for a variable-size entry", () => {
+    const pool: Entry[] = [
+      { kind: K.KIND_ARRAY_PREFIXED, lenKind: K.KIND_U32, refs: [1] },
+      { kind: K.KIND_U8, refs: [] },
+    ];
+    expect(fixedSizeOf(pool[0]!, resolve(pool))).toBeUndefined();
+  });
+
+  it("accounts for the OPTION_FIXED flag plus inner size", () => {
+    const pool: Entry[] = [
+      { kind: K.KIND_OPTION_FIXED, flagKind: K.KIND_U8, refs: [1] },
+      { kind: K.KIND_U32, refs: [] },
+    ];
+    expect(fixedSizeOf(pool[0]!, resolve(pool))).toBe(5);
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/dataReaders.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/dataReaders.ts
@@ -1,0 +1,253 @@
+import { bufferToHexaString } from "@ledgerhq/device-management-kit";
+
+import {
+  type Bs58Encoder,
+  DefaultBs58Encoder,
+} from "@internal/app-binder/services/bs58Encoder";
+
+import * as K from "./kinds";
+import {
+  fail,
+  MalformedDataError,
+  TruncatedDataError,
+  UnsupportedKindError,
+} from "./TypePoolDecoderError";
+import { type Entry, type LeafValue, type Ref } from "./types";
+
+const textDecoder = new TextDecoder("utf-8");
+
+function dataView(data: Uint8Array): DataView {
+  return new DataView(data.buffer, data.byteOffset, data.byteLength);
+}
+
+/**
+ * Decodes scalar values (little-endian) from a Solana instruction-data buffer.
+ * Injected into the decoder so the tree traversal stays decoder-agnostic and the
+ * decoding can be swapped/tested in isolation.
+ */
+export interface DataReader {
+  /**
+   * Read an unsigned integer of `kind` at `offset`, returned as a `number`.
+   * Supports the `SHORT_U16` varint (1–3 bytes) and the fixed unsigned/bool
+   * kinds. Used for counts, flags and enum discriminators.
+   */
+  readUnsigned(
+    data: Uint8Array,
+    offset: number,
+    kind: number,
+  ): [value: number, nextOffset: number];
+
+  /**
+   * Read a primitive leaf of `kind` at `offset`. 64-/128-bit integers are
+   * returned as `bigint`; smaller integers, floats and booleans as
+   * `number`/`boolean`; `PUBKEY_32` as a base58 string.
+   */
+  readPrimitive(
+    data: Uint8Array,
+    offset: number,
+    kind: number,
+  ): [value: LeafValue, nextOffset: number];
+
+  /** Decode raw bytes as UTF-8, or as hex when `encoding` is base16. */
+  decodeString(raw: Uint8Array, encoding: number | undefined): string;
+}
+
+export class DefaultDataReader implements DataReader {
+  constructor(private readonly bs58Encoder: Bs58Encoder = DefaultBs58Encoder) {}
+
+  readUnsigned(
+    data: Uint8Array,
+    offset: number,
+    kind: number,
+  ): [number, number] {
+    if (kind === K.KIND_SHORT_U16) {
+      let value = 0;
+      for (let i = 0; i < 3; i++) {
+        if (offset >= data.length) {
+          fail(new TruncatedDataError("truncated SHORT_U16"));
+        }
+        const byte = data[offset]!;
+        offset += 1;
+        value |= (byte & 0x7f) << (7 * i);
+        if ((byte & 0x80) === 0) return [value >>> 0, offset];
+      }
+      // Continuation bit still set after 3 bytes: not a valid ShortU16.
+      fail(new MalformedDataError("overlong SHORT_U16 varint"));
+    }
+
+    const size = K.PRIMITIVE_KIND_BYTE_SIZES.get(kind);
+    if (size === undefined || !K.UNSIGNED_INT_KINDS.has(kind)) {
+      fail(
+        new UnsupportedKindError(
+          `unsigned read not supported for kind 0x${kind
+            .toString(16)
+            .padStart(2, "0")}`,
+        ),
+      );
+    }
+    if (offset + size > data.length) {
+      fail(
+        new TruncatedDataError(
+          `truncated unsigned read (kind=0x${kind.toString(16)})`,
+        ),
+      );
+    }
+    // Little-endian accumulation in bigint, then fail closed if the value is
+    // not safely representable (these drive counts/flags/discriminators).
+    let value = 0n;
+    for (let i = size - 1; i >= 0; i--) {
+      value = value * 256n + BigInt(data[offset + i]!);
+    }
+    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+      fail(
+        new MalformedDataError(
+          `unsigned value too large to represent (kind=0x${kind.toString(16)})`,
+        ),
+      );
+    }
+    return [Number(value), offset + size];
+  }
+
+  readPrimitive(
+    data: Uint8Array,
+    offset: number,
+    kind: number,
+  ): [LeafValue, number] {
+    if (kind === K.KIND_SHORT_U16) {
+      return this.readUnsigned(data, offset, kind);
+    }
+
+    if (kind === K.KIND_PUBKEY_32) {
+      if (offset + 32 > data.length) {
+        fail(new TruncatedDataError("truncated PUBKEY_32"));
+      }
+      return [
+        this.bs58Encoder.encode(data.subarray(offset, offset + 32)),
+        offset + 32,
+      ];
+    }
+
+    const size = K.PRIMITIVE_KIND_BYTE_SIZES.get(kind);
+    if (size === undefined) {
+      fail(
+        new UnsupportedKindError(
+          `unknown primitive kind 0x${kind.toString(16).padStart(2, "0")}`,
+        ),
+      );
+    }
+    if (offset + size > data.length) {
+      fail(
+        new TruncatedDataError(
+          `truncated primitive (kind=0x${kind.toString(16)})`,
+        ),
+      );
+    }
+
+    const view = dataView(data);
+    const at = offset;
+    const end = offset + size;
+
+    switch (kind) {
+      case K.KIND_F32:
+        return [view.getFloat32(at, true), end];
+      case K.KIND_F64:
+        return [view.getFloat64(at, true), end];
+      case K.KIND_BOOL_U8:
+        return [data[at]! !== 0, end];
+      case K.KIND_BOOL_U16:
+        return [view.getUint16(at, true) !== 0, end];
+      case K.KIND_BOOL_U32:
+        return [view.getUint32(at, true) !== 0, end];
+      case K.KIND_U8:
+        return [data[at]!, end];
+      case K.KIND_U16:
+        return [view.getUint16(at, true), end];
+      case K.KIND_U32:
+        return [view.getUint32(at, true), end];
+      case K.KIND_U64:
+        return [view.getBigUint64(at, true), end];
+      case K.KIND_I8:
+        return [view.getInt8(at), end];
+      case K.KIND_I16:
+        return [view.getInt16(at, true), end];
+      case K.KIND_I32:
+        return [view.getInt32(at, true), end];
+      case K.KIND_I64:
+        return [view.getBigInt64(at, true), end];
+      case K.KIND_U128:
+      case K.KIND_I128: {
+        let value = 0n;
+        for (let i = size - 1; i >= 0; i--) {
+          value = (value << 8n) | BigInt(data[at + i]!);
+        }
+        if (kind === K.KIND_I128 && value & (1n << 127n)) {
+          value -= 1n << 128n;
+        }
+        return [value, end];
+      }
+      default:
+        fail(
+          new UnsupportedKindError(
+            `unknown primitive kind 0x${kind.toString(16).padStart(2, "0")}`,
+          ),
+        );
+    }
+  }
+
+  decodeString(raw: Uint8Array, encoding: number | undefined): string {
+    if (encoding === K.ENCODING_BASE16) {
+      return bufferToHexaString(raw, false);
+    }
+    return textDecoder.decode(raw);
+  }
+}
+
+/**
+ * Fixed serialized size of `entry`, or `undefined` if variable. Used by the
+ * decoder's `OPTION_FIXED` handler, which advances by `size(inner)` even when
+ * the flag is zero. A free function (not part of {@link DataReader}) because it
+ * only inspects the descriptor, never the instruction-data buffer.
+ */
+export function fixedSizeOf(
+  entry: Entry,
+  resolver: (ref: Ref) => Entry,
+): number | undefined {
+  const kind = entry.kind;
+  if (K.PRIMITIVE_KIND_BYTE_SIZES.has(kind)) {
+    return K.PRIMITIVE_KIND_BYTE_SIZES.get(kind);
+  }
+  if (kind === K.KIND_BYTES_FIXED || kind === K.KIND_STRING_FIXED) {
+    return entry.fixedSize;
+  }
+  if (kind === K.KIND_STRUCT || kind === K.KIND_TUPLE) {
+    let total = 0;
+    for (const ref of entry.refs) {
+      const fieldSize = fixedSizeOf(resolver(ref), resolver);
+      if (fieldSize === undefined) return undefined;
+      total += fieldSize;
+    }
+    return total;
+  }
+  if (kind === K.KIND_ARRAY_FIXED) {
+    const itemSize = fixedSizeOf(resolver(entry.refs[0]!), resolver);
+    if (itemSize === undefined) return undefined;
+    return (entry.fixedSize ?? 0) * itemSize;
+  }
+  if (kind === K.KIND_OPTION_FIXED) {
+    const flagSize =
+      K.PRIMITIVE_KIND_BYTE_SIZES.get(entry.flagKind ?? K.KIND_U8) ?? 1;
+    const innerSize = fixedSizeOf(resolver(entry.refs[0]!), resolver);
+    if (innerSize === undefined) return undefined;
+    return flagSize + innerSize;
+  }
+  if (kind === K.KIND_OPTION_ZEROABLE) {
+    return fixedSizeOf(resolver(entry.refs[0]!), resolver);
+  }
+  if (kind === K.KIND_HIDDEN_PREFIX || kind === K.KIND_HIDDEN_SUFFIX) {
+    const skipSize = fixedSizeOf(resolver(entry.refs[0]!), resolver);
+    const innerSize = fixedSizeOf(resolver(entry.refs[1]!), resolver);
+    if (skipSize === undefined || innerSize === undefined) return undefined;
+    return skipSize + innerSize;
+  }
+  return undefined;
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/decodeArgumentPath.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/decodeArgumentPath.test.ts
@@ -1,0 +1,64 @@
+import {
+  bytes,
+  optionDynamic,
+  pool,
+  struct,
+  u8,
+  u32,
+} from "./__tests__/fixtures/builders";
+import {
+  JUPITER_DATA,
+  JUPITER_IN_AMOUNT,
+  JUPITER_POOL,
+  JUPITER_ROOT,
+} from "./__tests__/fixtures/jupiterRoute";
+import { packPath } from "./argumentPaths";
+import { decodeArgumentPath } from "./decodeArgumentPath";
+import * as K from "./kinds";
+import { TruncatedDataError } from "./TypePoolDecoderError";
+import { type VariantCache } from "./types";
+
+const EMPTY_CACHE: VariantCache = new Map();
+
+describe("decodeArgumentPath", () => {
+  it("returns the leaf value at a given path (jupiter inAmount)", () => {
+    const path = packPath([[K.KIND_STRUCT, 2, undefined]]);
+    const result = decodeArgumentPath(
+      JUPITER_POOL,
+      JUPITER_ROOT,
+      EMPTY_CACHE,
+      path,
+      JUPITER_DATA,
+    );
+    expect(result.isRight()).toBe(true);
+    const value = result.unsafeCoerce();
+    expect(value.isJust()).toBe(true);
+    expect(value.unsafeCoerce()).toBe(JUPITER_IN_AMOUNT);
+  });
+
+  it("returns Nothing for a path no leaf is emitted at", () => {
+    // OPTION_DYNAMIC absent → inner leaf never emitted; path into it is empty.
+    const p = pool([struct([1]), optionDynamic(K.KIND_U8, 2), u32()]);
+    const path = packPath([
+      [K.KIND_STRUCT, 0, undefined],
+      [K.KIND_OPTION_DYNAMIC, 0, undefined],
+    ]);
+    const result = decodeArgumentPath(p, 0, EMPTY_CACHE, path, bytes(0));
+    expect(result.unsafeCoerce().isNothing()).toBe(true);
+  });
+
+  it("preserves falsy leaf values (0) as Just", () => {
+    const p = pool([struct([1]), u8()]);
+    const path = packPath([[K.KIND_STRUCT, 0, undefined]]);
+    const result = decodeArgumentPath(p, 0, EMPTY_CACHE, path, bytes(0));
+    expect(result.unsafeCoerce().extract()).toBe(0);
+  });
+
+  it("surfaces malformed input as a typed Left", () => {
+    const p = pool([struct([1]), u32()]);
+    const path = packPath([[K.KIND_STRUCT, 0, undefined]]);
+    const result = decodeArgumentPath(p, 0, EMPTY_CACHE, path, bytes(1, 2));
+    expect(result.isLeft()).toBe(true);
+    result.ifLeft((e) => expect(e).toBeInstanceOf(TruncatedDataError));
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/decodeArgumentPath.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/decodeArgumentPath.ts
@@ -1,0 +1,35 @@
+import { type Either, Maybe } from "purify-ts";
+
+import { pathsEqual } from "./argumentPaths";
+import { type DataReader, DefaultDataReader } from "./dataReaders";
+import { decodePoolBytes } from "./TypePoolDecoder";
+import { type TypePoolDecoderError } from "./TypePoolDecoderError";
+import { type LeafValue, type VariantCache } from "./types";
+
+/**
+ * Decode the leaf value at a given argument path. Returns `Nothing` when no
+ * leaf is emitted at that path (e.g. a non-selected option) — a valid outcome,
+ * not an error; malformed bytes surface as a typed {@link TypePoolDecoderError} `Left`.
+ *
+ * @param typePool raw `IDL_TYPE_POOL` TLV value (`u8 count || entries…`).
+ * @param rootType `IDL_ROOT_TYPE` pool index to start the decode from.
+ * @param enumCache variant payload metadata keyed by `(enumId, variantIndex)`.
+ * @param path packed argument path (`u8 step_count || <packed steps>`).
+ * @param data the instruction-data buffer.
+ * @param dataReader scalar decoder (defaults to {@link DefaultDataReader}).
+ */
+export function decodeArgumentPath(
+  typePool: Uint8Array,
+  rootType: number,
+  enumCache: VariantCache,
+  path: Uint8Array,
+  data: Uint8Array,
+  dataReader: DataReader = new DefaultDataReader(),
+): Either<TypePoolDecoderError, Maybe<LeafValue>> {
+  return decodePoolBytes(typePool, rootType, enumCache, data, dataReader).map(
+    (result) =>
+      Maybe.fromNullable(
+        result.leaves.find((leaf) => pathsEqual(leaf.path, path))?.value,
+      ),
+  );
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/findSelectedEnumVariants.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/findSelectedEnumVariants.test.ts
@@ -1,0 +1,73 @@
+import {
+  arrayPrefixed,
+  bytes,
+  concat,
+  enumEntry,
+  pool,
+  struct,
+  u32le,
+} from "./__tests__/fixtures/builders";
+import {
+  JUPITER_DATA,
+  JUPITER_POOL,
+  JUPITER_ROOT,
+  JUPITER_SWAP_VARIANT_INDEX,
+} from "./__tests__/fixtures/jupiterRoute";
+import { findSelectedEnumVariants } from "./findSelectedEnumVariants";
+import * as K from "./kinds";
+import { PoolIndexOutOfRangeError } from "./TypePoolDecoderError";
+import { type VariantCache } from "./types";
+
+const EMPTY_CACHE: VariantCache = new Map();
+
+describe("findSelectedEnumVariants", () => {
+  it("returns the single swap variant selected by the jupiter route", () => {
+    const result = findSelectedEnumVariants(
+      JUPITER_POOL,
+      JUPITER_ROOT,
+      EMPTY_CACHE,
+      JUPITER_DATA,
+    );
+    expect(result.unsafeCoerce()).toEqual([
+      { enumId: "swap", variantIndex: JUPITER_SWAP_VARIANT_INDEX },
+    ]);
+  });
+
+  it("deduplicates repeated selections while preserving first-seen order", () => {
+    // Vec<enum> with 3 elements selecting variants 1, 0, 1.
+    const p = pool([
+      struct([1]),
+      arrayPrefixed(K.KIND_U32, 2),
+      enumEntry(K.KIND_U8, 4, "kind"),
+    ]);
+    const data = concat(u32le(3), bytes(1, 0, 1));
+    const result = findSelectedEnumVariants(p, 0, EMPTY_CACHE, data);
+    expect(result.unsafeCoerce()).toEqual([
+      { enumId: "kind", variantIndex: 1 },
+      { enumId: "kind", variantIndex: 0 },
+    ]);
+  });
+
+  it("is deterministic across repeated calls", () => {
+    const once = findSelectedEnumVariants(
+      JUPITER_POOL,
+      JUPITER_ROOT,
+      EMPTY_CACHE,
+      JUPITER_DATA,
+    );
+    const twice = findSelectedEnumVariants(
+      JUPITER_POOL,
+      JUPITER_ROOT,
+      EMPTY_CACHE,
+      JUPITER_DATA,
+    );
+    expect(once.unsafeCoerce()).toEqual(twice.unsafeCoerce());
+  });
+
+  it("surfaces malformed input as a typed Left", () => {
+    const p = pool([struct([9])]); // out-of-range ref
+    const result = findSelectedEnumVariants(p, 0, EMPTY_CACHE, bytes(1));
+    expect(result.isLeft()).toBe(true);
+    result.ifLeft((e) => expect(e).toBeInstanceOf(PoolIndexOutOfRangeError));
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/findSelectedEnumVariants.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/findSelectedEnumVariants.ts
@@ -1,0 +1,45 @@
+import { type Either } from "purify-ts";
+
+import { type DataReader, DefaultDataReader } from "./dataReaders";
+import { decodePoolBytes } from "./TypePoolDecoder";
+import { type TypePoolDecoderError } from "./TypePoolDecoderError";
+import {
+  type SelectedEnumVariant,
+  type VariantCache,
+  variantCacheKey,
+} from "./types";
+
+/**
+ * Find the `(enumId, variantIndex)` pairs the instruction data selects,
+ * deduplicated in first-seen order. Lets callers stream only the observed
+ * `ENUM_VARIANT` descriptors to the device rather than all variants.
+ *
+ * @param typePool raw `IDL_TYPE_POOL` TLV value (`u8 count || entries…`).
+ * @param rootType `IDL_ROOT_TYPE` pool index to start the decode from.
+ * @param enumCache variant payload metadata; needed to advance past a payload
+ * so enums *after* it are reached.
+ * @param data the instruction-data buffer.
+ * @param dataReader scalar decoder (defaults to {@link DefaultDataReader}).
+ */
+export function findSelectedEnumVariants(
+  typePool: Uint8Array,
+  rootType: number,
+  enumCache: VariantCache,
+  data: Uint8Array,
+  dataReader: DataReader = new DefaultDataReader(),
+): Either<TypePoolDecoderError, SelectedEnumVariant[]> {
+  return decodePoolBytes(typePool, rootType, enumCache, data, dataReader).map(
+    (result) => {
+      const seen = new Set<string>();
+      const deduped: SelectedEnumVariant[] = [];
+      for (const selected of result.selectedEnumVariants) {
+        const key = variantCacheKey(selected.enumId, selected.variantIndex);
+        if (!seen.has(key)) {
+          seen.add(key);
+          deduped.push(selected);
+        }
+      }
+      return deduped;
+    },
+  );
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/index.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/index.ts
@@ -1,0 +1,34 @@
+export * from "./argumentPaths";
+export { buildEnumCache } from "./buildEnumCache";
+export { type DataReader, DefaultDataReader, fixedSizeOf } from "./dataReaders";
+export { decodeArgumentPath } from "./decodeArgumentPath";
+export { findSelectedEnumVariants } from "./findSelectedEnumVariants";
+export * from "./kinds";
+export { parseInlinePayload, parsePool } from "./parsePool";
+export { decode, decodePoolBytes } from "./TypePoolDecoder";
+export {
+  DecodeBudgetExceededError,
+  InvalidVariantPayloadError,
+  MalformedDataError,
+  MAX_DECODE_DEPTH,
+  MAX_DECODE_NODE_VISITS,
+  NoProgressError,
+  PoolIndexOutOfRangeError,
+  TrailingBytesError,
+  TruncatedDataError,
+  type TypePoolDecoderError,
+  UnknownKindError,
+  UnsupportedKindError,
+} from "./TypePoolDecoderError";
+export {
+  type CachedVariant,
+  type DecodeResult,
+  type Entry,
+  type Leaf,
+  type LeafValue,
+  type Ref,
+  type SelectedEnumVariant,
+  type VariantCache,
+  variantCacheKey,
+  type VariantPayload,
+} from "./types";

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/kinds.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/kinds.ts
@@ -1,0 +1,97 @@
+// Type-pool kind codes: the leading byte of every IDL_TYPE_POOL entry, also
+// reused inline as `*_kind` markers (e.g. ENUM.discKind, ARRAY_PREFIXED.lenKind).
+
+export const KIND_U8 = 0x01;
+export const KIND_U16 = 0x02;
+export const KIND_U32 = 0x03;
+export const KIND_U64 = 0x04;
+export const KIND_U128 = 0x05;
+export const KIND_I8 = 0x06;
+export const KIND_I16 = 0x07;
+export const KIND_I32 = 0x08;
+export const KIND_I64 = 0x09;
+export const KIND_I128 = 0x0a;
+export const KIND_F32 = 0x0b;
+export const KIND_F64 = 0x0c;
+export const KIND_SHORT_U16 = 0x0d;
+export const KIND_BOOL_U8 = 0x0e;
+export const KIND_BOOL_U16 = 0x0f;
+export const KIND_BOOL_U32 = 0x10;
+export const KIND_PUBKEY_32 = 0x11;
+export const KIND_BYTES_FIXED = 0x12;
+export const KIND_STRING_FIXED = 0x13;
+export const KIND_STRING_PREFIXED = 0x14;
+export const KIND_BYTES_REMAINDER = 0x15;
+
+export const KIND_STRUCT = 0x20;
+export const KIND_TUPLE = 0x21;
+export const KIND_OPTION_DYNAMIC = 0x22;
+export const KIND_OPTION_FIXED = 0x23;
+export const KIND_OPTION_ZEROABLE = 0x24;
+export const KIND_ARRAY_FIXED = 0x25;
+export const KIND_ARRAY_PREFIXED = 0x26;
+export const KIND_ARRAY_REMAINDER = 0x27;
+export const KIND_ENUM = 0x28;
+export const KIND_HIDDEN_PREFIX = 0x29;
+export const KIND_HIDDEN_SUFFIX = 0x2a;
+export const KIND_OPTION_REMAINDER = 0x2b;
+
+export const ENCODING_UTF8 = 0x00;
+export const ENCODING_BASE16 = 0x01;
+
+export const VARIANT_PAYLOAD_EMPTY = 0x00;
+export const VARIANT_PAYLOAD_INLINE = 0x02;
+export const VARIANT_PAYLOAD_RAW_SIZE = 0x03;
+
+// SHORT_U16 is intentionally absent: it is a 1–3 byte varint, not fixed-width.
+export const PRIMITIVE_KIND_BYTE_SIZES: ReadonlyMap<number, number> = new Map([
+  [KIND_U8, 1],
+  [KIND_U16, 2],
+  [KIND_U32, 4],
+  [KIND_U64, 8],
+  [KIND_U128, 16],
+  [KIND_I8, 1],
+  [KIND_I16, 2],
+  [KIND_I32, 4],
+  [KIND_I64, 8],
+  [KIND_I128, 16],
+  [KIND_F32, 4],
+  [KIND_F64, 8],
+  [KIND_BOOL_U8, 1],
+  [KIND_BOOL_U16, 2],
+  [KIND_BOOL_U32, 4],
+  [KIND_PUBKEY_32, 32],
+]);
+
+/** Kinds the decoder treats as scalar leaves (no recursion, single value). */
+export const PRIMITIVE_KINDS: ReadonlySet<number> = new Set([
+  KIND_U8,
+  KIND_U16,
+  KIND_U32,
+  KIND_U64,
+  KIND_U128,
+  KIND_I8,
+  KIND_I16,
+  KIND_I32,
+  KIND_I64,
+  KIND_I128,
+  KIND_F32,
+  KIND_F64,
+  KIND_SHORT_U16,
+  KIND_BOOL_U8,
+  KIND_BOOL_U16,
+  KIND_BOOL_U32,
+  KIND_PUBKEY_32,
+]);
+
+/** Unsigned integer kinds that `readUnsigned` accepts (excludes SHORT_U16). */
+export const UNSIGNED_INT_KINDS: ReadonlySet<number> = new Set([
+  KIND_U8,
+  KIND_U16,
+  KIND_U32,
+  KIND_U64,
+  KIND_U128,
+  KIND_BOOL_U8,
+  KIND_BOOL_U16,
+  KIND_BOOL_U32,
+]);

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/parsePool.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/parsePool.test.ts
@@ -1,0 +1,84 @@
+import {
+  bytes,
+  enumEntry,
+  pool,
+  struct,
+  u8,
+} from "./__tests__/fixtures/builders";
+import * as K from "./kinds";
+import { parseInlinePayload, parsePool } from "./parsePool";
+import {
+  TrailingBytesError,
+  TruncatedDataError,
+  TypePoolDecoderThrow,
+  UnknownKindError,
+} from "./TypePoolDecoderError";
+
+/** parsePool throws TypePoolDecoderThrow internally; capture the wrapped error. */
+function expectParseError(buf: Uint8Array): TypePoolDecoderThrow {
+  try {
+    parsePool(buf);
+  } catch (e) {
+    if (e instanceof TypePoolDecoderThrow) return e;
+    throw e;
+  }
+  throw new Error("expected parsePool to throw");
+}
+
+describe("parsePool", () => {
+  it("parses a pool with refs and an ENUM entry", () => {
+    const entries = parsePool(
+      pool([struct([1, 2]), u8(), enumEntry(K.KIND_U8, 142, "swap")]),
+    );
+    expect(entries).toHaveLength(3);
+    expect(entries[0]).toMatchObject({ kind: K.KIND_STRUCT, refs: [1, 2] });
+    expect(entries[2]).toMatchObject({
+      kind: K.KIND_ENUM,
+      discKind: K.KIND_U8,
+      totalVariants: 142,
+      enumId: "swap",
+    });
+  });
+
+  it("rejects an empty buffer", () => {
+    expect(expectParseError(bytes()).error).toBeInstanceOf(TruncatedDataError);
+  });
+
+  it("rejects trailing bytes after the declared entries", () => {
+    const buf = bytes(1, K.KIND_U8, 0xff); // count=1, one u8, then a stray byte
+    expect(expectParseError(buf).error).toBeInstanceOf(TrailingBytesError);
+  });
+
+  it("rejects an unknown kind byte", () => {
+    const buf = bytes(1, 0x99);
+    expect(expectParseError(buf).error).toBeInstanceOf(UnknownKindError);
+  });
+
+  it("rejects a truncated STRUCT ref list", () => {
+    const buf = bytes(1, K.KIND_STRUCT, 3, 0, 1); // declares 3 refs, only 2 present
+    expect(expectParseError(buf).error).toBeInstanceOf(TruncatedDataError);
+  });
+
+  describe("parseInlinePayload", () => {
+    it("parses a recursive inline STRUCT payload", () => {
+      const inline = bytes(K.KIND_STRUCT, 2, K.KIND_U8, K.KIND_U32);
+      const entry = parseInlinePayload(inline);
+      expect(entry.kind).toBe(K.KIND_STRUCT);
+      expect(entry.refs).toHaveLength(2);
+      // Inline refs are nested Entry objects, not numeric pool indices.
+      expect(typeof entry.refs[0]).toBe("object");
+      expect((entry.refs[0] as { kind: number }).kind).toBe(K.KIND_U8);
+    });
+
+    it("rejects trailing bytes in an inline payload", () => {
+      const inline = bytes(K.KIND_U8, 0xff);
+      let err: TypePoolDecoderThrow | undefined;
+      try {
+        parseInlinePayload(inline);
+      } catch (e) {
+        err = e as TypePoolDecoderThrow;
+      }
+      expect(err?.error).toBeInstanceOf(TrailingBytesError);
+    });
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/parsePool.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/parsePool.ts
@@ -1,0 +1,205 @@
+import * as K from "./kinds";
+import {
+  fail,
+  TrailingBytesError,
+  TruncatedDataError,
+  UnknownKindError,
+} from "./TypePoolDecoderError";
+import { type Entry, type Ref } from "./types";
+
+const textDecoder = new TextDecoder("utf-8");
+
+/**
+ * Cursor over a descriptor buffer with bounds-checked, self-advancing reads.
+ * Every read fails closed with a typed {@link TruncatedDataError}.
+ */
+class ByteReader {
+  constructor(
+    private readonly buffer: Uint8Array,
+    private offset = 0,
+  ) {}
+
+  private ensureAvailable(byteCount: number, context: string): void {
+    if (this.offset + byteCount > this.buffer.length) {
+      fail(new TruncatedDataError(context));
+    }
+  }
+
+  u8(context: string): number {
+    this.ensureAvailable(1, context);
+    return this.buffer[this.offset++]!;
+  }
+
+  u16be(context: string): number {
+    this.ensureAvailable(2, context);
+    const value =
+      (this.buffer[this.offset]! << 8) | this.buffer[this.offset + 1]!;
+    this.offset += 2;
+    return value;
+  }
+
+  take(byteCount: number, context: string): Uint8Array {
+    this.ensureAvailable(byteCount, context);
+    const slice = this.buffer.slice(this.offset, this.offset + byteCount);
+    this.offset += byteCount;
+    return slice;
+  }
+
+  get done(): boolean {
+    return this.offset >= this.buffer.length;
+  }
+
+  get remaining(): number {
+    return this.buffer.length - this.offset;
+  }
+}
+
+/** Reads the fields (everything past the kind byte) of one entry of a kind. */
+type EntryFieldsReader = (
+  reader: ByteReader,
+  readRef: () => Ref,
+) => Omit<Entry, "kind">;
+
+/**
+ * Per-kind field readers, keyed by kind byte. `readRef` yields a pool index in
+ * pool mode and a recursively-parsed nested {@link Entry} in inline mode — the
+ * only difference between the two parse modes, so one table serves both.
+ */
+const FIELD_READERS: ReadonlyMap<number, EntryFieldsReader> = (() => {
+  const readers = new Map<number, EntryFieldsReader>();
+  const leaf: EntryFieldsReader = () => ({ refs: [] });
+
+  // Scalar leaves carry no inline args.
+  for (const kind of K.PRIMITIVE_KINDS) readers.set(kind, leaf);
+  readers.set(K.KIND_BYTES_REMAINDER, leaf);
+
+  readers.set(K.KIND_BYTES_FIXED, (reader) => ({
+    refs: [],
+    fixedSize: reader.u16be("truncated BYTES_FIXED size"),
+  }));
+
+  readers.set(K.KIND_STRING_FIXED, (reader) => {
+    const fixedSize = reader.u16be("truncated STRING_FIXED size");
+    const encoding = reader.u8("truncated STRING_FIXED encoding");
+    return { refs: [], fixedSize, encoding };
+  });
+
+  readers.set(K.KIND_STRING_PREFIXED, (reader) => {
+    const lenKind = reader.u8("truncated STRING_PREFIXED len_kind");
+    const encoding = reader.u8("truncated STRING_PREFIXED encoding");
+    return { refs: [], lenKind, encoding };
+  });
+
+  const aggregate: EntryFieldsReader = (reader, readRef) => {
+    const fieldCount = reader.u8("truncated STRUCT/TUPLE count");
+    const refs: Ref[] = [];
+    for (let i = 0; i < fieldCount; i++) refs.push(readRef());
+    return { refs };
+  };
+  readers.set(K.KIND_STRUCT, aggregate);
+  readers.set(K.KIND_TUPLE, aggregate);
+
+  const option: EntryFieldsReader = (reader, readRef) => {
+    const flagKind = reader.u8("truncated OPTION_* flag_kind");
+    return { flagKind, refs: [readRef()] };
+  };
+  readers.set(K.KIND_OPTION_DYNAMIC, option);
+  readers.set(K.KIND_OPTION_FIXED, option);
+
+  readers.set(K.KIND_OPTION_ZEROABLE, (reader, readRef) => {
+    const inner = readRef();
+    const sentinelLen = reader.u8("truncated OPTION_ZEROABLE sentinel_len");
+    const sentinel = reader.take(
+      sentinelLen,
+      "truncated OPTION_ZEROABLE sentinel",
+    );
+    return { refs: [inner], sentinel };
+  });
+
+  readers.set(K.KIND_ARRAY_FIXED, (reader, readRef) => {
+    const fixedSize = reader.u16be("truncated ARRAY_FIXED count");
+    return { fixedSize, refs: [readRef()] };
+  });
+
+  readers.set(K.KIND_ARRAY_PREFIXED, (reader, readRef) => {
+    const lenKind = reader.u8("truncated ARRAY_PREFIXED len_kind");
+    return { lenKind, refs: [readRef()] };
+  });
+
+  const remainder: EntryFieldsReader = (_reader, readRef) => ({
+    refs: [readRef()],
+  });
+  readers.set(K.KIND_ARRAY_REMAINDER, remainder);
+  readers.set(K.KIND_OPTION_REMAINDER, remainder);
+
+  readers.set(K.KIND_ENUM, (reader) => {
+    const discKind = reader.u8("truncated ENUM disc_kind");
+    const totalVariants = reader.u16be("truncated ENUM total_variants");
+    const idLength = reader.u8("truncated ENUM enum_id_len");
+    const enumId = textDecoder.decode(
+      reader.take(idLength, "truncated ENUM enum_id"),
+    );
+    return { refs: [], discKind, totalVariants, enumId };
+  });
+
+  const hidden: EntryFieldsReader = (_reader, readRef) => {
+    const skip = readRef();
+    const inner = readRef();
+    return { refs: [skip, inner] };
+  };
+  readers.set(K.KIND_HIDDEN_PREFIX, hidden);
+  readers.set(K.KIND_HIDDEN_SUFFIX, hidden);
+
+  return readers;
+})();
+
+/**
+ * Parse a kind byte + its inline arguments from `reader`. When `inline` is
+ * true, every `*_ref` slot is a recursively-parsed descriptor (used inside
+ * `ENUM_VARIANT` payloads); otherwise refs are `u8` pool indices.
+ */
+function parseEntry(reader: ByteReader, inline: boolean): Entry {
+  const kind = reader.u8("truncated entry header");
+  const readFields = FIELD_READERS.get(kind);
+  if (readFields === undefined) {
+    fail(new UnknownKindError(kind));
+  }
+  const readRef = (): Ref =>
+    inline ? parseEntry(reader, true) : reader.u8("truncated ref");
+  return { kind, ...readFields(reader, readRef) };
+}
+
+/**
+ * Parse the `IDL_TYPE_POOL` TLV value into a list of {@link Entry}.
+ *
+ * The TLV value is `u8 count || entry_0 || ... || entry_{count-1}`.
+ *
+ * @throws never — wrap with the public `decode` entry points which return
+ * `Either`. Internally throws {@link TypePoolDecoderThrow}; do not call directly across
+ * a module boundary.
+ */
+export function parsePool(buffer: Uint8Array): Entry[] {
+  if (buffer.length === 0) {
+    fail(new TruncatedDataError("empty pool buffer"));
+  }
+  const reader = new ByteReader(buffer);
+  const entryCount = reader.u8("truncated pool count");
+  const entries: Entry[] = [];
+  for (let i = 0; i < entryCount; i++) {
+    entries.push(parseEntry(reader, false));
+  }
+  if (!reader.done) {
+    fail(new TrailingBytesError(reader.remaining, "pool"));
+  }
+  return entries;
+}
+
+/** Parse a self-contained inline variant-payload descriptor. */
+export function parseInlinePayload(buffer: Uint8Array): Entry {
+  const reader = new ByteReader(buffer);
+  const entry = parseEntry(reader, true);
+  if (!reader.done) {
+    fail(new TrailingBytesError(reader.remaining, "inline payload"));
+  }
+  return entry;
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/types.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/types.ts
@@ -1,0 +1,71 @@
+import {
+  type VARIANT_PAYLOAD_EMPTY,
+  type VARIANT_PAYLOAD_INLINE,
+  type VARIANT_PAYLOAD_RAW_SIZE,
+} from "./kinds";
+
+/**
+ * A `ref` slot in a parsed {@link Entry}: a numeric `u8` pool index for pool
+ * entries, or a nested {@link Entry} for inline ENUM_VARIANT payloads (which
+ * inline their descriptors instead of referencing the pool).
+ */
+export type Ref = number | Entry;
+
+/** Parsed view of a single type-pool entry (or inline variant payload). */
+export type Entry = {
+  kind: number;
+  refs: Ref[];
+  fixedSize?: number;
+  encoding?: number;
+  lenKind?: number;
+  flagKind?: number;
+  sentinel?: Uint8Array;
+  discKind?: number;
+  totalVariants?: number;
+  enumId?: string;
+};
+
+export type LeafValue = number | bigint | boolean | string | Uint8Array;
+
+/** A `(packedArgumentPath, value)` leaf emitted during a decode. */
+export type Leaf = {
+  /** Packed argument path: `u8 step_count || <packed kind-aware steps>`. */
+  path: Uint8Array;
+  value: LeafValue;
+};
+
+/** An `(enumId, variantIndex)` pair the instruction data selected. */
+export type SelectedEnumVariant = {
+  enumId: string;
+  variantIndex: number;
+};
+
+export type DecodeResult = {
+  leaves: Leaf[];
+  /** Selected variants in the order decoded; deduplication is the caller's concern. */
+  selectedEnumVariants: SelectedEnumVariant[];
+  /** Compare to `data.length` to detect under-/over-consumption. */
+  cursorEnd: number;
+};
+
+/**
+ * Decoded `ENUM_VARIANT` payload metadata:
+ * - `EMPTY`: no payload bytes follow the discriminator.
+ * - `INLINE`: payload is a parsed inline {@link Entry} the decoder recurses into.
+ * - `RAW_SIZE`: payload is an opaque byte count the decoder skips.
+ */
+export type VariantPayload =
+  | { kind: typeof VARIANT_PAYLOAD_EMPTY }
+  | { kind: typeof VARIANT_PAYLOAD_INLINE; payload: Entry }
+  | { kind: typeof VARIANT_PAYLOAD_RAW_SIZE; size: number };
+
+export type CachedVariant = {
+  variantName: string;
+} & VariantPayload;
+
+/** Keyed by {@link variantCacheKey} so lookups stay O(1) without a tuple key. */
+export type VariantCache = ReadonlyMap<string, CachedVariant>;
+
+export function variantCacheKey(enumId: string, variantIndex: number): string {
+  return `${enumId}:${variantIndex}`;
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/RequirementAccumulator.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/RequirementAccumulator.test.ts
@@ -1,0 +1,59 @@
+import { RequirementAccumulator } from "./RequirementAccumulator";
+
+describe("RequirementAccumulator", () => {
+  it("deduplicates each descriptor type by its key", () => {
+    const accumulator = new RequirementAccumulator();
+    accumulator.addInstructionInfo("P", "00");
+    accumulator.addInstructionInfo("P", "00");
+    accumulator.addEnumVariant("P", "e", 1);
+    accumulator.addEnumVariant("P", "e", 1);
+    accumulator.addTokenInfo("mint");
+    accumulator.addTokenInfo("mint");
+    accumulator.addTokenAccountState("ata");
+    accumulator.addTokenAccountState("ata");
+    accumulator.addAltResolution("ALT", 2);
+    accumulator.addAltResolution("ALT", 2);
+    accumulator.addTrustedName("name");
+    accumulator.addTrustedName("name");
+
+    const result = accumulator.build();
+    expect(result.instructionInfos).toHaveLength(1);
+    expect(result.enumVariants).toHaveLength(1);
+    expect(result.tokenInfos).toEqual(["mint"]);
+    expect(result.tokenAccountStates).toEqual(["ata"]);
+    expect(result.altResolutions).toEqual([
+      { altAddress: "ALT", entryIndex: 2 },
+    ]);
+    expect(result.trustedNames).toEqual(["name"]);
+  });
+
+  it("preserves first-seen insertion order", () => {
+    const accumulator = new RequirementAccumulator();
+    accumulator.addTokenInfo("c");
+    accumulator.addTokenInfo("a");
+    accumulator.addTokenInfo("b");
+    accumulator.addTokenInfo("a");
+    expect(accumulator.build().tokenInfos).toEqual(["c", "a", "b"]);
+  });
+
+  it("treats different keys of the same type as distinct", () => {
+    const accumulator = new RequirementAccumulator();
+    accumulator.addAltResolution("ALT", 1);
+    accumulator.addAltResolution("ALT", 2);
+    accumulator.addEnumVariant("P", "e", 1);
+    accumulator.addEnumVariant("P", "e", 2);
+    expect(accumulator.build().altResolutions).toHaveLength(2);
+    expect(accumulator.build().enumVariants).toHaveLength(2);
+  });
+
+  it("returns an empty set when nothing was added", () => {
+    expect(new RequirementAccumulator().build()).toEqual({
+      instructionInfos: [],
+      enumVariants: [],
+      tokenInfos: [],
+      tokenAccountStates: [],
+      altResolutions: [],
+      trustedNames: [],
+    });
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/RequirementAccumulator.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/RequirementAccumulator.ts
@@ -1,0 +1,83 @@
+import {
+  type AltEntryKey,
+  type DescriptorRequirements,
+  type EnumVariantKey,
+  type ProgramDiscriminator,
+} from "./model";
+
+/**
+ * Collects requirements while deduplicating by each descriptor's key and
+ * preserving first-seen order, so the output is deterministic.
+ */
+export class RequirementAccumulator {
+  private readonly instructionInfos = new OrderedSet<ProgramDiscriminator>();
+  private readonly enumVariants = new OrderedSet<EnumVariantKey>();
+  private readonly tokenInfos = new OrderedSet<string>();
+  private readonly tokenAccountStates = new OrderedSet<string>();
+  private readonly altResolutions = new OrderedSet<AltEntryKey>();
+  private readonly trustedNames = new OrderedSet<string>();
+
+  addInstructionInfo(programId: string, discriminator: string): void {
+    this.instructionInfos.add(`${programId}:${discriminator}`, {
+      programId,
+      discriminator,
+    });
+  }
+
+  addEnumVariant(
+    programId: string,
+    enumId: string,
+    variantIndex: number,
+  ): void {
+    this.enumVariants.add(`${programId}:${enumId}:${variantIndex}`, {
+      programId,
+      enumId,
+      variantIndex,
+    });
+  }
+
+  addTokenInfo(mint: string): void {
+    this.tokenInfos.add(mint, mint);
+  }
+
+  addTokenAccountState(account: string): void {
+    this.tokenAccountStates.add(account, account);
+  }
+
+  addAltResolution(altAddress: string, entryIndex: number): void {
+    this.altResolutions.add(`${altAddress}:${entryIndex}`, {
+      altAddress,
+      entryIndex,
+    });
+  }
+
+  addTrustedName(address: string): void {
+    this.trustedNames.add(address, address);
+  }
+
+  build(): DescriptorRequirements {
+    return {
+      instructionInfos: this.instructionInfos.values(),
+      enumVariants: this.enumVariants.values(),
+      tokenInfos: this.tokenInfos.values(),
+      tokenAccountStates: this.tokenAccountStates.values(),
+      altResolutions: this.altResolutions.values(),
+      trustedNames: this.trustedNames.values(),
+    };
+  }
+}
+
+class OrderedSet<T> {
+  private readonly seen = new Set<string>();
+  private readonly items: T[] = [];
+
+  add(key: string, item: T): void {
+    if (this.seen.has(key)) return;
+    this.seen.add(key);
+    this.items.push(item);
+  }
+
+  values(): T[] {
+    return [...this.items];
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/RequirementsError.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/RequirementsError.ts
@@ -1,0 +1,55 @@
+import { type DmkError } from "@ledgerhq/device-management-kit";
+
+/** Raised when a descriptor TLV runs past the end of its buffer. */
+export class TruncatedDescriptorError implements DmkError {
+  readonly _tag = "TruncatedDescriptorError";
+  readonly originalError: Error;
+
+  constructor(message: string) {
+    this.originalError = new Error(
+      `Truncated clear-sign descriptor: ${message}`,
+    );
+  }
+}
+
+/** Raised when an INSTRUCTION_INFO TLV lacks a mandatory field. */
+export class MissingInstructionFieldError implements DmkError {
+  readonly _tag = "MissingInstructionFieldError";
+  readonly originalError: Error;
+
+  constructor(field: string) {
+    this.originalError = new Error(
+      `INSTRUCTION_INFO is missing mandatory field: ${field}.`,
+    );
+  }
+}
+
+/** Raised when decoding the instruction data against the type pool fails. */
+export class RequirementsDecodeError implements DmkError {
+  readonly _tag = "RequirementsDecodeError";
+  readonly originalError: Error;
+
+  constructor(message: string) {
+    this.originalError = new Error(message);
+  }
+}
+
+export type RequirementsError =
+  | TruncatedDescriptorError
+  | MissingInstructionFieldError
+  | RequirementsDecodeError;
+
+/**
+ * Internal exception used to unwind the recursive TLV parsers; caught at the
+ * public boundary and surfaced as a `Left`. Never escapes the module.
+ */
+export class RequirementsThrow extends Error {
+  constructor(readonly error: RequirementsError) {
+    super(error.originalError.message);
+    this.name = "RequirementsThrow";
+  }
+}
+
+export function fail(error: RequirementsError): never {
+  throw new RequirementsThrow(error);
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/__tests__/fixtures/tlvBuilders.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/__tests__/fixtures/tlvBuilders.ts
@@ -1,0 +1,112 @@
+/**
+ * Byte-level builders for the CAL substructure / INSTRUCTION_INFO TLVs the
+ * requirement builder consumes. Deliberately dumb so tests pin exact bytes.
+ */
+
+export function bytes(...values: number[]): Uint8Array {
+  return Uint8Array.from(values);
+}
+
+export function concat(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+function derLength(length: number): Uint8Array {
+  if (length < 0x80) return bytes(length);
+  if (length <= 0xff) return bytes(0x81, length);
+  return bytes(0x82, (length >> 8) & 0xff, length & 0xff);
+}
+
+/** One DER-style `tag || length || value` record. */
+export function tlv(tag: number, value: Uint8Array): Uint8Array {
+  return concat(bytes(tag), derLength(value.length), value);
+}
+
+// ---- VALUE + TOKEN_VALUE --------------------------------------------------
+
+export function value(source: number, payload: Uint8Array): Uint8Array {
+  return concat(tlv(0x01, bytes(source)), tlv(0x02, payload));
+}
+
+export function tokenValue(
+  kind: number,
+  opts: { value?: Uint8Array; accountIndex?: number } = {},
+): Uint8Array {
+  const parts = [tlv(0x01, bytes(kind))];
+  if (opts.value) parts.push(tlv(0x02, opts.value));
+  if (opts.accountIndex !== undefined)
+    parts.push(tlv(0x03, bytes(opts.accountIndex)));
+  return concat(...parts);
+}
+
+// ---- substructure values --------------------------------------------------
+
+export function valueFlowPort(opts: {
+  /** Single candidate; convenience for the common single-account port. */
+  accountIndex?: number;
+  /** Ordered candidate list (overrides `accountIndex`); ACCOUNT_INDEX repeats. */
+  accountIndices?: number[];
+  /** `OPTIONAL_ACCOUNT_STRATEGY` byte (omitted when undefined). */
+  optionalAccountStrategy?: number;
+  tokenValue?: Uint8Array;
+}): Uint8Array {
+  const indices =
+    opts.accountIndices ??
+    (opts.accountIndex !== undefined ? [opts.accountIndex] : []);
+  const parts = indices.map((index) => tlv(0x02, bytes(index)));
+  if (opts.optionalAccountStrategy !== undefined)
+    parts.push(tlv(0x07, bytes(opts.optionalAccountStrategy)));
+  if (opts.tokenValue) parts.push(tlv(0x05, opts.tokenValue));
+  return concat(...parts);
+}
+
+export function accountReset(opts: {
+  accountIndex: number;
+  requirePreBalanceZero?: boolean;
+}): Uint8Array {
+  return concat(
+    tlv(0x01, bytes(opts.accountIndex)),
+    tlv(0x02, bytes(opts.requirePreBalanceZero ? 1 : 0)),
+  );
+}
+
+/** DISPLAY_FIELD with PARAM_TRUSTED_NAME (param type 0x07) wrapping a VALUE. */
+export function trustedNameDisplayField(valueBytes: Uint8Array): Uint8Array {
+  return concat(tlv(0x02, bytes(0x07)), tlv(0x03, tlv(0x01, valueBytes)));
+}
+
+/**
+ * DISPLAY_FIELD with PARAM_TOKEN_AMOUNT (param type 0x02). The TOKEN reference
+ * is a VALUE at PARAM tag 0x02; a sibling VALUE (tag 0x01) is included so the
+ * builder mirrors real descriptors.
+ */
+export function tokenAmountDisplayField(
+  tokenValueBytes: Uint8Array,
+): Uint8Array {
+  return concat(
+    tlv(0x02, bytes(0x02)),
+    tlv(
+      0x03,
+      concat(tlv(0x01, value(0x00, bytes(0))), tlv(0x02, tokenValueBytes)),
+    ),
+  );
+}
+
+export function instructionInfo(opts: {
+  typePool: Uint8Array;
+  rootType: number;
+  mintAssociations?: { accountIndex: number; mintIndex: number }[];
+}): Uint8Array {
+  const parts = [tlv(0x06, opts.typePool), tlv(0x07, bytes(opts.rootType))];
+  for (const { accountIndex, mintIndex } of opts.mintAssociations ?? []) {
+    parts.push(tlv(0x08, bytes(accountIndex)), tlv(0x09, bytes(mintIndex)));
+  }
+  return concat(...parts);
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/buildRequirements.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/buildRequirements.test.ts
@@ -1,0 +1,360 @@
+import { type Either, Right } from "purify-ts";
+
+import {
+  type SelectedEnumVariant,
+  type VariantCache,
+} from "@internal/app-binder/clear-sign/idl-type-pool";
+import { DefaultBs58Encoder } from "@internal/app-binder/services/bs58Encoder";
+
+import {
+  accountReset,
+  bytes,
+  instructionInfo,
+  tokenValue,
+  trustedNameDisplayField,
+  value,
+  valueFlowPort,
+} from "./__tests__/fixtures/tlvBuilders";
+import { buildRequirements } from "./buildRequirements";
+import {
+  type MatchedInstruction,
+  type RequirementAccount,
+  SubstructureKind,
+} from "./model";
+import { TokenKind, ValueSource } from "./records";
+import { MissingInstructionFieldError } from "./RequirementsError";
+import { type EnumVariantSelector } from "./rules";
+
+const EMPTY_CACHE: VariantCache = new Map();
+const NO_ENUMS: EnumVariantSelector = () => Right([]);
+
+function account(
+  address?: string,
+  altRef?: RequirementAccount["altRef"],
+): RequirementAccount {
+  return { address, altRef };
+}
+
+function port(
+  kind: TokenKind,
+  opts: {
+    accountIndex?: number;
+    tokenAccountIndex?: number;
+    value?: Uint8Array;
+  } = {},
+) {
+  return {
+    kind: SubstructureKind.VALUE_FLOW_PORT,
+    data: valueFlowPort({
+      accountIndex: opts.accountIndex ?? 0,
+      tokenValue: tokenValue(kind, {
+        accountIndex: opts.tokenAccountIndex,
+        value: opts.value,
+      }),
+    }),
+  };
+}
+
+function matched(opts: {
+  programId?: string;
+  discriminator?: string;
+  accounts: RequirementAccount[];
+  data?: Uint8Array;
+  typePool?: Uint8Array;
+  rootType?: number;
+  mintAssociations?: { accountIndex: number; mintIndex: number }[];
+  substructures?: { kind: SubstructureKind; data: Uint8Array }[];
+  enumCache?: VariantCache;
+}): MatchedInstruction {
+  return {
+    instruction: {
+      programId: opts.programId ?? "Prog",
+      accounts: opts.accounts,
+      data: opts.data ?? new Uint8Array(),
+    },
+    descriptor: {
+      discriminator: opts.discriminator ?? "00",
+      instructionInfo: instructionInfo({
+        typePool: opts.typePool ?? bytes(0x00),
+        rootType: opts.rootType ?? 0,
+        mintAssociations: opts.mintAssociations,
+      }),
+      substructures: opts.substructures ?? [],
+      enumCache: opts.enumCache ?? EMPTY_CACHE,
+    },
+  };
+}
+
+function run(matchedList: MatchedInstruction[], selector = NO_ENUMS) {
+  return buildRequirements(matchedList, {
+    selectEnumVariants: selector,
+  }).unsafeCoerce();
+}
+
+describe("buildRequirements", () => {
+  it("System transfer: only INSTRUCTION_INFO, native port pulls no token info", () => {
+    const result = run([
+      matched({
+        programId: "11111111111111111111111111111111",
+        discriminator: "02000000",
+        accounts: [account("from"), account("to")],
+        substructures: [port(TokenKind.NATIVE, { accountIndex: 0 })],
+      }),
+    ]);
+    expect(result.instructionInfos).toEqual([
+      {
+        programId: "11111111111111111111111111111111",
+        discriminator: "02000000",
+      },
+    ]);
+    expect(result.tokenInfos).toEqual([]);
+    expect(result.tokenAccountStates).toEqual([]);
+  });
+
+  it("DIRECT port: a constant mint becomes a TOKEN_INFO", () => {
+    const mintBytes = new Uint8Array(32).fill(9);
+    const result = run([
+      matched({
+        accounts: [account("a")],
+        substructures: [
+          port(TokenKind.DIRECT, {
+            value: value(ValueSource.CONSTANT, mintBytes),
+          }),
+        ],
+      }),
+    ]);
+    expect(result.tokenInfos).toEqual([DefaultBs58Encoder.encode(mintBytes)]);
+  });
+
+  it("DIRECT port: an ACCOUNT_PATH mint resolves to the account address", () => {
+    const result = run([
+      matched({
+        accounts: [account("tokenAcct"), account("theMint")],
+        substructures: [
+          port(TokenKind.DIRECT, {
+            value: value(ValueSource.ACCOUNT_PATH, bytes(1)),
+          }),
+        ],
+      }),
+    ]);
+    expect(result.tokenInfos).toEqual(["theMint"]);
+  });
+
+  it("RESOLVE port not covered by MINT_ASSOC: sends TOKEN_ACCOUNT_STATE", () => {
+    const result = run([
+      matched({
+        accounts: [account("userAta")],
+        substructures: [
+          port(TokenKind.RESOLVE, { accountIndex: 0, tokenAccountIndex: 0 }),
+        ],
+      }),
+    ]);
+    expect(result.tokenAccountStates).toEqual(["userAta"]);
+    expect(result.tokenInfos).toEqual([]);
+  });
+
+  it("RESOLVE port covered by MINT_ASSOC: emits TOKEN_INFO, skips account-state", () => {
+    const result = run([
+      matched({
+        accounts: [account("createdAta"), account("theMint")],
+        mintAssociations: [{ accountIndex: 0, mintIndex: 1 }],
+        substructures: [
+          port(TokenKind.RESOLVE, { accountIndex: 0, tokenAccountIndex: 0 }),
+        ],
+      }),
+    ]);
+    expect(result.tokenAccountStates).toEqual([]);
+    expect(result.tokenInfos).toEqual(["theMint"]);
+  });
+
+  it("NULL port pulls no token requirements", () => {
+    const result = run([
+      matched({
+        accounts: [account("x")],
+        substructures: [port(TokenKind.NULL)],
+      }),
+    ]);
+    expect(result.tokenInfos).toEqual([]);
+    expect(result.tokenAccountStates).toEqual([]);
+  });
+
+  it("ACCOUNT_RESET with requirePreBalanceZero forces a TOKEN_ACCOUNT_STATE", () => {
+    const result = run([
+      matched({
+        accounts: [account("ata")],
+        substructures: [
+          {
+            kind: SubstructureKind.ACCOUNT_RESET,
+            data: accountReset({
+              accountIndex: 0,
+              requirePreBalanceZero: true,
+            }),
+          },
+        ],
+      }),
+    ]);
+    expect(result.tokenAccountStates).toEqual(["ata"]);
+  });
+
+  it("ACCOUNT_RESET without the flag adds nothing", () => {
+    const result = run([
+      matched({
+        accounts: [account("ata")],
+        substructures: [
+          {
+            kind: SubstructureKind.ACCOUNT_RESET,
+            data: accountReset({ accountIndex: 0 }),
+          },
+        ],
+      }),
+    ]);
+    expect(result.tokenAccountStates).toEqual([]);
+  });
+
+  it("emits ALT_RESOLUTION for ALT-supplied accounts only", () => {
+    const result = run([
+      matched({
+        accounts: [
+          account("staticKey"),
+          account(undefined, { altAddress: "ALT", entryIndex: 3 }),
+        ],
+      }),
+    ]);
+    expect(result.altResolutions).toEqual([
+      { altAddress: "ALT", entryIndex: 3 },
+    ]);
+  });
+
+  it("emits TRUSTED_NAME for PARAM_TRUSTED_NAME fields (account path + constant)", () => {
+    const constantAddr = new Uint8Array(32).fill(5);
+    const result = run([
+      matched({
+        accounts: [account("ignored"), account("namedAccount")],
+        substructures: [
+          {
+            kind: SubstructureKind.DISPLAY_FIELD,
+            data: trustedNameDisplayField(
+              value(ValueSource.ACCOUNT_PATH, bytes(1)),
+            ),
+          },
+          {
+            kind: SubstructureKind.DISPLAY_FIELD,
+            data: trustedNameDisplayField(
+              value(ValueSource.CONSTANT, constantAddr),
+            ),
+          },
+        ],
+      }),
+    ]);
+    expect(result.trustedNames).toEqual([
+      "namedAccount",
+      DefaultBs58Encoder.encode(constantAddr),
+    ]);
+  });
+
+  it("decodes selected enum variants via the default decoder", () => {
+    // pool: [0] STRUCT{ref 1}, [1] ENUM disc=U8 enum_id="k"; data selects variant 2.
+    const typePool = bytes(
+      2,
+      0x20,
+      0x01,
+      0x01,
+      0x28,
+      0x01,
+      0x00,
+      0x01,
+      0x01,
+      0x6b,
+    );
+    const result = buildRequirements([
+      matched({
+        programId: "P",
+        accounts: [],
+        data: bytes(2),
+        typePool,
+        rootType: 0,
+      }),
+    ]).unsafeCoerce();
+    expect(result.enumVariants).toEqual([
+      { programId: "P", enumId: "k", variantIndex: 2 },
+    ]);
+  });
+
+  it("deduplicates across instructions and stays deterministic", () => {
+    const usdc = new Uint8Array(32).fill(1);
+    const direct = () =>
+      matched({
+        programId: "P",
+        discriminator: "01",
+        accounts: [account("a")],
+        substructures: [
+          port(TokenKind.DIRECT, { value: value(ValueSource.CONSTANT, usdc) }),
+        ],
+      });
+    const result = run([direct(), direct()]);
+    expect(result.instructionInfos).toEqual([
+      { programId: "P", discriminator: "01" },
+    ]);
+    expect(result.tokenInfos).toEqual([DefaultBs58Encoder.encode(usdc)]);
+  });
+
+  it("Jupiter-like route: enum + two token infos + ALT entry", () => {
+    const inMint = new Uint8Array(32).fill(2);
+    const outMint = new Uint8Array(32).fill(3);
+    const selector: EnumVariantSelector = () =>
+      Right([{ enumId: "swap", variantIndex: 46 }] as SelectedEnumVariant[]);
+    const result = run(
+      [
+        matched({
+          programId: "JUP",
+          discriminator: "e517cb977ae3ad2a",
+          accounts: [
+            account("inputAta"),
+            account("outputAta"),
+            account(undefined, { altAddress: "ALT", entryIndex: 7 }),
+          ],
+          substructures: [
+            port(TokenKind.DIRECT, {
+              accountIndex: 0,
+              value: value(ValueSource.CONSTANT, inMint),
+            }),
+            port(TokenKind.DIRECT, {
+              accountIndex: 1,
+              value: value(ValueSource.CONSTANT, outMint),
+            }),
+          ],
+        }),
+      ],
+      selector,
+    );
+    expect(result.enumVariants).toEqual([
+      { programId: "JUP", enumId: "swap", variantIndex: 46 },
+    ]);
+    expect(result.tokenInfos).toEqual([
+      DefaultBs58Encoder.encode(inMint),
+      DefaultBs58Encoder.encode(outMint),
+    ]);
+    expect(result.altResolutions).toEqual([
+      { altAddress: "ALT", entryIndex: 7 },
+    ]);
+  });
+
+  it("surfaces a malformed INSTRUCTION_INFO as a typed Left", () => {
+    const broken: MatchedInstruction = {
+      instruction: { programId: "P", accounts: [], data: new Uint8Array() },
+      descriptor: {
+        discriminator: "00",
+        instructionInfo: bytes(0x07, 0x01, 0x00), // root type only, no type pool
+        substructures: [],
+        enumCache: EMPTY_CACHE,
+      },
+    };
+    const result: Either<unknown, unknown> = buildRequirements([broken], {
+      selectEnumVariants: NO_ENUMS,
+    });
+    expect(result.isLeft()).toBe(true);
+    result.ifLeft((error) =>
+      expect(error).toBeInstanceOf(MissingInstructionFieldError),
+    );
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/buildRequirements.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/buildRequirements.ts
@@ -1,0 +1,117 @@
+import { type Either, Left, Right } from "purify-ts";
+
+import { findSelectedEnumVariants } from "@internal/app-binder/clear-sign/idl-type-pool";
+import {
+  type Bs58Encoder,
+  DefaultBs58Encoder,
+} from "@internal/app-binder/services/bs58Encoder";
+
+import { type DescriptorRequirements, type MatchedInstruction } from "./model";
+import { parseInstructionDescriptor } from "./parseInstruction";
+import { type ParsedInstruction } from "./records";
+import { RequirementAccumulator } from "./RequirementAccumulator";
+import {
+  RequirementsDecodeError,
+  type RequirementsError,
+  RequirementsThrow,
+} from "./RequirementsError";
+import {
+  applyAltResolutionRule,
+  applyEnumVariantRule,
+  applyInstructionInfoRule,
+  applyTokenRule,
+  applyTrustedNameRule,
+  type EnumVariantSelector,
+} from "./rules";
+
+export type BuildRequirementsOptions = {
+  /** Enum-variant decoder; defaults to the real type-pool decoder. */
+  selectEnumVariants?: EnumVariantSelector;
+  /** Base58 encoder for pubkey constants; defaults to {@link DefaultBs58Encoder}. */
+  bs58Encoder?: Bs58Encoder;
+};
+
+/** TX-derived `MINT_ASSOC` bindings: token-account address → mint address. */
+function buildMintBindings(
+  matched: MatchedInstruction[],
+  parsed: ParsedInstruction[],
+): Map<string, string> {
+  const bindings = new Map<string, string>();
+  matched.forEach((match, index) => {
+    const { accounts } = match.instruction;
+    for (const { accountIndex, mintIndex } of parsed[index]!.info
+      .mintAssociations) {
+      const account = accounts[accountIndex]?.address;
+      const mint = accounts[mintIndex]?.address;
+      if (account !== undefined && mint !== undefined) {
+        bindings.set(account, mint);
+      }
+    }
+  });
+  return bindings;
+}
+
+/**
+ * Given every TX instruction matched to its CAL descriptor, compute the
+ * deduplicated set of extra descriptors the device must fetch. Pure and
+ * deterministic; malformed descriptors surface as a typed
+ * {@link RequirementsError} `Left`.
+ */
+export function buildRequirements(
+  matched: MatchedInstruction[],
+  options: BuildRequirementsOptions = {},
+): Either<RequirementsError, DescriptorRequirements> {
+  const selectEnumVariants =
+    options.selectEnumVariants ?? findSelectedEnumVariants;
+  const bs58Encoder = options.bs58Encoder ?? DefaultBs58Encoder;
+  try {
+    const accumulator = new RequirementAccumulator();
+    const instructions = matched.map((match) => ({
+      match,
+      records: parseInstructionDescriptor(match.descriptor),
+    }));
+    const mintBindings = buildMintBindings(
+      matched,
+      instructions.map(({ records }) => records),
+    );
+
+    for (const { match, records } of instructions) {
+      applyInstructionInfoRule(match, accumulator);
+
+      const decodeFailure = applyEnumVariantRule(
+        match,
+        accumulator,
+        selectEnumVariants,
+        records.info.typePool,
+        records.info.rootType,
+      ).extract();
+      if (decodeFailure) return Left(decodeFailure);
+
+      applyTokenRule(
+        records,
+        match.instruction,
+        mintBindings,
+        accumulator,
+        bs58Encoder,
+      );
+      applyAltResolutionRule(match.instruction, accumulator);
+      applyTrustedNameRule(
+        records,
+        match.instruction,
+        accumulator,
+        bs58Encoder,
+      );
+    }
+
+    return Right(accumulator.build());
+  } catch (error) {
+    if (error instanceof RequirementsThrow) {
+      return Left(error.error);
+    }
+    return Left(
+      new RequirementsDecodeError(
+        error instanceof Error ? error.message : String(error),
+      ),
+    );
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/descriptorTlv.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/descriptorTlv.test.ts
@@ -1,0 +1,53 @@
+import { bytes, tlv } from "./__tests__/fixtures/tlvBuilders";
+import { firstTag, firstU8, readTlvEntries } from "./descriptorTlv";
+import {
+  RequirementsThrow,
+  TruncatedDescriptorError,
+} from "./RequirementsError";
+
+describe("readTlvEntries", () => {
+  it("parses sequential records in order", () => {
+    const buffer = bytes(0x01, 0x01, 0xaa, 0x02, 0x02, 0xbb, 0xcc);
+    const entries = readTlvEntries(buffer);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({ tag: 0x01 });
+    expect(Array.from(entries[1]!.value)).toEqual([0xbb, 0xcc]);
+  });
+
+  it("decodes DER extended lengths (> 127 bytes)", () => {
+    const value = new Uint8Array(200).fill(0x07);
+    const entries = readTlvEntries(tlv(0x09, value));
+    expect(entries[0]!.value).toHaveLength(200);
+  });
+
+  it("throws a typed error on a truncated value", () => {
+    let caught: unknown;
+    try {
+      readTlvEntries(bytes(0x01, 0x05, 0x00)); // claims 5, has 1
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(RequirementsThrow);
+    expect((caught as RequirementsThrow).error).toBeInstanceOf(
+      TruncatedDescriptorError,
+    );
+  });
+});
+
+describe("firstTag / firstU8", () => {
+  it("returns the first matching value or undefined", () => {
+    const entries = readTlvEntries(concatRecords());
+    expect(Array.from(firstTag(entries, 0x02)!)).toEqual([0x42]);
+    expect(firstTag(entries, 0x99)).toBeUndefined();
+  });
+
+  it("firstU8 returns the first byte or undefined", () => {
+    const entries = readTlvEntries(concatRecords());
+    expect(firstU8(entries, 0x02)).toBe(0x42);
+    expect(firstU8(entries, 0x99)).toBeUndefined();
+  });
+});
+
+function concatRecords(): Uint8Array {
+  return Uint8Array.from([0x01, 0x01, 0x10, 0x02, 0x01, 0x42]);
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/descriptorTlv.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/descriptorTlv.ts
@@ -1,0 +1,28 @@
+import {
+  readTlvEntries as readTlvEntriesRaw,
+  type TlvEntry,
+  TlvParseError,
+} from "@internal/app-binder/clear-sign/tlv";
+
+import { fail, TruncatedDescriptorError } from "./RequirementsError";
+
+export {
+  firstTag,
+  firstU8,
+  type TlvEntry,
+} from "@internal/app-binder/clear-sign/tlv";
+
+/**
+ * {@link readTlvEntriesRaw} wrapped to surface malformed framing as the
+ * requirement builder's own typed {@link TruncatedDescriptorError}.
+ */
+export function readTlvEntries(buffer: Uint8Array): TlvEntry[] {
+  try {
+    return readTlvEntriesRaw(buffer);
+  } catch (error) {
+    if (error instanceof TlvParseError) {
+      fail(new TruncatedDescriptorError(error.message));
+    }
+    throw error;
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/index.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/index.ts
@@ -1,0 +1,45 @@
+export {
+  buildRequirements,
+  type BuildRequirementsOptions,
+} from "./buildRequirements";
+export {
+  type AltEntryKey,
+  type DescriptorRequirements,
+  type EnumVariantKey,
+  type InstructionDescriptor,
+  type MatchedInstruction,
+  type ProgramDiscriminator,
+  type RequirementAccount,
+  type RequirementInstruction,
+  type SubstructureDescriptor,
+  SubstructureKind,
+} from "./model";
+export { parseInstructionDescriptor } from "./parseInstruction";
+export {
+  parseAccountReset,
+  parseDisplayField,
+  parseInstructionInfo,
+  parseValueFlowPort,
+} from "./parseSubstructures";
+export {
+  type MintAssociation,
+  OptionalAccountStrategy,
+  PARAM_TYPE_TOKEN_AMOUNT,
+  PARAM_TYPE_TRUSTED_NAME,
+  type ParsedAccountReset,
+  type ParsedDisplayField,
+  type ParsedInstruction,
+  type ParsedInstructionInfo,
+  type ParsedTokenValue,
+  type ParsedValue,
+  type ParsedValueFlowPort,
+  TokenKind,
+  ValueSource,
+} from "./records";
+export {
+  MissingInstructionFieldError,
+  RequirementsDecodeError,
+  type RequirementsError,
+  TruncatedDescriptorError,
+} from "./RequirementsError";
+export { type EnumVariantSelector } from "./rules";

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/model.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/model.ts
@@ -1,0 +1,69 @@
+import { type VariantCache } from "@internal/app-binder/clear-sign/idl-type-pool";
+
+/** Kind byte tagging an INSTRUCTION_INFO substructure descriptor. */
+export enum SubstructureKind {
+  DISPLAY_FIELD = 0x00,
+  VALUE_FLOW_PORT = 0x01,
+  HIDE_RULE = 0x02,
+  ACCOUNT_RESET = 0x03,
+}
+
+/** A `(altAddress, entryIndex)` reference into an Address Lookup Table. */
+export type AltEntryKey = { altAddress: string; entryIndex: number };
+
+/**
+ * One account slot of an instruction. `address` is the resolved base58 key;
+ * it is `undefined` for ALT-supplied slots that are not resolved at
+ * requirement-build time (DMK does not talk to RPC) — those still carry an
+ * `altRef` so an `ALT_RESOLUTION` requirement can be emitted.
+ */
+export type RequirementAccount = {
+  address?: string;
+  altRef?: AltEntryKey;
+};
+
+export type RequirementInstruction = {
+  programId: string;
+  accounts: RequirementAccount[];
+  data: Uint8Array;
+};
+
+/** One substructure descriptor as delivered by CAL (opaque TLV bytes). */
+export type SubstructureDescriptor = {
+  kind: SubstructureKind;
+  data: Uint8Array;
+};
+
+/** The matched CAL descriptor for one instruction. */
+export type InstructionDescriptor = {
+  discriminator: string;
+  instructionInfo: Uint8Array;
+  substructures: SubstructureDescriptor[];
+  enumCache: VariantCache;
+};
+
+/** A transaction instruction paired with its matched CAL descriptor. */
+export type MatchedInstruction = {
+  instruction: RequirementInstruction;
+  descriptor: InstructionDescriptor;
+};
+
+// ---- output ---------------------------------------------------------------
+
+export type ProgramDiscriminator = { programId: string; discriminator: string };
+
+export type EnumVariantKey = {
+  programId: string;
+  enumId: string;
+  variantIndex: number;
+};
+
+/** The deduplicated set of descriptors the device needs, per descriptor type. */
+export type DescriptorRequirements = {
+  instructionInfos: ProgramDiscriminator[];
+  enumVariants: EnumVariantKey[];
+  tokenInfos: string[];
+  tokenAccountStates: string[];
+  altResolutions: AltEntryKey[];
+  trustedNames: string[];
+};

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/parseInstruction.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/parseInstruction.test.ts
@@ -1,0 +1,80 @@
+import {
+  accountReset,
+  bytes,
+  instructionInfo,
+  tokenValue,
+  trustedNameDisplayField,
+  value,
+  valueFlowPort,
+} from "./__tests__/fixtures/tlvBuilders";
+import { type InstructionDescriptor, SubstructureKind } from "./model";
+import { parseInstructionDescriptor } from "./parseInstruction";
+import { TokenKind } from "./records";
+
+function descriptor(
+  substructures: { kind: SubstructureKind; data: Uint8Array }[],
+): InstructionDescriptor {
+  return {
+    discriminator: "00",
+    instructionInfo: instructionInfo({ typePool: bytes(0x00), rootType: 0 }),
+    substructures,
+    enumCache: new Map(),
+  };
+}
+
+describe("parseInstructionDescriptor", () => {
+  it("groups substructures by kind", () => {
+    const parsed = parseInstructionDescriptor(
+      descriptor([
+        {
+          kind: SubstructureKind.VALUE_FLOW_PORT,
+          data: valueFlowPort({
+            accountIndex: 0,
+            tokenValue: tokenValue(TokenKind.NATIVE),
+          }),
+        },
+        {
+          kind: SubstructureKind.ACCOUNT_RESET,
+          data: accountReset({ accountIndex: 1, requirePreBalanceZero: true }),
+        },
+        {
+          kind: SubstructureKind.DISPLAY_FIELD,
+          data: trustedNameDisplayField(value(0x01, bytes(2))),
+        },
+      ]),
+    );
+    expect(parsed.valueFlowPorts).toHaveLength(1);
+    expect(parsed.accountResets).toHaveLength(1);
+    expect(parsed.displayFields).toHaveLength(1);
+  });
+
+  it("ignores HIDE_RULE substructures (out of scope here)", () => {
+    const parsed = parseInstructionDescriptor(
+      descriptor([
+        { kind: SubstructureKind.HIDE_RULE, data: bytes(0x01, 0x01, 0x00) },
+      ]),
+    );
+    expect(parsed.valueFlowPorts).toEqual([]);
+    expect(parsed.accountResets).toEqual([]);
+    expect(parsed.displayFields).toEqual([]);
+  });
+
+  it("keeps multiple substructures of the same kind in order", () => {
+    const parsed = parseInstructionDescriptor(
+      descriptor([
+        {
+          kind: SubstructureKind.VALUE_FLOW_PORT,
+          data: valueFlowPort({ accountIndex: 0 }),
+        },
+        {
+          kind: SubstructureKind.VALUE_FLOW_PORT,
+          data: valueFlowPort({ accountIndex: 1 }),
+        },
+      ]),
+    );
+    expect(parsed.valueFlowPorts.map((port) => port.accountIndices)).toEqual([
+      [0],
+      [1],
+    ]);
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/parseInstruction.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/parseInstruction.ts
@@ -1,0 +1,42 @@
+import { type InstructionDescriptor, SubstructureKind } from "./model";
+import {
+  parseAccountReset,
+  parseDisplayField,
+  parseInstructionInfo,
+  parseValueFlowPort,
+} from "./parseSubstructures";
+import { type ParsedInstruction } from "./records";
+
+/**
+ * Parse a matched CAL descriptor's INSTRUCTION_INFO and substructure TLVs into
+ * structured records grouped by kind. HIDE_RULE substructures are ignored —
+ * they only drive post-resolution witness logic, out of scope here.
+ */
+export function parseInstructionDescriptor(
+  descriptor: InstructionDescriptor,
+): ParsedInstruction {
+  const parsed: ParsedInstruction = {
+    info: parseInstructionInfo(descriptor.instructionInfo),
+    valueFlowPorts: [],
+    accountResets: [],
+    displayFields: [],
+  };
+
+  for (const { kind, data } of descriptor.substructures) {
+    switch (kind) {
+      case SubstructureKind.VALUE_FLOW_PORT:
+        parsed.valueFlowPorts.push(parseValueFlowPort(data));
+        break;
+      case SubstructureKind.ACCOUNT_RESET:
+        parsed.accountResets.push(parseAccountReset(data));
+        break;
+      case SubstructureKind.DISPLAY_FIELD:
+        parsed.displayFields.push(parseDisplayField(data));
+        break;
+      default:
+        break;
+    }
+  }
+
+  return parsed;
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/parseSubstructures.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/parseSubstructures.test.ts
@@ -1,0 +1,151 @@
+import {
+  accountReset,
+  bytes,
+  instructionInfo,
+  tokenAmountDisplayField,
+  tokenValue,
+  trustedNameDisplayField,
+  value,
+  valueFlowPort,
+} from "./__tests__/fixtures/tlvBuilders";
+import {
+  parseAccountReset,
+  parseDisplayField,
+  parseInstructionInfo,
+  parseValueFlowPort,
+} from "./parseSubstructures";
+import {
+  PARAM_TYPE_TOKEN_AMOUNT,
+  PARAM_TYPE_TRUSTED_NAME,
+  TokenKind,
+  ValueSource,
+} from "./records";
+import {
+  MissingInstructionFieldError,
+  type RequirementsThrow,
+} from "./RequirementsError";
+
+describe("parseInstructionInfo", () => {
+  it("extracts type pool, root type and MINT_ASSOC pairs", () => {
+    const parsed = parseInstructionInfo(
+      instructionInfo({
+        typePool: bytes(0x01, 0x11),
+        rootType: 3,
+        mintAssociations: [{ accountIndex: 1, mintIndex: 4 }],
+      }),
+    );
+    expect(Array.from(parsed.typePool)).toEqual([0x01, 0x11]);
+    expect(parsed.rootType).toBe(3);
+    expect(parsed.mintAssociations).toEqual([
+      { accountIndex: 1, mintIndex: 4 },
+    ]);
+  });
+
+  it("fails when IDL_TYPE_POOL is missing", () => {
+    let caught: unknown;
+    try {
+      parseInstructionInfo(bytes(0x07, 0x01, 0x00)); // only root type
+    } catch (error) {
+      caught = error;
+    }
+    expect((caught as RequirementsThrow).error).toBeInstanceOf(
+      MissingInstructionFieldError,
+    );
+  });
+});
+
+describe("parseValueFlowPort", () => {
+  it("parses a RESOLVE port with an explicit token account index", () => {
+    const parsed = parseValueFlowPort(
+      valueFlowPort({
+        accountIndex: 2,
+        tokenValue: tokenValue(TokenKind.RESOLVE, { accountIndex: 5 }),
+      }),
+    );
+    expect(parsed.accountIndices).toEqual([2]);
+    expect(parsed.tokenValue).toMatchObject({
+      kind: TokenKind.RESOLVE,
+      accountIndex: 5,
+    });
+  });
+
+  it("collects a repeated ACCOUNT_INDEX into an ordered candidate list and reads the strategy", () => {
+    const parsed = parseValueFlowPort(
+      valueFlowPort({
+        accountIndices: [3, 7, 1],
+        optionalAccountStrategy: 0x01,
+      }),
+    );
+    expect(parsed.accountIndices).toEqual([3, 7, 1]);
+    expect(parsed.optionalAccountStrategy).toBe(0x01);
+  });
+
+  it("defaults a single-account port to the PROGRAM_ID strategy", () => {
+    const parsed = parseValueFlowPort(valueFlowPort({ accountIndex: 2 }));
+    expect(parsed.accountIndices).toEqual([2]);
+    expect(parsed.optionalAccountStrategy).toBe(0x00);
+  });
+
+  it("parses a DIRECT port with a constant mint", () => {
+    const mint = new Uint8Array(32).fill(7);
+    const parsed = parseValueFlowPort(
+      valueFlowPort({
+        accountIndex: 0,
+        tokenValue: tokenValue(TokenKind.DIRECT, {
+          value: value(ValueSource.CONSTANT, mint),
+        }),
+      }),
+    );
+    expect(parsed.tokenValue?.kind).toBe(TokenKind.DIRECT);
+    expect(parsed.tokenValue?.value).toMatchObject({
+      source: ValueSource.CONSTANT,
+    });
+    expect(parsed.tokenValue?.value?.payload).toHaveLength(32);
+  });
+
+  it("parses a NATIVE port with no value", () => {
+    const parsed = parseValueFlowPort(
+      valueFlowPort({
+        accountIndex: 1,
+        tokenValue: tokenValue(TokenKind.NATIVE),
+      }),
+    );
+    expect(parsed.tokenValue).toMatchObject({ kind: TokenKind.NATIVE });
+    expect(parsed.tokenValue?.value).toBeUndefined();
+  });
+});
+
+describe("parseAccountReset", () => {
+  it("reads the account index and the pre-balance-zero flag", () => {
+    expect(
+      parseAccountReset(
+        accountReset({ accountIndex: 4, requirePreBalanceZero: true }),
+      ),
+    ).toEqual({ accountIndex: 4, requirePreBalanceZero: true });
+    expect(parseAccountReset(accountReset({ accountIndex: 1 }))).toEqual({
+      accountIndex: 1,
+      requirePreBalanceZero: false,
+    });
+  });
+});
+
+describe("parseDisplayField", () => {
+  it("parses a trusted-name field's inner VALUE", () => {
+    const parsed = parseDisplayField(
+      trustedNameDisplayField(value(ValueSource.ACCOUNT_PATH, bytes(6))),
+    );
+    expect(parsed.paramType).toBe(PARAM_TYPE_TRUSTED_NAME);
+    expect(parsed.value).toMatchObject({ source: ValueSource.ACCOUNT_PATH });
+    expect(Array.from(parsed.value!.payload)).toEqual([6]);
+    expect(parsed.token).toBeUndefined();
+  });
+
+  it("parses a token-amount field's TOKEN reference (PARAM tag 0x02)", () => {
+    const parsed = parseDisplayField(
+      tokenAmountDisplayField(value(ValueSource.ACCOUNT_PATH, bytes(4))),
+    );
+    expect(parsed.paramType).toBe(PARAM_TYPE_TOKEN_AMOUNT);
+    expect(parsed.token).toMatchObject({ source: ValueSource.ACCOUNT_PATH });
+    expect(Array.from(parsed.token!.payload)).toEqual([4]);
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/parseSubstructures.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/parseSubstructures.ts
@@ -1,0 +1,167 @@
+import {
+  firstTag,
+  firstU8,
+  readTlvEntries,
+  type TlvEntry,
+} from "./descriptorTlv";
+import {
+  type MintAssociation,
+  OptionalAccountStrategy,
+  PARAM_TYPE_TOKEN_AMOUNT,
+  type ParsedAccountReset,
+  type ParsedDisplayField,
+  type ParsedInstructionInfo,
+  type ParsedTokenValue,
+  type ParsedValue,
+  type ParsedValueFlowPort,
+  type TokenKind,
+  type ValueSource,
+} from "./records";
+import { fail, MissingInstructionFieldError } from "./RequirementsError";
+
+const InstructionInfoTag = {
+  IDL_TYPE_POOL: 0x06,
+  IDL_ROOT_TYPE: 0x07,
+  MINT_ASSOC_ACCOUNT: 0x08,
+  MINT_ASSOC_MINT: 0x09,
+} as const;
+
+const ValueFlowPortTag = {
+  // ACCOUNT_INDEX MAY repeat to form an ordered candidate list.
+  ACCOUNT_INDEX: 0x02,
+  TOKEN_VALUE: 0x05,
+  OPTIONAL_ACCOUNT_STRATEGY: 0x07,
+} as const;
+
+const TokenValueTag = {
+  KIND: 0x01,
+  VALUE: 0x02,
+  ACCOUNT: 0x03,
+} as const;
+
+const ValueTag = {
+  SOURCE: 0x01,
+  PAYLOAD: 0x02,
+} as const;
+
+const DisplayFieldTag = {
+  PARAM_TYPE: 0x02,
+  PARAM: 0x03,
+} as const;
+
+// The VALUE tag is `0x01` inside every PARAM_* substructure.
+const PARAM_VALUE_TAG = 0x01;
+
+// `PARAM_TOKEN_AMOUNT.TOKEN` (the token reference) lives at tag `0x02`.
+const PARAM_TOKEN_AMOUNT_TOKEN_TAG = 0x02;
+
+/** Collect the leading byte of every entry carrying `tag` (for repeated tags). */
+function allU8(entries: TlvEntry[], tag: number): number[] {
+  const out: number[] = [];
+  for (const entry of entries) {
+    if (entry.tag === tag && entry.value.length > 0) out.push(entry.value[0]!);
+  }
+  return out;
+}
+
+const AccountResetTag = {
+  ACCOUNT_INDEX: 0x01,
+  REQUIRE_PRE_BALANCE_ZERO: 0x02,
+} as const;
+
+function parseValue(bytes: Uint8Array): ParsedValue {
+  const entries = readTlvEntries(bytes);
+  return {
+    source: (firstU8(entries, ValueTag.SOURCE) ?? 0) as ValueSource,
+    payload: firstTag(entries, ValueTag.PAYLOAD) ?? new Uint8Array(),
+  };
+}
+
+function parseTokenValue(bytes: Uint8Array): ParsedTokenValue {
+  const entries = readTlvEntries(bytes);
+  const valueBytes = firstTag(entries, TokenValueTag.VALUE);
+  return {
+    kind: (firstU8(entries, TokenValueTag.KIND) ?? 0) as TokenKind,
+    value: valueBytes ? parseValue(valueBytes) : undefined,
+    accountIndex: firstU8(entries, TokenValueTag.ACCOUNT),
+  };
+}
+
+/**
+ * Parse an INSTRUCTION_INFO TLV into the fields the requirement builder needs.
+ * `IDL_TYPE_POOL` and `IDL_ROOT_TYPE` are mandatory; `MINT_ASSOC_*` pairs are
+ * collected in order (an account tag immediately followed by its mint tag).
+ */
+export function parseInstructionInfo(bytes: Uint8Array): ParsedInstructionInfo {
+  const entries = readTlvEntries(bytes);
+  const typePool = firstTag(entries, InstructionInfoTag.IDL_TYPE_POOL);
+  if (typePool === undefined) {
+    fail(new MissingInstructionFieldError("IDL_TYPE_POOL"));
+  }
+  const rootType = firstU8(entries, InstructionInfoTag.IDL_ROOT_TYPE);
+  if (rootType === undefined) {
+    fail(new MissingInstructionFieldError("IDL_ROOT_TYPE"));
+  }
+
+  const mintAssociations: MintAssociation[] = [];
+  let pendingAccountIndex: number | undefined;
+  for (const { tag, value } of entries) {
+    if (tag === InstructionInfoTag.MINT_ASSOC_ACCOUNT && value.length > 0) {
+      pendingAccountIndex = value[0];
+    } else if (
+      tag === InstructionInfoTag.MINT_ASSOC_MINT &&
+      value.length > 0 &&
+      pendingAccountIndex !== undefined
+    ) {
+      mintAssociations.push({
+        accountIndex: pendingAccountIndex,
+        mintIndex: value[0]!,
+      });
+      pendingAccountIndex = undefined;
+    }
+  }
+
+  return { typePool, rootType, mintAssociations };
+}
+
+export function parseValueFlowPort(bytes: Uint8Array): ParsedValueFlowPort {
+  const entries = readTlvEntries(bytes);
+  const tokenValueBytes = firstTag(entries, ValueFlowPortTag.TOKEN_VALUE);
+  return {
+    accountIndices: allU8(entries, ValueFlowPortTag.ACCOUNT_INDEX),
+    optionalAccountStrategy: (firstU8(
+      entries,
+      ValueFlowPortTag.OPTIONAL_ACCOUNT_STRATEGY,
+    ) ?? OptionalAccountStrategy.PROGRAM_ID) as OptionalAccountStrategy,
+    tokenValue: tokenValueBytes ? parseTokenValue(tokenValueBytes) : undefined,
+  };
+}
+
+export function parseAccountReset(bytes: Uint8Array): ParsedAccountReset {
+  const entries = readTlvEntries(bytes);
+  return {
+    accountIndex: firstU8(entries, AccountResetTag.ACCOUNT_INDEX) ?? 0,
+    requirePreBalanceZero:
+      (firstU8(entries, AccountResetTag.REQUIRE_PRE_BALANCE_ZERO) ?? 0) !== 0,
+  };
+}
+
+export function parseDisplayField(bytes: Uint8Array): ParsedDisplayField {
+  const entries = readTlvEntries(bytes);
+  const paramType = firstU8(entries, DisplayFieldTag.PARAM_TYPE);
+  const paramBytes = firstTag(entries, DisplayFieldTag.PARAM);
+  const paramEntries = paramBytes ? readTlvEntries(paramBytes) : [];
+  const valueBytes = firstTag(paramEntries, PARAM_VALUE_TAG);
+  // The TOKEN reference only exists (and tag 0x02 only means TOKEN) for a
+  // PARAM_TOKEN_AMOUNT param; for other param types tag 0x02 carries unrelated
+  // fields (e.g. decimals), so guard on the param type.
+  const tokenBytes =
+    paramType === PARAM_TYPE_TOKEN_AMOUNT
+      ? firstTag(paramEntries, PARAM_TOKEN_AMOUNT_TOKEN_TAG)
+      : undefined;
+  return {
+    paramType,
+    value: valueBytes ? parseValue(valueBytes) : undefined,
+    token: tokenBytes ? parseValue(tokenBytes) : undefined,
+  };
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/records.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/records.ts
@@ -1,0 +1,84 @@
+/** Where a VALUE is sourced from (`VALUE.SOURCE`). */
+export enum ValueSource {
+  ARGUMENT_PATH = 0x00,
+  ACCOUNT_PATH = 0x01,
+  CONSTANT = 0x02,
+}
+
+/** How a port's token identity is resolved (`TOKEN_VALUE.KIND`). */
+export enum TokenKind {
+  DIRECT = 0x00,
+  RESOLVE = 0x01,
+  NULL = 0x02,
+  NATIVE = 0x03,
+}
+
+/**
+ * How a candidate-array port's optional (non-final) candidates are detected as
+ * *unset* (`VALUE_FLOW_PORT.OPTIONAL_ACCOUNT_STRATEGY`). Only meaningful when a
+ * port carries more than one candidate index; defaults to `PROGRAM_ID`.
+ */
+export enum OptionalAccountStrategy {
+  /** Slot is unset when its address equals the instruction's program id. */
+  PROGRAM_ID = 0x00,
+  /** Slot is unset only when out of range (an omitted trailing account). */
+  OMITTED = 0x01,
+}
+
+/** `DISPLAY_FIELD.PARAM_TYPE` value for an address resolved via trusted name. */
+export const PARAM_TYPE_TRUSTED_NAME = 0x07;
+
+/** `DISPLAY_FIELD.PARAM_TYPE` value for a token amount with a token reference. */
+export const PARAM_TYPE_TOKEN_AMOUNT = 0x02;
+
+export type ParsedValue = { source: ValueSource; payload: Uint8Array };
+
+export type ParsedTokenValue = {
+  kind: TokenKind;
+  value?: ParsedValue;
+  accountIndex?: number;
+};
+
+export type ParsedValueFlowPort = {
+  /**
+   * Ordered candidate account indices (length 1 for the common single-account
+   * port). Resolved to the first *provided* candidate; see
+   * `resolvePortAccountIndex`.
+   */
+  accountIndices: number[];
+  optionalAccountStrategy: OptionalAccountStrategy;
+  tokenValue?: ParsedTokenValue;
+};
+
+export type ParsedAccountReset = {
+  accountIndex: number;
+  requirePreBalanceZero: boolean;
+};
+
+export type ParsedDisplayField = {
+  paramType?: number;
+  value?: ParsedValue;
+  /**
+   * The `PARAM_TOKEN_AMOUNT.TOKEN` reference, populated only for a
+   * `PARAM_TYPE_TOKEN_AMOUNT` field. Identifies the token whose `TOKEN_INFO`
+   * the amount formatter needs; may point at a mint or, via a TX-derived
+   * `MINT_ASSOC` binding, at a token account.
+   */
+  token?: ParsedValue;
+};
+
+export type MintAssociation = { accountIndex: number; mintIndex: number };
+
+export type ParsedInstructionInfo = {
+  typePool: Uint8Array;
+  rootType: number;
+  mintAssociations: MintAssociation[];
+};
+
+/** An instruction's INSTRUCTION_INFO + its substructures, grouped by kind. */
+export type ParsedInstruction = {
+  info: ParsedInstructionInfo;
+  valueFlowPorts: ParsedValueFlowPort[];
+  accountResets: ParsedAccountReset[];
+  displayFields: ParsedDisplayField[];
+};

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/altResolutionRule.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/altResolutionRule.test.ts
@@ -1,0 +1,38 @@
+import { type RequirementInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import { RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+
+import { applyAltResolutionRule } from "./altResolutionRule";
+
+function run(instruction: RequirementInstruction) {
+  const accumulator = new RequirementAccumulator();
+  applyAltResolutionRule(instruction, accumulator);
+  return accumulator.build().altResolutions;
+}
+
+describe("applyAltResolutionRule", () => {
+  it("emits one ALT_RESOLUTION per ALT-supplied account, skipping static keys", () => {
+    const result = run({
+      programId: "P",
+      data: new Uint8Array(),
+      accounts: [
+        { address: "static" },
+        { address: undefined, altRef: { altAddress: "ALT", entryIndex: 1 } },
+        { address: "resolved", altRef: { altAddress: "ALT", entryIndex: 4 } },
+      ],
+    });
+    expect(result).toEqual([
+      { altAddress: "ALT", entryIndex: 1 },
+      { altAddress: "ALT", entryIndex: 4 },
+    ]);
+  });
+
+  it("emits nothing when no account is ALT-supplied", () => {
+    expect(
+      run({
+        programId: "P",
+        data: new Uint8Array(),
+        accounts: [{ address: "a" }],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/altResolutionRule.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/altResolutionRule.ts
@@ -1,0 +1,21 @@
+import { type RequirementInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import { type RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+
+/**
+ * Every ALT-supplied account an instruction references needs an `ALT_RESOLUTION`.
+ * ALT entries the instruction never references are absent from its account list
+ * and so are skipped.
+ */
+export function applyAltResolutionRule(
+  instruction: RequirementInstruction,
+  accumulator: RequirementAccumulator,
+): void {
+  for (const account of instruction.accounts) {
+    if (account.altRef !== undefined) {
+      accumulator.addAltResolution(
+        account.altRef.altAddress,
+        account.altRef.entryIndex,
+      );
+    }
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/enumVariantRule.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/enumVariantRule.test.ts
@@ -1,0 +1,84 @@
+import { Left, Right } from "purify-ts";
+
+import { type SelectedEnumVariant } from "@internal/app-binder/clear-sign/idl-type-pool";
+import { type MatchedInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import { RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+import { RequirementsDecodeError } from "@internal/app-binder/clear-sign/requirements/RequirementsError";
+
+import {
+  applyEnumVariantRule,
+  type EnumVariantSelector,
+} from "./enumVariantRule";
+
+const matched: MatchedInstruction = {
+  instruction: { programId: "P", accounts: [], data: Uint8Array.of(1, 2) },
+  descriptor: {
+    discriminator: "00",
+    instructionInfo: new Uint8Array(),
+    substructures: [],
+    enumCache: new Map(),
+  },
+};
+
+describe("applyEnumVariantRule", () => {
+  it("records each selected variant keyed by the instruction's programId", () => {
+    const selector: EnumVariantSelector = () =>
+      Right([
+        { enumId: "swap", variantIndex: 46 },
+        { enumId: "swap", variantIndex: 46 },
+      ] as SelectedEnumVariant[]);
+    const accumulator = new RequirementAccumulator();
+
+    const result = applyEnumVariantRule(
+      matched,
+      accumulator,
+      selector,
+      new Uint8Array(),
+      0,
+    );
+
+    expect(result.isRight()).toBe(true);
+    expect(accumulator.build().enumVariants).toEqual([
+      { programId: "P", enumId: "swap", variantIndex: 46 },
+    ]);
+  });
+
+  it("forwards the type pool, root type, cache and data to the selector", () => {
+    const calls: unknown[] = [];
+    const selector: EnumVariantSelector = (typePool, rootType, cache, data) => {
+      calls.push({ typePool, rootType, cache, data });
+      return Right([]);
+    };
+    applyEnumVariantRule(
+      matched,
+      new RequirementAccumulator(),
+      selector,
+      Uint8Array.of(9),
+      3,
+    );
+    expect(calls).toEqual([
+      {
+        typePool: Uint8Array.of(9),
+        rootType: 3,
+        cache: matched.descriptor.enumCache,
+        data: matched.instruction.data,
+      },
+    ]);
+  });
+
+  it("maps a decoder failure to a typed Left", () => {
+    const selector: EnumVariantSelector = () =>
+      Left({ originalError: new Error("bad pool") });
+    const result = applyEnumVariantRule(
+      matched,
+      new RequirementAccumulator(),
+      selector,
+      new Uint8Array(),
+      0,
+    );
+    expect(result.isLeft()).toBe(true);
+    result.ifLeft((error) =>
+      expect(error).toBeInstanceOf(RequirementsDecodeError),
+    );
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/enumVariantRule.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/enumVariantRule.ts
@@ -1,0 +1,49 @@
+import { type Either } from "purify-ts";
+
+import {
+  type SelectedEnumVariant,
+  type VariantCache,
+} from "@internal/app-binder/clear-sign/idl-type-pool";
+import { type MatchedInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import { type RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+import {
+  RequirementsDecodeError,
+  type RequirementsError,
+} from "@internal/app-binder/clear-sign/requirements/RequirementsError";
+
+/**
+ * Decodes the instruction data against the type pool to find the enum variants
+ * it selects. Injected (defaults to the real type-pool decoder) so the rule
+ * stays testable without a full decode.
+ */
+export type EnumVariantSelector = (
+  typePool: Uint8Array,
+  rootType: number,
+  enumCache: VariantCache,
+  data: Uint8Array,
+) => Either<{ originalError: Error }, SelectedEnumVariant[]>;
+
+/** One `ENUM_VARIANT` descriptor per `(programId, enumId, variantIndex)` selected. */
+export function applyEnumVariantRule(
+  matched: MatchedInstruction,
+  accumulator: RequirementAccumulator,
+  selectEnumVariants: EnumVariantSelector,
+  parsedTypePool: Uint8Array,
+  parsedRootType: number,
+): Either<RequirementsError, void> {
+  const { programId } = matched.instruction;
+  return selectEnumVariants(
+    parsedTypePool,
+    parsedRootType,
+    matched.descriptor.enumCache,
+    matched.instruction.data,
+  )
+    .mapLeft<RequirementsError>(
+      (error) => new RequirementsDecodeError(error.originalError.message),
+    )
+    .map((selected) => {
+      for (const { enumId, variantIndex } of selected) {
+        accumulator.addEnumVariant(programId, enumId, variantIndex);
+      }
+    });
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/index.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/index.ts
@@ -1,0 +1,8 @@
+export { applyAltResolutionRule } from "./altResolutionRule";
+export {
+  applyEnumVariantRule,
+  type EnumVariantSelector,
+} from "./enumVariantRule";
+export { applyInstructionInfoRule } from "./instructionInfoRule";
+export { applyTokenRule } from "./tokenRule";
+export { applyTrustedNameRule } from "./trustedNameRule";

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/instructionInfoRule.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/instructionInfoRule.test.ts
@@ -1,0 +1,24 @@
+import { type MatchedInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import { RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+
+import { applyInstructionInfoRule } from "./instructionInfoRule";
+
+describe("applyInstructionInfoRule", () => {
+  it("records the instruction's (programId, discriminator)", () => {
+    const matched = {
+      instruction: { programId: "P", accounts: [], data: new Uint8Array() },
+      descriptor: {
+        discriminator: "ab",
+        instructionInfo: new Uint8Array(),
+        substructures: [],
+        enumCache: new Map(),
+      },
+    } satisfies MatchedInstruction;
+
+    const accumulator = new RequirementAccumulator();
+    applyInstructionInfoRule(matched, accumulator);
+    expect(accumulator.build().instructionInfos).toEqual([
+      { programId: "P", discriminator: "ab" },
+    ]);
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/instructionInfoRule.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/instructionInfoRule.ts
@@ -1,0 +1,13 @@
+import { type MatchedInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import { type RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+
+/** Every matched instruction needs its `(programId, discriminator)` descriptor. */
+export function applyInstructionInfoRule(
+  matched: MatchedInstruction,
+  accumulator: RequirementAccumulator,
+): void {
+  accumulator.addInstructionInfo(
+    matched.instruction.programId,
+    matched.descriptor.discriminator,
+  );
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/tokenRule.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/tokenRule.test.ts
@@ -1,0 +1,346 @@
+import { type RequirementInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import {
+  OptionalAccountStrategy,
+  PARAM_TYPE_TOKEN_AMOUNT,
+  PARAM_TYPE_TRUSTED_NAME,
+  type ParsedAccountReset,
+  type ParsedDisplayField,
+  type ParsedInstruction,
+  type ParsedValue,
+  type ParsedValueFlowPort,
+  TokenKind,
+  ValueSource,
+} from "@internal/app-binder/clear-sign/requirements/records";
+import { RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+import { DefaultBs58Encoder } from "@internal/app-binder/services/bs58Encoder";
+
+import { applyTokenRule } from "./tokenRule";
+
+const EMPTY_INFO = {
+  typePool: new Uint8Array(),
+  rootType: 0,
+  mintAssociations: [],
+};
+
+/** Build a port, defaulting the candidate list and strategy. */
+function port(
+  overrides: Partial<ParsedValueFlowPort> & { accountIndex?: number },
+): ParsedValueFlowPort {
+  const { accountIndex, accountIndices, ...rest } = overrides;
+  return {
+    accountIndices:
+      accountIndices ?? (accountIndex !== undefined ? [accountIndex] : []),
+    optionalAccountStrategy: OptionalAccountStrategy.PROGRAM_ID,
+    ...rest,
+  };
+}
+
+/** A PARAM_TOKEN_AMOUNT display field whose TOKEN reference is `token`. */
+function tokenAmountField(token: ParsedValue): ParsedDisplayField {
+  return { paramType: PARAM_TYPE_TOKEN_AMOUNT, token };
+}
+
+function parsed(overrides: {
+  valueFlowPorts?: ParsedValueFlowPort[];
+  accountResets?: ParsedAccountReset[];
+  displayFields?: ParsedDisplayField[];
+}): ParsedInstruction {
+  return {
+    info: EMPTY_INFO,
+    valueFlowPorts: overrides.valueFlowPorts ?? [],
+    accountResets: overrides.accountResets ?? [],
+    displayFields: overrides.displayFields ?? [],
+  };
+}
+
+function makeInstruction(
+  addresses: (string | undefined)[],
+  programId = "P",
+): RequirementInstruction {
+  return {
+    programId,
+    accounts: addresses.map((address) => ({ address })),
+    data: new Uint8Array(),
+  };
+}
+
+function run(
+  records: ParsedInstruction,
+  instruction: RequirementInstruction,
+  bindings: Map<string, string> = new Map(),
+) {
+  const accumulator = new RequirementAccumulator();
+  applyTokenRule(records, instruction, bindings, accumulator);
+  return accumulator.build();
+}
+
+describe("applyTokenRule", () => {
+  describe("DIRECT port", () => {
+    it("emits TOKEN_INFO for a 32-byte constant mint", () => {
+      const mint = new Uint8Array(32).fill(4);
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({
+              accountIndex: 0,
+              tokenValue: {
+                kind: TokenKind.DIRECT,
+                value: { source: ValueSource.CONSTANT, payload: mint },
+              },
+            }),
+          ],
+        }),
+        makeInstruction(["a"]),
+      );
+      expect(result.tokenInfos).toEqual([DefaultBs58Encoder.encode(mint)]);
+    });
+
+    it("ignores a constant that is not 32 bytes", () => {
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({
+              accountIndex: 0,
+              tokenValue: {
+                kind: TokenKind.DIRECT,
+                value: {
+                  source: ValueSource.CONSTANT,
+                  payload: new Uint8Array(8),
+                },
+              },
+            }),
+          ],
+        }),
+        makeInstruction(["a"]),
+      );
+      expect(result.tokenInfos).toEqual([]);
+    });
+
+    it("resolves an ACCOUNT_PATH mint to the account address", () => {
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({
+              accountIndex: 0,
+              tokenValue: {
+                kind: TokenKind.DIRECT,
+                value: {
+                  source: ValueSource.ACCOUNT_PATH,
+                  payload: Uint8Array.of(1),
+                },
+              },
+            }),
+          ],
+        }),
+        makeInstruction(["acct", "theMint"]),
+      );
+      expect(result.tokenInfos).toEqual(["theMint"]);
+    });
+
+    it("ignores an out-of-bounds ACCOUNT_PATH index", () => {
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({
+              accountIndex: 0,
+              tokenValue: {
+                kind: TokenKind.DIRECT,
+                value: {
+                  source: ValueSource.ACCOUNT_PATH,
+                  payload: Uint8Array.of(9),
+                },
+              },
+            }),
+          ],
+        }),
+        makeInstruction(["a"]),
+      );
+      expect(result.tokenInfos).toEqual([]);
+    });
+  });
+
+  describe("RESOLVE port", () => {
+    it("sends TOKEN_ACCOUNT_STATE when no MINT_ASSOC binding covers it", () => {
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({ accountIndex: 0, tokenValue: { kind: TokenKind.RESOLVE } }),
+          ],
+        }),
+        makeInstruction(["userAta"]),
+      );
+      expect(result.tokenAccountStates).toEqual(["userAta"]);
+      expect(result.tokenInfos).toEqual([]);
+    });
+
+    it("emits TOKEN_INFO and skips account-state when MINT_ASSOC binds it", () => {
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({ accountIndex: 0, tokenValue: { kind: TokenKind.RESOLVE } }),
+          ],
+        }),
+        makeInstruction(["createdAta"]),
+        new Map([["createdAta", "boundMint"]]),
+      );
+      expect(result.tokenAccountStates).toEqual([]);
+      expect(result.tokenInfos).toEqual(["boundMint"]);
+    });
+
+    it("uses the explicit token account index overrides the port's own", () => {
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({
+              accountIndex: 0,
+              tokenValue: { kind: TokenKind.RESOLVE, accountIndex: 1 },
+            }),
+          ],
+        }),
+        makeInstruction(["wrong", "rightAta"]),
+      );
+      expect(result.tokenAccountStates).toEqual(["rightAta"]);
+    });
+
+    it("resolves a candidate-array port to its first provided candidate", () => {
+      // First candidate (index 0) holds the program id under PROGRAM_ID
+      // strategy, so it is unset; the next provided candidate (index 1) wins.
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({
+              accountIndices: [0, 1],
+              tokenValue: { kind: TokenKind.RESOLVE },
+            }),
+          ],
+        }),
+        makeInstruction(["P", "realAta"]),
+      );
+      expect(result.tokenAccountStates).toEqual(["realAta"]);
+    });
+
+    it("skips when the target account address is unresolved (ALT-supplied)", () => {
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({ accountIndex: 0, tokenValue: { kind: TokenKind.RESOLVE } }),
+          ],
+        }),
+        makeInstruction([undefined]),
+      );
+      expect(result.tokenAccountStates).toEqual([]);
+      expect(result.tokenInfos).toEqual([]);
+    });
+  });
+
+  it("ignores NATIVE and NULL ports and ports without a token value", () => {
+    const result = run(
+      parsed({
+        valueFlowPorts: [
+          port({ accountIndex: 0, tokenValue: { kind: TokenKind.NATIVE } }),
+          port({ accountIndex: 0, tokenValue: { kind: TokenKind.NULL } }),
+          port({ accountIndex: 0 }),
+        ],
+      }),
+      makeInstruction(["a"]),
+    );
+    expect(result.tokenInfos).toEqual([]);
+    expect(result.tokenAccountStates).toEqual([]);
+  });
+
+  describe("ACCOUNT_RESET", () => {
+    it("forces TOKEN_ACCOUNT_STATE when requirePreBalanceZero is set", () => {
+      const result = run(
+        parsed({
+          accountResets: [{ accountIndex: 0, requirePreBalanceZero: true }],
+        }),
+        makeInstruction(["ata"]),
+      );
+      expect(result.tokenAccountStates).toEqual(["ata"]);
+    });
+
+    it("does nothing without the flag or for an out-of-bounds index", () => {
+      const noFlag = run(
+        parsed({
+          accountResets: [{ accountIndex: 0, requirePreBalanceZero: false }],
+        }),
+        makeInstruction(["ata"]),
+      );
+      expect(noFlag.tokenAccountStates).toEqual([]);
+
+      const oob = run(
+        parsed({
+          accountResets: [{ accountIndex: 9, requirePreBalanceZero: true }],
+        }),
+        makeInstruction(["ata"]),
+      );
+      expect(oob.tokenAccountStates).toEqual([]);
+    });
+  });
+
+  describe("PARAM_TOKEN_AMOUNT display field", () => {
+    it("emits TOKEN_INFO for a constant-mint amount-formatter token", () => {
+      const mint = new Uint8Array(32).fill(9);
+      const result = run(
+        parsed({
+          displayFields: [
+            tokenAmountField({ source: ValueSource.CONSTANT, payload: mint }),
+          ],
+        }),
+        makeInstruction(["a"]),
+      );
+      expect(result.tokenInfos).toEqual([DefaultBs58Encoder.encode(mint)]);
+    });
+
+    it("treats an unbound ACCOUNT_PATH token as the mint", () => {
+      const result = run(
+        parsed({
+          displayFields: [
+            tokenAmountField({
+              source: ValueSource.ACCOUNT_PATH,
+              payload: Uint8Array.of(0),
+            }),
+          ],
+        }),
+        makeInstruction(["someMint"]),
+      );
+      expect(result.tokenInfos).toEqual(["someMint"]);
+      expect(result.tokenAccountStates).toEqual([]);
+    });
+
+    it("redirects a bound token-account reference to its mint", () => {
+      const result = run(
+        parsed({
+          displayFields: [
+            tokenAmountField({
+              source: ValueSource.ACCOUNT_PATH,
+              payload: Uint8Array.of(0),
+            }),
+          ],
+        }),
+        makeInstruction(["tokenAccount"]),
+        new Map([["tokenAccount", "itsMint"]]),
+      );
+      expect(result.tokenInfos).toEqual(["itsMint"]);
+      expect(result.tokenAccountStates).toEqual([]);
+    });
+
+    it("ignores non-token-amount display fields", () => {
+      const result = run(
+        parsed({
+          displayFields: [
+            {
+              paramType: PARAM_TYPE_TRUSTED_NAME,
+              value: {
+                source: ValueSource.ACCOUNT_PATH,
+                payload: Uint8Array.of(0),
+              },
+            },
+          ],
+        }),
+        makeInstruction(["addr"]),
+      );
+      expect(result.tokenInfos).toEqual([]);
+    });
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/tokenRule.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/tokenRule.ts
@@ -1,0 +1,85 @@
+import { type RequirementInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import {
+  PARAM_TYPE_TOKEN_AMOUNT,
+  type ParsedInstruction,
+  TokenKind,
+} from "@internal/app-binder/clear-sign/requirements/records";
+import { type RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+import {
+  accountAddressAt,
+  resolvePortAccountIndex,
+  resolvePubkeyValue,
+} from "@internal/app-binder/clear-sign/requirements/valueResolution";
+import {
+  type Bs58Encoder,
+  DefaultBs58Encoder,
+} from "@internal/app-binder/services/bs58Encoder";
+
+/**
+ * TOKEN_INFO + TOKEN_ACCOUNT_STATE requirements:
+ * - RESOLVE port: TOKEN_ACCOUNT_STATE for its token account unless a TX-derived
+ *   MINT_ASSOC binding already covers it; the bound mint (when any) needs
+ *   TOKEN_INFO. A candidate-array port resolves to its first *provided*
+ *   candidate.
+ * - DIRECT port: the embedded mint needs TOKEN_INFO.
+ * - ACCOUNT_RESET with `requirePreBalanceZero`: mandatory TOKEN_ACCOUNT_STATE
+ *   for the reset account (the device must read its pre-balance).
+ * - PARAM_TOKEN_AMOUNT display field: the amount formatter's token needs
+ *   TOKEN_INFO. The reference may be a mint directly, or — when a TX-derived
+ *   MINT_ASSOC binding covers it — a token account whose bound mint is used
+ *   instead. (The chain-only token-account case where no binding exists is out
+ *   of scope: DMK has no RPC to resolve such a mint, mirroring the POC, which
+ *   only resolves it from on-chain balances.)
+ *
+ * `mintBindings` maps a token-account address to its TX-derived mint address.
+ */
+export function applyTokenRule(
+  parsed: ParsedInstruction,
+  instruction: RequirementInstruction,
+  mintBindings: ReadonlyMap<string, string>,
+  accumulator: RequirementAccumulator,
+  bs58Encoder: Bs58Encoder = DefaultBs58Encoder,
+): void {
+  for (const port of parsed.valueFlowPorts) {
+    const tokenValue = port.tokenValue;
+    if (tokenValue === undefined) continue;
+
+    if (tokenValue.kind === TokenKind.RESOLVE) {
+      const account = accountAddressAt(
+        instruction,
+        tokenValue.accountIndex ?? resolvePortAccountIndex(port, instruction),
+      );
+      if (account === undefined) continue;
+      const boundMint = mintBindings.get(account);
+      if (boundMint === undefined) {
+        accumulator.addTokenAccountState(account);
+      } else {
+        accumulator.addTokenInfo(boundMint);
+      }
+    } else if (tokenValue.kind === TokenKind.DIRECT && tokenValue.value) {
+      const mint = resolvePubkeyValue(
+        tokenValue.value,
+        instruction,
+        bs58Encoder,
+      );
+      if (mint !== undefined) accumulator.addTokenInfo(mint);
+    }
+  }
+
+  for (const reset of parsed.accountResets) {
+    if (!reset.requirePreBalanceZero) continue;
+    const account = accountAddressAt(instruction, reset.accountIndex);
+    if (account !== undefined) accumulator.addTokenAccountState(account);
+  }
+
+  for (const field of parsed.displayFields) {
+    if (
+      field.paramType !== PARAM_TYPE_TOKEN_AMOUNT ||
+      field.token === undefined
+    )
+      continue;
+    const ref = resolvePubkeyValue(field.token, instruction, bs58Encoder);
+    if (ref === undefined) continue;
+    accumulator.addTokenInfo(mintBindings.get(ref) ?? ref);
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.test.ts
@@ -1,0 +1,93 @@
+import { type RequirementInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import {
+  PARAM_TYPE_TRUSTED_NAME,
+  type ParsedDisplayField,
+  type ParsedInstruction,
+  ValueSource,
+} from "@internal/app-binder/clear-sign/requirements/records";
+import { RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+import { DefaultBs58Encoder } from "@internal/app-binder/services/bs58Encoder";
+
+import { applyTrustedNameRule } from "./trustedNameRule";
+
+function run(
+  displayFields: ParsedDisplayField[],
+  addresses: (string | undefined)[],
+) {
+  const parsed: ParsedInstruction = {
+    info: { typePool: new Uint8Array(), rootType: 0, mintAssociations: [] },
+    valueFlowPorts: [],
+    accountResets: [],
+    displayFields,
+  };
+  const instruction: RequirementInstruction = {
+    programId: "P",
+    accounts: addresses.map((address) => ({ address })),
+    data: new Uint8Array(),
+  };
+  const accumulator = new RequirementAccumulator();
+  applyTrustedNameRule(parsed, instruction, accumulator);
+  return accumulator.build().trustedNames;
+}
+
+describe("applyTrustedNameRule", () => {
+  it("resolves an ACCOUNT_PATH trusted-name target", () => {
+    const result = run(
+      [
+        {
+          paramType: PARAM_TYPE_TRUSTED_NAME,
+          value: {
+            source: ValueSource.ACCOUNT_PATH,
+            payload: Uint8Array.of(1),
+          },
+        },
+      ],
+      ["ignored", "named"],
+    );
+    expect(result).toEqual(["named"]);
+  });
+
+  it("encodes a 32-byte CONSTANT trusted-name target", () => {
+    const addr = new Uint8Array(32).fill(8);
+    const result = run(
+      [
+        {
+          paramType: PARAM_TYPE_TRUSTED_NAME,
+          value: { source: ValueSource.CONSTANT, payload: addr },
+        },
+      ],
+      [],
+    );
+    expect(result).toEqual([DefaultBs58Encoder.encode(addr)]);
+  });
+
+  it("ignores non-trusted-name fields and unresolved account targets", () => {
+    const nonTrusted = run(
+      [
+        {
+          paramType: 0x02,
+          value: {
+            source: ValueSource.ACCOUNT_PATH,
+            payload: Uint8Array.of(0),
+          },
+        },
+      ],
+      ["a"],
+    );
+    expect(nonTrusted).toEqual([]);
+
+    const unresolved = run(
+      [
+        {
+          paramType: PARAM_TYPE_TRUSTED_NAME,
+          value: {
+            source: ValueSource.ACCOUNT_PATH,
+            payload: Uint8Array.of(0),
+          },
+        },
+      ],
+      [undefined],
+    );
+    expect(unresolved).toEqual([]);
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.ts
@@ -1,0 +1,30 @@
+import { type RequirementInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import {
+  PARAM_TYPE_TRUSTED_NAME,
+  type ParsedInstruction,
+} from "@internal/app-binder/clear-sign/requirements/records";
+import { type RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+import { resolvePubkeyValue } from "@internal/app-binder/clear-sign/requirements/valueResolution";
+import {
+  type Bs58Encoder,
+  DefaultBs58Encoder,
+} from "@internal/app-binder/services/bs58Encoder";
+
+/** Each `PARAM_TRUSTED_NAME` display field targets an address needing a name. */
+export function applyTrustedNameRule(
+  parsed: ParsedInstruction,
+  instruction: RequirementInstruction,
+  accumulator: RequirementAccumulator,
+  bs58Encoder: Bs58Encoder = DefaultBs58Encoder,
+): void {
+  for (const field of parsed.displayFields) {
+    if (
+      field.paramType !== PARAM_TYPE_TRUSTED_NAME ||
+      field.value === undefined
+    ) {
+      continue;
+    }
+    const target = resolvePubkeyValue(field.value, instruction, bs58Encoder);
+    if (target !== undefined) accumulator.addTrustedName(target);
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/valueResolution.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/valueResolution.test.ts
@@ -1,0 +1,132 @@
+import { DefaultBs58Encoder } from "@internal/app-binder/services/bs58Encoder";
+
+import { type RequirementInstruction } from "./model";
+import {
+  OptionalAccountStrategy,
+  type ParsedValueFlowPort,
+  ValueSource,
+} from "./records";
+import {
+  accountAddressAt,
+  resolvePortAccountIndex,
+  resolvePubkeyValue,
+} from "./valueResolution";
+
+const instruction: RequirementInstruction = {
+  programId: "P",
+  data: new Uint8Array(),
+  accounts: [
+    { address: "first" },
+    { address: undefined },
+    { address: "third" },
+  ],
+};
+
+describe("accountAddressAt", () => {
+  it("returns the resolved address or undefined", () => {
+    expect(accountAddressAt(instruction, 0)).toBe("first");
+    expect(accountAddressAt(instruction, 1)).toBeUndefined(); // unresolved (ALT)
+    expect(accountAddressAt(instruction, 9)).toBeUndefined(); // out of bounds
+    expect(accountAddressAt(instruction, -1)).toBeUndefined();
+  });
+});
+
+describe("resolvePubkeyValue", () => {
+  it("encodes a 32-byte CONSTANT", () => {
+    const payload = new Uint8Array(32).fill(3);
+    expect(
+      resolvePubkeyValue(
+        { source: ValueSource.CONSTANT, payload },
+        instruction,
+        DefaultBs58Encoder,
+      ),
+    ).toBe(DefaultBs58Encoder.encode(payload));
+  });
+
+  it("rejects a CONSTANT that is not 32 bytes", () => {
+    expect(
+      resolvePubkeyValue(
+        { source: ValueSource.CONSTANT, payload: new Uint8Array(4) },
+        instruction,
+        DefaultBs58Encoder,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("resolves an ACCOUNT_PATH to the account address", () => {
+    expect(
+      resolvePubkeyValue(
+        { source: ValueSource.ACCOUNT_PATH, payload: Uint8Array.of(2) },
+        instruction,
+        DefaultBs58Encoder,
+      ),
+    ).toBe("third");
+  });
+
+  it("returns undefined for ARGUMENT_PATH and empty/out-of-range paths", () => {
+    expect(
+      resolvePubkeyValue(
+        { source: ValueSource.ARGUMENT_PATH, payload: Uint8Array.of(1, 0) },
+        instruction,
+        DefaultBs58Encoder,
+      ),
+    ).toBeUndefined();
+    expect(
+      resolvePubkeyValue(
+        { source: ValueSource.ACCOUNT_PATH, payload: new Uint8Array() },
+        instruction,
+        DefaultBs58Encoder,
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("resolvePortAccountIndex", () => {
+  const makePort = (
+    accountIndices: number[],
+    optionalAccountStrategy = OptionalAccountStrategy.PROGRAM_ID,
+  ): ParsedValueFlowPort => ({ accountIndices, optionalAccountStrategy });
+
+  // `instruction` accounts: [0]="first", [1]=undefined, [2]="third".
+  // A separate fixture places the program id "P" in slot 0 for the sentinel
+  // cases.
+  const withProgramIdInSlot0: RequirementInstruction = {
+    programId: "P",
+    data: new Uint8Array(),
+    accounts: [{ address: "P" }, { address: "second" }],
+  };
+
+  it("returns the sole candidate for a single-account port", () => {
+    expect(resolvePortAccountIndex(makePort([2]), instruction)).toBe(2);
+  });
+
+  it("returns -1 for an empty candidate list", () => {
+    expect(resolvePortAccountIndex(makePort([]), instruction)).toBe(-1);
+  });
+
+  it("skips a PROGRAM_ID-sentinel non-final candidate", () => {
+    // slot 0 holds the program id → unset under PROGRAM_ID strategy.
+    expect(
+      resolvePortAccountIndex(makePort([0, 1]), withProgramIdInSlot0),
+    ).toBe(1);
+  });
+
+  it("skips an out-of-range non-final candidate", () => {
+    expect(resolvePortAccountIndex(makePort([9, 2]), instruction)).toBe(2);
+  });
+
+  it("does not treat the program-id slot as unset under the OMITTED strategy", () => {
+    expect(
+      resolvePortAccountIndex(
+        makePort([0, 1], OptionalAccountStrategy.OMITTED),
+        withProgramIdInSlot0,
+      ),
+    ).toBe(0);
+  });
+
+  it("always resolves the final candidate even when it holds the program id", () => {
+    expect(
+      resolvePortAccountIndex(makePort([9, 0]), withProgramIdInSlot0),
+    ).toBe(0);
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/valueResolution.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/valueResolution.ts
@@ -1,0 +1,71 @@
+import { type Bs58Encoder } from "@internal/app-binder/services/bs58Encoder";
+
+import { type RequirementInstruction } from "./model";
+import {
+  OptionalAccountStrategy,
+  type ParsedValue,
+  type ParsedValueFlowPort,
+  ValueSource,
+} from "./records";
+
+const PUBKEY_LENGTH = 32;
+
+/** The resolved address of an account slot, bounds-checked. */
+export function accountAddressAt(
+  instruction: RequirementInstruction,
+  index: number,
+): string | undefined {
+  if (index < 0 || index >= instruction.accounts.length) return undefined;
+  return instruction.accounts[index]!.address;
+}
+
+/**
+ * Resolve a value-flow port to a single account index. A single-candidate port
+ * returns that candidate. An ordered candidate list (optional accounts with
+ * fallbacks) returns the first *provided* candidate: a non-final candidate is
+ * *unset* when its slot is out of range, or — under the `PROGRAM_ID` strategy —
+ * when the slot holds the program id. The final candidate is non-optional and
+ * always resolves. Returns `-1` for an empty candidate list.
+ */
+export function resolvePortAccountIndex(
+  port: ParsedValueFlowPort,
+  instruction: RequirementInstruction,
+): number {
+  const indices = port.accountIndices;
+  if (indices.length === 0) return -1;
+  for (const idx of indices.slice(0, -1)) {
+    if (idx < 0 || idx >= instruction.accounts.length) continue;
+    if (
+      port.optionalAccountStrategy !== OptionalAccountStrategy.OMITTED &&
+      instruction.accounts[idx]!.address === instruction.programId
+    ) {
+      continue;
+    }
+    return idx;
+  }
+  return indices[indices.length - 1]!;
+}
+
+/**
+ * Resolve a pubkey-bearing VALUE to a base58 address: a 32-byte CONSTANT, or an
+ * ACCOUNT_PATH into the instruction's accounts. ARGUMENT_PATH and unresolved
+ * accounts yield `undefined`.
+ */
+export function resolvePubkeyValue(
+  value: ParsedValue,
+  instruction: RequirementInstruction,
+  bs58Encoder: Bs58Encoder,
+): string | undefined {
+  switch (value.source) {
+    case ValueSource.CONSTANT:
+      return value.payload.length === PUBKEY_LENGTH
+        ? bs58Encoder.encode(value.payload)
+        : undefined;
+    case ValueSource.ACCOUNT_PATH:
+      return value.payload.length > 0
+        ? accountAddressAt(instruction, value.payload[0]!)
+        : undefined;
+    default:
+      return undefined;
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/tlv.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/tlv.ts
@@ -1,0 +1,82 @@
+// DER Tag-Length-Value reader shared by the clear-sign sub-modules. Throws a
+// neutral TlvParseError that each caller maps to its own typed error.
+
+export type TlvEntry = { tag: number; value: Uint8Array };
+
+export class TlvParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TlvParseError";
+  }
+}
+
+// DER length encoding constants (X.690 §8.1.3).
+/** Bit 7 of the length head byte: set ⇒ long form, clear ⇒ short form. */
+const LONG_FORM_FLAG = 0x80;
+/** Low 7 bits of a long-form head byte hold the number of length bytes. */
+const LENGTH_SIZE_MASK = 0x7f;
+/** Cap on long-form length bytes; 4 keeps the result a JS safe integer. */
+const MAX_LENGTH_BYTES = 4;
+const BYTE_RADIX = 256;
+
+/** Decode a DER-encoded length at `offset`; returns `[length, nextOffset]`. */
+function decodeLength(buffer: Uint8Array, offset: number): [number, number] {
+  if (offset >= buffer.length) {
+    throw new TlvParseError("truncated TLV length byte");
+  }
+  const head = buffer[offset]!;
+  offset += 1;
+  if (head < LONG_FORM_FLAG) {
+    return [head, offset];
+  }
+  const lengthSize = head & LENGTH_SIZE_MASK;
+  if (lengthSize === 0) {
+    throw new TlvParseError("indefinite-length form not allowed");
+  }
+  // Cap the number of length bytes so an attacker can't make us iterate huge
+  // counts and so the result stays within JS safe-integer range (IEEE-754).
+  if (lengthSize > MAX_LENGTH_BYTES) {
+    throw new TlvParseError("extended TLV length too large");
+  }
+  if (offset + lengthSize > buffer.length) {
+    throw new TlvParseError("truncated extended TLV length");
+  }
+  let length = 0;
+  for (let i = 0; i < lengthSize; i++) {
+    length = length * BYTE_RADIX + buffer[offset + i]!;
+  }
+  return [length, offset + lengthSize];
+}
+
+/** Parse every `(tag, value)` record in `buffer`, in stream order. */
+export function readTlvEntries(buffer: Uint8Array): TlvEntry[] {
+  const entries: TlvEntry[] = [];
+  let offset = 0;
+  while (offset < buffer.length) {
+    const tag = buffer[offset]!;
+    const [length, afterLength] = decodeLength(buffer, offset + 1);
+    if (afterLength + length > buffer.length) {
+      throw new TlvParseError("truncated TLV value");
+    }
+    entries.push({
+      tag,
+      value: buffer.subarray(afterLength, afterLength + length),
+    });
+    offset = afterLength + length;
+  }
+  return entries;
+}
+
+/** First value tagged `tag`, or `undefined`. */
+export function firstTag(
+  entries: TlvEntry[],
+  tag: number,
+): Uint8Array | undefined {
+  return entries.find((entry) => entry.tag === tag)?.value;
+}
+
+/** First byte of the first value tagged `tag`, or `undefined` (for `uint8` fields). */
+export function firstU8(entries: TlvEntry[], tag: number): number | undefined {
+  const value = firstTag(entries, tag);
+  return value !== undefined && value.length > 0 ? value[0]! : undefined;
+}


### PR DESCRIPTION
### 📝 Description

Adds the host-side **`IDL_TYPE_POOL` decoder** (`TypePoolDecoder`) for the Solana generic clear-signing pipeline: a pure, kind-driven decoder over the trimmed Codama type pool that CAL ships inside every `INSTRUCTION_INFO`.

It takes the type-pool bytes, a per-program enum-variant cache and an instruction-data buffer, then traverses the type tree the same way the device does.

Two functions surface what the rest of the pipeline needs:

- **`decodeArgumentPath(...)`**: the leaf value at a given `ARGUMENT_PATH`.
- **`findSelectedEnumVariants(...)`**: the `(enumId, variantIndex)` pairs the data actually selects (so we stream only the observed `ENUM_VARIANT` descriptors, not all of them).

New module under `packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/`.

## How it fits together

```mermaid
flowchart TD
    subgraph CAL["From CAL INSTRUCTION_INFO"]
        POOL["IDL_TYPE_POOL bytes"]
        EV["ENUM_VARIANT TLVs"]
    end
    DATA["Instruction data bytes"]

    POOL -->|parsePool| ENTRIES["Entry[]"]
    EV -->|buildEnumCache| CACHE["VariantCache"]

    ENTRIES --> DECODE["TypePoolDecoder.decode"]
    CACHE --> DECODE
    DATA --> DECODE
    READER["DataReader<br/>(injected · default DefaultDataReader)"] -.-> DECODE

    DECODE --> RES["DecodeResult<br/>leaves · selectedEnumVariants · cursorEnd"]

    RES --> DAP["decodeArgumentPath()<br/>→ Maybe&lt;LeafValue&gt;"]
    RES --> FSV["findSelectedEnumVariants()<br/>→ SelectedEnumVariant[]"]

    DAP --> OUT["Either&lt;TypePoolDecoderError, …&gt;"]
    FSV --> OUT
```

`decodePoolBytes()` is the convenience wrapper that runs `parsePool` + `decode` in one call, both public entry points build on it.

## Module layout

| File | Responsibility |
|------|----------------|
| `kinds.ts` | Kind codes + byte-size/format tables |
| `types.ts` | `Entry`, `Leaf`, `DecodeResult`, `VariantCache`, … |
| `parsePool.ts` | `parsePool` / `parseInlinePayload` — kind-keyed `ByteReader` dispatch |
| `argumentPaths.ts` | Packed argument-path encoding + equality |
| `dataReaders.ts` | `DataReader` interface + `DefaultDataReader` + `fixedSizeOf` |
| `TypePoolDecoder.ts` | Core traversal (`decode` / `decodePoolBytes`) — kind→handler dispatch |
| `decodeArgumentPath.ts`, `findSelectedEnumVariants.ts` | Public entry points |
| `buildEnumCache.ts` | Builds the `VariantCache` from `ENUM_VARIANT` TLVs |
| `TypePoolDecoderError.ts` | Typed `DmkError`s + traversal budgets |
| `index.ts` | Barrel |

## Design notes

- **Pure & deterministic.** No I/O, no DI container, no mutable singletons, identical inputs always yield identical leaves and variant order.
- **Typed errors, never throws.** Every entry point returns `Either<TypePoolDecoderError, …>`, malformed descriptor/instruction bytes map to named errors (`TruncatedDataError`, `MalformedDataError`, `PoolIndexOutOfRangeError`, `UnknownKindError`, …). Defensive at every read: depth + node-visit budgets guard recursive type-pool cycles and adversarial length prefixes, and decoding fails closed on overlong `SHORT_U16` varints and unsigned values that exceed `Number.MAX_SAFE_INTEGER`.
- **Open for extension.** Both the parser and the decoder dispatch through kind-keyed tables, so a new kind is a new table row rather than another `if`.
- **Correctness details:** 64-/128-bit leaves are `bigint`; argument-path packing uses `% 256` (not `& 0xff`) and requires `Number.isSafeInteger` to stay exact above 2^31.

## Original documentation 
https://github.com/LedgerHQ/poc-solana-clear-signing/blob/main/spec/device/idl_descriptor.md

- **JIRA or GitHub link**: [DSDK-1145](https://ledgerhq.atlassian.net/browse/DSDK-1145)

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.

[DSDK-1145]: https://ledgerhq.atlassian.net/browse/DSDK-1145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ