### PR TITLE
✨ (sample) [NO-ISSUE]: Unify Speculos and mock server into independent toggles

### DIFF
--- a/apps/sample/src/components/FloatingIcon/index.tsx
+++ b/apps/sample/src/components/FloatingIcon/index.tsx
@@ -14,8 +14,8 @@ import styled from "styled-components";
 
 import { VncViewer } from "@/components/VncViewer";
 import {
+  selectSpeculosEnabled,
   selectSpeculosVncUrl,
-  selectTransportType,
 } from "@/state/settings/selectors";
 
 const CONSTANTS = {
@@ -96,7 +96,7 @@ export const FloatingIcon: React.FC<FloatingIconProps> = ({
   onDragStart,
   onDragEnd,
 }) => {
-  const transportType = useSelector(selectTransportType);
+  const speculosEnabled = useSelector(selectSpeculosEnabled);
   const speculosVncUrl = useSelector(selectSpeculosVncUrl);
 
   const [position, setPosition] = useState<Position>(
@@ -244,7 +244,7 @@ export const FloatingIcon: React.FC<FloatingIconProps> = ({
     return () => window.removeEventListener("resize", handleResize);
   }, [calculateBounds, isVncOpen]);
 
-  if (transportType !== "speculos") {
+  if (!speculosEnabled) {
     return null;
   }
 

--- a/apps/sample/src/components/Menu/index.tsx
+++ b/apps/sample/src/components/Menu/index.tsx
@@ -4,7 +4,7 @@ import { Flex, Icons, Link } from "@ledgerhq/react-ui";
 import { useRouter } from "next/navigation";
 import styled from "styled-components";
 
-import { selectTransportType } from "@/state/settings/selectors";
+import { selectMockServerEnabled } from "@/state/settings/selectors";
 
 const MenuItem = styled(Flex).attrs({ p: 3, pl: 5 })`
   align-items: center;
@@ -18,7 +18,7 @@ const MenuTitle = styled(Link).attrs({
 
 export const Menu: React.FC = () => {
   const router = useRouter();
-  const transportType = useSelector(selectTransportType);
+  const mockServerEnabled = useSelector(selectMockServerEnabled);
 
   return (
     <>
@@ -93,7 +93,7 @@ export const Menu: React.FC = () => {
         <Icons.SettingsAlt2 />
         <MenuTitle onClick={() => router.push("/settings")}>Settings</MenuTitle>
       </MenuItem>
-      {transportType === "mockserver" && (
+      {mockServerEnabled && (
         <MenuItem>
           <Icons.Settings />
           <MenuTitle

--- a/apps/sample/src/components/SettingsView/MockServerToggleSetting.tsx
+++ b/apps/sample/src/components/SettingsView/MockServerToggleSetting.tsx
@@ -2,29 +2,26 @@ import React, { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Flex, Switch } from "@ledgerhq/react-ui";
 
-import { type TransportType } from "@/state/settings/schema";
-import { selectTransportType } from "@/state/settings/selectors";
-import { setTransportType } from "@/state/settings/slice";
+import { selectMockServerEnabled } from "@/state/settings/selectors";
+import { setMockServerEnabled } from "@/state/settings/slice";
 
 import { ResetSettingCTA } from "./ResetSetting";
 import { SettingBox } from "./SettingBox";
 
 export const MockServerToggleSetting: React.FC = () => {
-  const transportType = useSelector(selectTransportType);
+  const mockServerEnabled = useSelector(selectMockServerEnabled);
   const dispatch = useDispatch();
 
-  const mockServerEnabled = transportType === "mockserver";
-
-  const setTransportTypeFn = useCallback(
-    (value: TransportType) => {
-      dispatch(setTransportType({ transportType: value }));
+  const setMockServerEnabledFn = useCallback(
+    (value: boolean) => {
+      dispatch(setMockServerEnabled({ mockServerEnabled: value }));
     },
     [dispatch],
   );
 
   const onToggle = useCallback(() => {
-    setTransportTypeFn(mockServerEnabled ? "default" : "mockserver");
-  }, [setTransportTypeFn, mockServerEnabled]);
+    setMockServerEnabledFn(!mockServerEnabled);
+  }, [setMockServerEnabledFn, mockServerEnabled]);
 
   return (
     <SettingBox>
@@ -38,8 +35,8 @@ export const MockServerToggleSetting: React.FC = () => {
         />
       </Flex>
       <ResetSettingCTA
-        stateSelector={selectTransportType}
-        setStateAction={setTransportTypeFn}
+        stateSelector={selectMockServerEnabled}
+        setStateAction={setMockServerEnabledFn}
       />
     </SettingBox>
   );

--- a/apps/sample/src/components/SettingsView/SpeculosToggleSetting.tsx
+++ b/apps/sample/src/components/SettingsView/SpeculosToggleSetting.tsx
@@ -2,29 +2,26 @@ import React, { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Flex, Switch } from "@ledgerhq/react-ui";
 
-import { type TransportType } from "@/state/settings/schema";
-import { selectTransportType } from "@/state/settings/selectors";
-import { setTransportType } from "@/state/settings/slice";
+import { selectSpeculosEnabled } from "@/state/settings/selectors";
+import { setSpeculosEnabled } from "@/state/settings/slice";
 
 import { ResetSettingCTA } from "./ResetSetting";
 import { SettingBox } from "./SettingBox";
 
 export const SpeculosToggleSetting: React.FC = () => {
-  const transportType = useSelector(selectTransportType);
+  const speculosEnabled = useSelector(selectSpeculosEnabled);
   const dispatch = useDispatch();
 
-  const speculosEnabled = transportType === "speculos";
-
-  const setTransportTypeFn = useCallback(
-    (value: TransportType) => {
-      dispatch(setTransportType({ transportType: value }));
+  const setSpeculosEnabledFn = useCallback(
+    (value: boolean) => {
+      dispatch(setSpeculosEnabled({ speculosEnabled: value }));
     },
     [dispatch],
   );
 
   const onToggle = useCallback(() => {
-    setTransportTypeFn(speculosEnabled ? "default" : "speculos");
-  }, [setTransportTypeFn, speculosEnabled]);
+    setSpeculosEnabledFn(!speculosEnabled);
+  }, [setSpeculosEnabledFn, speculosEnabled]);
 
   return (
     <SettingBox>
@@ -38,8 +35,8 @@ export const SpeculosToggleSetting: React.FC = () => {
         />
       </Flex>
       <ResetSettingCTA
-        stateSelector={selectTransportType}
-        setStateAction={setTransportTypeFn}
+        stateSelector={selectSpeculosEnabled}
+        setStateAction={setSpeculosEnabledFn}
       />
     </SettingBox>
   );

--- a/apps/sample/src/components/Sidebar/index.tsx
+++ b/apps/sample/src/components/Sidebar/index.tsx
@@ -20,24 +20,16 @@ import {
 } from "@/state/sessions/selectors";
 import { setSelectedSession } from "@/state/sessions/slice";
 import {
+  selectMockServerEnabled,
   selectPollingInterval,
-  selectTransportType,
 } from "@/state/settings/selectors";
 import { buildSessionRefresherOptions } from "@/utils/sessionRefresherOptions";
 
 const Root = styled(Flex).attrs({ py: 8, px: 6, rowGap: 6 })`
   flex-direction: column;
   width: 280px;
-  background-color: ${({
-    theme,
-    mockServerEnabled,
-  }: {
-    theme: DefaultTheme;
-    mockServerEnabled: boolean;
-  }) =>
-    mockServerEnabled
-      ? theme.colors.constant.purple
-      : theme.colors.background.card};
+  background-color: ${({ theme }: { theme: DefaultTheme }) =>
+    theme.colors.background.card};
   overflow-y: auto;
 `;
 
@@ -64,7 +56,7 @@ export const Sidebar: React.FC = () => {
   const orderedConnectedDevices = useSelector(selectOrderedConnectedDevices);
   const selectedSessionId = useSelector(selectSelectedSessionId);
   const dispatch = useDispatch();
-  const transportType = useSelector(selectTransportType);
+  const mockServerEnabled = useSelector(selectMockServerEnabled);
   const pollingInterval = useSelector(selectPollingInterval);
 
   const selectSession = useCallback(
@@ -113,7 +105,7 @@ export const Sidebar: React.FC = () => {
 
   const router = useRouter();
   return (
-    <Root mockServerEnabled={transportType === "mockserver"}>
+    <Root>
       <Link
         onClick={() => router.push("/")}
         mb={8}
@@ -123,7 +115,7 @@ export const Sidebar: React.FC = () => {
         }}
       >
         Ledger Device Management Kit
-        {transportType === "mockserver" && <span> (MOCKED)</span>}
+        {mockServerEnabled && <span> (MOCKED)</span>}
       </Link>
 
       <Flex data-testid="container_devices" rowGap={4} flexDirection="column">

--- a/apps/sample/src/hooks/useConnectDevice.ts
+++ b/apps/sample/src/hooks/useConnectDevice.ts
@@ -4,12 +4,12 @@ import { type DmkError } from "@ledgerhq/device-management-kit";
 
 import { useDmk } from "@/providers/DeviceManagementKitProvider";
 import {
+  getTransportOptions,
   type TransportOption,
-  transportOptionsMap,
 } from "@/providers/DeviceManagementKitProvider/transportConfig";
 import {
   selectPollingInterval,
-  selectTransportType,
+  selectTransportConfig,
 } from "@/state/settings/selectors";
 import { setDisplayedError } from "@/state/ui/slice";
 import { buildSessionRefresherOptions } from "@/utils/sessionRefresherOptions";
@@ -26,7 +26,7 @@ type UseConnectDeviceResult = {
 export function useConnectDevice(): UseConnectDeviceResult {
   const dispatch = useDispatch();
 
-  const transportType = useSelector(selectTransportType);
+  const transportConfig = useSelector(selectTransportConfig);
   const pollingInterval = useSelector(selectPollingInterval);
   const dmk = useDmk();
 
@@ -37,7 +37,7 @@ export function useConnectDevice(): UseConnectDeviceResult {
     [dispatch],
   );
 
-  const transportOptions = transportOptionsMap[transportType];
+  const transportOptions = getTransportOptions(transportConfig);
 
   const connectWithTransport = useCallback(
     (transportIdentifier: string) => {

--- a/apps/sample/src/providers/DeviceManagementKitProvider/transportConfig.ts
+++ b/apps/sample/src/providers/DeviceManagementKitProvider/transportConfig.ts
@@ -16,10 +16,7 @@ import {
   webHidTransportFactory,
 } from "@ledgerhq/device-transport-kit-web-hid";
 
-import {
-  type TransportConfig,
-  type TransportType,
-} from "@/state/settings/schema";
+import { type TransportConfig } from "@/state/settings/schema";
 
 export type TransportOption = {
   identifier: string;
@@ -27,22 +24,42 @@ export type TransportOption = {
 };
 
 /**
- * Map of transport type to available transport options (identifiers + labels).
- * Used by ConnectDeviceActions to show available transports.
+ * Get the available transport options (identifiers + labels) based on the transport config.
+ * When speculos and/or mock server are enabled, their connect options are shown together.
+ * Otherwise, fall back to the default USB/BLE options.
  */
-export const transportOptionsMap: Record<TransportType, TransportOption[]> = {
-  default: [
-    { identifier: webHidIdentifier, label: "Select a USB device" },
-    { identifier: webBleIdentifier, label: "Select a BLE device" },
-  ],
-  mockserver: [
-    { identifier: mockserverIdentifier, label: "Connect to Mock Server" },
-  ],
-  speculos: [{ identifier: speculosIdentifier, label: "Connect to Speculos" }],
-};
+export function getTransportOptions(
+  transportConfig: TransportConfig,
+): TransportOption[] {
+  const options: TransportOption[] = [];
+
+  if (transportConfig.speculos) {
+    options.push({
+      identifier: speculosIdentifier,
+      label: "Connect to Speculos",
+    });
+  }
+  if (transportConfig.mockServer) {
+    options.push({
+      identifier: mockserverIdentifier,
+      label: "Connect to Mock Server",
+    });
+  }
+
+  if (options.length === 0) {
+    return [
+      { identifier: webHidIdentifier, label: "Select a USB device" },
+      { identifier: webBleIdentifier, label: "Select a BLE device" },
+    ];
+  }
+
+  return options;
+}
 
 /**
  * Get the transport factories to add to the DMK builder based on the transport config.
+ * Speculos and mock server can be enabled together; when neither is enabled, the
+ * default USB/BLE transports are used.
  * Returns an array of factories and optional config to apply.
  */
 export function getTransportFactoriesForConfig(
@@ -51,25 +68,28 @@ export function getTransportFactoriesForConfig(
   factories: TransportFactory[];
   config?: { mockUrl: string };
 } {
-  switch (transportConfig.type) {
-    case "speculos":
-      return {
-        factories: [
-          speculosTransportFactory(
-            transportConfig.url,
-            false,
-            transportConfig.deviceModelId,
-          ),
-        ],
-      };
-    case "mockserver":
-      return {
-        factories: [mockserverTransportFactory],
-        config: { mockUrl: transportConfig.url },
-      };
-    default:
-      return {
-        factories: [webHidTransportFactory, webBleTransportFactory],
-      };
+  const factories: TransportFactory[] = [];
+  let config: { mockUrl: string } | undefined;
+
+  if (transportConfig.speculos) {
+    factories.push(
+      speculosTransportFactory(
+        transportConfig.speculos.url,
+        false,
+        transportConfig.speculos.deviceModelId,
+      ),
+    );
   }
+  if (transportConfig.mockServer) {
+    factories.push(mockserverTransportFactory);
+    config = { mockUrl: transportConfig.mockServer.url };
+  }
+
+  if (factories.length === 0) {
+    return {
+      factories: [webHidTransportFactory, webBleTransportFactory],
+    };
+  }
+
+  return { factories, config };
 }

--- a/apps/sample/src/state/settings/persistence.ts
+++ b/apps/sample/src/state/settings/persistence.ts
@@ -9,8 +9,23 @@ export function loadPersistedSettings(): SettingsState {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (!stored) return initialState;
 
-    const parsed = JSON.parse(stored) as Partial<SettingsState>;
-    return { ...initialState, ...parsed };
+    const parsed = JSON.parse(stored) as Partial<SettingsState> & {
+      transportType?: "default" | "speculos" | "mockserver";
+    };
+
+    // Migrate legacy mutually-exclusive `transportType` to independent flags.
+    const { transportType, ...rest } = parsed;
+    const migrated: Partial<SettingsState> = { ...rest };
+    if (transportType !== undefined) {
+      if (rest.speculosEnabled === undefined) {
+        migrated.speculosEnabled = transportType === "speculos";
+      }
+      if (rest.mockServerEnabled === undefined) {
+        migrated.mockServerEnabled = transportType === "mockserver";
+      }
+    }
+
+    return { ...initialState, ...migrated };
   } catch {
     return initialState;
   }

--- a/apps/sample/src/state/settings/schema.ts
+++ b/apps/sample/src/state/settings/schema.ts
@@ -17,24 +17,30 @@ export type DatasourceProxy = NonNullable<
   ContextModuleDatasourceConfig["proxy"]
 >;
 
-export type TransportType = "default" | "speculos" | "mockserver";
+export type TransportConfig = {
+  speculos: { url: string; deviceModelId: DeviceModelId } | null;
+  mockServer: { url: string } | null;
+};
 
-export type TransportConfig =
-  | { type: "default" }
-  | { type: "speculos"; url: string; deviceModelId: DeviceModelId }
-  | { type: "mockserver"; url: string };
+type TransportFlags = {
+  speculosEnabled: boolean;
+  mockServerEnabled: boolean;
+};
 
-function getInitialTransportType(): TransportType {
+function getInitialTransportFlags(): TransportFlags {
   const envTransport = process.env.DMK_CONFIG_TRANSPORT;
-  if (envTransport === "speculos" || envTransport === "mockserver") {
-    return envTransport;
-  }
-  return "default";
+  const enabled = (envTransport ?? "").split(",").map((value) => value.trim());
+  const isTest = enabled.includes("test") || enabled.includes("both");
+  return {
+    speculosEnabled: isTest || enabled.includes("speculos"),
+    mockServerEnabled: isTest || enabled.includes("mockserver"),
+  };
 }
 
 export type SettingsState = {
   // Transport settings
-  transportType: TransportType;
+  speculosEnabled: boolean;
+  mockServerEnabled: boolean;
   mockServerUrl: string;
   speculosUrl: string;
   speculosVncUrl: string;
@@ -54,9 +60,12 @@ export type SettingsState = {
   datasourceConfig: ContextModuleDatasourceConfig;
 };
 
+const initialTransportFlags = getInitialTransportFlags();
+
 export const initialState: SettingsState = {
   // Transport settings
-  transportType: getInitialTransportType(),
+  speculosEnabled: initialTransportFlags.speculosEnabled,
+  mockServerEnabled: initialTransportFlags.mockServerEnabled,
   mockServerUrl: "http://127.0.0.1:8080/",
   speculosUrl: DEFAULT_SPECULOS_URL,
   speculosVncUrl: DEFAULT_SPECULOS_VNC_URL,

--- a/apps/sample/src/state/settings/selectors.ts
+++ b/apps/sample/src/state/settings/selectors.ts
@@ -5,8 +5,10 @@ import { type RootState } from "@/state/store";
 import { type TransportConfig } from "./schema";
 
 // Transport settings selectors
-export const selectTransportType = (state: RootState) =>
-  state.settings.transportType;
+export const selectSpeculosEnabled = (state: RootState) =>
+  state.settings.speculosEnabled;
+export const selectMockServerEnabled = (state: RootState) =>
+  state.settings.mockServerEnabled;
 export const selectMockServerUrl = (state: RootState) =>
   state.settings.mockServerUrl;
 export const selectSpeculosUrl = (state: RootState) =>
@@ -19,30 +21,24 @@ export const selectSpeculosDeviceModel = (state: RootState) =>
 // Derived transport config selector (memoized to avoid creating new objects on every render)
 export const selectTransportConfig = createSelector(
   [
-    selectTransportType,
+    selectSpeculosEnabled,
+    selectMockServerEnabled,
     selectMockServerUrl,
     selectSpeculosUrl,
     selectSpeculosDeviceModel,
   ],
   (
-    transportType,
+    speculosEnabled,
+    mockServerEnabled,
     mockServerUrl,
     speculosUrl,
     speculosDeviceModel,
-  ): TransportConfig => {
-    switch (transportType) {
-      case "speculos":
-        return {
-          type: "speculos",
-          url: speculosUrl,
-          deviceModelId: speculosDeviceModel,
-        };
-      case "mockserver":
-        return { type: "mockserver", url: mockServerUrl };
-      default:
-        return { type: "default" };
-    }
-  },
+  ): TransportConfig => ({
+    speculos: speculosEnabled
+      ? { url: speculosUrl, deviceModelId: speculosDeviceModel }
+      : null,
+    mockServer: mockServerEnabled ? { url: mockServerUrl } : null,
+  }),
 );
 
 // DMK settings selectors

--- a/apps/sample/src/state/settings/slice.ts
+++ b/apps/sample/src/state/settings/slice.ts
@@ -8,7 +8,6 @@ import {
   type DatasourceProxy,
   initialState,
   type SettingsState,
-  type TransportType,
 } from "./schema";
 
 export const settingsSlice = createSlice({
@@ -17,11 +16,17 @@ export const settingsSlice = createSlice({
   initialState,
   reducers: {
     // Transport settings
-    setTransportType: (
+    setSpeculosEnabled: (
       state,
-      action: PayloadAction<{ transportType: TransportType }>,
+      action: PayloadAction<{ speculosEnabled: boolean }>,
     ) => {
-      state.transportType = action.payload.transportType;
+      state.speculosEnabled = action.payload.speculosEnabled;
+    },
+    setMockServerEnabled: (
+      state,
+      action: PayloadAction<{ mockServerEnabled: boolean }>,
+    ) => {
+      state.mockServerEnabled = action.payload.mockServerEnabled;
     },
     setMockServerUrl: (
       state,
@@ -134,7 +139,8 @@ export const settingsSlice = createSlice({
 });
 
 export const {
-  setTransportType,
+  setSpeculosEnabled,
+  setMockServerEnabled,
   setMockServerUrl,
   setSpeculosUrl,
   setSpeculosVncUrl,


### PR DESCRIPTION
### 📝 Description

Unifies how Speculos and the mock server are configured in the sample app. Previously a single mutually-exclusive `transportType` (`"default" | "speculos" | "mockserver"`) meant enabling one transport disabled the other. This replaces it with two independent boolean flags (`speculosEnabled`, `mockServerEnabled`) so both can be enabled together as a single test environment.

Key changes:
- New combined `TransportConfig` (`{ speculos: {...} | null, mockServer: {...} | null }`) derived from the two flags.
- `getTransportFactoriesForConfig` now accumulates both transport factories (and applies `{ mockUrl }` only when the mock server is enabled), falling back to USB/BLE when neither is on.
- `getTransportOptions` replaces the old `transportOptionsMap`, surfacing both "Connect to Speculos" and "Connect to Mock Server" buttons when each transport is enabled.
- Settings toggles are now plain independent booleans; enabling one no longer disables the other.
- Legacy persisted `transportType` is migrated to the new flags so existing users keep their mode.
- `DMK_CONFIG_TRANSPORT` supports `speculos`, `mockserver`, comma-separated combos, and a `test`/`both` shorthand that enables both.
- Removed the purple sidebar background that showed when the mock server was enabled (the `(MOCKED)` title indicator is kept).

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Single test environment that can enable Speculos and the mock server simultaneously, with a dedicated mock server connect button.

### ✅ Checklist

- [ ] **Covered by automatic tests** — no automated tests added; changes are UI/state wiring in the sample app and were verified manually + via typecheck.
- [ ] **Changeset is provided** — not needed: changes only affect `apps/sample` (an app), not a published package.
- [x] **Documentation is up-to-date** — no docs impacted.
- [ ] **Impact of the changes:**
  - Sample app transport settings refactored from `transportType` enum to independent `speculosEnabled` / `mockServerEnabled` flags.
  - Speculos and mock server can now be enabled together; both connect buttons appear.
  - Legacy persisted settings are migrated automatically.
  - Sidebar purple background removed.

Made with [Cursor](https://cursor.com)