### PR TITLE
✨ (solana-signer) [DSDK-1145]: Add requirement builder

### DIFF
--- a/.changeset/khaki-tips-flow.md
+++ b/.changeset/khaki-tips-flow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": minor
+---
+
+Add requirement builder

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/buildEnumCache.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/idl-type-pool/buildEnumCache.ts
@@ -1,5 +1,10 @@
 import { type Either, Left, Right } from "purify-ts";
 
+import {
+  readTlvEntries,
+  TlvParseError,
+} from "@internal/app-binder/clear-sign/tlv";
+
 import * as K from "./kinds";
 import { parseInlinePayload } from "./parsePool";
 import {
@@ -24,48 +29,6 @@ const TAG_EV_PAYLOAD = 0x25;
 
 const textDecoder = new TextDecoder("utf-8");
 
-type TlvRecord = { tag: number; value: Uint8Array };
-
-/** Decode a DER-encoded length at `offset`. Returns `[length, newOffset]`. */
-function decodeLength(buf: Uint8Array, offset: number): [number, number] {
-  if (offset >= buf.length) {
-    fail(new TruncatedDataError("truncated TLV length byte"));
-  }
-  const head = buf[offset]!;
-  offset += 1;
-  if (head < 0x80) {
-    return [head, offset];
-  }
-  const lengthSize = head & 0x7f;
-  if (lengthSize === 0) {
-    fail(new TruncatedDataError("indefinite-length form not allowed in DER"));
-  }
-  if (offset + lengthSize > buf.length) {
-    fail(new TruncatedDataError("truncated extended TLV length"));
-  }
-  let length = 0;
-  for (let i = 0; i < lengthSize; i++) {
-    length = length * 256 + buf[offset + i]!;
-  }
-  return [length, offset + lengthSize];
-}
-
-/** Parse every `(tag, value)` record in `buf` in stream order. */
-function readTlvRecords(buf: Uint8Array): TlvRecord[] {
-  const records: TlvRecord[] = [];
-  let offset = 0;
-  while (offset < buf.length) {
-    const tag = buf[offset]!;
-    const [length, afterLen] = decodeLength(buf, offset + 1);
-    if (afterLen + length > buf.length) {
-      fail(new TruncatedDataError("truncated TLV value"));
-    }
-    records.push({ tag, value: buf.subarray(afterLen, afterLen + length) });
-    offset = afterLen + length;
-  }
-  return records;
-}
-
 function readBE(buf: Uint8Array, size: number): number {
   let value = 0;
   for (let i = 0; i < size; i++) {
@@ -77,7 +40,7 @@ function readBE(buf: Uint8Array, size: number): number {
 function buildOne(
   tlv: Uint8Array,
 ): { key: string; variant: CachedVariant } | null {
-  const records = readTlvRecords(tlv);
+  const records = readTlvEntries(tlv);
   let enumId: string | undefined;
   let variantIndex: number | undefined;
   let variantName: string | undefined;
@@ -175,6 +138,9 @@ export function buildEnumCache(
   } catch (error) {
     if (error instanceof TypePoolDecoderThrow) {
       return Left(error.error);
+    }
+    if (error instanceof TlvParseError) {
+      return Left(new TruncatedDataError(error.message));
     }
     return Left(
       new InvalidVariantPayloadError(

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/RequirementAccumulator.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/RequirementAccumulator.test.ts
@@ -1,0 +1,59 @@
+import { RequirementAccumulator } from "./RequirementAccumulator";
+
+describe("RequirementAccumulator", () => {
+  it("deduplicates each descriptor type by its key", () => {
+    const accumulator = new RequirementAccumulator();
+    accumulator.addInstructionInfo("P", "00");
+    accumulator.addInstructionInfo("P", "00");
+    accumulator.addEnumVariant("P", "e", 1);
+    accumulator.addEnumVariant("P", "e", 1);
+    accumulator.addTokenInfo("mint");
+    accumulator.addTokenInfo("mint");
+    accumulator.addTokenAccountState("ata");
+    accumulator.addTokenAccountState("ata");
+    accumulator.addAltResolution("ALT", 2);
+    accumulator.addAltResolution("ALT", 2);
+    accumulator.addTrustedName("name");
+    accumulator.addTrustedName("name");
+
+    const result = accumulator.build();
+    expect(result.instructionInfos).toHaveLength(1);
+    expect(result.enumVariants).toHaveLength(1);
+    expect(result.tokenInfos).toEqual(["mint"]);
+    expect(result.tokenAccountStates).toEqual(["ata"]);
+    expect(result.altResolutions).toEqual([
+      { altAddress: "ALT", entryIndex: 2 },
+    ]);
+    expect(result.trustedNames).toEqual(["name"]);
+  });
+
+  it("preserves first-seen insertion order", () => {
+    const accumulator = new RequirementAccumulator();
+    accumulator.addTokenInfo("c");
+    accumulator.addTokenInfo("a");
+    accumulator.addTokenInfo("b");
+    accumulator.addTokenInfo("a");
+    expect(accumulator.build().tokenInfos).toEqual(["c", "a", "b"]);
+  });
+
+  it("treats different keys of the same type as distinct", () => {
+    const accumulator = new RequirementAccumulator();
+    accumulator.addAltResolution("ALT", 1);
+    accumulator.addAltResolution("ALT", 2);
+    accumulator.addEnumVariant("P", "e", 1);
+    accumulator.addEnumVariant("P", "e", 2);
+    expect(accumulator.build().altResolutions).toHaveLength(2);
+    expect(accumulator.build().enumVariants).toHaveLength(2);
+  });
+
+  it("returns an empty set when nothing was added", () => {
+    expect(new RequirementAccumulator().build()).toEqual({
+      instructionInfos: [],
+      enumVariants: [],
+      tokenInfos: [],
+      tokenAccountStates: [],
+      altResolutions: [],
+      trustedNames: [],
+    });
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/RequirementAccumulator.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/RequirementAccumulator.ts
@@ -1,0 +1,83 @@
+import {
+  type AltEntryKey,
+  type DescriptorRequirements,
+  type EnumVariantKey,
+  type ProgramDiscriminator,
+} from "./model";
+
+/**
+ * Collects requirements while deduplicating by each descriptor's key and
+ * preserving first-seen order, so the output is deterministic.
+ */
+export class RequirementAccumulator {
+  private readonly instructionInfos = new OrderedSet<ProgramDiscriminator>();
+  private readonly enumVariants = new OrderedSet<EnumVariantKey>();
+  private readonly tokenInfos = new OrderedSet<string>();
+  private readonly tokenAccountStates = new OrderedSet<string>();
+  private readonly altResolutions = new OrderedSet<AltEntryKey>();
+  private readonly trustedNames = new OrderedSet<string>();
+
+  addInstructionInfo(programId: string, discriminator: string): void {
+    this.instructionInfos.add(`${programId}:${discriminator}`, {
+      programId,
+      discriminator,
+    });
+  }
+
+  addEnumVariant(
+    programId: string,
+    enumId: string,
+    variantIndex: number,
+  ): void {
+    this.enumVariants.add(`${programId}:${enumId}:${variantIndex}`, {
+      programId,
+      enumId,
+      variantIndex,
+    });
+  }
+
+  addTokenInfo(mint: string): void {
+    this.tokenInfos.add(mint, mint);
+  }
+
+  addTokenAccountState(account: string): void {
+    this.tokenAccountStates.add(account, account);
+  }
+
+  addAltResolution(altAddress: string, entryIndex: number): void {
+    this.altResolutions.add(`${altAddress}:${entryIndex}`, {
+      altAddress,
+      entryIndex,
+    });
+  }
+
+  addTrustedName(address: string): void {
+    this.trustedNames.add(address, address);
+  }
+
+  build(): DescriptorRequirements {
+    return {
+      instructionInfos: this.instructionInfos.values(),
+      enumVariants: this.enumVariants.values(),
+      tokenInfos: this.tokenInfos.values(),
+      tokenAccountStates: this.tokenAccountStates.values(),
+      altResolutions: this.altResolutions.values(),
+      trustedNames: this.trustedNames.values(),
+    };
+  }
+}
+
+class OrderedSet<T> {
+  private readonly seen = new Set<string>();
+  private readonly items: T[] = [];
+
+  add(key: string, item: T): void {
+    if (this.seen.has(key)) return;
+    this.seen.add(key);
+    this.items.push(item);
+  }
+
+  values(): T[] {
+    return [...this.items];
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/RequirementsError.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/RequirementsError.ts
@@ -1,0 +1,55 @@
+import { type DmkError } from "@ledgerhq/device-management-kit";
+
+/** Raised when a descriptor TLV runs past the end of its buffer. */
+export class TruncatedDescriptorError implements DmkError {
+  readonly _tag = "TruncatedDescriptorError";
+  readonly originalError: Error;
+
+  constructor(message: string) {
+    this.originalError = new Error(
+      `Truncated clear-sign descriptor: ${message}`,
+    );
+  }
+}
+
+/** Raised when an INSTRUCTION_INFO TLV lacks a mandatory field. */
+export class MissingInstructionFieldError implements DmkError {
+  readonly _tag = "MissingInstructionFieldError";
+  readonly originalError: Error;
+
+  constructor(field: string) {
+    this.originalError = new Error(
+      `INSTRUCTION_INFO is missing mandatory field: ${field}.`,
+    );
+  }
+}
+
+/** Raised when decoding the instruction data against the type pool fails. */
+export class RequirementsDecodeError implements DmkError {
+  readonly _tag = "RequirementsDecodeError";
+  readonly originalError: Error;
+
+  constructor(message: string) {
+    this.originalError = new Error(message);
+  }
+}
+
+export type RequirementsError =
+  | TruncatedDescriptorError
+  | MissingInstructionFieldError
+  | RequirementsDecodeError;
+
+/**
+ * Internal exception used to unwind the recursive TLV parsers; caught at the
+ * public boundary and surfaced as a `Left`. Never escapes the module.
+ */
+export class RequirementsThrow extends Error {
+  constructor(readonly error: RequirementsError) {
+    super(error.originalError.message);
+    this.name = "RequirementsThrow";
+  }
+}
+
+export function fail(error: RequirementsError): never {
+  throw new RequirementsThrow(error);
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/__tests__/fixtures/tlvBuilders.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/__tests__/fixtures/tlvBuilders.ts
@@ -1,0 +1,112 @@
+/**
+ * Byte-level builders for the CAL substructure / INSTRUCTION_INFO TLVs the
+ * requirement builder consumes. Deliberately dumb so tests pin exact bytes.
+ */
+
+export function bytes(...values: number[]): Uint8Array {
+  return Uint8Array.from(values);
+}
+
+export function concat(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+function derLength(length: number): Uint8Array {
+  if (length < 0x80) return bytes(length);
+  if (length <= 0xff) return bytes(0x81, length);
+  return bytes(0x82, (length >> 8) & 0xff, length & 0xff);
+}
+
+/** One DER-style `tag || length || value` record. */
+export function tlv(tag: number, value: Uint8Array): Uint8Array {
+  return concat(bytes(tag), derLength(value.length), value);
+}
+
+// ---- VALUE + TOKEN_VALUE --------------------------------------------------
+
+export function value(source: number, payload: Uint8Array): Uint8Array {
+  return concat(tlv(0x01, bytes(source)), tlv(0x02, payload));
+}
+
+export function tokenValue(
+  kind: number,
+  opts: { value?: Uint8Array; accountIndex?: number } = {},
+): Uint8Array {
+  const parts = [tlv(0x01, bytes(kind))];
+  if (opts.value) parts.push(tlv(0x02, opts.value));
+  if (opts.accountIndex !== undefined)
+    parts.push(tlv(0x03, bytes(opts.accountIndex)));
+  return concat(...parts);
+}
+
+// ---- substructure values --------------------------------------------------
+
+export function valueFlowPort(opts: {
+  /** Single candidate; convenience for the common single-account port. */
+  accountIndex?: number;
+  /** Ordered candidate list (overrides `accountIndex`); ACCOUNT_INDEX repeats. */
+  accountIndices?: number[];
+  /** `OPTIONAL_ACCOUNT_STRATEGY` byte (omitted when undefined). */
+  optionalAccountStrategy?: number;
+  tokenValue?: Uint8Array;
+}): Uint8Array {
+  const indices =
+    opts.accountIndices ??
+    (opts.accountIndex !== undefined ? [opts.accountIndex] : []);
+  const parts = indices.map((index) => tlv(0x02, bytes(index)));
+  if (opts.optionalAccountStrategy !== undefined)
+    parts.push(tlv(0x07, bytes(opts.optionalAccountStrategy)));
+  if (opts.tokenValue) parts.push(tlv(0x05, opts.tokenValue));
+  return concat(...parts);
+}
+
+export function accountReset(opts: {
+  accountIndex: number;
+  requirePreBalanceZero?: boolean;
+}): Uint8Array {
+  return concat(
+    tlv(0x01, bytes(opts.accountIndex)),
+    tlv(0x02, bytes(opts.requirePreBalanceZero ? 1 : 0)),
+  );
+}
+
+/** DISPLAY_FIELD with PARAM_TRUSTED_NAME (param type 0x07) wrapping a VALUE. */
+export function trustedNameDisplayField(valueBytes: Uint8Array): Uint8Array {
+  return concat(tlv(0x02, bytes(0x07)), tlv(0x03, tlv(0x01, valueBytes)));
+}
+
+/**
+ * DISPLAY_FIELD with PARAM_TOKEN_AMOUNT (param type 0x02). The TOKEN reference
+ * is a VALUE at PARAM tag 0x02; a sibling VALUE (tag 0x01) is included so the
+ * builder mirrors real descriptors.
+ */
+export function tokenAmountDisplayField(
+  tokenValueBytes: Uint8Array,
+): Uint8Array {
+  return concat(
+    tlv(0x02, bytes(0x02)),
+    tlv(
+      0x03,
+      concat(tlv(0x01, value(0x00, bytes(0))), tlv(0x02, tokenValueBytes)),
+    ),
+  );
+}
+
+export function instructionInfo(opts: {
+  typePool: Uint8Array;
+  rootType: number;
+  mintAssociations?: { accountIndex: number; mintIndex: number }[];
+}): Uint8Array {
+  const parts = [tlv(0x06, opts.typePool), tlv(0x07, bytes(opts.rootType))];
+  for (const { accountIndex, mintIndex } of opts.mintAssociations ?? []) {
+    parts.push(tlv(0x08, bytes(accountIndex)), tlv(0x09, bytes(mintIndex)));
+  }
+  return concat(...parts);
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/buildRequirements.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/buildRequirements.test.ts
@@ -1,0 +1,360 @@
+import { type Either, Right } from "purify-ts";
+
+import {
+  type SelectedEnumVariant,
+  type VariantCache,
+} from "@internal/app-binder/clear-sign/idl-type-pool";
+import { DefaultBs58Encoder } from "@internal/app-binder/services/bs58Encoder";
+
+import {
+  accountReset,
+  bytes,
+  instructionInfo,
+  tokenValue,
+  trustedNameDisplayField,
+  value,
+  valueFlowPort,
+} from "./__tests__/fixtures/tlvBuilders";
+import { buildRequirements } from "./buildRequirements";
+import {
+  type MatchedInstruction,
+  type RequirementAccount,
+  SubstructureKind,
+} from "./model";
+import { TokenKind, ValueSource } from "./records";
+import { MissingInstructionFieldError } from "./RequirementsError";
+import { type EnumVariantSelector } from "./rules";
+
+const EMPTY_CACHE: VariantCache = new Map();
+const NO_ENUMS: EnumVariantSelector = () => Right([]);
+
+function account(
+  address?: string,
+  altRef?: RequirementAccount["altRef"],
+): RequirementAccount {
+  return { address, altRef };
+}
+
+function port(
+  kind: TokenKind,
+  opts: {
+    accountIndex?: number;
+    tokenAccountIndex?: number;
+    value?: Uint8Array;
+  } = {},
+) {
+  return {
+    kind: SubstructureKind.VALUE_FLOW_PORT,
+    data: valueFlowPort({
+      accountIndex: opts.accountIndex ?? 0,
+      tokenValue: tokenValue(kind, {
+        accountIndex: opts.tokenAccountIndex,
+        value: opts.value,
+      }),
+    }),
+  };
+}
+
+function matched(opts: {
+  programId?: string;
+  discriminator?: string;
+  accounts: RequirementAccount[];
+  data?: Uint8Array;
+  typePool?: Uint8Array;
+  rootType?: number;
+  mintAssociations?: { accountIndex: number; mintIndex: number }[];
+  substructures?: { kind: SubstructureKind; data: Uint8Array }[];
+  enumCache?: VariantCache;
+}): MatchedInstruction {
+  return {
+    instruction: {
+      programId: opts.programId ?? "Prog",
+      accounts: opts.accounts,
+      data: opts.data ?? new Uint8Array(),
+    },
+    descriptor: {
+      discriminator: opts.discriminator ?? "00",
+      instructionInfo: instructionInfo({
+        typePool: opts.typePool ?? bytes(0x00),
+        rootType: opts.rootType ?? 0,
+        mintAssociations: opts.mintAssociations,
+      }),
+      substructures: opts.substructures ?? [],
+      enumCache: opts.enumCache ?? EMPTY_CACHE,
+    },
+  };
+}
+
+function run(matchedList: MatchedInstruction[], selector = NO_ENUMS) {
+  return buildRequirements(matchedList, {
+    selectEnumVariants: selector,
+  }).unsafeCoerce();
+}
+
+describe("buildRequirements", () => {
+  it("System transfer: only INSTRUCTION_INFO, native port pulls no token info", () => {
+    const result = run([
+      matched({
+        programId: "11111111111111111111111111111111",
+        discriminator: "02000000",
+        accounts: [account("from"), account("to")],
+        substructures: [port(TokenKind.NATIVE, { accountIndex: 0 })],
+      }),
+    ]);
+    expect(result.instructionInfos).toEqual([
+      {
+        programId: "11111111111111111111111111111111",
+        discriminator: "02000000",
+      },
+    ]);
+    expect(result.tokenInfos).toEqual([]);
+    expect(result.tokenAccountStates).toEqual([]);
+  });
+
+  it("DIRECT port: a constant mint becomes a TOKEN_INFO", () => {
+    const mintBytes = new Uint8Array(32).fill(9);
+    const result = run([
+      matched({
+        accounts: [account("a")],
+        substructures: [
+          port(TokenKind.DIRECT, {
+            value: value(ValueSource.CONSTANT, mintBytes),
+          }),
+        ],
+      }),
+    ]);
+    expect(result.tokenInfos).toEqual([DefaultBs58Encoder.encode(mintBytes)]);
+  });
+
+  it("DIRECT port: an ACCOUNT_PATH mint resolves to the account address", () => {
+    const result = run([
+      matched({
+        accounts: [account("tokenAcct"), account("theMint")],
+        substructures: [
+          port(TokenKind.DIRECT, {
+            value: value(ValueSource.ACCOUNT_PATH, bytes(1)),
+          }),
+        ],
+      }),
+    ]);
+    expect(result.tokenInfos).toEqual(["theMint"]);
+  });
+
+  it("RESOLVE port not covered by MINT_ASSOC: sends TOKEN_ACCOUNT_STATE", () => {
+    const result = run([
+      matched({
+        accounts: [account("userAta")],
+        substructures: [
+          port(TokenKind.RESOLVE, { accountIndex: 0, tokenAccountIndex: 0 }),
+        ],
+      }),
+    ]);
+    expect(result.tokenAccountStates).toEqual(["userAta"]);
+    expect(result.tokenInfos).toEqual([]);
+  });
+
+  it("RESOLVE port covered by MINT_ASSOC: emits TOKEN_INFO, skips account-state", () => {
+    const result = run([
+      matched({
+        accounts: [account("createdAta"), account("theMint")],
+        mintAssociations: [{ accountIndex: 0, mintIndex: 1 }],
+        substructures: [
+          port(TokenKind.RESOLVE, { accountIndex: 0, tokenAccountIndex: 0 }),
+        ],
+      }),
+    ]);
+    expect(result.tokenAccountStates).toEqual([]);
+    expect(result.tokenInfos).toEqual(["theMint"]);
+  });
+
+  it("NULL port pulls no token requirements", () => {
+    const result = run([
+      matched({
+        accounts: [account("x")],
+        substructures: [port(TokenKind.NULL)],
+      }),
+    ]);
+    expect(result.tokenInfos).toEqual([]);
+    expect(result.tokenAccountStates).toEqual([]);
+  });
+
+  it("ACCOUNT_RESET with requirePreBalanceZero forces a TOKEN_ACCOUNT_STATE", () => {
+    const result = run([
+      matched({
+        accounts: [account("ata")],
+        substructures: [
+          {
+            kind: SubstructureKind.ACCOUNT_RESET,
+            data: accountReset({
+              accountIndex: 0,
+              requirePreBalanceZero: true,
+            }),
+          },
+        ],
+      }),
+    ]);
+    expect(result.tokenAccountStates).toEqual(["ata"]);
+  });
+
+  it("ACCOUNT_RESET without the flag adds nothing", () => {
+    const result = run([
+      matched({
+        accounts: [account("ata")],
+        substructures: [
+          {
+            kind: SubstructureKind.ACCOUNT_RESET,
+            data: accountReset({ accountIndex: 0 }),
+          },
+        ],
+      }),
+    ]);
+    expect(result.tokenAccountStates).toEqual([]);
+  });
+
+  it("emits ALT_RESOLUTION for ALT-supplied accounts only", () => {
+    const result = run([
+      matched({
+        accounts: [
+          account("staticKey"),
+          account(undefined, { altAddress: "ALT", entryIndex: 3 }),
+        ],
+      }),
+    ]);
+    expect(result.altResolutions).toEqual([
+      { altAddress: "ALT", entryIndex: 3 },
+    ]);
+  });
+
+  it("emits TRUSTED_NAME for PARAM_TRUSTED_NAME fields (account path + constant)", () => {
+    const constantAddr = new Uint8Array(32).fill(5);
+    const result = run([
+      matched({
+        accounts: [account("ignored"), account("namedAccount")],
+        substructures: [
+          {
+            kind: SubstructureKind.DISPLAY_FIELD,
+            data: trustedNameDisplayField(
+              value(ValueSource.ACCOUNT_PATH, bytes(1)),
+            ),
+          },
+          {
+            kind: SubstructureKind.DISPLAY_FIELD,
+            data: trustedNameDisplayField(
+              value(ValueSource.CONSTANT, constantAddr),
+            ),
+          },
+        ],
+      }),
+    ]);
+    expect(result.trustedNames).toEqual([
+      "namedAccount",
+      DefaultBs58Encoder.encode(constantAddr),
+    ]);
+  });
+
+  it("decodes selected enum variants via the default decoder", () => {
+    // pool: [0] STRUCT{ref 1}, [1] ENUM disc=U8 enum_id="k"; data selects variant 2.
+    const typePool = bytes(
+      2,
+      0x20,
+      0x01,
+      0x01,
+      0x28,
+      0x01,
+      0x00,
+      0x01,
+      0x01,
+      0x6b,
+    );
+    const result = buildRequirements([
+      matched({
+        programId: "P",
+        accounts: [],
+        data: bytes(2),
+        typePool,
+        rootType: 0,
+      }),
+    ]).unsafeCoerce();
+    expect(result.enumVariants).toEqual([
+      { programId: "P", enumId: "k", variantIndex: 2 },
+    ]);
+  });
+
+  it("deduplicates across instructions and stays deterministic", () => {
+    const usdc = new Uint8Array(32).fill(1);
+    const direct = () =>
+      matched({
+        programId: "P",
+        discriminator: "01",
+        accounts: [account("a")],
+        substructures: [
+          port(TokenKind.DIRECT, { value: value(ValueSource.CONSTANT, usdc) }),
+        ],
+      });
+    const result = run([direct(), direct()]);
+    expect(result.instructionInfos).toEqual([
+      { programId: "P", discriminator: "01" },
+    ]);
+    expect(result.tokenInfos).toEqual([DefaultBs58Encoder.encode(usdc)]);
+  });
+
+  it("Jupiter-like route: enum + two token infos + ALT entry", () => {
+    const inMint = new Uint8Array(32).fill(2);
+    const outMint = new Uint8Array(32).fill(3);
+    const selector: EnumVariantSelector = () =>
+      Right([{ enumId: "swap", variantIndex: 46 }] as SelectedEnumVariant[]);
+    const result = run(
+      [
+        matched({
+          programId: "JUP",
+          discriminator: "e517cb977ae3ad2a",
+          accounts: [
+            account("inputAta"),
+            account("outputAta"),
+            account(undefined, { altAddress: "ALT", entryIndex: 7 }),
+          ],
+          substructures: [
+            port(TokenKind.DIRECT, {
+              accountIndex: 0,
+              value: value(ValueSource.CONSTANT, inMint),
+            }),
+            port(TokenKind.DIRECT, {
+              accountIndex: 1,
+              value: value(ValueSource.CONSTANT, outMint),
+            }),
+          ],
+        }),
+      ],
+      selector,
+    );
+    expect(result.enumVariants).toEqual([
+      { programId: "JUP", enumId: "swap", variantIndex: 46 },
+    ]);
+    expect(result.tokenInfos).toEqual([
+      DefaultBs58Encoder.encode(inMint),
+      DefaultBs58Encoder.encode(outMint),
+    ]);
+    expect(result.altResolutions).toEqual([
+      { altAddress: "ALT", entryIndex: 7 },
+    ]);
+  });
+
+  it("surfaces a malformed INSTRUCTION_INFO as a typed Left", () => {
+    const broken: MatchedInstruction = {
+      instruction: { programId: "P", accounts: [], data: new Uint8Array() },
+      descriptor: {
+        discriminator: "00",
+        instructionInfo: bytes(0x07, 0x01, 0x00), // root type only, no type pool
+        substructures: [],
+        enumCache: EMPTY_CACHE,
+      },
+    };
+    const result: Either<unknown, unknown> = buildRequirements([broken], {
+      selectEnumVariants: NO_ENUMS,
+    });
+    expect(result.isLeft()).toBe(true);
+    result.ifLeft((error) =>
+      expect(error).toBeInstanceOf(MissingInstructionFieldError),
+    );
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/buildRequirements.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/buildRequirements.ts
@@ -1,0 +1,117 @@
+import { type Either, Left, Right } from "purify-ts";
+
+import { findSelectedEnumVariants } from "@internal/app-binder/clear-sign/idl-type-pool";
+import {
+  type Bs58Encoder,
+  DefaultBs58Encoder,
+} from "@internal/app-binder/services/bs58Encoder";
+
+import { type DescriptorRequirements, type MatchedInstruction } from "./model";
+import { parseInstructionDescriptor } from "./parseInstruction";
+import { type ParsedInstruction } from "./records";
+import { RequirementAccumulator } from "./RequirementAccumulator";
+import {
+  RequirementsDecodeError,
+  type RequirementsError,
+  RequirementsThrow,
+} from "./RequirementsError";
+import {
+  applyAltResolutionRule,
+  applyEnumVariantRule,
+  applyInstructionInfoRule,
+  applyTokenRule,
+  applyTrustedNameRule,
+  type EnumVariantSelector,
+} from "./rules";
+
+export type BuildRequirementsOptions = {
+  /** Enum-variant decoder; defaults to the real type-pool decoder. */
+  selectEnumVariants?: EnumVariantSelector;
+  /** Base58 encoder for pubkey constants; defaults to {@link DefaultBs58Encoder}. */
+  bs58Encoder?: Bs58Encoder;
+};
+
+/** TX-derived `MINT_ASSOC` bindings: token-account address → mint address. */
+function buildMintBindings(
+  matched: MatchedInstruction[],
+  parsed: ParsedInstruction[],
+): Map<string, string> {
+  const bindings = new Map<string, string>();
+  matched.forEach((match, index) => {
+    const { accounts } = match.instruction;
+    for (const { accountIndex, mintIndex } of parsed[index]!.info
+      .mintAssociations) {
+      const account = accounts[accountIndex]?.address;
+      const mint = accounts[mintIndex]?.address;
+      if (account !== undefined && mint !== undefined) {
+        bindings.set(account, mint);
+      }
+    }
+  });
+  return bindings;
+}
+
+/**
+ * Given every TX instruction matched to its CAL descriptor, compute the
+ * deduplicated set of extra descriptors the device must fetch. Pure and
+ * deterministic; malformed descriptors surface as a typed
+ * {@link RequirementsError} `Left`.
+ */
+export function buildRequirements(
+  matched: MatchedInstruction[],
+  options: BuildRequirementsOptions = {},
+): Either<RequirementsError, DescriptorRequirements> {
+  const selectEnumVariants =
+    options.selectEnumVariants ?? findSelectedEnumVariants;
+  const bs58Encoder = options.bs58Encoder ?? DefaultBs58Encoder;
+  try {
+    const accumulator = new RequirementAccumulator();
+    const instructions = matched.map((match) => ({
+      match,
+      records: parseInstructionDescriptor(match.descriptor),
+    }));
+    const mintBindings = buildMintBindings(
+      matched,
+      instructions.map(({ records }) => records),
+    );
+
+    for (const { match, records } of instructions) {
+      applyInstructionInfoRule(match, accumulator);
+
+      const decodeFailure = applyEnumVariantRule(
+        match,
+        accumulator,
+        selectEnumVariants,
+        records.info.typePool,
+        records.info.rootType,
+      ).extract();
+      if (decodeFailure) return Left(decodeFailure);
+
+      applyTokenRule(
+        records,
+        match.instruction,
+        mintBindings,
+        accumulator,
+        bs58Encoder,
+      );
+      applyAltResolutionRule(match.instruction, accumulator);
+      applyTrustedNameRule(
+        records,
+        match.instruction,
+        accumulator,
+        bs58Encoder,
+      );
+    }
+
+    return Right(accumulator.build());
+  } catch (error) {
+    if (error instanceof RequirementsThrow) {
+      return Left(error.error);
+    }
+    return Left(
+      new RequirementsDecodeError(
+        error instanceof Error ? error.message : String(error),
+      ),
+    );
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/descriptorTlv.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/descriptorTlv.test.ts
@@ -1,0 +1,53 @@
+import { bytes, tlv } from "./__tests__/fixtures/tlvBuilders";
+import { firstTag, firstU8, readTlvEntries } from "./descriptorTlv";
+import {
+  RequirementsThrow,
+  TruncatedDescriptorError,
+} from "./RequirementsError";
+
+describe("readTlvEntries", () => {
+  it("parses sequential records in order", () => {
+    const buffer = bytes(0x01, 0x01, 0xaa, 0x02, 0x02, 0xbb, 0xcc);
+    const entries = readTlvEntries(buffer);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({ tag: 0x01 });
+    expect(Array.from(entries[1]!.value)).toEqual([0xbb, 0xcc]);
+  });
+
+  it("decodes DER extended lengths (> 127 bytes)", () => {
+    const value = new Uint8Array(200).fill(0x07);
+    const entries = readTlvEntries(tlv(0x09, value));
+    expect(entries[0]!.value).toHaveLength(200);
+  });
+
+  it("throws a typed error on a truncated value", () => {
+    let caught: unknown;
+    try {
+      readTlvEntries(bytes(0x01, 0x05, 0x00)); // claims 5, has 1
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(RequirementsThrow);
+    expect((caught as RequirementsThrow).error).toBeInstanceOf(
+      TruncatedDescriptorError,
+    );
+  });
+});
+
+describe("firstTag / firstU8", () => {
+  it("returns the first matching value or undefined", () => {
+    const entries = readTlvEntries(concatRecords());
+    expect(Array.from(firstTag(entries, 0x02)!)).toEqual([0x42]);
+    expect(firstTag(entries, 0x99)).toBeUndefined();
+  });
+
+  it("firstU8 returns the first byte or undefined", () => {
+    const entries = readTlvEntries(concatRecords());
+    expect(firstU8(entries, 0x02)).toBe(0x42);
+    expect(firstU8(entries, 0x99)).toBeUndefined();
+  });
+});
+
+function concatRecords(): Uint8Array {
+  return Uint8Array.from([0x01, 0x01, 0x10, 0x02, 0x01, 0x42]);
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/descriptorTlv.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/descriptorTlv.ts
@@ -1,0 +1,28 @@
+import {
+  readTlvEntries as readTlvEntriesRaw,
+  type TlvEntry,
+  TlvParseError,
+} from "@internal/app-binder/clear-sign/tlv";
+
+import { fail, TruncatedDescriptorError } from "./RequirementsError";
+
+export {
+  firstTag,
+  firstU8,
+  type TlvEntry,
+} from "@internal/app-binder/clear-sign/tlv";
+
+/**
+ * {@link readTlvEntriesRaw} wrapped to surface malformed framing as the
+ * requirement builder's own typed {@link TruncatedDescriptorError}.
+ */
+export function readTlvEntries(buffer: Uint8Array): TlvEntry[] {
+  try {
+    return readTlvEntriesRaw(buffer);
+  } catch (error) {
+    if (error instanceof TlvParseError) {
+      fail(new TruncatedDescriptorError(error.message));
+    }
+    throw error;
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/index.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/index.ts
@@ -1,0 +1,45 @@
+export {
+  buildRequirements,
+  type BuildRequirementsOptions,
+} from "./buildRequirements";
+export {
+  type AltEntryKey,
+  type DescriptorRequirements,
+  type EnumVariantKey,
+  type InstructionDescriptor,
+  type MatchedInstruction,
+  type ProgramDiscriminator,
+  type RequirementAccount,
+  type RequirementInstruction,
+  type SubstructureDescriptor,
+  SubstructureKind,
+} from "./model";
+export { parseInstructionDescriptor } from "./parseInstruction";
+export {
+  parseAccountReset,
+  parseDisplayField,
+  parseInstructionInfo,
+  parseValueFlowPort,
+} from "./parseSubstructures";
+export {
+  type MintAssociation,
+  OptionalAccountStrategy,
+  PARAM_TYPE_TOKEN_AMOUNT,
+  PARAM_TYPE_TRUSTED_NAME,
+  type ParsedAccountReset,
+  type ParsedDisplayField,
+  type ParsedInstruction,
+  type ParsedInstructionInfo,
+  type ParsedTokenValue,
+  type ParsedValue,
+  type ParsedValueFlowPort,
+  TokenKind,
+  ValueSource,
+} from "./records";
+export {
+  MissingInstructionFieldError,
+  RequirementsDecodeError,
+  type RequirementsError,
+  TruncatedDescriptorError,
+} from "./RequirementsError";
+export { type EnumVariantSelector } from "./rules";

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/model.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/model.ts
@@ -1,0 +1,69 @@
+import { type VariantCache } from "@internal/app-binder/clear-sign/idl-type-pool";
+
+/** Kind byte tagging an INSTRUCTION_INFO substructure descriptor. */
+export enum SubstructureKind {
+  DISPLAY_FIELD = 0x00,
+  VALUE_FLOW_PORT = 0x01,
+  HIDE_RULE = 0x02,
+  ACCOUNT_RESET = 0x03,
+}
+
+/** A `(altAddress, entryIndex)` reference into an Address Lookup Table. */
+export type AltEntryKey = { altAddress: string; entryIndex: number };
+
+/**
+ * One account slot of an instruction. `address` is the resolved base58 key;
+ * it is `undefined` for ALT-supplied slots that are not resolved at
+ * requirement-build time (DMK does not talk to RPC) — those still carry an
+ * `altRef` so an `ALT_RESOLUTION` requirement can be emitted.
+ */
+export type RequirementAccount = {
+  address?: string;
+  altRef?: AltEntryKey;
+};
+
+export type RequirementInstruction = {
+  programId: string;
+  accounts: RequirementAccount[];
+  data: Uint8Array;
+};
+
+/** One substructure descriptor as delivered by CAL (opaque TLV bytes). */
+export type SubstructureDescriptor = {
+  kind: SubstructureKind;
+  data: Uint8Array;
+};
+
+/** The matched CAL descriptor for one instruction. */
+export type InstructionDescriptor = {
+  discriminator: string;
+  instructionInfo: Uint8Array;
+  substructures: SubstructureDescriptor[];
+  enumCache: VariantCache;
+};
+
+/** A transaction instruction paired with its matched CAL descriptor. */
+export type MatchedInstruction = {
+  instruction: RequirementInstruction;
+  descriptor: InstructionDescriptor;
+};
+
+// ---- output ---------------------------------------------------------------
+
+export type ProgramDiscriminator = { programId: string; discriminator: string };
+
+export type EnumVariantKey = {
+  programId: string;
+  enumId: string;
+  variantIndex: number;
+};
+
+/** The deduplicated set of descriptors the device needs, per descriptor type. */
+export type DescriptorRequirements = {
+  instructionInfos: ProgramDiscriminator[];
+  enumVariants: EnumVariantKey[];
+  tokenInfos: string[];
+  tokenAccountStates: string[];
+  altResolutions: AltEntryKey[];
+  trustedNames: string[];
+};

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/parseInstruction.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/parseInstruction.test.ts
@@ -1,0 +1,80 @@
+import {
+  accountReset,
+  bytes,
+  instructionInfo,
+  tokenValue,
+  trustedNameDisplayField,
+  value,
+  valueFlowPort,
+} from "./__tests__/fixtures/tlvBuilders";
+import { type InstructionDescriptor, SubstructureKind } from "./model";
+import { parseInstructionDescriptor } from "./parseInstruction";
+import { TokenKind } from "./records";
+
+function descriptor(
+  substructures: { kind: SubstructureKind; data: Uint8Array }[],
+): InstructionDescriptor {
+  return {
+    discriminator: "00",
+    instructionInfo: instructionInfo({ typePool: bytes(0x00), rootType: 0 }),
+    substructures,
+    enumCache: new Map(),
+  };
+}
+
+describe("parseInstructionDescriptor", () => {
+  it("groups substructures by kind", () => {
+    const parsed = parseInstructionDescriptor(
+      descriptor([
+        {
+          kind: SubstructureKind.VALUE_FLOW_PORT,
+          data: valueFlowPort({
+            accountIndex: 0,
+            tokenValue: tokenValue(TokenKind.NATIVE),
+          }),
+        },
+        {
+          kind: SubstructureKind.ACCOUNT_RESET,
+          data: accountReset({ accountIndex: 1, requirePreBalanceZero: true }),
+        },
+        {
+          kind: SubstructureKind.DISPLAY_FIELD,
+          data: trustedNameDisplayField(value(0x01, bytes(2))),
+        },
+      ]),
+    );
+    expect(parsed.valueFlowPorts).toHaveLength(1);
+    expect(parsed.accountResets).toHaveLength(1);
+    expect(parsed.displayFields).toHaveLength(1);
+  });
+
+  it("ignores HIDE_RULE substructures (out of scope here)", () => {
+    const parsed = parseInstructionDescriptor(
+      descriptor([
+        { kind: SubstructureKind.HIDE_RULE, data: bytes(0x01, 0x01, 0x00) },
+      ]),
+    );
+    expect(parsed.valueFlowPorts).toEqual([]);
+    expect(parsed.accountResets).toEqual([]);
+    expect(parsed.displayFields).toEqual([]);
+  });
+
+  it("keeps multiple substructures of the same kind in order", () => {
+    const parsed = parseInstructionDescriptor(
+      descriptor([
+        {
+          kind: SubstructureKind.VALUE_FLOW_PORT,
+          data: valueFlowPort({ accountIndex: 0 }),
+        },
+        {
+          kind: SubstructureKind.VALUE_FLOW_PORT,
+          data: valueFlowPort({ accountIndex: 1 }),
+        },
+      ]),
+    );
+    expect(parsed.valueFlowPorts.map((port) => port.accountIndices)).toEqual([
+      [0],
+      [1],
+    ]);
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/parseInstruction.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/parseInstruction.ts
@@ -1,0 +1,42 @@
+import { type InstructionDescriptor, SubstructureKind } from "./model";
+import {
+  parseAccountReset,
+  parseDisplayField,
+  parseInstructionInfo,
+  parseValueFlowPort,
+} from "./parseSubstructures";
+import { type ParsedInstruction } from "./records";
+
+/**
+ * Parse a matched CAL descriptor's INSTRUCTION_INFO and substructure TLVs into
+ * structured records grouped by kind. HIDE_RULE substructures are ignored —
+ * they only drive post-resolution witness logic, out of scope here.
+ */
+export function parseInstructionDescriptor(
+  descriptor: InstructionDescriptor,
+): ParsedInstruction {
+  const parsed: ParsedInstruction = {
+    info: parseInstructionInfo(descriptor.instructionInfo),
+    valueFlowPorts: [],
+    accountResets: [],
+    displayFields: [],
+  };
+
+  for (const { kind, data } of descriptor.substructures) {
+    switch (kind) {
+      case SubstructureKind.VALUE_FLOW_PORT:
+        parsed.valueFlowPorts.push(parseValueFlowPort(data));
+        break;
+      case SubstructureKind.ACCOUNT_RESET:
+        parsed.accountResets.push(parseAccountReset(data));
+        break;
+      case SubstructureKind.DISPLAY_FIELD:
+        parsed.displayFields.push(parseDisplayField(data));
+        break;
+      default:
+        break;
+    }
+  }
+
+  return parsed;
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/parseSubstructures.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/parseSubstructures.test.ts
@@ -1,0 +1,151 @@
+import {
+  accountReset,
+  bytes,
+  instructionInfo,
+  tokenAmountDisplayField,
+  tokenValue,
+  trustedNameDisplayField,
+  value,
+  valueFlowPort,
+} from "./__tests__/fixtures/tlvBuilders";
+import {
+  parseAccountReset,
+  parseDisplayField,
+  parseInstructionInfo,
+  parseValueFlowPort,
+} from "./parseSubstructures";
+import {
+  PARAM_TYPE_TOKEN_AMOUNT,
+  PARAM_TYPE_TRUSTED_NAME,
+  TokenKind,
+  ValueSource,
+} from "./records";
+import {
+  MissingInstructionFieldError,
+  type RequirementsThrow,
+} from "./RequirementsError";
+
+describe("parseInstructionInfo", () => {
+  it("extracts type pool, root type and MINT_ASSOC pairs", () => {
+    const parsed = parseInstructionInfo(
+      instructionInfo({
+        typePool: bytes(0x01, 0x11),
+        rootType: 3,
+        mintAssociations: [{ accountIndex: 1, mintIndex: 4 }],
+      }),
+    );
+    expect(Array.from(parsed.typePool)).toEqual([0x01, 0x11]);
+    expect(parsed.rootType).toBe(3);
+    expect(parsed.mintAssociations).toEqual([
+      { accountIndex: 1, mintIndex: 4 },
+    ]);
+  });
+
+  it("fails when IDL_TYPE_POOL is missing", () => {
+    let caught: unknown;
+    try {
+      parseInstructionInfo(bytes(0x07, 0x01, 0x00)); // only root type
+    } catch (error) {
+      caught = error;
+    }
+    expect((caught as RequirementsThrow).error).toBeInstanceOf(
+      MissingInstructionFieldError,
+    );
+  });
+});
+
+describe("parseValueFlowPort", () => {
+  it("parses a RESOLVE port with an explicit token account index", () => {
+    const parsed = parseValueFlowPort(
+      valueFlowPort({
+        accountIndex: 2,
+        tokenValue: tokenValue(TokenKind.RESOLVE, { accountIndex: 5 }),
+      }),
+    );
+    expect(parsed.accountIndices).toEqual([2]);
+    expect(parsed.tokenValue).toMatchObject({
+      kind: TokenKind.RESOLVE,
+      accountIndex: 5,
+    });
+  });
+
+  it("collects a repeated ACCOUNT_INDEX into an ordered candidate list and reads the strategy", () => {
+    const parsed = parseValueFlowPort(
+      valueFlowPort({
+        accountIndices: [3, 7, 1],
+        optionalAccountStrategy: 0x01,
+      }),
+    );
+    expect(parsed.accountIndices).toEqual([3, 7, 1]);
+    expect(parsed.optionalAccountStrategy).toBe(0x01);
+  });
+
+  it("defaults a single-account port to the PROGRAM_ID strategy", () => {
+    const parsed = parseValueFlowPort(valueFlowPort({ accountIndex: 2 }));
+    expect(parsed.accountIndices).toEqual([2]);
+    expect(parsed.optionalAccountStrategy).toBe(0x00);
+  });
+
+  it("parses a DIRECT port with a constant mint", () => {
+    const mint = new Uint8Array(32).fill(7);
+    const parsed = parseValueFlowPort(
+      valueFlowPort({
+        accountIndex: 0,
+        tokenValue: tokenValue(TokenKind.DIRECT, {
+          value: value(ValueSource.CONSTANT, mint),
+        }),
+      }),
+    );
+    expect(parsed.tokenValue?.kind).toBe(TokenKind.DIRECT);
+    expect(parsed.tokenValue?.value).toMatchObject({
+      source: ValueSource.CONSTANT,
+    });
+    expect(parsed.tokenValue?.value?.payload).toHaveLength(32);
+  });
+
+  it("parses a NATIVE port with no value", () => {
+    const parsed = parseValueFlowPort(
+      valueFlowPort({
+        accountIndex: 1,
+        tokenValue: tokenValue(TokenKind.NATIVE),
+      }),
+    );
+    expect(parsed.tokenValue).toMatchObject({ kind: TokenKind.NATIVE });
+    expect(parsed.tokenValue?.value).toBeUndefined();
+  });
+});
+
+describe("parseAccountReset", () => {
+  it("reads the account index and the pre-balance-zero flag", () => {
+    expect(
+      parseAccountReset(
+        accountReset({ accountIndex: 4, requirePreBalanceZero: true }),
+      ),
+    ).toEqual({ accountIndex: 4, requirePreBalanceZero: true });
+    expect(parseAccountReset(accountReset({ accountIndex: 1 }))).toEqual({
+      accountIndex: 1,
+      requirePreBalanceZero: false,
+    });
+  });
+});
+
+describe("parseDisplayField", () => {
+  it("parses a trusted-name field's inner VALUE", () => {
+    const parsed = parseDisplayField(
+      trustedNameDisplayField(value(ValueSource.ACCOUNT_PATH, bytes(6))),
+    );
+    expect(parsed.paramType).toBe(PARAM_TYPE_TRUSTED_NAME);
+    expect(parsed.value).toMatchObject({ source: ValueSource.ACCOUNT_PATH });
+    expect(Array.from(parsed.value!.payload)).toEqual([6]);
+    expect(parsed.token).toBeUndefined();
+  });
+
+  it("parses a token-amount field's TOKEN reference (PARAM tag 0x02)", () => {
+    const parsed = parseDisplayField(
+      tokenAmountDisplayField(value(ValueSource.ACCOUNT_PATH, bytes(4))),
+    );
+    expect(parsed.paramType).toBe(PARAM_TYPE_TOKEN_AMOUNT);
+    expect(parsed.token).toMatchObject({ source: ValueSource.ACCOUNT_PATH });
+    expect(Array.from(parsed.token!.payload)).toEqual([4]);
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/parseSubstructures.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/parseSubstructures.ts
@@ -1,0 +1,167 @@
+import {
+  firstTag,
+  firstU8,
+  readTlvEntries,
+  type TlvEntry,
+} from "./descriptorTlv";
+import {
+  type MintAssociation,
+  OptionalAccountStrategy,
+  PARAM_TYPE_TOKEN_AMOUNT,
+  type ParsedAccountReset,
+  type ParsedDisplayField,
+  type ParsedInstructionInfo,
+  type ParsedTokenValue,
+  type ParsedValue,
+  type ParsedValueFlowPort,
+  type TokenKind,
+  type ValueSource,
+} from "./records";
+import { fail, MissingInstructionFieldError } from "./RequirementsError";
+
+const InstructionInfoTag = {
+  IDL_TYPE_POOL: 0x06,
+  IDL_ROOT_TYPE: 0x07,
+  MINT_ASSOC_ACCOUNT: 0x08,
+  MINT_ASSOC_MINT: 0x09,
+} as const;
+
+const ValueFlowPortTag = {
+  // ACCOUNT_INDEX MAY repeat to form an ordered candidate list.
+  ACCOUNT_INDEX: 0x02,
+  TOKEN_VALUE: 0x05,
+  OPTIONAL_ACCOUNT_STRATEGY: 0x07,
+} as const;
+
+const TokenValueTag = {
+  KIND: 0x01,
+  VALUE: 0x02,
+  ACCOUNT: 0x03,
+} as const;
+
+const ValueTag = {
+  SOURCE: 0x01,
+  PAYLOAD: 0x02,
+} as const;
+
+const DisplayFieldTag = {
+  PARAM_TYPE: 0x02,
+  PARAM: 0x03,
+} as const;
+
+// The VALUE tag is `0x01` inside every PARAM_* substructure.
+const PARAM_VALUE_TAG = 0x01;
+
+// `PARAM_TOKEN_AMOUNT.TOKEN` (the token reference) lives at tag `0x02`.
+const PARAM_TOKEN_AMOUNT_TOKEN_TAG = 0x02;
+
+/** Collect the leading byte of every entry carrying `tag` (for repeated tags). */
+function allU8(entries: TlvEntry[], tag: number): number[] {
+  const out: number[] = [];
+  for (const entry of entries) {
+    if (entry.tag === tag && entry.value.length > 0) out.push(entry.value[0]!);
+  }
+  return out;
+}
+
+const AccountResetTag = {
+  ACCOUNT_INDEX: 0x01,
+  REQUIRE_PRE_BALANCE_ZERO: 0x02,
+} as const;
+
+function parseValue(bytes: Uint8Array): ParsedValue {
+  const entries = readTlvEntries(bytes);
+  return {
+    source: (firstU8(entries, ValueTag.SOURCE) ?? 0) as ValueSource,
+    payload: firstTag(entries, ValueTag.PAYLOAD) ?? new Uint8Array(),
+  };
+}
+
+function parseTokenValue(bytes: Uint8Array): ParsedTokenValue {
+  const entries = readTlvEntries(bytes);
+  const valueBytes = firstTag(entries, TokenValueTag.VALUE);
+  return {
+    kind: (firstU8(entries, TokenValueTag.KIND) ?? 0) as TokenKind,
+    value: valueBytes ? parseValue(valueBytes) : undefined,
+    accountIndex: firstU8(entries, TokenValueTag.ACCOUNT),
+  };
+}
+
+/**
+ * Parse an INSTRUCTION_INFO TLV into the fields the requirement builder needs.
+ * `IDL_TYPE_POOL` and `IDL_ROOT_TYPE` are mandatory; `MINT_ASSOC_*` pairs are
+ * collected in order (an account tag immediately followed by its mint tag).
+ */
+export function parseInstructionInfo(bytes: Uint8Array): ParsedInstructionInfo {
+  const entries = readTlvEntries(bytes);
+  const typePool = firstTag(entries, InstructionInfoTag.IDL_TYPE_POOL);
+  if (typePool === undefined) {
+    fail(new MissingInstructionFieldError("IDL_TYPE_POOL"));
+  }
+  const rootType = firstU8(entries, InstructionInfoTag.IDL_ROOT_TYPE);
+  if (rootType === undefined) {
+    fail(new MissingInstructionFieldError("IDL_ROOT_TYPE"));
+  }
+
+  const mintAssociations: MintAssociation[] = [];
+  let pendingAccountIndex: number | undefined;
+  for (const { tag, value } of entries) {
+    if (tag === InstructionInfoTag.MINT_ASSOC_ACCOUNT && value.length > 0) {
+      pendingAccountIndex = value[0];
+    } else if (
+      tag === InstructionInfoTag.MINT_ASSOC_MINT &&
+      value.length > 0 &&
+      pendingAccountIndex !== undefined
+    ) {
+      mintAssociations.push({
+        accountIndex: pendingAccountIndex,
+        mintIndex: value[0]!,
+      });
+      pendingAccountIndex = undefined;
+    }
+  }
+
+  return { typePool, rootType, mintAssociations };
+}
+
+export function parseValueFlowPort(bytes: Uint8Array): ParsedValueFlowPort {
+  const entries = readTlvEntries(bytes);
+  const tokenValueBytes = firstTag(entries, ValueFlowPortTag.TOKEN_VALUE);
+  return {
+    accountIndices: allU8(entries, ValueFlowPortTag.ACCOUNT_INDEX),
+    optionalAccountStrategy: (firstU8(
+      entries,
+      ValueFlowPortTag.OPTIONAL_ACCOUNT_STRATEGY,
+    ) ?? OptionalAccountStrategy.PROGRAM_ID) as OptionalAccountStrategy,
+    tokenValue: tokenValueBytes ? parseTokenValue(tokenValueBytes) : undefined,
+  };
+}
+
+export function parseAccountReset(bytes: Uint8Array): ParsedAccountReset {
+  const entries = readTlvEntries(bytes);
+  return {
+    accountIndex: firstU8(entries, AccountResetTag.ACCOUNT_INDEX) ?? 0,
+    requirePreBalanceZero:
+      (firstU8(entries, AccountResetTag.REQUIRE_PRE_BALANCE_ZERO) ?? 0) !== 0,
+  };
+}
+
+export function parseDisplayField(bytes: Uint8Array): ParsedDisplayField {
+  const entries = readTlvEntries(bytes);
+  const paramType = firstU8(entries, DisplayFieldTag.PARAM_TYPE);
+  const paramBytes = firstTag(entries, DisplayFieldTag.PARAM);
+  const paramEntries = paramBytes ? readTlvEntries(paramBytes) : [];
+  const valueBytes = firstTag(paramEntries, PARAM_VALUE_TAG);
+  // The TOKEN reference only exists (and tag 0x02 only means TOKEN) for a
+  // PARAM_TOKEN_AMOUNT param; for other param types tag 0x02 carries unrelated
+  // fields (e.g. decimals), so guard on the param type.
+  const tokenBytes =
+    paramType === PARAM_TYPE_TOKEN_AMOUNT
+      ? firstTag(paramEntries, PARAM_TOKEN_AMOUNT_TOKEN_TAG)
+      : undefined;
+  return {
+    paramType,
+    value: valueBytes ? parseValue(valueBytes) : undefined,
+    token: tokenBytes ? parseValue(tokenBytes) : undefined,
+  };
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/records.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/records.ts
@@ -1,0 +1,84 @@
+/** Where a VALUE is sourced from (`VALUE.SOURCE`). */
+export enum ValueSource {
+  ARGUMENT_PATH = 0x00,
+  ACCOUNT_PATH = 0x01,
+  CONSTANT = 0x02,
+}
+
+/** How a port's token identity is resolved (`TOKEN_VALUE.KIND`). */
+export enum TokenKind {
+  DIRECT = 0x00,
+  RESOLVE = 0x01,
+  NULL = 0x02,
+  NATIVE = 0x03,
+}
+
+/**
+ * How a candidate-array port's optional (non-final) candidates are detected as
+ * *unset* (`VALUE_FLOW_PORT.OPTIONAL_ACCOUNT_STRATEGY`). Only meaningful when a
+ * port carries more than one candidate index; defaults to `PROGRAM_ID`.
+ */
+export enum OptionalAccountStrategy {
+  /** Slot is unset when its address equals the instruction's program id. */
+  PROGRAM_ID = 0x00,
+  /** Slot is unset only when out of range (an omitted trailing account). */
+  OMITTED = 0x01,
+}
+
+/** `DISPLAY_FIELD.PARAM_TYPE` value for an address resolved via trusted name. */
+export const PARAM_TYPE_TRUSTED_NAME = 0x07;
+
+/** `DISPLAY_FIELD.PARAM_TYPE` value for a token amount with a token reference. */
+export const PARAM_TYPE_TOKEN_AMOUNT = 0x02;
+
+export type ParsedValue = { source: ValueSource; payload: Uint8Array };
+
+export type ParsedTokenValue = {
+  kind: TokenKind;
+  value?: ParsedValue;
+  accountIndex?: number;
+};
+
+export type ParsedValueFlowPort = {
+  /**
+   * Ordered candidate account indices (length 1 for the common single-account
+   * port). Resolved to the first *provided* candidate; see
+   * `resolvePortAccountIndex`.
+   */
+  accountIndices: number[];
+  optionalAccountStrategy: OptionalAccountStrategy;
+  tokenValue?: ParsedTokenValue;
+};
+
+export type ParsedAccountReset = {
+  accountIndex: number;
+  requirePreBalanceZero: boolean;
+};
+
+export type ParsedDisplayField = {
+  paramType?: number;
+  value?: ParsedValue;
+  /**
+   * The `PARAM_TOKEN_AMOUNT.TOKEN` reference, populated only for a
+   * `PARAM_TYPE_TOKEN_AMOUNT` field. Identifies the token whose `TOKEN_INFO`
+   * the amount formatter needs; may point at a mint or, via a TX-derived
+   * `MINT_ASSOC` binding, at a token account.
+   */
+  token?: ParsedValue;
+};
+
+export type MintAssociation = { accountIndex: number; mintIndex: number };
+
+export type ParsedInstructionInfo = {
+  typePool: Uint8Array;
+  rootType: number;
+  mintAssociations: MintAssociation[];
+};
+
+/** An instruction's INSTRUCTION_INFO + its substructures, grouped by kind. */
+export type ParsedInstruction = {
+  info: ParsedInstructionInfo;
+  valueFlowPorts: ParsedValueFlowPort[];
+  accountResets: ParsedAccountReset[];
+  displayFields: ParsedDisplayField[];
+};

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/altResolutionRule.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/altResolutionRule.test.ts
@@ -1,0 +1,38 @@
+import { type RequirementInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import { RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+
+import { applyAltResolutionRule } from "./altResolutionRule";
+
+function run(instruction: RequirementInstruction) {
+  const accumulator = new RequirementAccumulator();
+  applyAltResolutionRule(instruction, accumulator);
+  return accumulator.build().altResolutions;
+}
+
+describe("applyAltResolutionRule", () => {
+  it("emits one ALT_RESOLUTION per ALT-supplied account, skipping static keys", () => {
+    const result = run({
+      programId: "P",
+      data: new Uint8Array(),
+      accounts: [
+        { address: "static" },
+        { address: undefined, altRef: { altAddress: "ALT", entryIndex: 1 } },
+        { address: "resolved", altRef: { altAddress: "ALT", entryIndex: 4 } },
+      ],
+    });
+    expect(result).toEqual([
+      { altAddress: "ALT", entryIndex: 1 },
+      { altAddress: "ALT", entryIndex: 4 },
+    ]);
+  });
+
+  it("emits nothing when no account is ALT-supplied", () => {
+    expect(
+      run({
+        programId: "P",
+        data: new Uint8Array(),
+        accounts: [{ address: "a" }],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/altResolutionRule.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/altResolutionRule.ts
@@ -1,0 +1,21 @@
+import { type RequirementInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import { type RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+
+/**
+ * Every ALT-supplied account an instruction references needs an `ALT_RESOLUTION`.
+ * ALT entries the instruction never references are absent from its account list
+ * and so are skipped.
+ */
+export function applyAltResolutionRule(
+  instruction: RequirementInstruction,
+  accumulator: RequirementAccumulator,
+): void {
+  for (const account of instruction.accounts) {
+    if (account.altRef !== undefined) {
+      accumulator.addAltResolution(
+        account.altRef.altAddress,
+        account.altRef.entryIndex,
+      );
+    }
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/enumVariantRule.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/enumVariantRule.test.ts
@@ -1,0 +1,84 @@
+import { Left, Right } from "purify-ts";
+
+import { type SelectedEnumVariant } from "@internal/app-binder/clear-sign/idl-type-pool";
+import { type MatchedInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import { RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+import { RequirementsDecodeError } from "@internal/app-binder/clear-sign/requirements/RequirementsError";
+
+import {
+  applyEnumVariantRule,
+  type EnumVariantSelector,
+} from "./enumVariantRule";
+
+const matched: MatchedInstruction = {
+  instruction: { programId: "P", accounts: [], data: Uint8Array.of(1, 2) },
+  descriptor: {
+    discriminator: "00",
+    instructionInfo: new Uint8Array(),
+    substructures: [],
+    enumCache: new Map(),
+  },
+};
+
+describe("applyEnumVariantRule", () => {
+  it("records each selected variant keyed by the instruction's programId", () => {
+    const selector: EnumVariantSelector = () =>
+      Right([
+        { enumId: "swap", variantIndex: 46 },
+        { enumId: "swap", variantIndex: 46 },
+      ] as SelectedEnumVariant[]);
+    const accumulator = new RequirementAccumulator();
+
+    const result = applyEnumVariantRule(
+      matched,
+      accumulator,
+      selector,
+      new Uint8Array(),
+      0,
+    );
+
+    expect(result.isRight()).toBe(true);
+    expect(accumulator.build().enumVariants).toEqual([
+      { programId: "P", enumId: "swap", variantIndex: 46 },
+    ]);
+  });
+
+  it("forwards the type pool, root type, cache and data to the selector", () => {
+    const calls: unknown[] = [];
+    const selector: EnumVariantSelector = (typePool, rootType, cache, data) => {
+      calls.push({ typePool, rootType, cache, data });
+      return Right([]);
+    };
+    applyEnumVariantRule(
+      matched,
+      new RequirementAccumulator(),
+      selector,
+      Uint8Array.of(9),
+      3,
+    );
+    expect(calls).toEqual([
+      {
+        typePool: Uint8Array.of(9),
+        rootType: 3,
+        cache: matched.descriptor.enumCache,
+        data: matched.instruction.data,
+      },
+    ]);
+  });
+
+  it("maps a decoder failure to a typed Left", () => {
+    const selector: EnumVariantSelector = () =>
+      Left({ originalError: new Error("bad pool") });
+    const result = applyEnumVariantRule(
+      matched,
+      new RequirementAccumulator(),
+      selector,
+      new Uint8Array(),
+      0,
+    );
+    expect(result.isLeft()).toBe(true);
+    result.ifLeft((error) =>
+      expect(error).toBeInstanceOf(RequirementsDecodeError),
+    );
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/enumVariantRule.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/enumVariantRule.ts
@@ -1,0 +1,49 @@
+import { type Either } from "purify-ts";
+
+import {
+  type SelectedEnumVariant,
+  type VariantCache,
+} from "@internal/app-binder/clear-sign/idl-type-pool";
+import { type MatchedInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import { type RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+import {
+  RequirementsDecodeError,
+  type RequirementsError,
+} from "@internal/app-binder/clear-sign/requirements/RequirementsError";
+
+/**
+ * Decodes the instruction data against the type pool to find the enum variants
+ * it selects. Injected (defaults to the real type-pool decoder) so the rule
+ * stays testable without a full decode.
+ */
+export type EnumVariantSelector = (
+  typePool: Uint8Array,
+  rootType: number,
+  enumCache: VariantCache,
+  data: Uint8Array,
+) => Either<{ originalError: Error }, SelectedEnumVariant[]>;
+
+/** One `ENUM_VARIANT` descriptor per `(programId, enumId, variantIndex)` selected. */
+export function applyEnumVariantRule(
+  matched: MatchedInstruction,
+  accumulator: RequirementAccumulator,
+  selectEnumVariants: EnumVariantSelector,
+  parsedTypePool: Uint8Array,
+  parsedRootType: number,
+): Either<RequirementsError, void> {
+  const { programId } = matched.instruction;
+  return selectEnumVariants(
+    parsedTypePool,
+    parsedRootType,
+    matched.descriptor.enumCache,
+    matched.instruction.data,
+  )
+    .mapLeft<RequirementsError>(
+      (error) => new RequirementsDecodeError(error.originalError.message),
+    )
+    .map((selected) => {
+      for (const { enumId, variantIndex } of selected) {
+        accumulator.addEnumVariant(programId, enumId, variantIndex);
+      }
+    });
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/index.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/index.ts
@@ -1,0 +1,8 @@
+export { applyAltResolutionRule } from "./altResolutionRule";
+export {
+  applyEnumVariantRule,
+  type EnumVariantSelector,
+} from "./enumVariantRule";
+export { applyInstructionInfoRule } from "./instructionInfoRule";
+export { applyTokenRule } from "./tokenRule";
+export { applyTrustedNameRule } from "./trustedNameRule";

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/instructionInfoRule.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/instructionInfoRule.test.ts
@@ -1,0 +1,24 @@
+import { type MatchedInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import { RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+
+import { applyInstructionInfoRule } from "./instructionInfoRule";
+
+describe("applyInstructionInfoRule", () => {
+  it("records the instruction's (programId, discriminator)", () => {
+    const matched = {
+      instruction: { programId: "P", accounts: [], data: new Uint8Array() },
+      descriptor: {
+        discriminator: "ab",
+        instructionInfo: new Uint8Array(),
+        substructures: [],
+        enumCache: new Map(),
+      },
+    } satisfies MatchedInstruction;
+
+    const accumulator = new RequirementAccumulator();
+    applyInstructionInfoRule(matched, accumulator);
+    expect(accumulator.build().instructionInfos).toEqual([
+      { programId: "P", discriminator: "ab" },
+    ]);
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/instructionInfoRule.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/instructionInfoRule.ts
@@ -1,0 +1,13 @@
+import { type MatchedInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import { type RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+
+/** Every matched instruction needs its `(programId, discriminator)` descriptor. */
+export function applyInstructionInfoRule(
+  matched: MatchedInstruction,
+  accumulator: RequirementAccumulator,
+): void {
+  accumulator.addInstructionInfo(
+    matched.instruction.programId,
+    matched.descriptor.discriminator,
+  );
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/tokenRule.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/tokenRule.test.ts
@@ -1,0 +1,346 @@
+import { type RequirementInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import {
+  OptionalAccountStrategy,
+  PARAM_TYPE_TOKEN_AMOUNT,
+  PARAM_TYPE_TRUSTED_NAME,
+  type ParsedAccountReset,
+  type ParsedDisplayField,
+  type ParsedInstruction,
+  type ParsedValue,
+  type ParsedValueFlowPort,
+  TokenKind,
+  ValueSource,
+} from "@internal/app-binder/clear-sign/requirements/records";
+import { RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+import { DefaultBs58Encoder } from "@internal/app-binder/services/bs58Encoder";
+
+import { applyTokenRule } from "./tokenRule";
+
+const EMPTY_INFO = {
+  typePool: new Uint8Array(),
+  rootType: 0,
+  mintAssociations: [],
+};
+
+/** Build a port, defaulting the candidate list and strategy. */
+function port(
+  overrides: Partial<ParsedValueFlowPort> & { accountIndex?: number },
+): ParsedValueFlowPort {
+  const { accountIndex, accountIndices, ...rest } = overrides;
+  return {
+    accountIndices:
+      accountIndices ?? (accountIndex !== undefined ? [accountIndex] : []),
+    optionalAccountStrategy: OptionalAccountStrategy.PROGRAM_ID,
+    ...rest,
+  };
+}
+
+/** A PARAM_TOKEN_AMOUNT display field whose TOKEN reference is `token`. */
+function tokenAmountField(token: ParsedValue): ParsedDisplayField {
+  return { paramType: PARAM_TYPE_TOKEN_AMOUNT, token };
+}
+
+function parsed(overrides: {
+  valueFlowPorts?: ParsedValueFlowPort[];
+  accountResets?: ParsedAccountReset[];
+  displayFields?: ParsedDisplayField[];
+}): ParsedInstruction {
+  return {
+    info: EMPTY_INFO,
+    valueFlowPorts: overrides.valueFlowPorts ?? [],
+    accountResets: overrides.accountResets ?? [],
+    displayFields: overrides.displayFields ?? [],
+  };
+}
+
+function makeInstruction(
+  addresses: (string | undefined)[],
+  programId = "P",
+): RequirementInstruction {
+  return {
+    programId,
+    accounts: addresses.map((address) => ({ address })),
+    data: new Uint8Array(),
+  };
+}
+
+function run(
+  records: ParsedInstruction,
+  instruction: RequirementInstruction,
+  bindings: Map<string, string> = new Map(),
+) {
+  const accumulator = new RequirementAccumulator();
+  applyTokenRule(records, instruction, bindings, accumulator);
+  return accumulator.build();
+}
+
+describe("applyTokenRule", () => {
+  describe("DIRECT port", () => {
+    it("emits TOKEN_INFO for a 32-byte constant mint", () => {
+      const mint = new Uint8Array(32).fill(4);
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({
+              accountIndex: 0,
+              tokenValue: {
+                kind: TokenKind.DIRECT,
+                value: { source: ValueSource.CONSTANT, payload: mint },
+              },
+            }),
+          ],
+        }),
+        makeInstruction(["a"]),
+      );
+      expect(result.tokenInfos).toEqual([DefaultBs58Encoder.encode(mint)]);
+    });
+
+    it("ignores a constant that is not 32 bytes", () => {
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({
+              accountIndex: 0,
+              tokenValue: {
+                kind: TokenKind.DIRECT,
+                value: {
+                  source: ValueSource.CONSTANT,
+                  payload: new Uint8Array(8),
+                },
+              },
+            }),
+          ],
+        }),
+        makeInstruction(["a"]),
+      );
+      expect(result.tokenInfos).toEqual([]);
+    });
+
+    it("resolves an ACCOUNT_PATH mint to the account address", () => {
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({
+              accountIndex: 0,
+              tokenValue: {
+                kind: TokenKind.DIRECT,
+                value: {
+                  source: ValueSource.ACCOUNT_PATH,
+                  payload: Uint8Array.of(1),
+                },
+              },
+            }),
+          ],
+        }),
+        makeInstruction(["acct", "theMint"]),
+      );
+      expect(result.tokenInfos).toEqual(["theMint"]);
+    });
+
+    it("ignores an out-of-bounds ACCOUNT_PATH index", () => {
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({
+              accountIndex: 0,
+              tokenValue: {
+                kind: TokenKind.DIRECT,
+                value: {
+                  source: ValueSource.ACCOUNT_PATH,
+                  payload: Uint8Array.of(9),
+                },
+              },
+            }),
+          ],
+        }),
+        makeInstruction(["a"]),
+      );
+      expect(result.tokenInfos).toEqual([]);
+    });
+  });
+
+  describe("RESOLVE port", () => {
+    it("sends TOKEN_ACCOUNT_STATE when no MINT_ASSOC binding covers it", () => {
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({ accountIndex: 0, tokenValue: { kind: TokenKind.RESOLVE } }),
+          ],
+        }),
+        makeInstruction(["userAta"]),
+      );
+      expect(result.tokenAccountStates).toEqual(["userAta"]);
+      expect(result.tokenInfos).toEqual([]);
+    });
+
+    it("emits TOKEN_INFO and skips account-state when MINT_ASSOC binds it", () => {
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({ accountIndex: 0, tokenValue: { kind: TokenKind.RESOLVE } }),
+          ],
+        }),
+        makeInstruction(["createdAta"]),
+        new Map([["createdAta", "boundMint"]]),
+      );
+      expect(result.tokenAccountStates).toEqual([]);
+      expect(result.tokenInfos).toEqual(["boundMint"]);
+    });
+
+    it("uses the explicit token account index overrides the port's own", () => {
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({
+              accountIndex: 0,
+              tokenValue: { kind: TokenKind.RESOLVE, accountIndex: 1 },
+            }),
+          ],
+        }),
+        makeInstruction(["wrong", "rightAta"]),
+      );
+      expect(result.tokenAccountStates).toEqual(["rightAta"]);
+    });
+
+    it("resolves a candidate-array port to its first provided candidate", () => {
+      // First candidate (index 0) holds the program id under PROGRAM_ID
+      // strategy, so it is unset; the next provided candidate (index 1) wins.
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({
+              accountIndices: [0, 1],
+              tokenValue: { kind: TokenKind.RESOLVE },
+            }),
+          ],
+        }),
+        makeInstruction(["P", "realAta"]),
+      );
+      expect(result.tokenAccountStates).toEqual(["realAta"]);
+    });
+
+    it("skips when the target account address is unresolved (ALT-supplied)", () => {
+      const result = run(
+        parsed({
+          valueFlowPorts: [
+            port({ accountIndex: 0, tokenValue: { kind: TokenKind.RESOLVE } }),
+          ],
+        }),
+        makeInstruction([undefined]),
+      );
+      expect(result.tokenAccountStates).toEqual([]);
+      expect(result.tokenInfos).toEqual([]);
+    });
+  });
+
+  it("ignores NATIVE and NULL ports and ports without a token value", () => {
+    const result = run(
+      parsed({
+        valueFlowPorts: [
+          port({ accountIndex: 0, tokenValue: { kind: TokenKind.NATIVE } }),
+          port({ accountIndex: 0, tokenValue: { kind: TokenKind.NULL } }),
+          port({ accountIndex: 0 }),
+        ],
+      }),
+      makeInstruction(["a"]),
+    );
+    expect(result.tokenInfos).toEqual([]);
+    expect(result.tokenAccountStates).toEqual([]);
+  });
+
+  describe("ACCOUNT_RESET", () => {
+    it("forces TOKEN_ACCOUNT_STATE when requirePreBalanceZero is set", () => {
+      const result = run(
+        parsed({
+          accountResets: [{ accountIndex: 0, requirePreBalanceZero: true }],
+        }),
+        makeInstruction(["ata"]),
+      );
+      expect(result.tokenAccountStates).toEqual(["ata"]);
+    });
+
+    it("does nothing without the flag or for an out-of-bounds index", () => {
+      const noFlag = run(
+        parsed({
+          accountResets: [{ accountIndex: 0, requirePreBalanceZero: false }],
+        }),
+        makeInstruction(["ata"]),
+      );
+      expect(noFlag.tokenAccountStates).toEqual([]);
+
+      const oob = run(
+        parsed({
+          accountResets: [{ accountIndex: 9, requirePreBalanceZero: true }],
+        }),
+        makeInstruction(["ata"]),
+      );
+      expect(oob.tokenAccountStates).toEqual([]);
+    });
+  });
+
+  describe("PARAM_TOKEN_AMOUNT display field", () => {
+    it("emits TOKEN_INFO for a constant-mint amount-formatter token", () => {
+      const mint = new Uint8Array(32).fill(9);
+      const result = run(
+        parsed({
+          displayFields: [
+            tokenAmountField({ source: ValueSource.CONSTANT, payload: mint }),
+          ],
+        }),
+        makeInstruction(["a"]),
+      );
+      expect(result.tokenInfos).toEqual([DefaultBs58Encoder.encode(mint)]);
+    });
+
+    it("treats an unbound ACCOUNT_PATH token as the mint", () => {
+      const result = run(
+        parsed({
+          displayFields: [
+            tokenAmountField({
+              source: ValueSource.ACCOUNT_PATH,
+              payload: Uint8Array.of(0),
+            }),
+          ],
+        }),
+        makeInstruction(["someMint"]),
+      );
+      expect(result.tokenInfos).toEqual(["someMint"]);
+      expect(result.tokenAccountStates).toEqual([]);
+    });
+
+    it("redirects a bound token-account reference to its mint", () => {
+      const result = run(
+        parsed({
+          displayFields: [
+            tokenAmountField({
+              source: ValueSource.ACCOUNT_PATH,
+              payload: Uint8Array.of(0),
+            }),
+          ],
+        }),
+        makeInstruction(["tokenAccount"]),
+        new Map([["tokenAccount", "itsMint"]]),
+      );
+      expect(result.tokenInfos).toEqual(["itsMint"]);
+      expect(result.tokenAccountStates).toEqual([]);
+    });
+
+    it("ignores non-token-amount display fields", () => {
+      const result = run(
+        parsed({
+          displayFields: [
+            {
+              paramType: PARAM_TYPE_TRUSTED_NAME,
+              value: {
+                source: ValueSource.ACCOUNT_PATH,
+                payload: Uint8Array.of(0),
+              },
+            },
+          ],
+        }),
+        makeInstruction(["addr"]),
+      );
+      expect(result.tokenInfos).toEqual([]);
+    });
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/tokenRule.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/tokenRule.ts
@@ -1,0 +1,85 @@
+import { type RequirementInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import {
+  PARAM_TYPE_TOKEN_AMOUNT,
+  type ParsedInstruction,
+  TokenKind,
+} from "@internal/app-binder/clear-sign/requirements/records";
+import { type RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+import {
+  accountAddressAt,
+  resolvePortAccountIndex,
+  resolvePubkeyValue,
+} from "@internal/app-binder/clear-sign/requirements/valueResolution";
+import {
+  type Bs58Encoder,
+  DefaultBs58Encoder,
+} from "@internal/app-binder/services/bs58Encoder";
+
+/**
+ * TOKEN_INFO + TOKEN_ACCOUNT_STATE requirements:
+ * - RESOLVE port: TOKEN_ACCOUNT_STATE for its token account unless a TX-derived
+ *   MINT_ASSOC binding already covers it; the bound mint (when any) needs
+ *   TOKEN_INFO. A candidate-array port resolves to its first *provided*
+ *   candidate.
+ * - DIRECT port: the embedded mint needs TOKEN_INFO.
+ * - ACCOUNT_RESET with `requirePreBalanceZero`: mandatory TOKEN_ACCOUNT_STATE
+ *   for the reset account (the device must read its pre-balance).
+ * - PARAM_TOKEN_AMOUNT display field: the amount formatter's token needs
+ *   TOKEN_INFO. The reference may be a mint directly, or — when a TX-derived
+ *   MINT_ASSOC binding covers it — a token account whose bound mint is used
+ *   instead. (The chain-only token-account case where no binding exists is out
+ *   of scope: DMK has no RPC to resolve such a mint, mirroring the POC, which
+ *   only resolves it from on-chain balances.)
+ *
+ * `mintBindings` maps a token-account address to its TX-derived mint address.
+ */
+export function applyTokenRule(
+  parsed: ParsedInstruction,
+  instruction: RequirementInstruction,
+  mintBindings: ReadonlyMap<string, string>,
+  accumulator: RequirementAccumulator,
+  bs58Encoder: Bs58Encoder = DefaultBs58Encoder,
+): void {
+  for (const port of parsed.valueFlowPorts) {
+    const tokenValue = port.tokenValue;
+    if (tokenValue === undefined) continue;
+
+    if (tokenValue.kind === TokenKind.RESOLVE) {
+      const account = accountAddressAt(
+        instruction,
+        tokenValue.accountIndex ?? resolvePortAccountIndex(port, instruction),
+      );
+      if (account === undefined) continue;
+      const boundMint = mintBindings.get(account);
+      if (boundMint === undefined) {
+        accumulator.addTokenAccountState(account);
+      } else {
+        accumulator.addTokenInfo(boundMint);
+      }
+    } else if (tokenValue.kind === TokenKind.DIRECT && tokenValue.value) {
+      const mint = resolvePubkeyValue(
+        tokenValue.value,
+        instruction,
+        bs58Encoder,
+      );
+      if (mint !== undefined) accumulator.addTokenInfo(mint);
+    }
+  }
+
+  for (const reset of parsed.accountResets) {
+    if (!reset.requirePreBalanceZero) continue;
+    const account = accountAddressAt(instruction, reset.accountIndex);
+    if (account !== undefined) accumulator.addTokenAccountState(account);
+  }
+
+  for (const field of parsed.displayFields) {
+    if (
+      field.paramType !== PARAM_TYPE_TOKEN_AMOUNT ||
+      field.token === undefined
+    )
+      continue;
+    const ref = resolvePubkeyValue(field.token, instruction, bs58Encoder);
+    if (ref === undefined) continue;
+    accumulator.addTokenInfo(mintBindings.get(ref) ?? ref);
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.test.ts
@@ -1,0 +1,93 @@
+import { type RequirementInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import {
+  PARAM_TYPE_TRUSTED_NAME,
+  type ParsedDisplayField,
+  type ParsedInstruction,
+  ValueSource,
+} from "@internal/app-binder/clear-sign/requirements/records";
+import { RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+import { DefaultBs58Encoder } from "@internal/app-binder/services/bs58Encoder";
+
+import { applyTrustedNameRule } from "./trustedNameRule";
+
+function run(
+  displayFields: ParsedDisplayField[],
+  addresses: (string | undefined)[],
+) {
+  const parsed: ParsedInstruction = {
+    info: { typePool: new Uint8Array(), rootType: 0, mintAssociations: [] },
+    valueFlowPorts: [],
+    accountResets: [],
+    displayFields,
+  };
+  const instruction: RequirementInstruction = {
+    programId: "P",
+    accounts: addresses.map((address) => ({ address })),
+    data: new Uint8Array(),
+  };
+  const accumulator = new RequirementAccumulator();
+  applyTrustedNameRule(parsed, instruction, accumulator);
+  return accumulator.build().trustedNames;
+}
+
+describe("applyTrustedNameRule", () => {
+  it("resolves an ACCOUNT_PATH trusted-name target", () => {
+    const result = run(
+      [
+        {
+          paramType: PARAM_TYPE_TRUSTED_NAME,
+          value: {
+            source: ValueSource.ACCOUNT_PATH,
+            payload: Uint8Array.of(1),
+          },
+        },
+      ],
+      ["ignored", "named"],
+    );
+    expect(result).toEqual(["named"]);
+  });
+
+  it("encodes a 32-byte CONSTANT trusted-name target", () => {
+    const addr = new Uint8Array(32).fill(8);
+    const result = run(
+      [
+        {
+          paramType: PARAM_TYPE_TRUSTED_NAME,
+          value: { source: ValueSource.CONSTANT, payload: addr },
+        },
+      ],
+      [],
+    );
+    expect(result).toEqual([DefaultBs58Encoder.encode(addr)]);
+  });
+
+  it("ignores non-trusted-name fields and unresolved account targets", () => {
+    const nonTrusted = run(
+      [
+        {
+          paramType: 0x02,
+          value: {
+            source: ValueSource.ACCOUNT_PATH,
+            payload: Uint8Array.of(0),
+          },
+        },
+      ],
+      ["a"],
+    );
+    expect(nonTrusted).toEqual([]);
+
+    const unresolved = run(
+      [
+        {
+          paramType: PARAM_TYPE_TRUSTED_NAME,
+          value: {
+            source: ValueSource.ACCOUNT_PATH,
+            payload: Uint8Array.of(0),
+          },
+        },
+      ],
+      [undefined],
+    );
+    expect(unresolved).toEqual([]);
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.ts
@@ -1,0 +1,30 @@
+import { type RequirementInstruction } from "@internal/app-binder/clear-sign/requirements/model";
+import {
+  PARAM_TYPE_TRUSTED_NAME,
+  type ParsedInstruction,
+} from "@internal/app-binder/clear-sign/requirements/records";
+import { type RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+import { resolvePubkeyValue } from "@internal/app-binder/clear-sign/requirements/valueResolution";
+import {
+  type Bs58Encoder,
+  DefaultBs58Encoder,
+} from "@internal/app-binder/services/bs58Encoder";
+
+/** Each `PARAM_TRUSTED_NAME` display field targets an address needing a name. */
+export function applyTrustedNameRule(
+  parsed: ParsedInstruction,
+  instruction: RequirementInstruction,
+  accumulator: RequirementAccumulator,
+  bs58Encoder: Bs58Encoder = DefaultBs58Encoder,
+): void {
+  for (const field of parsed.displayFields) {
+    if (
+      field.paramType !== PARAM_TYPE_TRUSTED_NAME ||
+      field.value === undefined
+    ) {
+      continue;
+    }
+    const target = resolvePubkeyValue(field.value, instruction, bs58Encoder);
+    if (target !== undefined) accumulator.addTrustedName(target);
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/valueResolution.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/valueResolution.test.ts
@@ -1,0 +1,132 @@
+import { DefaultBs58Encoder } from "@internal/app-binder/services/bs58Encoder";
+
+import { type RequirementInstruction } from "./model";
+import {
+  OptionalAccountStrategy,
+  type ParsedValueFlowPort,
+  ValueSource,
+} from "./records";
+import {
+  accountAddressAt,
+  resolvePortAccountIndex,
+  resolvePubkeyValue,
+} from "./valueResolution";
+
+const instruction: RequirementInstruction = {
+  programId: "P",
+  data: new Uint8Array(),
+  accounts: [
+    { address: "first" },
+    { address: undefined },
+    { address: "third" },
+  ],
+};
+
+describe("accountAddressAt", () => {
+  it("returns the resolved address or undefined", () => {
+    expect(accountAddressAt(instruction, 0)).toBe("first");
+    expect(accountAddressAt(instruction, 1)).toBeUndefined(); // unresolved (ALT)
+    expect(accountAddressAt(instruction, 9)).toBeUndefined(); // out of bounds
+    expect(accountAddressAt(instruction, -1)).toBeUndefined();
+  });
+});
+
+describe("resolvePubkeyValue", () => {
+  it("encodes a 32-byte CONSTANT", () => {
+    const payload = new Uint8Array(32).fill(3);
+    expect(
+      resolvePubkeyValue(
+        { source: ValueSource.CONSTANT, payload },
+        instruction,
+        DefaultBs58Encoder,
+      ),
+    ).toBe(DefaultBs58Encoder.encode(payload));
+  });
+
+  it("rejects a CONSTANT that is not 32 bytes", () => {
+    expect(
+      resolvePubkeyValue(
+        { source: ValueSource.CONSTANT, payload: new Uint8Array(4) },
+        instruction,
+        DefaultBs58Encoder,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("resolves an ACCOUNT_PATH to the account address", () => {
+    expect(
+      resolvePubkeyValue(
+        { source: ValueSource.ACCOUNT_PATH, payload: Uint8Array.of(2) },
+        instruction,
+        DefaultBs58Encoder,
+      ),
+    ).toBe("third");
+  });
+
+  it("returns undefined for ARGUMENT_PATH and empty/out-of-range paths", () => {
+    expect(
+      resolvePubkeyValue(
+        { source: ValueSource.ARGUMENT_PATH, payload: Uint8Array.of(1, 0) },
+        instruction,
+        DefaultBs58Encoder,
+      ),
+    ).toBeUndefined();
+    expect(
+      resolvePubkeyValue(
+        { source: ValueSource.ACCOUNT_PATH, payload: new Uint8Array() },
+        instruction,
+        DefaultBs58Encoder,
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("resolvePortAccountIndex", () => {
+  const makePort = (
+    accountIndices: number[],
+    optionalAccountStrategy = OptionalAccountStrategy.PROGRAM_ID,
+  ): ParsedValueFlowPort => ({ accountIndices, optionalAccountStrategy });
+
+  // `instruction` accounts: [0]="first", [1]=undefined, [2]="third".
+  // A separate fixture places the program id "P" in slot 0 for the sentinel
+  // cases.
+  const withProgramIdInSlot0: RequirementInstruction = {
+    programId: "P",
+    data: new Uint8Array(),
+    accounts: [{ address: "P" }, { address: "second" }],
+  };
+
+  it("returns the sole candidate for a single-account port", () => {
+    expect(resolvePortAccountIndex(makePort([2]), instruction)).toBe(2);
+  });
+
+  it("returns -1 for an empty candidate list", () => {
+    expect(resolvePortAccountIndex(makePort([]), instruction)).toBe(-1);
+  });
+
+  it("skips a PROGRAM_ID-sentinel non-final candidate", () => {
+    // slot 0 holds the program id → unset under PROGRAM_ID strategy.
+    expect(
+      resolvePortAccountIndex(makePort([0, 1]), withProgramIdInSlot0),
+    ).toBe(1);
+  });
+
+  it("skips an out-of-range non-final candidate", () => {
+    expect(resolvePortAccountIndex(makePort([9, 2]), instruction)).toBe(2);
+  });
+
+  it("does not treat the program-id slot as unset under the OMITTED strategy", () => {
+    expect(
+      resolvePortAccountIndex(
+        makePort([0, 1], OptionalAccountStrategy.OMITTED),
+        withProgramIdInSlot0,
+      ),
+    ).toBe(0);
+  });
+
+  it("always resolves the final candidate even when it holds the program id", () => {
+    expect(
+      resolvePortAccountIndex(makePort([9, 0]), withProgramIdInSlot0),
+    ).toBe(0);
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/valueResolution.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/valueResolution.ts
@@ -1,0 +1,71 @@
+import { type Bs58Encoder } from "@internal/app-binder/services/bs58Encoder";
+
+import { type RequirementInstruction } from "./model";
+import {
+  OptionalAccountStrategy,
+  type ParsedValue,
+  type ParsedValueFlowPort,
+  ValueSource,
+} from "./records";
+
+const PUBKEY_LENGTH = 32;
+
+/** The resolved address of an account slot, bounds-checked. */
+export function accountAddressAt(
+  instruction: RequirementInstruction,
+  index: number,
+): string | undefined {
+  if (index < 0 || index >= instruction.accounts.length) return undefined;
+  return instruction.accounts[index]!.address;
+}
+
+/**
+ * Resolve a value-flow port to a single account index. A single-candidate port
+ * returns that candidate. An ordered candidate list (optional accounts with
+ * fallbacks) returns the first *provided* candidate: a non-final candidate is
+ * *unset* when its slot is out of range, or — under the `PROGRAM_ID` strategy —
+ * when the slot holds the program id. The final candidate is non-optional and
+ * always resolves. Returns `-1` for an empty candidate list.
+ */
+export function resolvePortAccountIndex(
+  port: ParsedValueFlowPort,
+  instruction: RequirementInstruction,
+): number {
+  const indices = port.accountIndices;
+  if (indices.length === 0) return -1;
+  for (const idx of indices.slice(0, -1)) {
+    if (idx < 0 || idx >= instruction.accounts.length) continue;
+    if (
+      port.optionalAccountStrategy !== OptionalAccountStrategy.OMITTED &&
+      instruction.accounts[idx]!.address === instruction.programId
+    ) {
+      continue;
+    }
+    return idx;
+  }
+  return indices[indices.length - 1]!;
+}
+
+/**
+ * Resolve a pubkey-bearing VALUE to a base58 address: a 32-byte CONSTANT, or an
+ * ACCOUNT_PATH into the instruction's accounts. ARGUMENT_PATH and unresolved
+ * accounts yield `undefined`.
+ */
+export function resolvePubkeyValue(
+  value: ParsedValue,
+  instruction: RequirementInstruction,
+  bs58Encoder: Bs58Encoder,
+): string | undefined {
+  switch (value.source) {
+    case ValueSource.CONSTANT:
+      return value.payload.length === PUBKEY_LENGTH
+        ? bs58Encoder.encode(value.payload)
+        : undefined;
+    case ValueSource.ACCOUNT_PATH:
+      return value.payload.length > 0
+        ? accountAddressAt(instruction, value.payload[0]!)
+        : undefined;
+    default:
+      return undefined;
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/tlv.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/tlv.ts
@@ -1,0 +1,82 @@
+// DER Tag-Length-Value reader shared by the clear-sign sub-modules. Throws a
+// neutral TlvParseError that each caller maps to its own typed error.
+
+export type TlvEntry = { tag: number; value: Uint8Array };
+
+export class TlvParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TlvParseError";
+  }
+}
+
+// DER length encoding constants (X.690 §8.1.3).
+/** Bit 7 of the length head byte: set ⇒ long form, clear ⇒ short form. */
+const LONG_FORM_FLAG = 0x80;
+/** Low 7 bits of a long-form head byte hold the number of length bytes. */
+const LENGTH_SIZE_MASK = 0x7f;
+/** Cap on long-form length bytes; 4 keeps the result a JS safe integer. */
+const MAX_LENGTH_BYTES = 4;
+const BYTE_RADIX = 256;
+
+/** Decode a DER-encoded length at `offset`; returns `[length, nextOffset]`. */
+function decodeLength(buffer: Uint8Array, offset: number): [number, number] {
+  if (offset >= buffer.length) {
+    throw new TlvParseError("truncated TLV length byte");
+  }
+  const head = buffer[offset]!;
+  offset += 1;
+  if (head < LONG_FORM_FLAG) {
+    return [head, offset];
+  }
+  const lengthSize = head & LENGTH_SIZE_MASK;
+  if (lengthSize === 0) {
+    throw new TlvParseError("indefinite-length form not allowed");
+  }
+  // Cap the number of length bytes so an attacker can't make us iterate huge
+  // counts and so the result stays within JS safe-integer range (IEEE-754).
+  if (lengthSize > MAX_LENGTH_BYTES) {
+    throw new TlvParseError("extended TLV length too large");
+  }
+  if (offset + lengthSize > buffer.length) {
+    throw new TlvParseError("truncated extended TLV length");
+  }
+  let length = 0;
+  for (let i = 0; i < lengthSize; i++) {
+    length = length * BYTE_RADIX + buffer[offset + i]!;
+  }
+  return [length, offset + lengthSize];
+}
+
+/** Parse every `(tag, value)` record in `buffer`, in stream order. */
+export function readTlvEntries(buffer: Uint8Array): TlvEntry[] {
+  const entries: TlvEntry[] = [];
+  let offset = 0;
+  while (offset < buffer.length) {
+    const tag = buffer[offset]!;
+    const [length, afterLength] = decodeLength(buffer, offset + 1);
+    if (afterLength + length > buffer.length) {
+      throw new TlvParseError("truncated TLV value");
+    }
+    entries.push({
+      tag,
+      value: buffer.subarray(afterLength, afterLength + length),
+    });
+    offset = afterLength + length;
+  }
+  return entries;
+}
+
+/** First value tagged `tag`, or `undefined`. */
+export function firstTag(
+  entries: TlvEntry[],
+  tag: number,
+): Uint8Array | undefined {
+  return entries.find((entry) => entry.tag === tag)?.value;
+}
+
+/** First byte of the first value tagged `tag`, or `undefined` (for `uint8` fields). */
+export function firstU8(entries: TlvEntry[], tag: number): number | undefined {
+  const value = firstTag(entries, tag);
+  return value !== undefined && value.length > 0 ? value[0]! : undefined;
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Adds the host-side **requirement builder**: given every transaction instruction already matched to its CAL descriptor, it walks the decision table and computes the **minimal, deduplicated** set of extra descriptors the device must fetch.

It consumes the matched descriptors (whose substructures CAL ships as opaque signed TLV), parses them into structured records, and applies one rule per descriptor type, decoding instruction data through the `TypePoolDecoder` where needed. Output is a single deterministic `DescriptorRequirements`:

- **`INSTRUCTION_INFO`**: one per `(programId, discriminator)`.
- **`ENUM_VARIANT`**: only the variants the data selects (via the decoder).
- **`TOKEN_INFO`**: mints from DIRECT ports and TX-derived `MINT_ASSOC` bindings.
- **`TOKEN_ACCOUNT_STATE`**: RESOLVE ports not covered by a binding, plus mandatory `requirePreBalanceZero` resets.
- **`ALT_RESOLUTION`**: every ALT-supplied account an instruction references.
- **`TRUSTED_NAME`**: `PARAM_TRUSTED_NAME` display-field targets.

New module under `packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/`. Builds on the `TypePoolDecoder` (PR #1534) and is designed to land on top of it.

## How it fits together

```mermaid
flowchart TD
    IN["MatchedInstruction[]<br/>(tx view + CAL descriptor)"] --> PARSE["parseInstructionDescriptor<br/>(TLV → records)"]
    PARSE --> REC["ParsedInstruction records"]
    REC --> RULES

    subgraph RULES["rules/ (pure, one per descriptor type)"]
      direction LR
      I["instructionInfo"]
      E["enumVariant<br/>(injected selector →<br/>TypePoolDecoder)"]
      T["token<br/>(TOKEN_INFO +<br/>TOKEN_ACCOUNT_STATE)"]
      A["altResolution"]
      N["trustedName"]
    end

    RULES --> ACC["RequirementAccumulator<br/>(dedup + first-seen order)"]
    ACC --> OUT["Either&lt;RequirementsError,<br/>DescriptorRequirements&gt;"]
```

## Module layout

| File | Responsibility |
|------|----------------|
| `model.ts` | Input (`MatchedInstruction`, `RequirementAccount`, …) + output (`DescriptorRequirements`) |
| `records.ts` | Parsed substructure record types + enums (`TokenKind`, `ValueSource`, …) |
| `parseSubstructures.ts` | TLV → records: INSTRUCTION_INFO, VALUE_FLOW_PORT, ACCOUNT_RESET, DISPLAY_FIELD, VALUE |
| `parseInstruction.ts` | Group a descriptor's substructures by kind |
| `valueResolution.ts` | Shared pubkey-VALUE resolution (CONSTANT / ACCOUNT_PATH) |
| `rules/` | One pure rule per descriptor type |
| `RequirementAccumulator.ts` | Deduplication + deterministic ordering |
| `buildRequirements.ts` | Orchestrator → `DescriptorRequirements` |
| `../tlv.ts` | DER-TLV reader shared with the `TypePoolDecoder` module |

Documentation at: https://github.com/LedgerHQ/poc-solana-clear-signing/blob/main/spec/dmk/clear_signing_pipeline.md

- **JIRA or GitHub link**: [DSDK-1145](https://ledgerhq.atlassian.net/browse/DSDK-1145)

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- 58 requirement-builder unit tests (136 total in the clear-sign module) -->
- [x] **Changeset is provided**
- [ ] **Documentation is up-to-date**
- [ ] **Impact of the changes:**
  - _Adds the stage-2 requirement builder; no existing behaviour changes._

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[DSDK-1145]: https://ledgerhq.atlassian.net/browse/DSDK-1145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ