### PR TITLE
📝 (docs) [NO-ISSUE]: Remove production readiness warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,6 @@ The Device Management Kit (DMK) is a TypeScript library that provides easy commu
 - App installation and management
 - 🔜 OS updates
 
-⚠️
-<mark>
-** The Device Management Kit is in alpha stage and is subject to significant changes!!!**
-</mark>
-⚠️
-
 ## How it works
 
 The Device Management Kit features an interface for applications to handle any Ledger device (a.k. hardware wallets). It converts intention into

--- a/apps/docs/pages/docs/getting-started.mdx
+++ b/apps/docs/pages/docs/getting-started.mdx
@@ -1,5 +1,3 @@
-import { Callout } from "nextra/components";
-
 # Documentation
 
 <iframe
@@ -13,18 +11,6 @@ import { Callout } from "nextra/components";
 ></iframe>
 
 Here you will find all the documentation related to the Device Management Kit and the signers that come along with it.
-
-<Callout type="warning" emoji="⚠️">
-  This project is still in early development so we allow ourselves to make
-  breaking changes regarding the usage of the Libraries.
-
-That's why any feedback is relevant for us in order to be able to make it stable as soon as
-possible. Get in touch with us on the [Ledger Discord
-server](https://developers.ledger.com/discord/) to provide your feedbacks.
-
-You can follow the migration guidelines for the DMK [here](./integration/migrations/dmk/05_to_06) and for the signers [here](./integration/migrations/signers/eth/1_1_0_to_1_2_0).
-
-</Callout>
 
 ## Glossary
 


### PR DESCRIPTION
### 📝 Description

The Device Management Kit and its signers are now production ready. This PR removes outdated readiness warnings from the public-facing documentation:

- Removed the `early development` / `breaking changes` warning callout from `apps/docs/pages/docs/getting-started.mdx` (along with the now-unused `Callout` import).
- Removed the `alpha stage and is subject to significant changes` block from the root `README.md`.

### ❓ Context

- **JIRA or GitHub link**: NO-ISSUE
- **Feature**: Documentation cleanup to reflect current production-ready status of DMK and signers.

### ✅ Checklist

- [x] **Covered by automatic tests** — N/A, documentation-only change (no behavior modified).
- [x] **Changeset is provided** — Not required: changes only affect the docs app and the root README, neither of which is a published package (per `CONTRIBUTING.md`).
- [x] **Documentation is up-to-date** — This PR is the documentation update.
- [x] **Impact of the changes:**
  - Users visiting the documentation site no longer see the "early development" warning callout on the Getting Started page.
  - The root README no longer advertises the project as being in "alpha stage".
  - No code, API, or behavior is changed.


Made with [Cursor](https://cursor.com)