### PR TITLE
♻️ (device-management-kit) [NO-ISSUE]: Use WaitForAppAndVersionDeviceAction in GetDeviceStatusDeviceAction

### DIFF
--- a/.changeset/spicy-snails-eat.md
+++ b/.changeset/spicy-snails-eat.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+use WaitForAppAndVersionDeviceAction in GetDeviceStatusDeviceAction

--- a/packages/device-management-kit/src/api/device-action/__test-utils__/setupTestMachine.ts
+++ b/packages/device-management-kit/src/api/device-action/__test-utils__/setupTestMachine.ts
@@ -2,6 +2,7 @@ import { Left, Right } from "purify-ts";
 import { type Mock } from "vitest";
 import { assign, createMachine } from "xstate";
 
+import { type GetAppAndVersionResponse } from "@api/command/os/GetAppAndVersionCommand";
 import { UserInteractionRequired } from "@api/device-action/model/UserInteractionRequired";
 import { UnknownDAError } from "@api/device-action/os/Errors";
 import { GetDeviceMetadataDeviceAction } from "@api/device-action/os/GetDeviceMetadata/GetDeviceMetadataDeviceAction";
@@ -22,6 +23,8 @@ import { ListAppsDeviceAction } from "@api/device-action/os/ListApps/ListAppsDev
 import { listAppsDAStateStep } from "@api/device-action/os/ListApps/types";
 import { OpenAppDeviceAction } from "@api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction";
 import { openAppDAStateStep } from "@api/device-action/os/OpenAppDeviceAction/types";
+import { waitForAppAndVersionDAStateStep } from "@api/device-action/os/WaitForAppAndVersion/types";
+import { WaitForAppAndVersionDeviceAction } from "@api/device-action/os/WaitForAppAndVersion/WaitForAppAndVersionDeviceAction";
 import { type DmkError } from "@api/Error";
 import { ListInstalledAppsDeviceAction } from "@api/secure-channel/device-action/ListInstalledApps/ListInstalledAppsDeviceAction";
 import { type InstalledApp } from "@api/secure-channel/device-action/ListInstalledApps/types";
@@ -272,4 +275,43 @@ export const setupListInstalledAppsMock = (
       }),
     ),
   }));
+};
+
+export const setupWaitForAppAndVersionMock = (
+  output: GetAppAndVersionResponse | DmkError,
+  requiredUserInteraction: UserInteractionRequired = UserInteractionRequired.None,
+) => {
+  (WaitForAppAndVersionDeviceAction as unknown as Mock).mockImplementation(
+    () => ({
+      makeStateMachine: vi.fn().mockImplementation(() =>
+        createMachine({
+          id: "MockWaitForAppAndVersionDeviceAction",
+          initial: "ready",
+          context: {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: waitForAppAndVersionDAStateStep.GET_APP_AND_VERSION,
+            },
+          },
+          states: {
+            ready: {
+              after: {
+                0: "done",
+              },
+              entry: assign({
+                intermediateValue: () => ({
+                  requiredUserInteraction,
+                  step: waitForAppAndVersionDAStateStep.GET_APP_AND_VERSION,
+                }),
+              }),
+            },
+            done: {
+              type: "final",
+            },
+          },
+          output: () => ("_tag" in output ? Left(output) : Right(output)),
+        }),
+      ),
+    }),
+  );
 };

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.test.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.test.ts
@@ -1,7 +1,6 @@
-import { interval, Observable } from "rxjs";
-
 import { CommandResultFactory } from "@api/command/model/CommandResult";
 import { getOsVersionCommandResponseMockBuilder } from "@api/command/os/__mocks__/GetOsVersionCommand";
+import { type GetAppAndVersionResponse } from "@api/command/os/GetAppAndVersionCommand";
 import { type GetOsVersionResponse } from "@api/command/os/GetOsVersionCommand";
 import {
   GLOBAL_ERRORS,
@@ -10,6 +9,7 @@ import {
 import { DeviceModelId } from "@api/device/DeviceModel";
 import { DeviceStatus } from "@api/device/DeviceStatus";
 import { makeDeviceActionInternalApiMock } from "@api/device-action/__test-utils__/makeInternalApi";
+import { setupWaitForAppAndVersionMock } from "@api/device-action/__test-utils__/setupTestMachine";
 import { testDeviceActionStates } from "@api/device-action/__test-utils__/testDeviceActionStates";
 import { DeviceActionStatus } from "@api/device-action/model/DeviceActionState";
 import { UserInteractionRequired } from "@api/device-action/model/UserInteractionRequired";
@@ -22,9 +22,14 @@ import { DeviceSessionStateType } from "@api/device-session/DeviceSessionState";
 
 import { GetDeviceStatusDeviceAction } from "./GetDeviceStatusDeviceAction";
 import {
+  type GetDeviceStatusDARequiredInteraction,
   type GetDeviceStatusDAState,
   getDeviceStatusDAStateStep,
 } from "./types";
+
+vi.mock(
+  "@api/device-action/os/WaitForAppAndVersion/WaitForAppAndVersionDeviceAction",
+);
 
 const osVersionCommandResult = (
   props: Partial<GetOsVersionResponse> = {},
@@ -34,65 +39,43 @@ const osVersionCommandResult = (
     data: getOsVersionCommandResponseMockBuilder(deviceModelId, props),
   });
 
-const appAndVersionResult = (name: string, version: string) =>
-  CommandResultFactory({
-    data: {
-      name,
-      version,
-    },
-  });
+const appAndVersion = (
+  name: string,
+  version: string,
+): GetAppAndVersionResponse => ({
+  name,
+  version,
+});
 
-const lockedErrorResult = () =>
-  CommandResultFactory({
-    error: new GlobalCommandError({
-      ...GLOBAL_ERRORS["5515"],
-      errorCode: "5515",
-    }),
-  });
-
-const onboardCheckPendingState = (): GetDeviceStatusDAState => ({
+const onboardCheckPendingState = (
+  requiredUserInteraction: GetDeviceStatusDARequiredInteraction = UserInteractionRequired.None,
+): GetDeviceStatusDAState => ({
   intermediateValue: {
-    requiredUserInteraction: UserInteractionRequired.None,
+    requiredUserInteraction,
     step: getDeviceStatusDAStateStep.ONBOARD_CHECK,
   },
   status: DeviceActionStatus.Pending,
 });
 
-const onboardCheckPendingStatesWithOsVersionFetch =
-  (): Array<GetDeviceStatusDAState> => [
-    onboardCheckPendingState(),
-    onboardCheckPendingState(),
-  ];
-
-const unlockRequestedPendingState = (): GetDeviceStatusDAState => ({
+const waitForAppAndVersionPendingState = (
+  requiredUserInteraction: GetDeviceStatusDARequiredInteraction = UserInteractionRequired.None,
+): GetDeviceStatusDAState => ({
   intermediateValue: {
-    requiredUserInteraction: UserInteractionRequired.UnlockDevice,
-    step: getDeviceStatusDAStateStep.UNLOCK_DEVICE,
-  },
-  status: DeviceActionStatus.Pending,
-});
-
-const unlockResolvedPendingState = (): GetDeviceStatusDAState => ({
-  intermediateValue: {
-    requiredUserInteraction: UserInteractionRequired.None,
-    step: getDeviceStatusDAStateStep.UNLOCK_DEVICE,
+    requiredUserInteraction,
+    step: getDeviceStatusDAStateStep.WAIT_FOR_APP_AND_VERSION,
   },
   status: DeviceActionStatus.Pending,
 });
 
 describe("GetDeviceStatusDeviceAction", () => {
-  const getAppAndVersionMock = vi.fn();
   const getOsVersionMock = vi.fn();
   const getDeviceSessionStateMock = vi.fn();
-  const waitForDeviceUnlockMock = vi.fn();
   const setDeviceSessionState = vi.fn();
 
   function extractDependenciesMock() {
     return {
-      getAppAndVersion: getAppAndVersionMock,
       getOsVersion: getOsVersionMock,
       getDeviceSessionState: getDeviceSessionStateMock,
-      waitForDeviceUnlock: waitForDeviceUnlockMock,
       setDeviceSessionState: setDeviceSessionState,
     };
   }
@@ -100,19 +83,17 @@ describe("GetDeviceStatusDeviceAction", () => {
   const {
     sendCommand: sendCommandMock,
     getDeviceSessionState: apiGetDeviceSessionStateMock,
-    getDeviceSessionStateObservable: apiGetDeviceSessionStateObservableMock,
   } = makeDeviceActionInternalApiMock();
+
   beforeEach(() => {
     vi.resetAllMocks();
     getOsVersionMock.mockResolvedValue(osVersionCommandResult());
   });
 
   describe("without overriding `extractDependencies`", () => {
-    it("should run the device action with an unlocked device", () =>
+    it("should run the device action with the device on the dashboard", () =>
       new Promise<void>((resolve, reject) => {
-        const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
-          input: { unlockTimeout: 500 },
-        });
+        setupWaitForAppAndVersionMock(appAndVersion("BOLOS", "1.0.0"));
 
         apiGetDeviceSessionStateMock.mockReturnValue({
           sessionStateType: DeviceSessionStateType.Connected,
@@ -120,16 +101,17 @@ describe("GetDeviceStatusDeviceAction", () => {
           deviceModelId: DeviceModelId.NANO_X,
         });
 
-        // GetAppAndVersion is called first to determine the current app, then
-        // GetOsVersion is called because the app is BOLOS (dashboard).
-        sendCommandMock.mockImplementation((command) =>
-          command.name === "getOsVersion"
-            ? Promise.resolve(osVersionCommandResult())
-            : Promise.resolve(appAndVersionResult("BOLOS", "1.0.0")),
-        );
+        // The current app is BOLOS (dashboard), so the OS version is fetched.
+        sendCommandMock.mockResolvedValue(osVersionCommandResult());
+
+        const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
+          input: { unlockTimeout: 500 },
+        });
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
-          ...onboardCheckPendingStatesWithOsVersionFetch(),
+          waitForAppAndVersionPendingState(),
+          waitForAppAndVersionPendingState(),
+          onboardCheckPendingState(),
           {
             output: {
               currentApp: "BOLOS",
@@ -150,137 +132,35 @@ describe("GetDeviceStatusDeviceAction", () => {
         );
       }));
 
-    it("should run the device action with a locked device", () =>
+    it("should run the device action when the device needs to be unlocked", () =>
       new Promise<void>((resolve, reject) => {
-        const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
-          input: { unlockTimeout: 1500 },
-        });
+        setupWaitForAppAndVersionMock(
+          appAndVersion("BOLOS", "1.0.0"),
+          UserInteractionRequired.UnlockDevice,
+        );
 
         apiGetDeviceSessionStateMock.mockReturnValue({
-          sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+          sessionStateType: DeviceSessionStateType.Connected,
           deviceStatus: DeviceStatus.LOCKED,
-          currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
-          installedApps: [],
           deviceModelId: DeviceModelId.NANO_X,
-          isSecureConnectionAllowed: false,
         });
 
-        // First GetAppAndVersion fails because the device is locked, then it
-        // succeeds (BOLOS) once unlocked, then GetOsVersion is fetched.
-        let appCall = 0;
-        sendCommandMock.mockImplementation((command) => {
-          if (command.name === "getOsVersion") {
-            return Promise.resolve(osVersionCommandResult());
-          }
-          appCall += 1;
-          if (appCall === 1) {
-            return Promise.resolve(lockedErrorResult());
-          }
-          return Promise.resolve(appAndVersionResult("BOLOS", "1.0.0"));
-        });
+        sendCommandMock.mockResolvedValue(osVersionCommandResult());
 
-        const expectedStates: Array<GetDeviceStatusDAState> = [
-          onboardCheckPendingState(),
-          unlockRequestedPendingState(),
-          unlockResolvedPendingState(),
-          unlockResolvedPendingState(),
-          {
-            output: {
-              currentApp: "BOLOS",
-              currentAppVersion: "1.0.0",
-            },
-            status: DeviceActionStatus.Completed,
-          },
-        ];
-
-        testDeviceActionStates(
-          getDeviceStateDeviceAction,
-          expectedStates,
-          makeDeviceActionInternalApiMock(),
-          {
-            onDone: resolve,
-            onError: reject,
-          },
-        );
-      }));
-
-    it("should timeout with a locked device", () =>
-      new Promise<void>((resolve, reject) => {
-        const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
-          input: { unlockTimeout: 200 },
-        });
-
-        apiGetDeviceSessionStateMock.mockReturnValue({
-          sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-          deviceStatus: DeviceStatus.LOCKED,
-          currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
-          installedApps: [],
-          deviceModelId: DeviceModelId.NANO_X,
-          isSecureConnectionAllowed: false,
-        });
-
-        // GetAppAndVersion always reports a locked device, so the unlock
-        // polling times out.
-        sendCommandMock.mockImplementation((command) =>
-          command.name === "getOsVersion"
-            ? Promise.resolve(osVersionCommandResult())
-            : Promise.resolve(lockedErrorResult()),
-        );
-
-        const expectedStates: Array<GetDeviceStatusDAState> = [
-          onboardCheckPendingState(),
-          unlockRequestedPendingState(),
-          {
-            error: new DeviceLockedError("Device locked."),
-            status: DeviceActionStatus.Error,
-          },
-        ];
-
-        testDeviceActionStates(
-          getDeviceStateDeviceAction,
-          expectedStates,
-          makeDeviceActionInternalApiMock(),
-          {
-            onDone: resolve,
-            onError: reject,
-          },
-        );
-      }));
-
-    it("should run the device action with an old firmware not supporting GetAppAndVersion", () =>
-      new Promise<void>((resolve, reject) => {
         const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
           input: { unlockTimeout: 500 },
         });
 
-        apiGetDeviceSessionStateMock.mockReturnValue({
-          sessionStateType: DeviceSessionStateType.Connected,
-          deviceStatus: DeviceStatus.CONNECTED,
-          deviceModelId: DeviceModelId.NANO_X,
-        });
-
-        // GetAppAndVersion is not supported (CLA_NOT_SUPPORTED), which means we
-        // are on the dashboard of an old firmware: the current app is BOLOS so
-        // the OS version can still be fetched.
-        sendCommandMock.mockImplementation((command) =>
-          command.name === "getOsVersion"
-            ? Promise.resolve(osVersionCommandResult())
-            : Promise.resolve(
-                CommandResultFactory({
-                  error: new GlobalCommandError({
-                    ...GLOBAL_ERRORS["6e00"],
-                    errorCode: "6e00",
-                  }),
-                }),
-              ),
-        );
-
         const expectedStates: Array<GetDeviceStatusDAState> = [
-          ...onboardCheckPendingStatesWithOsVersionFetch(),
+          waitForAppAndVersionPendingState(),
+          waitForAppAndVersionPendingState(
+            UserInteractionRequired.UnlockDevice,
+          ),
+          onboardCheckPendingState(),
           {
             output: {
               currentApp: "BOLOS",
-              currentAppVersion: "0.0.0",
+              currentAppVersion: "1.0.0",
             },
             status: DeviceActionStatus.Completed,
           },
@@ -299,17 +179,15 @@ describe("GetDeviceStatusDeviceAction", () => {
   });
 
   describe("success cases", () => {
-    it("should return the device status if the device is unlocked", () =>
+    it("should return the device status if the device is on the dashboard", () =>
       new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersionMock(appAndVersion("BOLOS", "1.0.0"));
+
         getDeviceSessionStateMock.mockReturnValue({
           sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
           deviceStatus: DeviceStatus.CONNECTED,
           currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
         });
-
-        getAppAndVersionMock.mockResolvedValue(
-          appAndVersionResult("BOLOS", "1.0.0"),
-        );
 
         const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
           input: { unlockTimeout: undefined },
@@ -321,7 +199,9 @@ describe("GetDeviceStatusDeviceAction", () => {
         ).mockReturnValue(extractDependenciesMock());
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
-          ...onboardCheckPendingStatesWithOsVersionFetch(),
+          waitForAppAndVersionPendingState(),
+          waitForAppAndVersionPendingState(),
+          onboardCheckPendingState(),
           {
             status: DeviceActionStatus.Completed,
             output: {
@@ -336,42 +216,32 @@ describe("GetDeviceStatusDeviceAction", () => {
           expectedStates,
           makeDeviceActionInternalApiMock(),
           {
-            onDone: () => {
-              // Session should be updated with current app
-              expect(setDeviceSessionState).toHaveBeenCalledWith({
-                sessionStateType:
-                  DeviceSessionStateType.ReadyWithoutSecureChannel,
-                deviceStatus: DeviceStatus.CONNECTED,
-                currentApp: {
-                  name: "BOLOS",
-                  version: "1.0.0",
-                },
-              });
-              resolve();
-            },
+            onDone: resolve,
             onError: reject,
           },
         );
       }));
 
-    it("should return the device status and update session if the device is not ready", () =>
+    it("should return the device status and update the session firmware version", () =>
       new Promise<void>((resolve, reject) => {
-        // The session state is stateful so the firmware version enrichment from
-        // the OS version (which reads back the ready state) can be observed.
+        setupWaitForAppAndVersionMock(appAndVersion("BOLOS", "1.0.0"));
+
+        // The session must already be ready (not Connected) for the firmware
+        // version enrichment from the OS version to be applied. The session
+        // state is stateful so the enrichment can be observed.
         let sessionState: object = {
-          sessionStateType: DeviceSessionStateType.Connected,
+          sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
           deviceStatus: DeviceStatus.CONNECTED,
+          currentApp: { name: "BOLOS", version: "1.0.0" },
+          installedApps: [],
           deviceModelId: DeviceModelId.NANO_X,
+          isSecureConnectionAllowed: false,
         };
         getDeviceSessionStateMock.mockImplementation(() => sessionState);
         setDeviceSessionState.mockImplementation((state) => {
           sessionState = state;
           return state;
         });
-
-        getAppAndVersionMock.mockResolvedValue(
-          appAndVersionResult("BOLOS", "1.0.0"),
-        );
 
         const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
           input: { unlockTimeout: undefined },
@@ -386,7 +256,9 @@ describe("GetDeviceStatusDeviceAction", () => {
           DeviceModelId.NANO_X,
         );
         const expectedStates: Array<GetDeviceStatusDAState> = [
-          ...onboardCheckPendingStatesWithOsVersionFetch(),
+          waitForAppAndVersionPendingState(),
+          waitForAppAndVersionPendingState(),
+          onboardCheckPendingState(),
           {
             status: DeviceActionStatus.Completed,
             output: {
@@ -402,27 +274,19 @@ describe("GetDeviceStatusDeviceAction", () => {
           makeDeviceActionInternalApiMock(),
           {
             onDone: () => {
-              // Session should be set as ready if GetAppAndVersionCommand was successful
-              // and then enriched with the firmware version from the OS version.
-              expect(setDeviceSessionState).toHaveBeenCalledWith({
-                deviceModelId: DeviceModelId.NANO_X,
-                sessionStateType:
-                  DeviceSessionStateType.ReadyWithoutSecureChannel,
-                deviceStatus: DeviceStatus.CONNECTED,
-                currentApp: {
-                  name: "BOLOS",
-                  version: "1.0.0",
-                },
-                installedApps: [],
-                isSecureConnectionAllowed:
-                  osVersionData.secureElementFlags.isSecureConnectionAllowed,
-                firmwareVersion: {
-                  mcu: osVersionData.mcuSephVersion,
-                  bootloader: osVersionData.mcuBootloaderVersion,
-                  os: osVersionData.seVersion,
-                  metadata: osVersionData,
-                },
-              });
+              // Session should be enriched with the firmware version from the OS version.
+              expect(setDeviceSessionState).toHaveBeenCalledWith(
+                expect.objectContaining({
+                  isSecureConnectionAllowed:
+                    osVersionData.secureElementFlags.isSecureConnectionAllowed,
+                  firmwareVersion: {
+                    mcu: osVersionData.mcuSephVersion,
+                    bootloader: osVersionData.mcuBootloaderVersion,
+                    os: osVersionData.seVersion,
+                    metadata: osVersionData,
+                  },
+                }),
+              );
               resolve();
             },
             onError: reject,
@@ -432,17 +296,13 @@ describe("GetDeviceStatusDeviceAction", () => {
 
     it("should not fetch the OS version when an app other than BOLOS is open", () =>
       new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersionMock(appAndVersion("Bitcoin", "2.1.0"));
+
         getDeviceSessionStateMock.mockReturnValue({
           sessionStateType: DeviceSessionStateType.Connected,
           deviceStatus: DeviceStatus.CONNECTED,
           deviceModelId: DeviceModelId.NANO_X,
         });
-
-        // An application is open: the device is necessarily onboarded and the
-        // OS version cannot be read outside of the dashboard.
-        getAppAndVersionMock.mockResolvedValue(
-          appAndVersionResult("Bitcoin", "2.1.0"),
-        );
 
         const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
           input: { unlockTimeout: undefined },
@@ -454,7 +314,8 @@ describe("GetDeviceStatusDeviceAction", () => {
         ).mockReturnValue(extractDependenciesMock());
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
-          onboardCheckPendingState(),
+          waitForAppAndVersionPendingState(),
+          waitForAppAndVersionPendingState(),
           {
             status: DeviceActionStatus.Completed,
             output: {
@@ -481,6 +342,8 @@ describe("GetDeviceStatusDeviceAction", () => {
     it("GIVEN a non-onboarded device WHEN checking the device status THEN it returns the device status by default", () =>
       new Promise<void>((resolve, reject) => {
         // GIVEN
+        setupWaitForAppAndVersionMock(appAndVersion("BOLOS", "1.0.0"));
+
         getDeviceSessionStateMock.mockReturnValue({
           sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
           deviceStatus: DeviceStatus.CONNECTED,
@@ -489,9 +352,7 @@ describe("GetDeviceStatusDeviceAction", () => {
           deviceModelId: DeviceModelId.NANO_X,
           isSecureConnectionAllowed: false,
         });
-        getAppAndVersionMock.mockResolvedValue(
-          appAndVersionResult("BOLOS", "1.0.0"),
-        );
+
         getOsVersionMock.mockResolvedValue(
           osVersionCommandResult({
             secureElementFlags: {
@@ -511,7 +372,9 @@ describe("GetDeviceStatusDeviceAction", () => {
         ).mockReturnValue(extractDependenciesMock());
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
-          ...onboardCheckPendingStatesWithOsVersionFetch(),
+          waitForAppAndVersionPendingState(),
+          waitForAppAndVersionPendingState(),
+          onboardCheckPendingState(),
           {
             status: DeviceActionStatus.Completed,
             output: {
@@ -534,53 +397,18 @@ describe("GetDeviceStatusDeviceAction", () => {
         );
       }));
 
-    it("should return the device status if the device is locked and the user unlocks the device", () =>
+    it("should surface the unlock interaction then return the device status", () =>
       new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersionMock(
+          appAndVersion("BOLOS", "1.0.0"),
+          UserInteractionRequired.UnlockDevice,
+        );
+
         getDeviceSessionStateMock.mockReturnValue({
           sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
           deviceStatus: DeviceStatus.LOCKED,
           currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
         });
-
-        getAppAndVersionMock
-          .mockResolvedValueOnce(lockedErrorResult())
-          .mockResolvedValueOnce(appAndVersionResult("BOLOS", "1.0.0"));
-
-        waitForDeviceUnlockMock.mockImplementation(
-          () =>
-            new Observable((o) => {
-              const inner = interval(50).subscribe({
-                next: (i) => {
-                  if (i > 2) {
-                    o.next({
-                      sessionStateType:
-                        DeviceSessionStateType.ReadyWithoutSecureChannel,
-                      deviceStatus: DeviceStatus.CONNECTED,
-                      currentApp: {
-                        name: "mockedCurrentApp",
-                        version: "1.0.0",
-                      },
-                    });
-                    o.complete();
-                  } else {
-                    o.next({
-                      sessionStateType:
-                        DeviceSessionStateType.ReadyWithoutSecureChannel,
-                      deviceStatus: DeviceStatus.LOCKED,
-                      currentApp: {
-                        name: "mockedCurrentApp",
-                        version: "1.0.0",
-                      },
-                    });
-                  }
-                },
-              });
-
-              return () => {
-                inner.unsubscribe();
-              };
-            }),
-        );
 
         const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
           input: { unlockTimeout: 500 },
@@ -592,10 +420,11 @@ describe("GetDeviceStatusDeviceAction", () => {
         ).mockReturnValue(extractDependenciesMock());
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
+          waitForAppAndVersionPendingState(),
+          waitForAppAndVersionPendingState(
+            UserInteractionRequired.UnlockDevice,
+          ),
           onboardCheckPendingState(),
-          unlockRequestedPendingState(),
-          unlockResolvedPendingState(),
-          unlockResolvedPendingState(),
           {
             status: DeviceActionStatus.Completed,
             output: {
@@ -621,6 +450,8 @@ describe("GetDeviceStatusDeviceAction", () => {
     it("GIVEN a non-onboarded device and the non-onboarded allowance is disabled WHEN checking the device status THEN it returns a not-onboarded error", () =>
       new Promise<void>((resolve, reject) => {
         // GIVEN
+        setupWaitForAppAndVersionMock(appAndVersion("BOLOS", "1.0.0"));
+
         getDeviceSessionStateMock.mockReturnValue({
           sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
           deviceStatus: DeviceStatus.CONNECTED,
@@ -629,11 +460,9 @@ describe("GetDeviceStatusDeviceAction", () => {
           deviceModelId: DeviceModelId.NANO_X,
           isSecureConnectionAllowed: false,
         });
-        // A non-onboarded device sits on the dashboard (BOLOS), so the app check
-        // succeeds and the OS version reveals the onboarding status.
-        getAppAndVersionMock.mockResolvedValue(
-          appAndVersionResult("BOLOS", "1.0.0"),
-        );
+
+        // The device sits on the dashboard (BOLOS), so the OS version reveals
+        // the onboarding status.
         getOsVersionMock.mockResolvedValue(
           osVersionCommandResult({
             secureElementFlags: {
@@ -656,7 +485,9 @@ describe("GetDeviceStatusDeviceAction", () => {
         ).mockReturnValue(extractDependenciesMock());
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
-          ...onboardCheckPendingStatesWithOsVersionFetch(),
+          waitForAppAndVersionPendingState(),
+          waitForAppAndVersionPendingState(),
+          onboardCheckPendingState(),
           {
             error: new DeviceNotOnboardedError(),
             status: DeviceActionStatus.Error,
@@ -678,43 +509,16 @@ describe("GetDeviceStatusDeviceAction", () => {
 
     it("should end in an error if the device is locked and the user does not unlock", () =>
       new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersionMock(
+          new DeviceLockedError("Device locked."),
+          UserInteractionRequired.UnlockDevice,
+        );
+
         getDeviceSessionStateMock.mockReturnValue({
           sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
           deviceStatus: DeviceStatus.LOCKED,
           currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
         });
-
-        getAppAndVersionMock.mockResolvedValue(lockedErrorResult());
-
-        waitForDeviceUnlockMock.mockImplementation(
-          () =>
-            new Observable((o) => {
-              o.error(new DeviceLockedError("Device locked."));
-            }),
-        );
-
-        apiGetDeviceSessionStateObservableMock.mockImplementation(
-          () =>
-            new Observable((o) => {
-              const inner = interval(200).subscribe({
-                next: () => {
-                  o.next({
-                    sessionStateType:
-                      DeviceSessionStateType.ReadyWithoutSecureChannel,
-                    deviceStatus: DeviceStatus.LOCKED,
-                    currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
-                    installedApps: [],
-                    deviceModelId: DeviceModelId.NANO_X,
-                    isSecureConnectionAllowed: false,
-                  });
-                },
-              });
-
-              return () => {
-                inner.unsubscribe();
-              };
-            }),
-        );
 
         const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
           input: { unlockTimeout: 500 },
@@ -726,8 +530,10 @@ describe("GetDeviceStatusDeviceAction", () => {
         ).mockReturnValue(extractDependenciesMock());
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
-          onboardCheckPendingState(),
-          unlockRequestedPendingState(),
+          waitForAppAndVersionPendingState(),
+          waitForAppAndVersionPendingState(
+            UserInteractionRequired.UnlockDevice,
+          ),
           {
             error: new DeviceLockedError("Device locked."),
             status: DeviceActionStatus.Error,
@@ -745,27 +551,20 @@ describe("GetDeviceStatusDeviceAction", () => {
         );
       }));
 
-    it("should end in an error if the GetAppAndVersion command fails", () =>
+    it("should end in an error if the WaitForAppAndVersion sub-action fails", () =>
       new Promise<void>((resolve, reject) => {
-        getDeviceSessionStateMock.mockReturnValue({
-          sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-          deviceStatus: DeviceStatus.LOCKED,
-          currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
-        });
-
         const error = new GlobalCommandError({
           ...GLOBAL_ERRORS["5501"],
           errorCode: "5501",
         });
 
-        getAppAndVersionMock.mockResolvedValue(CommandResultFactory({ error }));
+        setupWaitForAppAndVersionMock(error);
 
-        waitForDeviceUnlockMock.mockImplementation(
-          () =>
-            new Observable((o) => {
-              o.complete();
-            }),
-        );
+        getDeviceSessionStateMock.mockReturnValue({
+          sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+          deviceStatus: DeviceStatus.LOCKED,
+          currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
+        });
 
         const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
           input: { unlockTimeout: 500 },
@@ -777,6 +576,54 @@ describe("GetDeviceStatusDeviceAction", () => {
         ).mockReturnValue(extractDependenciesMock());
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
+          waitForAppAndVersionPendingState(),
+          waitForAppAndVersionPendingState(),
+          {
+            error,
+            status: DeviceActionStatus.Error,
+          },
+        ];
+
+        testDeviceActionStates(
+          getDeviceStateDeviceAction,
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          {
+            onDone: resolve,
+            onError: reject,
+          },
+        );
+      }));
+
+    it("should end in an error if the GetOsVersion command fails", () =>
+      new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersionMock(appAndVersion("BOLOS", "1.0.0"));
+
+        getDeviceSessionStateMock.mockReturnValue({
+          sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+          deviceStatus: DeviceStatus.CONNECTED,
+          currentApp: { name: "BOLOS", version: "1.0.0" },
+        });
+
+        const error = new GlobalCommandError({
+          ...GLOBAL_ERRORS["5501"],
+          errorCode: "5501",
+        });
+
+        getOsVersionMock.mockResolvedValue(CommandResultFactory({ error }));
+
+        const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
+          input: { unlockTimeout: 500 },
+        });
+
+        vi.spyOn(
+          getDeviceStateDeviceAction,
+          "extractDependencies",
+        ).mockReturnValue(extractDependenciesMock());
+
+        const expectedStates: Array<GetDeviceStatusDAState> = [
+          waitForAppAndVersionPendingState(),
+          waitForAppAndVersionPendingState(),
           onboardCheckPendingState(),
           {
             error,
@@ -795,24 +642,19 @@ describe("GetDeviceStatusDeviceAction", () => {
         );
       }));
 
-    it("should end in an error if getAppAndVersion actor throws an error", () =>
+    it("should end in an error if the getOsVersion actor throws an error", () =>
       new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersionMock(appAndVersion("BOLOS", "1.0.0"));
+
         getDeviceSessionStateMock.mockReturnValue({
           sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-          deviceStatus: DeviceStatus.LOCKED,
-          currentApp: { name: "mockedCurrentApp", version: "1.0.0" },
+          deviceStatus: DeviceStatus.CONNECTED,
+          currentApp: { name: "BOLOS", version: "1.0.0" },
         });
 
-        getAppAndVersionMock.mockImplementation(() => {
+        getOsVersionMock.mockImplementation(() => {
           throw new UnknownDAError("error");
         });
-
-        waitForDeviceUnlockMock.mockImplementation(
-          () =>
-            new Observable((o) => {
-              o.complete();
-            }),
-        );
 
         const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
           input: { unlockTimeout: 500 },
@@ -824,6 +666,8 @@ describe("GetDeviceStatusDeviceAction", () => {
         ).mockReturnValue(extractDependenciesMock());
 
         const expectedStates: Array<GetDeviceStatusDAState> = [
+          waitForAppAndVersionPendingState(),
+          waitForAppAndVersionPendingState(),
           onboardCheckPendingState(),
           {
             error: new UnknownDAError("error"),
@@ -845,6 +689,8 @@ describe("GetDeviceStatusDeviceAction", () => {
 
   it("should emit a stopped state if the action is cancelled", () =>
     new Promise<void>((resolve, reject) => {
+      setupWaitForAppAndVersionMock(appAndVersion("BOLOS", "1.0.0"));
+
       apiGetDeviceSessionStateMock.mockReturnValue({
         sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
         deviceStatus: DeviceStatus.CONNECTED,
@@ -854,18 +700,15 @@ describe("GetDeviceStatusDeviceAction", () => {
         isSecureConnectionAllowed: false,
       });
 
-      sendCommandMock.mockImplementation((command) =>
-        command.name === "getOsVersion"
-          ? Promise.resolve(osVersionCommandResult())
-          : Promise.resolve(appAndVersionResult("BOLOS", "1.0.0")),
-      );
+      sendCommandMock.mockResolvedValue(osVersionCommandResult());
 
       const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
         input: { unlockTimeout: 500 },
       });
 
       const expectedStates: Array<GetDeviceStatusDAState> = [
-        onboardCheckPendingState(),
+        waitForAppAndVersionPendingState(),
+        waitForAppAndVersionPendingState(),
         {
           status: DeviceActionStatus.Stopped,
         },

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.ts
@@ -1,22 +1,7 @@
 import { Left, Right } from "purify-ts";
-import {
-  EMPTY,
-  from,
-  interval,
-  mergeMap,
-  type Observable,
-  of,
-  switchMap,
-  take,
-} from "rxjs";
-import { timeout } from "rxjs/operators";
-import { assign, fromObservable, fromPromise, setup } from "xstate";
+import { assign, fromPromise, setup } from "xstate";
 
 import { isSuccessCommandResult } from "@api/command/model/CommandResult";
-import {
-  GetAppAndVersionCommand,
-  type GetAppAndVersionCommandResult,
-} from "@api/command/os/GetAppAndVersionCommand";
 import {
   GetOsVersionCommand,
   type GetOsVersionCommandResult,
@@ -26,10 +11,8 @@ import { DeviceStatus } from "@api/device/DeviceStatus";
 import { type InternalApi } from "@api/device-action/DeviceAction";
 import { UserInteractionRequired } from "@api/device-action/model/UserInteractionRequired";
 import { DEFAULT_UNLOCK_TIMEOUT_MS } from "@api/device-action/os/Const";
-import {
-  DeviceLockedError,
-  DeviceNotOnboardedError,
-} from "@api/device-action/os/Errors";
+import { DeviceNotOnboardedError } from "@api/device-action/os/Errors";
+import { WaitForAppAndVersionDeviceAction } from "@api/device-action/os/WaitForAppAndVersion/WaitForAppAndVersionDeviceAction";
 import { type StateMachineTypes } from "@api/device-action/xstate-utils/StateMachineTypes";
 import {
   type DeviceActionStateMachine,
@@ -40,7 +23,7 @@ import {
   DeviceSessionStateType,
   type FirmwareVersion,
 } from "@api/device-session/DeviceSessionState";
-import { isDashboardName, LEDGER_OS_NAME } from "@api/utils/AppName";
+import { isDashboardName } from "@api/utils/AppName";
 
 import {
   type GetDeviceStatusDAError,
@@ -52,7 +35,6 @@ import {
 
 type GetDeviceStatusMachineInternalState = {
   readonly onboarded: boolean;
-  readonly locked: boolean;
   readonly currentApp: string | null;
   readonly currentAppVersion: string | null;
   readonly osVersionMetadata: GetOsVersionResponse | null;
@@ -60,12 +42,8 @@ type GetDeviceStatusMachineInternalState = {
 };
 
 export type MachineDependencies = {
-  readonly getAppAndVersion: () => Promise<GetAppAndVersionCommandResult>;
   readonly getOsVersion: () => Promise<GetOsVersionCommandResult>;
   readonly getDeviceSessionState: () => DeviceSessionState;
-  readonly waitForDeviceUnlock: (args: {
-    input: { unlockTimeout: number };
-  }) => Observable<void>;
   readonly setDeviceSessionState: (
     state: DeviceSessionState,
   ) => DeviceSessionState;
@@ -108,13 +86,8 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
       GetDeviceStatusMachineInternalState
     >;
 
-    const {
-      getAppAndVersion,
-      getOsVersion,
-      getDeviceSessionState,
-      setDeviceSessionState,
-      waitForDeviceUnlock,
-    } = this.extractDependencies(internalApi);
+    const { getOsVersion, getDeviceSessionState, setDeviceSessionState } =
+      this.extractDependencies(internalApi);
 
     const unlockTimeout = this.input.unlockTimeout ?? DEFAULT_UNLOCK_TIMEOUT_MS;
     const allowNonOnboardedDevice = this.input.allowNonOnboardedDevice ?? true;
@@ -132,6 +105,12 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
       });
     };
 
+    const waitForAppAndVersion = new WaitForAppAndVersionDeviceAction({
+      input: {
+        unlockTimeout,
+      },
+    }).makeStateMachine(internalApi);
+
     return setup({
       types: {
         input: {
@@ -142,9 +121,8 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
         output: {} as types["output"],
       },
       actors: {
-        getAppAndVersion: fromPromise(getAppAndVersion),
+        waitForAppAndVersion,
         getOsVersion: fromPromise(getOsVersion),
-        waitForDeviceUnlock: fromObservable(waitForDeviceUnlock),
       },
       guards: {
         isCurrentAppBolos: ({ context }) =>
@@ -160,7 +138,6 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
             secureElementFlags?.isOnboarded === false
           );
         },
-        isDeviceLocked: ({ context }) => context._internalState.locked,
         hasError: ({ context }) => context._internalState.error !== null,
       },
       actions: {
@@ -170,36 +147,11 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
             error: new DeviceNotOnboardedError(),
           }),
         }),
-        assignErrorDeviceLocked: assign({
-          _internalState: (_) => ({
-            ..._.context._internalState,
-            error: new DeviceLockedError(),
-          }),
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.UnlockDevice,
-            step: getDeviceStatusDAStateStep.UNLOCK_DEVICE,
-          },
-        }),
         assignErrorFromEvent: assign({
           _internalState: (_) => ({
             ..._.context._internalState,
             error: _.event["error"], // NOTE: it should never happen, the error is not typed anymore here
           }),
-        }),
-        assignNoUserActionNeeded: assign({
-          intermediateValue: (_) =>
-            ({
-              ..._.context.intermediateValue,
-              requiredUserInteraction: UserInteractionRequired.None,
-            }) satisfies types["context"]["intermediateValue"],
-        }),
-        assignUserActionUnlockNeeded: assign({
-          intermediateValue: (_) =>
-            ({
-              ..._.context.intermediateValue,
-              requiredUserInteraction: UserInteractionRequired.UnlockDevice,
-              step: getDeviceStatusDAStateStep.UNLOCK_DEVICE,
-            }) satisfies types["context"]["intermediateValue"],
         }),
       },
     }).createMachine({
@@ -216,11 +168,10 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
           },
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: getDeviceStatusDAStateStep.ONBOARD_CHECK,
+            step: getDeviceStatusDAStateStep.WAIT_FOR_APP_AND_VERSION,
           },
           _internalState: {
             onboarded: false,
-            locked: false,
             currentApp:
               sessionStateType ===
               DeviceSessionStateType.ReadyWithoutSecureChannel
@@ -235,79 +186,70 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
       states: {
         DeviceReady: {
           always: {
-            target: "AppAndVersionCheck",
+            target: "WaitForAppAndVersion",
           },
         },
-        AppAndVersionCheck: {
+        WaitForAppAndVersion: {
           // We check the current app and version using the getAppAndVersion
           // command. This command is supported both on the dashboard (BOLOS)
           // and inside applications, so it is used to determine the currently
           // running app before deciding whether to read the OS version.
           invoke: {
-            src: "getAppAndVersion",
-            onDone: {
-              target: "ApplicationAvailableResultCheck",
+            src: "waitForAppAndVersion",
+            input: (_) => ({
+              unlockTimeout: _.context.input.unlockTimeout,
+            }),
+            onSnapshot: {
               actions: assign({
-                _internalState: (_) => {
-                  if (isSuccessCommandResult(_.event.output)) {
-                    const state: DeviceSessionState = getDeviceSessionState();
-                    if (
-                      state.sessionStateType !==
-                      DeviceSessionStateType.Connected
-                    ) {
-                      // Update the current app
-                      setDeviceSessionState({
-                        ...state,
-                        currentApp: _.event.output.data,
-                      });
-                    } else {
-                      // The device can be set to Ready if GetAppAndVersionCommand was successful.
-                      // The firmware version and secure connection flag are enriched later from
-                      // the OS version, which can only be read on the dashboard.
-                      setDeviceSessionState({
-                        deviceModelId: state.deviceModelId,
-                        sessionStateType:
-                          DeviceSessionStateType.ReadyWithoutSecureChannel,
-                        deviceStatus: DeviceStatus.CONNECTED,
-                        currentApp: _.event.output.data,
-                        installedApps: [],
-                        isSecureConnectionAllowed: false,
-                      });
-                    }
-                    return {
-                      ..._.context._internalState,
-                      locked: false,
-                      currentApp: _.event.output.data.name,
-                      currentAppVersion: _.event.output.data.version,
-                    };
-                  }
-                  if ("errorCode" in _.event.output.error) {
-                    if (_.event.output.error.errorCode === "5515") {
-                      // Locked device error
-                      return {
+                intermediateValue: (_) => ({
+                  ..._.context.intermediateValue,
+                  requiredUserInteraction:
+                    _.event.snapshot.context.intermediateValue
+                      .requiredUserInteraction,
+                }),
+              }),
+            },
+            onDone: {
+              target: "WaitForAppAndVersionResultCheck",
+              actions: assign({
+                _internalState: (_): GetDeviceStatusMachineInternalState => {
+                  return _.event.output.caseOf<GetDeviceStatusMachineInternalState>(
+                    {
+                      Left: (error) => ({
                         ..._.context._internalState,
-                        locked: true,
-                      };
-                    } else if (_.event.output.error.errorCode === "6e00") {
-                      // CLA not supported
-                      // GetAppAndVersion should always be supported by the firmware or any app.
-                      // But on old firmware versions, that APDU was not supported in the dashboard.
-                      // On those firmwares, it fails with CLA_NOT_SUPPORTED in BOLOS, and INS_NOT_SUPPORTED
-                      // in applications. Therefore if CLA is not supported, we can consider we're on the
-                      // dashboard on an old firmware. We should therefore return that information to
-                      // ensure the user can still update his firmware and is not blocked at this step.
-                      return {
-                        ..._.context._internalState,
-                        locked: false,
-                        currentApp: LEDGER_OS_NAME,
-                        currentAppVersion: "0.0.0",
-                      };
-                    }
-                  }
-                  return {
-                    ..._.context._internalState,
-                    error: _.event.output.error,
-                  };
+                        error,
+                      }),
+                      Right: (output) => {
+                        const state: DeviceSessionState =
+                          getDeviceSessionState();
+                        if (
+                          state.sessionStateType !==
+                          DeviceSessionStateType.Connected
+                        ) {
+                          // Update the current app
+                          setDeviceSessionState({
+                            ...state,
+                            currentApp: output,
+                          });
+                        } else {
+                          setDeviceSessionState({
+                            deviceModelId: state.deviceModelId,
+                            sessionStateType:
+                              DeviceSessionStateType.ReadyWithoutSecureChannel,
+                            deviceStatus: DeviceStatus.CONNECTED,
+                            currentApp: output,
+                            installedApps: [],
+                            isSecureConnectionAllowed: false,
+                          });
+                        }
+                        return {
+                          ..._.context._internalState,
+                          currentApp: output.name,
+                          currentAppVersion: output.version,
+                        };
+                      },
+                    },
+                  );
                 },
               }),
             },
@@ -317,15 +259,11 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
             },
           },
         },
-        ApplicationAvailableResultCheck: {
+        WaitForAppAndVersionResultCheck: {
           always: [
             {
               guard: "hasError",
               target: "Error",
-            },
-            {
-              target: "UserActionUnlockDevice",
-              guard: "isDeviceLocked",
             },
             {
               target: "OnboardingCheck",
@@ -333,6 +271,13 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
           ],
         },
         OnboardingCheck: {
+          entry: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: getDeviceStatusDAStateStep.ONBOARD_CHECK,
+            }),
+          }),
           always: [
             {
               // The OS version (and thus the onboarding flag) can only be read
@@ -408,31 +353,6 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
             },
           ],
         },
-        UserActionUnlockDevice: {
-          // we wait for the device to be unlocked (default timeout is 15s)
-          entry: "assignUserActionUnlockNeeded",
-          exit: "assignNoUserActionNeeded",
-          invoke: {
-            id: "UserActionUnlockDevice",
-            src: "waitForDeviceUnlock",
-            input: (_) => ({
-              unlockTimeout,
-            }),
-            onDone: {
-              target: "AppAndVersionCheck",
-              actions: assign({
-                _internalState: (_) => ({
-                  ..._.context._internalState,
-                  locked: false,
-                }),
-              }),
-            },
-            onError: {
-              target: "Error",
-              actions: "assignErrorDeviceLocked",
-            },
-          },
-        },
         Success: {
           type: "final",
         },
@@ -456,37 +376,8 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
   }
 
   extractDependencies(internalApi: InternalApi): MachineDependencies {
-    const getAppAndVersion = () => {
-      return internalApi.sendCommand(new GetAppAndVersionCommand());
-    };
-
-    const waitForDeviceUnlock = ({
-      input,
-    }: {
-      input: { unlockTimeout: number };
-    }) =>
-      interval(1000).pipe(
-        switchMap(() =>
-          from(internalApi.sendCommand(new GetAppAndVersionCommand())),
-        ),
-        mergeMap((output) => {
-          const isLocked =
-            !isSuccessCommandResult(output) &&
-            "errorCode" in output.error &&
-            output.error.errorCode === "5515";
-          if (isLocked) {
-            return EMPTY; // Continue the polling
-          }
-          return of(undefined); // Complete the observable
-        }),
-        take(1),
-        timeout(input.unlockTimeout),
-      );
-
     return {
-      getAppAndVersion,
       getOsVersion: () => internalApi.sendCommand(new GetOsVersionCommand()),
-      waitForDeviceUnlock,
       getDeviceSessionState: () => internalApi.getDeviceSessionState(),
       setDeviceSessionState: (state: DeviceSessionState) =>
         internalApi.setDeviceSessionState(state),

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/types.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/types.ts
@@ -1,15 +1,11 @@
-import { type CommandErrorResult } from "@api/command/model/CommandResult";
 import { type DeviceActionState } from "@api/device-action/model/DeviceActionState";
 import { type UserInteractionRequired } from "@api/device-action/model/UserInteractionRequired";
-import {
-  type DeviceLockedError,
-  type DeviceNotOnboardedError,
-  type UnknownDAError,
-} from "@api/device-action/os/Errors";
+import { type DeviceNotOnboardedError } from "@api/device-action/os/Errors";
+import { type WaitForAppAndVersionDAError } from "@api/device-action/os/WaitForAppAndVersion/types";
 
 export const getDeviceStatusDAStateStep = Object.freeze({
+  WAIT_FOR_APP_AND_VERSION: "os.getDeviceStatus.steps.waitForAppAndVersion",
   ONBOARD_CHECK: "os.getDeviceStatus.steps.onboardCheck",
-  UNLOCK_DEVICE: "os.getDeviceStatus.steps.unlockDevice",
 } as const);
 
 export type GetDeviceStatusDAStateStep =
@@ -25,10 +21,8 @@ export type GetDeviceStatusDAInput = {
 };
 
 export type GetDeviceStatusDAError =
-  | DeviceNotOnboardedError
-  | DeviceLockedError
-  | UnknownDAError
-  | CommandErrorResult["error"];
+  | WaitForAppAndVersionDAError
+  | DeviceNotOnboardedError;
 
 export type GetDeviceStatusDARequiredInteraction =
   | UserInteractionRequired.None


### PR DESCRIPTION
### 📝 Description

This PR refactors `GetDeviceStatusDeviceAction` to reuse the existing `WaitForAppAndVersionDeviceAction` instead of duplicating its logic (see merged [PR](https://github.com/LedgerHQ/device-sdk-ts/pull/1532)).

Previously, `GetDeviceStatusDeviceAction` implemented its own app/version retrieval and device-unlock handling: a `getAppAndVersion` command call, a `waitForDeviceUnlock` observable that polled every second with a timeout, and a dedicated `UserActionUnlockDevice` state with all the related error/locked-state handling (`5515` locked device, `6e00` CLA not supported, etc.).

All of that logic now lives in `WaitForAppAndVersionDeviceAction`, so this DA simply invokes it as a child state machine, forwarding the `unlockTimeout` input and propagating the `requiredUserInteraction` via `onSnapshot`. The result is handled with a clean `Left`/`Right` `caseOf`, delegating locked-device and old-firmware edge cases to the shared action.

This removes ~270 lines of duplicated state-machine logic and centralizes the "wait for app and version (handling unlock)" behavior in a single place.

Key changes:
- Replaced the `getAppAndVersion` actor and `waitForDeviceUnlock` observable with a single `waitForAppAndVersion` child machine.
- Removed the `UserActionUnlockDevice` state, the `locked` internal state, the `isDeviceLocked` guard, and the unlock-related actions/errors.
- Renamed states `AppAndVersionCheck` → `WaitForAppAndVersion` and `ApplicationAvailableResultCheck` → `WaitForAppAndVersionResultCheck`.
- Updated `GetDeviceStatusDAError` to reuse `WaitForAppAndVersionDAError` (dropping `DeviceLockedError`, `UnknownDAError`, and the raw command error).
- Updated step constants (`WAIT_FOR_APP_AND_VERSION` added, `UNLOCK_DEVICE` removed).
- Added a `setupWaitForAppAndVersionMock` test helper and reworked the test suite accordingly.

### ❓ Context

- **JIRA or GitHub link**: NO-ISSUE

- **Feature**: Internal refactor of `GetDeviceStatusDeviceAction` to delegate app/version + unlock handling to `WaitForAppAndVersionDeviceAction`, reducing duplication.

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date**
- [ ] **Impact of the changes:**
  - `GetDeviceStatusDeviceAction` now depends on `WaitForAppAndVersionDeviceAction`; QA should verify the full GetDeviceStatus flow on dashboard (BOLOS) and inside apps.
  - Locked-device behavior: confirm the unlock prompt still appears and that unlocking within the timeout resumes correctly, and that timing out surfaces the expected error.
  - Old-firmware / CLA-not-supported (`6e00`) and locked (`5515`) edge cases still behave as before.
  - Onboarding detection and OS-version reading remain unaffected.

---

### 🧐 Checklist for the PR Reviewers

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.