### PR TITLE
🔧 (eslint) [DSDK-1215]: Ban & remove non-portable runtime APIs (Buffer etc.)

### DIFF
--- a/.changeset/good-readers-kick.md
+++ b/.changeset/good-readers-kick.md
@@ -1,5 +1,7 @@
 ---
-"@ledgerhq/device-management-kit": major
+"@ledgerhq/device-management-kit": minor
 ---
 
 Remove request `signal` support and the now-unused `isAbort` error field from `DmkNetworkClient`, implement portable timeout handling with `AbortController`, and remove Node `url` usage from secure-channel WebSocket URL formatting.
+
+Make the Base64 helpers (`base64StringToBuffer`, `bufferToBase64String`, `isBase64String`) portable across runtimes: prefer `window.atob`/`window.btoa` in browsers, fall back to the global `atob`/`btoa` (e.g. Hermes) and then to `Buffer` (Node). Decoding and validation now tolerate MIME-style whitespace (e.g. line breaks), so Base64 emitted by native encoders decodes correctly.

--- a/.changeset/good-readers-kick.md
+++ b/.changeset/good-readers-kick.md
@@ -2,4 +2,4 @@
 "@ledgerhq/device-management-kit": major
 ---
 
-Remove request `signal` support from `DmkNetworkClient` and implement portable timeout handling with `AbortController`.
+Remove request `signal` support and the now-unused `isAbort` error field from `DmkNetworkClient`, implement portable timeout handling with `AbortController`, and remove Node `url` usage from secure-channel WebSocket URL formatting.

--- a/.changeset/good-readers-kick.md
+++ b/.changeset/good-readers-kick.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": major
+---
+
+Remove request `signal` support from `DmkNetworkClient` and implement portable timeout handling with `AbortController`.

--- a/.changeset/nine-cups-admire.md
+++ b/.changeset/nine-cups-admire.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-bitcoin": patch
+---
+
+Replace Node `Buffer` empty-byte fallbacks with `Uint8Array` in transaction extraction.

--- a/.changeset/olive-flowers-wait.md
+++ b/.changeset/olive-flowers-wait.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": patch
+---
+
+Decode base64 instruction data without importing Node `Buffer`.

--- a/.changeset/rn-hid-portable-base64-helpers.md
+++ b/.changeset/rn-hid-portable-base64-helpers.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-transport-kit-react-native-hid": patch
+---
+
+Encode and decode Base64 through the shared portable Device Management Kit helpers (`bufferToBase64String`/`base64StringToBuffer`) instead of the bare `btoa`/`atob` globals.

--- a/apps/clear-signing-tester/eslint.config.mjs
+++ b/apps/clear-signing-tester/eslint.config.mjs
@@ -1,7 +1,8 @@
-import config from "@ledgerhq/eslint-config-dsdk";
+import config, { nodeRuntimeOverrides } from "@ledgerhq/eslint-config-dsdk";
 
 export default [
   ...config,
+  ...nodeRuntimeOverrides,
   {
     ignores: ["eslint.config.mjs", "lib", "scripts/*.mjs"],
     languageOptions: {

--- a/apps/ldmk-cli/eslint.config.mjs
+++ b/apps/ldmk-cli/eslint.config.mjs
@@ -1,7 +1,8 @@
-import config from "@ledgerhq/eslint-config-dsdk";
+import config, { nodeRuntimeOverrides } from "@ledgerhq/eslint-config-dsdk";
 
 export default [
   ...config,
+  ...nodeRuntimeOverrides,
   {
     languageOptions: {
       parserOptions: {

--- a/apps/mobile/src/components/SendCommandModal.tsx
+++ b/apps/mobile/src/components/SendCommandModal.tsx
@@ -4,6 +4,7 @@ import { useForm } from "_hooks/useForm";
 import { CommandResultStatus } from "@ledgerhq/device-management-kit";
 import { Icons, InfiniteLoader, Popin, Text } from "@ledgerhq/native-ui";
 import styled from "styled-components/native";
+// eslint-disable-next-line no-restricted-imports -- React Native provides a util.inspect polyfill.
 import { inspect } from "util";
 
 type SendCommandModalProps = {

--- a/apps/mobile/src/components/SendDeviceActionModal.tsx
+++ b/apps/mobile/src/components/SendDeviceActionModal.tsx
@@ -4,6 +4,7 @@ import { useForm } from "_hooks/useForm";
 import { DeviceActionStatus } from "@ledgerhq/device-management-kit";
 import { Icons, InfiniteLoader, Popin, Text } from "@ledgerhq/native-ui";
 import styled from "styled-components/native";
+// eslint-disable-next-line no-restricted-imports -- React Native provides a util.inspect polyfill.
 import { inspect } from "util";
 
 type SendDeviceActionModalProps = {

--- a/apps/sample/eslint.config.mjs
+++ b/apps/sample/eslint.config.mjs
@@ -1,8 +1,9 @@
-import baseConfig from "@ledgerhq/eslint-config-dsdk";
+import baseConfig, { webRuntimeOverrides } from "@ledgerhq/eslint-config-dsdk";
 import globals from "globals";
 
 export default [
   ...baseConfig,
+  ...webRuntimeOverrides,
   {
     ignores: [".next"],
   },
@@ -19,6 +20,13 @@ export default [
       parserOptions: {
         project: null,
       },
+    },
+  },
+  {
+    files: ["playwright.config.ts"],
+    rules: {
+      "no-restricted-globals": "off",
+      "no-restricted-imports": "off",
     },
   },
   {

--- a/apps/sample/src/components/DeviceActionsView/DeviceActionResponse.tsx
+++ b/apps/sample/src/components/DeviceActionsView/DeviceActionResponse.tsx
@@ -9,6 +9,7 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { Flex, Icons, Tag, Text, Tooltip } from "@ledgerhq/react-ui";
 import styled from "styled-components";
+// eslint-disable-next-line no-restricted-imports -- Next.js polyfills util.inspect in client bundles.
 import { inspect } from "util";
 
 import { type FieldType } from "@/hooks/useForm";

--- a/apps/sample/src/utils/crypto.ts
+++ b/apps/sample/src/utils/crypto.ts
@@ -1,14 +1,22 @@
-import { bufferToHexaString } from "@ledgerhq/device-management-kit";
+import {
+  base64StringToBuffer,
+  bufferToBase64String,
+  bufferToHexaString,
+} from "@ledgerhq/device-management-kit";
 import * as secp from "@noble/secp256k1";
 
 export function bytesFromBase64(base64: string): Uint8Array {
   // return Uint8Array.fromBase64(base64) // Not supported in all browsers yet
-  return Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+  const bytes = base64StringToBuffer(base64);
+  if (bytes === null) {
+    throw new Error(`Invalid Base64 string: ${base64}`);
+  }
+  return bytes;
 }
 
 export function base64FromBytes(bytes: Uint8Array): string {
   // return bytes.toBase64() // Not supported in all browsers yet
-  return btoa(String.fromCharCode(...bytes));
+  return bufferToBase64String(bytes);
 }
 
 export function genIdentity() {

--- a/packages/config/eslint/index.js
+++ b/packages/config/eslint/index.js
@@ -319,6 +319,7 @@ export default [
 export const nodeRuntimeOverrides = [
   {
     files: productionSourceFiles,
+    ignores: productionSourceIgnores,
     rules: {
       // Node globals are allowed, but `atob`/`btoa` stay banned so Base64 work
       // keeps going through the shared, portable helpers.
@@ -335,6 +336,7 @@ export const nodeRuntimeOverrides = [
 export const webRuntimeOverrides = [
   {
     files: productionSourceFiles,
+    ignores: productionSourceIgnores,
     rules: {
       // Browser/app packages can use Web globals at the application boundary.
       // `process.env` is also common in web app toolchains at build time.

--- a/packages/config/eslint/index.js
+++ b/packages/config/eslint/index.js
@@ -99,29 +99,60 @@ const abortSignalPropertyRestrictions = [
   },
 ];
 
-const nodeBuiltinImportRestrictions = [
-  "crypto",
-  "stream",
-  "fs",
-  "path",
+const nodeBuiltinImportNames = [
+  "assert",
+  "async_hooks",
   "buffer",
-  "os",
-  "util",
-  "events",
-  "http",
-  "https",
-  "zlib",
   "child_process",
-  "net",
-  "tls",
+  "cluster",
+  "console",
+  "crypto",
+  "dgram",
+  "diagnostics_channel",
   "dns",
-].map((name) => ({
+  "domain",
+  "events",
+  "fs",
+  "http",
+  "http2",
+  "https",
+  "inspector",
+  "module",
+  "net",
+  "os",
+  "path",
+  "perf_hooks",
+  "process",
+  "punycode",
+  "querystring",
+  "readline",
+  "repl",
+  "stream",
+  "string_decoder",
+  "timers",
+  "tls",
+  "trace_events",
+  "tty",
+  "url",
+  "util",
+  "v8",
+  "vm",
+  "wasi",
+  "worker_threads",
+  "zlib",
+];
+
+const nodeBuiltinImportRestrictions = nodeBuiltinImportNames.map((name) => ({
   name,
   message: `Node built-in "${name}" is not portable. Use @noble/hashes for hashing, Uint8Array/DataView for bytes.`,
 }));
 
 const portableImportRestrictions = {
-  patterns: [...relativeImportRestrictions.patterns, "node:*"],
+  patterns: [
+    ...relativeImportRestrictions.patterns,
+    "node:*",
+    ...nodeBuiltinImportNames.map((name) => `${name}/*`),
+  ],
   paths: nodeBuiltinImportRestrictions,
 };
 

--- a/packages/config/eslint/index.js
+++ b/packages/config/eslint/index.js
@@ -39,6 +39,23 @@ const processGlobalRestriction = {
   message: "Node-only global; not available in browser/RN/Hermes.",
 };
 
+// `atob`/`btoa` exist in browsers, Node and Hermes, but each runtime exposes a
+// different preferred entry point (window.atob, Buffer, the bare global...).
+// Rather than special-casing every runtime, route all Base64 work through the
+// shared, portable helpers, which pick the right implementation internally.
+const base64GlobalRestrictions = [
+  {
+    name: "atob",
+    message:
+      "Not portable. Decode Base64 via base64StringToBuffer from @ledgerhq/device-management-kit (returns Uint8Array | null).",
+  },
+  {
+    name: "btoa",
+    message:
+      "Not portable. Encode bytes via bufferToBase64String from @ledgerhq/device-management-kit.",
+  },
+];
+
 const problematicWebGlobalRestrictions = [
   {
     name: "URL",
@@ -270,6 +287,7 @@ export default [
         ...nodeOnlyGlobalRestrictions,
         processGlobalRestriction,
         ...problematicWebGlobalRestrictions,
+        ...base64GlobalRestrictions,
       ],
       "no-restricted-properties": ["error", ...abortSignalPropertyRestrictions],
       "no-restricted-imports": ["error", portableImportRestrictions],
@@ -302,7 +320,9 @@ export const nodeRuntimeOverrides = [
   {
     files: productionSourceFiles,
     rules: {
-      "no-restricted-globals": "off",
+      // Node globals are allowed, but `atob`/`btoa` stay banned so Base64 work
+      // keeps going through the shared, portable helpers.
+      "no-restricted-globals": ["error", ...base64GlobalRestrictions],
       "no-restricted-properties": "off",
       "no-restricted-imports": ["error", relativeImportRestrictions],
     },
@@ -318,7 +338,11 @@ export const webRuntimeOverrides = [
     rules: {
       // Browser/app packages can use Web globals at the application boundary.
       // `process.env` is also common in web app toolchains at build time.
-      "no-restricted-globals": ["error", ...nodeOnlyGlobalRestrictions],
+      "no-restricted-globals": [
+        "error",
+        ...nodeOnlyGlobalRestrictions,
+        ...base64GlobalRestrictions,
+      ],
       "no-restricted-properties": "off",
       "no-restricted-imports": ["error", portableImportRestrictions],
     },

--- a/packages/config/eslint/index.js
+++ b/packages/config/eslint/index.js
@@ -7,6 +7,107 @@ import eslintPluginReact from "eslint-plugin-react";
 import eslintPluginReactHooks from "eslint-plugin-react-hooks";
 import { fixupPluginRules } from "@eslint/compat";
 
+const productionSourceFiles = ["**/*.ts", "**/*.tsx"];
+
+const productionSourceIgnores = [
+  "**/*.test.ts",
+  "**/*.test.tsx",
+  "**/__tests__/**",
+  "**/__mocks__/**",
+  "**/__fixtures__/**",
+];
+
+const relativeImportRestrictions = { patterns: ["../*"] };
+
+const nodeOnlyGlobalRestrictions = [
+  {
+    name: "Buffer",
+    message:
+      "Not portable. Use Uint8Array + byte/hex helpers (see signer-utils).",
+  },
+  { name: "__dirname", message: "Node-only." },
+  { name: "__filename", message: "Node-only." },
+  { name: "global", message: "Use globalThis if truly needed." },
+  {
+    name: "setImmediate",
+    message: "Node-only; use queueMicrotask/setTimeout.",
+  },
+];
+
+const processGlobalRestriction = {
+  name: "process",
+  message: "Node-only global; not available in browser/RN/Hermes.",
+};
+
+const problematicWebGlobalRestrictions = [
+  {
+    name: "URL",
+    message:
+      "React Native URL.toString() appends a stray trailing slash (#1484); build URL strings manually.",
+  },
+  {
+    name: "URLSearchParams",
+    message:
+      "URLSearchParams.set missing on some React Native versions (#1467); serialize manually.",
+  },
+  {
+    name: "Blob",
+    message:
+      "Not guaranteed in React Native/Hermes; guard with typeof before use.",
+  },
+  {
+    name: "FormData",
+    message:
+      "Not guaranteed in React Native/Hermes; guard with typeof before use.",
+  },
+  {
+    name: "ReadableStream",
+    message:
+      "Not guaranteed in React Native/Hermes; guard with typeof before use.",
+  },
+];
+
+const abortSignalPropertyRestrictions = [
+  {
+    object: "AbortSignal",
+    property: "timeout",
+    message:
+      "Not guaranteed in React Native/Hermes; build the signal using AbortController.",
+  },
+  {
+    object: "AbortSignal",
+    property: "any",
+    message:
+      "Not guaranteed in React Native/Hermes; build the signal using AbortController.",
+  },
+];
+
+const nodeBuiltinImportRestrictions = [
+  "crypto",
+  "stream",
+  "fs",
+  "path",
+  "buffer",
+  "os",
+  "util",
+  "events",
+  "http",
+  "https",
+  "zlib",
+  "child_process",
+  "net",
+  "tls",
+  "dns",
+].map((name) => ({
+  name,
+  message: `Node built-in "${name}" is not portable. Use @noble/hashes for hashing, Uint8Array/DataView for bytes.`,
+}));
+
+const portableImportRestrictions = {
+  patterns: [...relativeImportRestrictions.patterns, "node:*"],
+  paths: nodeBuiltinImportRestrictions,
+};
+
 export default [
   {
     ignores: [
@@ -153,6 +254,28 @@ export default [
     },
   },
 
+  // Portable-runtime API ban: shared/runtime packages
+  // must not rely on Node-only or proven-problematic Web globals/imports, so
+  // packages stay consumable across Node, browsers, React Native and Hermes.
+  // Node-only packages/apps opt out via `nodeRuntimeOverrides` (see below).
+  {
+    files: productionSourceFiles,
+    ignores: productionSourceIgnores,
+    // Re-declared in full: flat config replaces (not merges) rule options for
+    // the most specific matching block, so the base `../*` ban must be repeated
+    // here alongside the portable-runtime bans.
+    rules: {
+      "no-restricted-globals": [
+        "error",
+        ...nodeOnlyGlobalRestrictions,
+        processGlobalRestriction,
+        ...problematicWebGlobalRestrictions,
+      ],
+      "no-restricted-properties": ["error", ...abortSignalPropertyRestrictions],
+      "no-restricted-imports": ["error", portableImportRestrictions],
+    },
+  },
+
   {
     files: ["**/*.tsx"],
     plugins: {
@@ -167,6 +290,37 @@ export default [
       react: {
         version: "detect",
       },
+    },
+  },
+];
+
+// Opt-out for Node-only packages/apps (transports, CLIs, build tools, servers,
+// and environment-specific apps). Spread this AFTER the default config to
+// disable the portable-runtime API ban while keeping the base `../*` import
+// restriction in place.
+export const nodeRuntimeOverrides = [
+  {
+    files: productionSourceFiles,
+    rules: {
+      "no-restricted-globals": "off",
+      "no-restricted-properties": "off",
+      "no-restricted-imports": ["error", relativeImportRestrictions],
+    },
+  },
+];
+
+// Opt-out for browser/app packages where platform globals are expected at the
+// application boundary (for example sample apps and devtools UI). Shared
+// runtime packages should not use this override.
+export const webRuntimeOverrides = [
+  {
+    files: productionSourceFiles,
+    rules: {
+      // Browser/app packages can use Web globals at the application boundary.
+      // `process.env` is also common in web app toolchains at build time.
+      "no-restricted-globals": ["error", ...nodeOnlyGlobalRestrictions],
+      "no-restricted-properties": "off",
+      "no-restricted-imports": ["error", portableImportRestrictions],
     },
   },
 ];

--- a/packages/device-management-kit/package.json
+++ b/packages/device-management-kit/package.json
@@ -43,7 +43,6 @@
     "purify-ts": "catalog:",
     "reflect-metadata": "catalog:",
     "semver": "catalog:",
-    "url": "catalog:",
     "uuid": "catalog:",
     "ws": "catalog:",
     "xstate": "catalog:"

--- a/packages/device-management-kit/src/api/logger-subscriber/service/WebLogsExporterLogger.ts
+++ b/packages/device-management-kit/src/api/logger-subscriber/service/WebLogsExporterLogger.ts
@@ -90,8 +90,10 @@ export class WebLogsExporterLogger implements LoggerSubscriberService {
    */
   public exportLogsToJSON(): void {
     const logs = this.formatLogsToJSON();
+    /* eslint-disable no-restricted-globals -- Browser-only log export path uses Blob URLs to trigger a JSON file download. */
     const blob = new Blob([logs], { type: "application/json" });
     const url = URL.createObjectURL(blob);
+    /* eslint-enable no-restricted-globals */
     const a = document.createElement("a");
     a.href = url;
     a.download = `ledger-device-management-kit-logs-${new Date().toISOString()}.json`;

--- a/packages/device-management-kit/src/api/network/DmkNetworkClient.test.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClient.test.ts
@@ -239,7 +239,6 @@ describe("DmkNetworkClient", () => {
       expect(dmkError.statusText).toBe("Server Error");
       expect(dmkError.responseBody).toBe("boom");
       expect(dmkError.isTimeout).toBe(false);
-      expect(dmkError.isAbort).toBe(false);
     });
 
     it("should not throw when throwOnHttpError is disabled", async () => {
@@ -342,7 +341,6 @@ describe("DmkNetworkClient", () => {
 
       expect(error).toBeInstanceOf(DmkNetworkClientError);
       expect((error as DmkNetworkClientError).isTimeout).toBe(true);
-      expect((error as DmkNetworkClientError).isAbort).toBe(false);
     });
   });
 

--- a/packages/device-management-kit/src/api/network/DmkNetworkClient.test.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClient.test.ts
@@ -329,6 +329,31 @@ describe("DmkNetworkClient", () => {
       expect(init.signal?.aborted).toBe(false);
     });
 
+    it("GIVEN a pending request with timeout WHEN the timeout signal aborts fetch THEN it throws a timeout error", async () => {
+      vi.useFakeTimers();
+      const fetchMock = vi.fn(
+        (_url: string | URL | Request, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => {
+              const abortError = new Error("The operation was aborted");
+              abortError.name = "AbortError";
+              reject(abortError);
+            });
+          }),
+      );
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      const request = client
+        .get("https://api.example.com/items", { timeoutMs: 1000 })
+        .catch((e: unknown) => e);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      const error = await request;
+
+      expect(error).toBeInstanceOf(DmkNetworkClientError);
+      expect((error as DmkNetworkClientError).isTimeout).toBe(true);
+    });
+
     it("should mark the error as a timeout when fetch rejects with TimeoutError", async () => {
       const timeoutError = new Error("The operation was aborted");
       timeoutError.name = "TimeoutError";

--- a/packages/device-management-kit/src/api/network/DmkNetworkClient.test.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClient.test.ts
@@ -275,6 +275,10 @@ describe("DmkNetworkClient", () => {
   });
 
   describe("timeout", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it("should pass an AbortSignal when timeoutMs is configured", async () => {
       const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
       const client = new DmkNetworkClient({ fetch: fetchMock });
@@ -295,6 +299,37 @@ describe("DmkNetworkClient", () => {
       expect(init.signal).toBeUndefined();
     });
 
+    it("GIVEN a successful request with timeout WHEN fetch resolves THEN it clears the timeout", async () => {
+      vi.useFakeTimers();
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      await client.get("https://api.example.com/items", { timeoutMs: 1000 });
+      const init = fetchMock.mock.calls[0]![1] as RequestInit;
+
+      vi.advanceTimersByTime(1000);
+
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+      expect(init.signal?.aborted).toBe(false);
+    });
+
+    it("GIVEN a failed request with timeout WHEN fetch rejects THEN it clears the timeout", async () => {
+      vi.useFakeTimers();
+      const cause = new TypeError("network down");
+      const fetchMock = vi.fn().mockRejectedValue(cause);
+      const client = new DmkNetworkClient({ fetch: fetchMock });
+
+      await client
+        .get("https://api.example.com/items", { timeoutMs: 1000 })
+        .catch(() => undefined);
+      const init = fetchMock.mock.calls[0]![1] as RequestInit;
+
+      vi.advanceTimersByTime(1000);
+
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+      expect(init.signal?.aborted).toBe(false);
+    });
+
     it("should mark the error as a timeout when fetch rejects with TimeoutError", async () => {
       const timeoutError = new Error("The operation was aborted");
       timeoutError.name = "TimeoutError";
@@ -308,25 +343,6 @@ describe("DmkNetworkClient", () => {
       expect(error).toBeInstanceOf(DmkNetworkClientError);
       expect((error as DmkNetworkClientError).isTimeout).toBe(true);
       expect((error as DmkNetworkClientError).isAbort).toBe(false);
-    });
-
-    it("should mark the error as an abort when the caller signal is aborted", async () => {
-      const abortController = new AbortController();
-      abortController.abort();
-      const abortError = new Error("aborted");
-      abortError.name = "AbortError";
-      const fetchMock = vi.fn().mockRejectedValue(abortError);
-      const client = new DmkNetworkClient({ fetch: fetchMock });
-
-      const error = await client
-        .get("https://api.example.com/items", {
-          signal: abortController.signal,
-        })
-        .catch((e: unknown) => e);
-
-      expect(error).toBeInstanceOf(DmkNetworkClientError);
-      expect((error as DmkNetworkClientError).isAbort).toBe(true);
-      expect((error as DmkNetworkClientError).isTimeout).toBe(false);
     });
   });
 

--- a/packages/device-management-kit/src/api/network/DmkNetworkClient.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClient.ts
@@ -28,11 +28,6 @@ export type DmkRequestConfig = {
    */
   timeoutMs?: number;
   /**
-   * External abort signal. Composed with the internal timeout signal, so
-   * either one firing will abort the request.
-   */
-  signal?: AbortSignal;
-  /**
    * How to parse the response body. Defaults to `"json"`, except for `head`
    * which always resolves to `void`.
    */
@@ -82,7 +77,7 @@ type InternalRequestConfig = DmkRequestConfig & {
  * - URL composition (base URL + relative path + query params from an object)
  * - Automatic JSON body encoding and `Content-Type` header
  * - Default and per-request headers merging
- * - Request timeout via `AbortSignal.timeout`, composable with a caller signal
+ * - Request timeout via `AbortController`
  * - Automatic `response.ok` check with a typed {@link DmkNetworkClientError}
  * - Typed JSON / text / blob / arrayBuffer response parsing
  *
@@ -178,47 +173,50 @@ export class DmkNetworkClient {
       defaultHeaders: this.defaultHeaders,
       perRequestHeaders: config.headers,
     });
-    const signal = buildSignal({
+    const { signal, cleanup } = buildSignal({
       timeoutMs: config.timeoutMs,
-      externalSignal: config.signal,
     });
     const throwOnHttpError = config.throwOnHttpError ?? true;
     const responseType: DmkResponseType = config.responseType ?? "json";
 
-    let response: Response;
     try {
-      response = await this.getFetch()(url, {
-        method: config.method,
-        headers,
-        body,
-        signal,
-      });
-    } catch (cause) {
-      throw wrapFetchError({
-        cause,
-        externalSignal: config.signal,
-        timeoutMs: config.timeoutMs,
-      });
-    }
+      let response: Response;
+      try {
+        response = await this.getFetch()(url, {
+          method: config.method,
+          headers,
+          body,
+          signal,
+        });
+      } catch (cause) {
+        throw wrapFetchError({
+          cause,
+          timeoutMs: config.timeoutMs,
+        });
+      }
 
-    if (!response.ok && throwOnHttpError) {
-      const responseBody = await safeReadText(response);
-      throw new DmkNetworkClientError({
-        message: `HTTP error ${response.status} ${response.statusText}`.trim(),
+      if (!response.ok && throwOnHttpError) {
+        const responseBody = await safeReadText(response);
+        throw new DmkNetworkClientError({
+          message:
+            `HTTP error ${response.status} ${response.statusText}`.trim(),
+          status: response.status,
+          statusText: response.statusText,
+          responseBody,
+        });
+      }
+
+      const data = await parseBody(response, responseType);
+
+      return {
+        data,
         status: response.status,
         statusText: response.statusText,
-        responseBody,
-      });
+        headers: response.headers,
+        ok: response.ok,
+      };
+    } finally {
+      cleanup();
     }
-
-    const data = await parseBody(response, responseType);
-
-    return {
-      data,
-      status: response.status,
-      statusText: response.statusText,
-      headers: response.headers,
-      ok: response.ok,
-    };
   }
 }

--- a/packages/device-management-kit/src/api/network/DmkNetworkClientError.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClientError.ts
@@ -4,22 +4,18 @@ export type DmkNetworkClientErrorParams = {
   statusText?: string;
   responseBody?: string;
   isTimeout?: boolean;
-  isAbort?: boolean;
   cause?: unknown;
 };
 
 /**
- * Error thrown by {@link DmkNetworkClient} for HTTP, timeout, abort or
- * transport-level failures.
+ * Error thrown by {@link DmkNetworkClient} for HTTP, timeout or transport-level
+ * failures.
  *
  * - When the remote returned a non-2xx response, {@link status} and
  *   {@link statusText} are populated and {@link responseBody} contains the
  *   raw text body (best effort).
  * - When the request timed out via the client's `timeoutMs`,
  *   {@link isTimeout} is `true`.
- * - When a fetch implementation rejects with an abort error unrelated to
- *   `timeoutMs`, {@link isAbort} is `false` and the message is
- *   `"Request aborted"`.
  * - For other fetch/network failures, {@link cause} carries the original
  *   error.
  */
@@ -28,7 +24,6 @@ export class DmkNetworkClientError extends Error {
   public readonly statusText?: string;
   public readonly responseBody?: string;
   public readonly isTimeout: boolean;
-  public readonly isAbort: boolean;
   public override readonly cause?: unknown;
 
   constructor(params: DmkNetworkClientErrorParams) {
@@ -38,7 +33,6 @@ export class DmkNetworkClientError extends Error {
     this.statusText = params.statusText;
     this.responseBody = params.responseBody;
     this.isTimeout = params.isTimeout ?? false;
-    this.isAbort = params.isAbort ?? false;
     this.cause = params.cause;
   }
 }

--- a/packages/device-management-kit/src/api/network/DmkNetworkClientError.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClientError.ts
@@ -17,8 +17,9 @@ export type DmkNetworkClientErrorParams = {
  *   raw text body (best effort).
  * - When the request timed out via the client's `timeoutMs`,
  *   {@link isTimeout} is `true`.
- * - When the request was aborted through the caller's `signal`,
- *   {@link isAbort} is `true`.
+ * - When a fetch implementation rejects with an abort error unrelated to
+ *   `timeoutMs`, {@link isAbort} is `false` and the message is
+ *   `"Request aborted"`.
  * - For other fetch/network failures, {@link cause} carries the original
  *   error.
  */

--- a/packages/device-management-kit/src/api/network/DmkNetworkClientHelpers.test.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClientHelpers.test.ts
@@ -413,7 +413,6 @@ describe("DmkNetworkClientHelpers", () => {
       expect(error.message).toBe("network down");
       expect(error.cause).toBe(cause);
       expect(error.isTimeout).toBe(false);
-      expect(error.isAbort).toBe(false);
     });
 
     it("should fall back to a generic message for non-Error causes", () => {
@@ -433,7 +432,6 @@ describe("DmkNetworkClientHelpers", () => {
         timeoutMs: 10,
       });
       expect(error.isTimeout).toBe(true);
-      expect(error.isAbort).toBe(false);
       expect(error.message).toBe("Request timed out");
     });
 
@@ -445,7 +443,6 @@ describe("DmkNetworkClientHelpers", () => {
         timeoutMs: 1000,
       });
       expect(error.isTimeout).toBe(true);
-      expect(error.isAbort).toBe(false);
     });
 
     it("should treat AbortError with no timeout and no external abort as a plain abort", () => {
@@ -456,7 +453,6 @@ describe("DmkNetworkClientHelpers", () => {
         timeoutMs: undefined,
       });
       expect(error.isTimeout).toBe(false);
-      expect(error.isAbort).toBe(false);
       expect(error.message).toBe("Request aborted");
     });
   });

--- a/packages/device-management-kit/src/api/network/DmkNetworkClientHelpers.test.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClientHelpers.test.ts
@@ -266,61 +266,71 @@ describe("DmkNetworkClientHelpers", () => {
   });
 
   describe("buildSignal", () => {
-    it("should return undefined when no timeout and no external signal", () => {
-      expect(
-        buildSignal({
-          timeoutMs: undefined,
-          externalSignal: undefined,
-        }),
-      ).toBeUndefined();
+    afterEach(() => {
+      vi.useRealTimers();
     });
 
-    it("should return undefined when timeout is zero and no external signal", () => {
-      expect(
-        buildSignal({
-          timeoutMs: 0,
-          externalSignal: undefined,
-        }),
-      ).toBeUndefined();
-    });
-
-    it("should return the external signal alone when no timeout is configured", () => {
-      const controller = new AbortController();
-      const signal = buildSignal({
+    it("GIVEN no timeout WHEN building a signal THEN it returns no signal", () => {
+      const result = buildSignal({
         timeoutMs: undefined,
-        externalSignal: controller.signal,
       });
-      expect(signal).toBe(controller.signal);
+
+      expect(result.signal).toBeUndefined();
+      expect(result.cleanup).toEqual(expect.any(Function));
     });
 
-    it("should return a timeout signal when only a timeout is configured", () => {
-      const signal = buildSignal({
+    it("GIVEN a zero timeout WHEN building a signal THEN it returns no signal", () => {
+      const result = buildSignal({
+        timeoutMs: 0,
+      });
+
+      expect(result.signal).toBeUndefined();
+      expect(result.cleanup).toEqual(expect.any(Function));
+    });
+
+    it("GIVEN a negative timeout WHEN building a signal THEN it returns no signal", () => {
+      const result = buildSignal({
+        timeoutMs: -1,
+      });
+
+      expect(result.signal).toBeUndefined();
+      expect(result.cleanup).toEqual(expect.any(Function));
+    });
+
+    it("GIVEN a positive timeout WHEN building a signal THEN it returns an AbortSignal", () => {
+      const { signal, cleanup } = buildSignal({
         timeoutMs: 1000,
-        externalSignal: undefined,
       });
+
       expect(signal).toBeInstanceOf(AbortSignal);
+      expect(signal?.aborted).toBe(false);
+      cleanup();
     });
 
-    it("should use the provided timeout value for AbortSignal.timeout", () => {
-      const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
-      buildSignal({
-        timeoutMs: 50,
-        externalSignal: undefined,
+    it("GIVEN a positive timeout WHEN the delay elapses THEN it aborts the signal", () => {
+      vi.useFakeTimers();
+      const { signal, cleanup } = buildSignal({
+        timeoutMs: 1000,
       });
-      expect(timeoutSpy).toHaveBeenCalledWith(50);
-      timeoutSpy.mockRestore();
+
+      expect(signal?.aborted).toBe(false);
+      vi.advanceTimersByTime(999);
+      expect(signal?.aborted).toBe(false);
+      vi.advanceTimersByTime(1);
+      expect(signal?.aborted).toBe(true);
+      cleanup();
     });
 
-    it("should compose both signals with AbortSignal.any when both are set", () => {
-      const anySpy = vi.spyOn(AbortSignal, "any");
-      const controller = new AbortController();
-      const signal = buildSignal({
+    it("GIVEN a timeout signal WHEN cleanup runs before the delay THEN it does not abort", () => {
+      vi.useFakeTimers();
+      const { signal, cleanup } = buildSignal({
         timeoutMs: 100,
-        externalSignal: controller.signal,
       });
-      expect(signal).toBeInstanceOf(AbortSignal);
-      expect(anySpy).toHaveBeenCalledTimes(1);
-      anySpy.mockRestore();
+
+      cleanup();
+      vi.advanceTimersByTime(100);
+
+      expect(signal?.aborted).toBe(false);
     });
   });
 
@@ -397,7 +407,6 @@ describe("DmkNetworkClientHelpers", () => {
       const cause = new TypeError("network down");
       const error = wrapFetchError({
         cause,
-        externalSignal: undefined,
         timeoutMs: undefined,
       });
       expect(error).toBeInstanceOf(DmkNetworkClientError);
@@ -410,7 +419,6 @@ describe("DmkNetworkClientHelpers", () => {
     it("should fall back to a generic message for non-Error causes", () => {
       const error = wrapFetchError({
         cause: "something",
-        externalSignal: undefined,
         timeoutMs: undefined,
       });
       expect(error.message).toBe("Network request failed");
@@ -422,7 +430,6 @@ describe("DmkNetworkClientHelpers", () => {
       cause.name = "TimeoutError";
       const error = wrapFetchError({
         cause,
-        externalSignal: undefined,
         timeoutMs: 10,
       });
       expect(error.isTimeout).toBe(true);
@@ -435,26 +442,10 @@ describe("DmkNetworkClientHelpers", () => {
       cause.name = "AbortError";
       const error = wrapFetchError({
         cause,
-        externalSignal: undefined,
         timeoutMs: 1000,
       });
       expect(error.isTimeout).toBe(true);
       expect(error.isAbort).toBe(false);
-    });
-
-    it("should flag AbortError as an external abort when the caller signal is aborted", () => {
-      const controller = new AbortController();
-      controller.abort();
-      const cause = new Error("aborted");
-      cause.name = "AbortError";
-      const error = wrapFetchError({
-        cause,
-        externalSignal: controller.signal,
-        timeoutMs: undefined,
-      });
-      expect(error.isAbort).toBe(true);
-      expect(error.isTimeout).toBe(false);
-      expect(error.message).toBe("Request aborted");
     });
 
     it("should treat AbortError with no timeout and no external abort as a plain abort", () => {
@@ -462,7 +453,6 @@ describe("DmkNetworkClientHelpers", () => {
       cause.name = "AbortError";
       const error = wrapFetchError({
         cause,
-        externalSignal: undefined,
         timeoutMs: undefined,
       });
       expect(error.isTimeout).toBe(false);

--- a/packages/device-management-kit/src/api/network/DmkNetworkClientHelpers.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClientHelpers.ts
@@ -241,7 +241,6 @@ export function wrapFetchError(args: {
     return new DmkNetworkClientError({
       message: timedOut ? `Request timed out` : "Request aborted",
       isTimeout: timedOut,
-      isAbort: false,
       cause,
     });
   }

--- a/packages/device-management-kit/src/api/network/DmkNetworkClientHelpers.ts
+++ b/packages/device-management-kit/src/api/network/DmkNetworkClientHelpers.ts
@@ -93,12 +93,14 @@ export function isRawBody(body: unknown): body is BodyInit {
   if (typeof body === "string") return true;
   if (body instanceof ArrayBuffer) return true;
   if (ArrayBuffer.isView(body)) return true;
+  /* eslint-disable no-restricted-globals -- Each Web global is guarded so the checks are safe when the global is missing in RN/Hermes. */
   if (typeof Blob !== "undefined" && body instanceof Blob) return true;
   if (typeof FormData !== "undefined" && body instanceof FormData) return true;
   if (typeof URLSearchParams !== "undefined" && body instanceof URLSearchParams)
     return true;
   if (typeof ReadableStream !== "undefined" && body instanceof ReadableStream)
     return true;
+  /* eslint-enable no-restricted-globals */
   return false;
 }
 
@@ -133,23 +135,38 @@ export function buildBodyAndHeaders(args: {
   return { body: JSON.stringify(body), headers };
 }
 
+export type TimeoutSignal = {
+  signal: AbortSignal | undefined;
+  cleanup: () => void;
+};
+
 /**
- * Composes the effective abort signal for a request. If both a timeout and an
- * external signal are present, they are merged via `AbortSignal.any` so that
- * either one firing aborts the request.
+ * Builds an abort signal for request timeouts using `AbortController`.
+ *
+ * `AbortSignal.timeout` is intentionally avoided because React Native/Hermes
+ * does not reliably provide that static helper.
  */
 export function buildSignal(args: {
   timeoutMs: number | undefined;
-  externalSignal: AbortSignal | undefined;
-}): AbortSignal | undefined {
-  const { timeoutMs, externalSignal } = args;
-  const timeoutSignal =
-    timeoutMs && timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined;
+}): TimeoutSignal {
+  const { timeoutMs } = args;
 
-  if (timeoutSignal && externalSignal) {
-    return AbortSignal.any([externalSignal, timeoutSignal]);
+  if (!timeoutMs || timeoutMs <= 0) {
+    return {
+      signal: undefined,
+      cleanup: () => {},
+    };
   }
-  return timeoutSignal ?? externalSignal;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+
+  return {
+    signal: controller.signal,
+    cleanup: () => clearTimeout(timeoutId),
+  };
 }
 
 /**
@@ -207,27 +224,24 @@ export async function safeReadText(
 
 /**
  * Wraps a `fetch` rejection into a typed {@link DmkNetworkClientError},
- * discriminating between external aborts, timeouts and generic failures.
+ * discriminating between request timeouts and generic failures.
  */
 export function wrapFetchError(args: {
   cause: unknown;
-  externalSignal: AbortSignal | undefined;
   timeoutMs: number | undefined;
 }): DmkNetworkClientError {
-  const { cause, externalSignal, timeoutMs } = args;
+  const { cause, timeoutMs } = args;
   const hasTimeout = Boolean(timeoutMs && timeoutMs > 0);
   const isAbortError =
     cause instanceof Error &&
     (cause.name === "AbortError" || cause.name === "TimeoutError");
 
   if (isAbortError) {
-    const externallyAborted = externalSignal?.aborted ?? false;
-    const timedOut =
-      !externallyAborted && (cause.name === "TimeoutError" || hasTimeout);
+    const timedOut = cause.name === "TimeoutError" || hasTimeout;
     return new DmkNetworkClientError({
       message: timedOut ? `Request timed out` : "Request aborted",
       isTimeout: timedOut,
-      isAbort: externallyAborted,
+      isAbort: false,
       cause,
     });
   }

--- a/packages/device-management-kit/src/api/utils/Base64String.test.ts
+++ b/packages/device-management-kit/src/api/utils/Base64String.test.ts
@@ -54,6 +54,17 @@ describe("Base64String", () => {
       expect(result).toBeTruthy();
     });
 
+    it("GIVEN a base64 string with whitespace WHEN validating THEN it returns true", () => {
+      // GIVEN
+      const value = "AQID\nkAA=";
+
+      // WHEN
+      const result = isBase64String(value);
+
+      // THEN
+      expect(result).toBeTruthy();
+    });
+
     it("should return false for an invalid base64 string", () => {
       // GIVEN
       const value = "invalid base64 string";
@@ -126,6 +137,19 @@ describe("Base64String", () => {
 
       // THEN
       expect(result).toStrictEqual(null);
+    });
+
+    it("GIVEN a base64 string with whitespace WHEN decoding THEN it ignores the whitespace", () => {
+      // GIVEN
+      const value = "AQID\nkAA=";
+
+      // WHEN
+      const result = base64StringToBuffer(value);
+
+      // THEN
+      expect(result).toStrictEqual(
+        Uint8Array.from([0x01, 0x02, 0x03, 0x90, 0x00]),
+      );
     });
 
     describe("runtime compatibility fallbacks", () => {

--- a/packages/device-management-kit/src/api/utils/Base64String.test.ts
+++ b/packages/device-management-kit/src/api/utils/Base64String.test.ts
@@ -89,8 +89,21 @@ describe("Base64String", () => {
   });
 
   describe("base64StringToBuffer function", () => {
+    const originalAtob = (globalThis as any).atob;
+    const originalBuffer = (globalThis as any).Buffer;
+    const originalWindow = (globalThis as any).window;
+
     beforeEach(() => {
-      vi.resetAllMocks();
+      vi.restoreAllMocks();
+      (globalThis as any).atob = originalAtob;
+      (globalThis as any).Buffer = originalBuffer;
+      (globalThis as any).window = undefined;
+    });
+
+    afterAll(() => {
+      (globalThis as any).atob = originalAtob;
+      (globalThis as any).Buffer = originalBuffer;
+      (globalThis as any).window = originalWindow;
     });
 
     it("should convert empty input to empty buffer", () => {
@@ -115,39 +128,78 @@ describe("Base64String", () => {
       expect(result).toStrictEqual(null);
     });
 
-    it("should convert a base64 string to a buffer using browser's atob", () => {
-      // GIVEN
-      const value = "Zmlyc3QgdGVzdCBzdHJpbmc=";
+    describe("runtime compatibility fallbacks", () => {
+      it("GIVEN window.atob is available WHEN decoding THEN it uses window.atob", () => {
+        // GIVEN
+        const value = "Zmlyc3QgdGVzdCBzdHJpbmc=";
+        const windowAtob = vi.fn(() => "first test string");
+        const globalAtob = vi.fn(() => "unexpected");
+        (globalThis as any).window = { atob: windowAtob };
+        (globalThis as any).atob = globalAtob;
 
-      // WHEN
-      const result = base64StringToBuffer(value);
+        // WHEN
+        const result = base64StringToBuffer(value);
 
-      // THEN
-      expect(result).toStrictEqual(
-        Uint8Array.from([
-          0x66, 0x69, 0x72, 0x73, 0x74, 0x20, 0x74, 0x65, 0x73, 0x74, 0x20,
-          0x73, 0x74, 0x72, 0x69, 0x6e, 0x67,
-        ]),
-      );
-    });
-
-    it("should convert a base64 string to a buffer using Buffer", () => {
-      // GIVEN
-      vi.spyOn(global, "atob").mockImplementation(() => {
-        throw new Error("atob is not defined");
+        // THEN
+        expect(result).toStrictEqual(
+          Uint8Array.from([
+            0x66, 0x69, 0x72, 0x73, 0x74, 0x20, 0x74, 0x65, 0x73, 0x74, 0x20,
+            0x73, 0x74, 0x72, 0x69, 0x6e, 0x67,
+          ]),
+        );
+        expect(windowAtob).toHaveBeenCalledWith(value);
+        expect(globalAtob).not.toHaveBeenCalled();
       });
-      const value = "Zmlyc3QgdGVzdCBzdHJpbmc=";
 
-      // WHEN
-      const result = base64StringToBuffer(value);
+      it("GIVEN global atob is available WHEN decoding THEN it uses global atob", () => {
+        // GIVEN
+        const value = "Zmlyc3QgdGVzdCBzdHJpbmc=";
+        const globalAtob = vi.fn(() => "first test string");
+        (globalThis as any).atob = globalAtob;
 
-      // THEN
-      expect(result).toStrictEqual(
-        Uint8Array.from([
-          0x66, 0x69, 0x72, 0x73, 0x74, 0x20, 0x74, 0x65, 0x73, 0x74, 0x20,
-          0x73, 0x74, 0x72, 0x69, 0x6e, 0x67,
-        ]),
-      );
+        // WHEN
+        const result = base64StringToBuffer(value);
+
+        // THEN
+        expect(result).toStrictEqual(
+          Uint8Array.from([
+            0x66, 0x69, 0x72, 0x73, 0x74, 0x20, 0x74, 0x65, 0x73, 0x74, 0x20,
+            0x73, 0x74, 0x72, 0x69, 0x6e, 0x67,
+          ]),
+        );
+        expect(globalAtob).toHaveBeenCalledWith(value);
+      });
+
+      it("GIVEN atob is not available WHEN decoding THEN it uses Buffer", () => {
+        // GIVEN
+        (globalThis as any).atob = undefined;
+        const value = "Zmlyc3QgdGVzdCBzdHJpbmc=";
+        const bufferFromSpy = vi.spyOn(Buffer, "from");
+
+        // WHEN
+        const result = base64StringToBuffer(value);
+
+        // THEN
+        expect(result).toStrictEqual(
+          Uint8Array.from([
+            0x66, 0x69, 0x72, 0x73, 0x74, 0x20, 0x74, 0x65, 0x73, 0x74, 0x20,
+            0x73, 0x74, 0x72, 0x69, 0x6e, 0x67,
+          ]),
+        );
+        expect(bufferFromSpy).toHaveBeenCalledWith(value, "base64");
+      });
+
+      it("GIVEN no decoder is available WHEN decoding THEN it throws", () => {
+        // GIVEN
+        (globalThis as any).atob = undefined;
+        (globalThis as any).Buffer = undefined;
+        const value = "Zmlyc3QgdGVzdCBzdHJpbmc=";
+
+        // WHEN / THEN
+        expect(() => base64StringToBuffer(value)).toThrowError(
+          "No Base64 decoder available in this environment.",
+        );
+      });
     });
   });
 });
@@ -155,16 +207,19 @@ describe("Base64String", () => {
 describe("bufferToBase64String", () => {
   const originalBtoa = (globalThis as any).btoa;
   const originalBuffer = (globalThis as any).Buffer;
+  const originalWindow = (globalThis as any).window;
 
   beforeEach(() => {
     vi.restoreAllMocks();
     (globalThis as any).btoa = originalBtoa;
     (globalThis as any).Buffer = originalBuffer;
+    (globalThis as any).window = undefined;
   });
 
   afterAll(() => {
     (globalThis as any).btoa = originalBtoa;
     (globalThis as any).Buffer = originalBuffer;
+    (globalThis as any).window = originalWindow;
   });
 
   it("should encode an empty buffer to an empty base64 string when btoa is available", () => {
@@ -184,53 +239,73 @@ describe("bufferToBase64String", () => {
     expect(globalThis.btoa).toHaveBeenCalledTimes(1);
   });
 
-  it("should encode a buffer to base64 using btoa when available", () => {
-    // GIVEN
-    const text = "first testing str";
-    const bytes = Uint8Array.from(text.split("").map((c) => c.charCodeAt(0)));
+  describe("runtime compatibility fallbacks", () => {
+    it("GIVEN global btoa is available WHEN encoding THEN it uses global btoa", () => {
+      // GIVEN
+      const text = "first testing str";
+      const bytes = Uint8Array.from(text.split("").map((c) => c.charCodeAt(0)));
 
-    (globalThis as any).btoa = vi.fn((input: string) => {
-      expect(input).toBe(text);
-      return "Zmlyc3QgdGVzdGluZyBzdHI=";
+      (globalThis as any).btoa = vi.fn((input: string) => {
+        expect(input).toBe(text);
+        return "Zmlyc3QgdGVzdGluZyBzdHI=";
+      });
+
+      // WHEN
+      const result = bufferToBase64String(bytes);
+
+      // THEN
+      expect(result).toBe("Zmlyc3QgdGVzdGluZyBzdHI=");
+      expect(globalThis.btoa).toHaveBeenCalledTimes(1);
     });
 
-    // WHEN
-    const result = bufferToBase64String(bytes);
+    it("GIVEN window.btoa is available WHEN encoding THEN it uses window.btoa", () => {
+      // GIVEN
+      const text = "first testing str";
+      const bytes = Uint8Array.from(text.split("").map((c) => c.charCodeAt(0)));
+      const windowBtoa = vi.fn(() => "Zmlyc3QgdGVzdGluZyBzdHI=");
+      const globalBtoa = vi.fn(() => "unexpected");
+      (globalThis as any).window = { btoa: windowBtoa };
+      (globalThis as any).btoa = globalBtoa;
 
-    // THEN
-    expect(result).toBe("Zmlyc3QgdGVzdGluZyBzdHI=");
-    expect(globalThis.btoa).toHaveBeenCalledTimes(1);
-  });
+      // WHEN
+      const result = bufferToBase64String(bytes);
 
-  it("should encode a buffer to base64 using Buffer when btoa is not available", () => {
-    // GIVEN
-    (globalThis as any).btoa = undefined;
+      // THEN
+      expect(result).toBe("Zmlyc3QgdGVzdGluZyBzdHI=");
+      expect(windowBtoa).toHaveBeenCalledWith(text);
+      expect(globalBtoa).not.toHaveBeenCalled();
+    });
 
-    const text = "testing str";
-    const expectedBase64 = Buffer.from(text, "binary").toString("base64");
-    const bytes = Uint8Array.from(text.split("").map((c) => c.charCodeAt(0)));
+    it("GIVEN btoa is not available WHEN encoding THEN it uses Buffer", () => {
+      // GIVEN
+      (globalThis as any).btoa = undefined;
 
-    const bufferFromSpy = vi.spyOn(Buffer, "from");
+      const text = "testing str";
+      const expectedBase64 = Buffer.from(text, "binary").toString("base64");
+      const bytes = Uint8Array.from(text.split("").map((c) => c.charCodeAt(0)));
 
-    // WHEN
-    const result = bufferToBase64String(bytes);
+      const bufferFromSpy = vi.spyOn(Buffer, "from");
 
-    // THEN
-    expect(result).toBe(expectedBase64);
-    expect(bufferFromSpy).toHaveBeenCalledTimes(1);
-  });
+      // WHEN
+      const result = bufferToBase64String(bytes);
 
-  it("should throw an error when no Base64 encoder is available", () => {
-    // GIVEN
-    (globalThis as any).btoa = undefined;
-    (globalThis as any).Buffer = undefined;
+      // THEN
+      expect(result).toBe(expectedBase64);
+      expect(bufferFromSpy).toHaveBeenCalledTimes(1);
+    });
 
-    const bytes = Uint8Array.from([0x01, 0x02, 0x03]);
+    it("GIVEN no encoder is available WHEN encoding THEN it throws", () => {
+      // GIVEN
+      (globalThis as any).btoa = undefined;
+      (globalThis as any).Buffer = undefined;
 
-    // WHEN / THEN
-    expect(() => bufferToBase64String(bytes)).toThrowError(
-      "No Base64 encoder available in this environment.",
-    );
+      const bytes = Uint8Array.from([0x01, 0x02, 0x03]);
+
+      // WHEN / THEN
+      expect(() => bufferToBase64String(bytes)).toThrowError(
+        "No Base64 encoder available in this environment.",
+      );
+    });
   });
 
   it("should throw if an undefined byte is encountered (defensive check)", () => {

--- a/packages/device-management-kit/src/api/utils/Base64String.ts
+++ b/packages/device-management-kit/src/api/utils/Base64String.ts
@@ -1,10 +1,17 @@
+function normalizeBase64String(value: string): string {
+  return value.replace(/\s/g, "");
+}
+
 export function isBase64String(value: string): boolean {
+  const normalizedValue = normalizeBase64String(value);
   // Valid base64 characters are [A-Za-z0-9+/]
   // They are always grouped by 4 characters.
   // Optional padding at the end with one or two '='.
+  // ASCII whitespace is ignored because some native APIs emit MIME-style
+  // Base64 with line breaks.
   // see section 4 of: https://www.rfc-editor.org/rfc/rfc4648.txt
   return /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
-    value,
+    normalizedValue,
   );
 }
 
@@ -16,9 +23,9 @@ function getAtob(): ((data: string) => string) | undefined {
   if (typeof window !== "undefined" && typeof window.atob === "function") {
     return window.atob.bind(window);
   }
-  // eslint-disable-next-line no-restricted-globals
+  // eslint-disable-next-line no-restricted-globals -- portable smart-switch: probe the bare global as a Hermes/RN fallback.
   if (typeof atob === "function") {
-    // eslint-disable-next-line no-restricted-globals
+    // eslint-disable-next-line no-restricted-globals -- portable smart-switch: probe the bare global as a Hermes/RN fallback.
     return atob;
   }
   return undefined;
@@ -32,25 +39,26 @@ function getBtoa(): ((data: string) => string) | undefined {
   if (typeof window !== "undefined" && typeof window.btoa === "function") {
     return window.btoa.bind(window);
   }
-  // eslint-disable-next-line no-restricted-globals
+  // eslint-disable-next-line no-restricted-globals -- portable smart-switch: probe the bare global as a Hermes/RN fallback.
   if (typeof btoa === "function") {
-    // eslint-disable-next-line no-restricted-globals
+    // eslint-disable-next-line no-restricted-globals -- portable smart-switch: probe the bare global as a Hermes/RN fallback.
     return btoa;
   }
   return undefined;
 }
 
 export function base64StringToBuffer(value: string): Uint8Array | null {
-  if (value.length === 0) {
+  const normalizedValue = normalizeBase64String(value);
+  if (normalizedValue.length === 0) {
     return new Uint8Array();
   }
-  if (!isBase64String(value)) {
+  if (!isBase64String(normalizedValue)) {
     return null;
   }
   const atobFn = getAtob();
 
   if (atobFn) {
-    const base64Decoded = atobFn(value);
+    const base64Decoded = atobFn(normalizedValue);
     const buffer = new Uint8Array(base64Decoded.length);
     for (let i = 0; i < base64Decoded.length; i++) {
       buffer[i] = base64Decoded.charCodeAt(i);
@@ -59,7 +67,7 @@ export function base64StringToBuffer(value: string): Uint8Array | null {
   }
 
   if (typeof globalThis.Buffer !== "undefined") {
-    return Uint8Array.from(globalThis.Buffer.from(value, "base64"));
+    return Uint8Array.from(globalThis.Buffer.from(normalizedValue, "base64"));
   }
 
   throw new Error("No Base64 decoder available in this environment.");

--- a/packages/device-management-kit/src/api/utils/Base64String.ts
+++ b/packages/device-management-kit/src/api/utils/Base64String.ts
@@ -8,6 +8,34 @@ export function isBase64String(value: string): boolean {
   );
 }
 
+/**
+ * Prefer `window.atob` in browser runtimes where Base64 helpers are exposed on
+ * `window`; fall back to global `atob` for runtimes such as Hermes.
+ */
+function getAtob(): ((data: string) => string) | undefined {
+  if (typeof window !== "undefined" && typeof window.atob === "function") {
+    return window.atob.bind(window);
+  }
+  if (typeof atob === "function") {
+    return atob;
+  }
+  return undefined;
+}
+
+/**
+ * Prefer `window.btoa` in browser runtimes where Base64 helpers are exposed on
+ * `window`; fall back to global `btoa` for runtimes such as Hermes.
+ */
+function getBtoa(): ((data: string) => string) | undefined {
+  if (typeof window !== "undefined" && typeof window.btoa === "function") {
+    return window.btoa.bind(window);
+  }
+  if (typeof btoa === "function") {
+    return btoa;
+  }
+  return undefined;
+}
+
 export function base64StringToBuffer(value: string): Uint8Array | null {
   if (value.length === 0) {
     return new Uint8Array();
@@ -15,27 +43,28 @@ export function base64StringToBuffer(value: string): Uint8Array | null {
   if (!isBase64String(value)) {
     return null;
   }
-  try {
-    // Use the browser implementation of atob
-    const base64Decoded = atob(value);
+  const atobFn = getAtob();
+
+  if (atobFn) {
+    const base64Decoded = atobFn(value);
     const buffer = new Uint8Array(base64Decoded.length);
     for (let i = 0; i < base64Decoded.length; i++) {
       buffer[i] = base64Decoded.charCodeAt(i);
     }
     return buffer;
-  } catch (_error: unknown) {
-    // Use the implementation of Buffer for environments such as node
-    return Uint8Array.from(Buffer.from(value, "base64"));
   }
+
+  if (typeof globalThis.Buffer !== "undefined") {
+    return Uint8Array.from(globalThis.Buffer.from(value, "base64"));
+  }
+
+  throw new Error("No Base64 decoder available in this environment.");
 }
 
 export function bufferToBase64String(bytes: Uint8Array): string {
-  const g = globalThis as typeof globalThis & {
-    Buffer?: typeof Buffer;
-    btoa?: (data: string) => string;
-  };
+  const btoaFn = getBtoa();
 
-  if (typeof g.btoa === "function") {
+  if (btoaFn) {
     // convert bytes to a binary string for btoa
     let binary = "";
     for (let i = 0; i < bytes.length; i++) {
@@ -45,12 +74,11 @@ export function bufferToBase64String(bytes: Uint8Array): string {
       }
       binary += String.fromCharCode(byte);
     }
-    return g.btoa(binary);
+    return btoaFn(binary);
   }
 
-  const Buf = g.Buffer;
-  if (typeof Buf !== "undefined") {
-    return Buf.from(bytes).toString("base64");
+  if (typeof globalThis.Buffer !== "undefined") {
+    return globalThis.Buffer.from(bytes).toString("base64");
   }
 
   throw new Error("No Base64 encoder available in this environment.");

--- a/packages/device-management-kit/src/api/utils/Base64String.ts
+++ b/packages/device-management-kit/src/api/utils/Base64String.ts
@@ -16,7 +16,9 @@ function getAtob(): ((data: string) => string) | undefined {
   if (typeof window !== "undefined" && typeof window.atob === "function") {
     return window.atob.bind(window);
   }
+  // eslint-disable-next-line no-restricted-globals
   if (typeof atob === "function") {
+    // eslint-disable-next-line no-restricted-globals
     return atob;
   }
   return undefined;
@@ -30,7 +32,9 @@ function getBtoa(): ((data: string) => string) | undefined {
   if (typeof window !== "undefined" && typeof window.btoa === "function") {
     return window.btoa.bind(window);
   }
+  // eslint-disable-next-line no-restricted-globals
   if (typeof btoa === "function") {
+    // eslint-disable-next-line no-restricted-globals
     return btoa;
   }
   return undefined;

--- a/packages/device-management-kit/src/internal/secure-channel/data/DefaultSecureChannelDataSource.test.ts
+++ b/packages/device-management-kit/src/internal/secure-channel/data/DefaultSecureChannelDataSource.test.ts
@@ -25,7 +25,7 @@ describe("Secure Channel Data Source", () => {
       vi.clearAllMocks();
     });
 
-    it("should return an error if the WebSocket connection fails", () => {
+    it("should return a WebSocket if the WebSocket connection succeeds", () => {
       // given
       const api = new DefaultSecureChannelDataSource({
         webSocketUrl: "wss://test-websocket-url",
@@ -83,6 +83,30 @@ describe("Secure Channel Data Source", () => {
         (api as DefaultSecureChannelDataSource)._connectWebSocket,
       ).toHaveBeenCalledWith(
         "wss://test-websocket-url/genuine?targetId=targetId&perso=perso",
+      );
+    });
+
+    it("GIVEN a trailing slash base URL and special query characters WHEN genuineCheck connects THEN it builds one encoded URL string", () => {
+      // given
+      api = new DefaultSecureChannelDataSource({
+        webSocketUrl: "wss://test-websocket-url/",
+      } as DmkConfig);
+      vi.spyOn(
+        api as DefaultSecureChannelDataSource,
+        "_connectWebSocket",
+      ).mockReturnValue(Right({} as WebSocket));
+
+      // when
+      api.genuineCheck({
+        targetId: "target id",
+        perso: "perso&value",
+      });
+
+      // then
+      expect(
+        (api as DefaultSecureChannelDataSource)._connectWebSocket,
+      ).toHaveBeenCalledWith(
+        "wss://test-websocket-url/genuine?targetId=target%20id&perso=perso%26value",
       );
     });
 

--- a/packages/device-management-kit/src/internal/secure-channel/data/DefaultSecureChannelDataSource.ts
+++ b/packages/device-management-kit/src/internal/secure-channel/data/DefaultSecureChannelDataSource.ts
@@ -1,9 +1,9 @@
 import { inject, injectable } from "inversify";
 import WebSocket from "isomorphic-ws";
 import { Either, Left, Right } from "purify-ts";
-import URL from "url";
 
 import { type DmkConfig } from "@api/DmkConfig";
+import { buildUrl } from "@api/network/DmkNetworkClientHelpers";
 import { secureChannelTypes } from "@internal/secure-channel/di/secureChannelTypes";
 import { WebSocketConnectionError } from "@internal/secure-channel/model/Errors";
 import {
@@ -31,9 +31,10 @@ export class DefaultSecureChannelDataSource implements SecureChannelDataSource {
   genuineCheck(
     params: GenuineCheckParams,
   ): Either<WebSocketConnectionError, WebSocket> {
-    const address = URL.format({
-      pathname: `${this.webSocketBaseUrl}/genuine`,
-      query: params,
+    const address = buildUrl({
+      baseUrl: this.webSocketBaseUrl,
+      url: "/genuine",
+      params,
     });
     return this._connectWebSocket(address);
   }
@@ -41,9 +42,10 @@ export class DefaultSecureChannelDataSource implements SecureChannelDataSource {
   installApp(
     params: InstallAppsParams,
   ): Either<WebSocketConnectionError, WebSocket> {
-    const address = URL.format({
-      pathname: `${this.webSocketBaseUrl}/install`,
-      query: params,
+    const address = buildUrl({
+      baseUrl: this.webSocketBaseUrl,
+      url: "/install",
+      params,
     });
     return this._connectWebSocket(address);
   }
@@ -51,9 +53,10 @@ export class DefaultSecureChannelDataSource implements SecureChannelDataSource {
   listInstalledApps(
     params: ListInstalledAppsParams,
   ): Either<WebSocketConnectionError, WebSocket> {
-    const address = URL.format({
-      pathname: `${this.webSocketBaseUrl}/apps/list`,
-      query: params,
+    const address = buildUrl({
+      baseUrl: this.webSocketBaseUrl,
+      url: "/apps/list",
+      params,
     });
     return this._connectWebSocket(address);
   }
@@ -61,9 +64,10 @@ export class DefaultSecureChannelDataSource implements SecureChannelDataSource {
   uninstallApp(
     params: UninstallAppsParams,
   ): Either<WebSocketConnectionError, WebSocket> {
-    const address = URL.format({
-      pathname: `${this.webSocketBaseUrl}/install`,
-      query: params,
+    const address = buildUrl({
+      baseUrl: this.webSocketBaseUrl,
+      url: "/install",
+      params,
     });
     return this._connectWebSocket(address);
   }
@@ -71,9 +75,10 @@ export class DefaultSecureChannelDataSource implements SecureChannelDataSource {
   updateFirmware(
     params: UpdateFirmwareParams,
   ): Either<WebSocketConnectionError, WebSocket> {
-    const address = URL.format({
-      pathname: `${this.webSocketBaseUrl}/install`,
-      query: params,
+    const address = buildUrl({
+      baseUrl: this.webSocketBaseUrl,
+      url: "/install",
+      params,
     });
     return this._connectWebSocket(address);
   }
@@ -81,9 +86,10 @@ export class DefaultSecureChannelDataSource implements SecureChannelDataSource {
   updateMcu(
     params: UpdateMcuParams,
   ): Either<WebSocketConnectionError, WebSocket> {
-    const address = URL.format({
-      pathname: `${this.webSocketBaseUrl}/mcu`,
-      query: params,
+    const address = buildUrl({
+      baseUrl: this.webSocketBaseUrl,
+      url: "/mcu",
+      params,
     });
     return this._connectWebSocket(address);
   }

--- a/packages/devtools/ui/eslint.config.mjs
+++ b/packages/devtools/ui/eslint.config.mjs
@@ -1,7 +1,8 @@
-import config from "@ledgerhq/eslint-config-dsdk";
+import config, { webRuntimeOverrides } from "@ledgerhq/eslint-config-dsdk";
 
 export default [
   ...config,
+  ...webRuntimeOverrides,
   {
     ignores: ["eslint.config.mjs", "vitest.*.mjs", "scripts/*.mjs", "lib/*"],
     languageOptions: {

--- a/packages/devtools/websocket-server/eslint.config.mjs
+++ b/packages/devtools/websocket-server/eslint.config.mjs
@@ -1,7 +1,8 @@
-import config from "@ledgerhq/eslint-config-dsdk";
+import config, { nodeRuntimeOverrides } from "@ledgerhq/eslint-config-dsdk";
 
 export default [
   ...config,
+  ...nodeRuntimeOverrides,
   {
     ignores: ["eslint.config.mjs", "vitest.*.mjs", "scripts/*.mjs", "lib/*"],
     languageOptions: {

--- a/packages/mockserver-client/eslint.config.mjs
+++ b/packages/mockserver-client/eslint.config.mjs
@@ -1,7 +1,8 @@
-import config from "@ledgerhq/eslint-config-dsdk";
+import config, { nodeRuntimeOverrides } from "@ledgerhq/eslint-config-dsdk";
 
 export default [
   ...config,
+  ...nodeRuntimeOverrides,
   {
     ignores: ["eslint.config.mjs", "vitest.*.mjs", "scripts/*.mjs", "lib/*"],
     languageOptions: {

--- a/packages/signer/signer-btc/src/internal/app-binder/task/ExtractTransactionTask.ts
+++ b/packages/signer/signer-btc/src/internal/app-binder/task/ExtractTransactionTask.ts
@@ -55,7 +55,7 @@ export class ExtractTransactionTask {
       transaction.addBufferToData(
         psbt
           .getInputValue(i, PsbtIn.PREVIOUS_TXID)
-          .mapOrDefault((v) => v.data, Buffer.from([])),
+          .mapOrDefault((v) => v.data, new Uint8Array()),
       );
       const outputIndex = psbt
         .getInputValue(i, PsbtIn.OUTPUT_INDEX)
@@ -91,7 +91,7 @@ export class ExtractTransactionTask {
         .orDefault(0n);
       const script = psbt
         .getOutputValue(o, PsbtOut.SCRIPT)
-        .mapOrDefault((v) => v.data, Buffer.from([]));
+        .mapOrDefault((v) => v.data, new Uint8Array());
       transaction.add64BitIntToData(amount, false);
       transaction.addBufferToData(encodeVarint(script.length).extract()!);
       transaction.addBufferToData(script);

--- a/packages/signer/signer-btc/src/internal/psbt/service/psbt/DefaultPsbtMapper.test.ts
+++ b/packages/signer/signer-btc/src/internal/psbt/service/psbt/DefaultPsbtMapper.test.ts
@@ -116,7 +116,7 @@ describe("DefaultPsbtMapper tests", () => {
     const mapper = new DefaultPsbtMapper(mockSerializer, mockNormalizer);
 
     // When
-    const mapped = mapper.map("some random string");
+    const mapped = mapper.map("some non base64 string!");
 
     // Then
     expect(mapped.isRight()).toStrictEqual(false);

--- a/packages/signer/signer-solana/src/internal/app-binder/services/utils/TransactionParser.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/services/utils/TransactionParser.test.ts
@@ -327,6 +327,28 @@ describe("TransactionParser", () => {
     });
   });
 
+  describe("compiled instructions", () => {
+    it("GIVEN instruction data as a base64 string WHEN building compiled instructions THEN it decodes bytes", () => {
+      // GIVEN
+      const compiledInstructions = [
+        {
+          programIdIndex: 0,
+          accountKeyIndexes: [0],
+          data: "AQID/w==" as unknown as Uint8Array,
+        },
+      ];
+
+      // WHEN
+      const result = buildCompiledInstructions(compiledInstructions, [true], 1);
+
+      // THEN
+      expect(result.isRight()).toBe(true);
+      expect(result.unsafeCoerce()[0]?.data).toStrictEqual(
+        Uint8Array.from([1, 2, 3, 255]),
+      );
+    });
+  });
+
   describe("address lookup tables", () => {
     it("resolves ALT entries when a resolver is provided (existing behaviour)", async () => {
       const payer = Keypair.generate();

--- a/packages/signer/signer-solana/src/internal/app-binder/services/utils/TransactionParser.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/services/utils/TransactionParser.ts
@@ -1,3 +1,4 @@
+import { base64StringToBuffer } from "@ledgerhq/device-management-kit";
 import {
   type Message,
   type MessageV0,
@@ -6,7 +7,6 @@ import {
   VersionedMessage,
   VersionedTransaction,
 } from "@solana/web3.js";
-import { Buffer } from "buffer";
 import { type Either, EitherAsync, Left, Right } from "purify-ts";
 
 import {
@@ -317,7 +317,7 @@ export function buildCompiledInstructions(
       ci.data instanceof Uint8Array
         ? ci.data
         : typeof ci.data === "string"
-          ? Buffer.from(ci.data, "base64")
+          ? (base64StringToBuffer(ci.data) ?? new Uint8Array())
           : Uint8Array.from(ci.data ?? []);
 
     out.push({

--- a/packages/speculos-device-controller/eslint.config.mjs
+++ b/packages/speculos-device-controller/eslint.config.mjs
@@ -1,7 +1,8 @@
-import config from "@ledgerhq/eslint-config-dsdk";
+import config, { nodeRuntimeOverrides } from "@ledgerhq/eslint-config-dsdk";
 
 export default [
   ...config,
+  ...nodeRuntimeOverrides,
   {
     ignores: [
       "eslint.config.mjs",

--- a/packages/tools/cal-interceptor/eslint.config.mjs
+++ b/packages/tools/cal-interceptor/eslint.config.mjs
@@ -1,7 +1,8 @@
-import config from "@ledgerhq/eslint-config-dsdk";
+import config, { nodeRuntimeOverrides } from "@ledgerhq/eslint-config-dsdk";
 
 export default [
   ...config,
+  ...nodeRuntimeOverrides,
   {
     ignores: ["eslint.config.mjs", "lib/*"],
     languageOptions: {

--- a/packages/tools/ldmk-tool/eslint.config.mjs
+++ b/packages/tools/ldmk-tool/eslint.config.mjs
@@ -1,8 +1,9 @@
-import config from "@ledgerhq/eslint-config-dsdk";
+import config, { nodeRuntimeOverrides } from "@ledgerhq/eslint-config-dsdk";
 import * as globals from "zx/globals";
 
 export default [
   ...config,
+  ...nodeRuntimeOverrides,
   {
     files: ["**/*.cjs"],
     globals: {

--- a/packages/tools/ldmk-tool/generate-signer.cjs
+++ b/packages/tools/ldmk-tool/generate-signer.cjs
@@ -989,9 +989,19 @@ node_modules/
 `);
 
     // Generate eslint.config.mjs
-    writeFile(`${baseDir}/eslint.config.mjs`, `import { eslintConfigDmk } from "@ledgerhq/eslint-config-dsdk";
+    writeFile(`${baseDir}/eslint.config.mjs`, `import config from "@ledgerhq/eslint-config-dsdk";
 
-export default eslintConfigDmk;
+export default [
+  ...config,
+  {
+    ignores: ["eslint.config.mjs", "lib/*", "vitest.*.mjs"],
+    languageOptions: {
+      parserOptions: {
+        project: "./tsconfig.json",
+      },
+    },
+  },
+];
 `);
 
     // Generate src/index.ts

--- a/packages/tools/solana-tools/eslint.config.mjs
+++ b/packages/tools/solana-tools/eslint.config.mjs
@@ -1,7 +1,8 @@
-import config from "@ledgerhq/eslint-config-dsdk";
+import config, { nodeRuntimeOverrides } from "@ledgerhq/eslint-config-dsdk";
 
 export default [
   ...config,
+  ...nodeRuntimeOverrides,
   {
     ignores: ["eslint.config.mjs", "lib/*", "vitest.*.mjs"],
     languageOptions: {

--- a/packages/tools/solana-tools/eslint.config.mjs
+++ b/packages/tools/solana-tools/eslint.config.mjs
@@ -1,8 +1,7 @@
-import config, { nodeRuntimeOverrides } from "@ledgerhq/eslint-config-dsdk";
+import config from "@ledgerhq/eslint-config-dsdk";
 
 export default [
   ...config,
-  ...nodeRuntimeOverrides,
   {
     ignores: ["eslint.config.mjs", "lib/*", "vitest.*.mjs"],
     languageOptions: {

--- a/packages/tools/solana-tools/src/internal/services/GenerateSolanaTransaction.ts
+++ b/packages/tools/solana-tools/src/internal/services/GenerateSolanaTransaction.ts
@@ -1,3 +1,4 @@
+import { bufferToBase64String } from "@ledgerhq/device-management-kit";
 import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
   createTransferCheckedInstruction,
@@ -111,15 +112,6 @@ export class GenerateSolanaTransaction {
   }
 
   private toBase64(bytes: Uint8Array): string {
-    let bin = "";
-    for (const b of bytes) {
-      if (typeof b !== "number") throw new Error("Invalid byte value");
-      bin += String.fromCharCode(b);
-    }
-    try {
-      return btoa(bin);
-    } catch {
-      return Buffer.from(bytes).toString("base64");
-    }
+    return bufferToBase64String(bytes);
   }
 }

--- a/packages/transport/node-hid/eslint.config.mjs
+++ b/packages/transport/node-hid/eslint.config.mjs
@@ -1,7 +1,8 @@
-import config from "@ledgerhq/eslint-config-dsdk";
+import config, { nodeRuntimeOverrides } from "@ledgerhq/eslint-config-dsdk";
 
 export default [
   ...config,
+  ...nodeRuntimeOverrides,
   {
     ignores: ["eslint.config.mjs", "lib/*", "vitest.*.mjs"],
     languageOptions: {

--- a/packages/transport/rn-hid/android/src/main/kotlin/com/ledger/androidtransporthid/bridge/serialization.kt
+++ b/packages/transport/rn-hid/android/src/main/kotlin/com/ledger/androidtransporthid/bridge/serialization.kt
@@ -88,7 +88,7 @@ internal fun SendApduResult.toWritableMap(): WritableMap {
         is SendApduResult.Success -> {
             return Arguments.createMap().apply {
                 putBoolean("success", true)
-                putString("apdu", Base64.encodeToString(apdu, Base64.DEFAULT))
+                putString("apdu", Base64.encodeToString(apdu, Base64.NO_WRAP))
             }
         }
         is SendApduResult.Failure -> {

--- a/packages/transport/rn-hid/src/api/bridge/mapper.test.ts
+++ b/packages/transport/rn-hid/src/api/bridge/mapper.test.ts
@@ -327,6 +327,23 @@ describe("mapper", () => {
       ).toEqual(expectedSendApduResult);
     });
 
+    test("GIVEN a native success response with base64 line break WHEN mapping THEN it decodes the APDU", () => {
+      const resultApduString = "AQIDkAA=\n";
+      const nativeSendApduResult: NativeSendApduResult = {
+        success: true,
+        apdu: resultApduString,
+      };
+      const expectedSendApduResult: SendApduResult = Right(
+        new ApduResponse({
+          data: new Uint8Array([0x01, 0x02, 0x03]),
+          statusCode: new Uint8Array([0x90, 0x00]),
+        }),
+      );
+      expect(
+        mapNativeSendApduResultToSendApduResult(nativeSendApduResult),
+      ).toEqual(expectedSendApduResult);
+    });
+
     test("failure", () => {
       const nativeSendApduResult: NativeSendApduResult = {
         success: false,

--- a/packages/transport/rn-hid/src/api/helpers/base64Utils.ts
+++ b/packages/transport/rn-hid/src/api/helpers/base64Utils.ts
@@ -1,14 +1,15 @@
+import {
+  base64StringToBuffer,
+  bufferToBase64String,
+} from "@ledgerhq/device-management-kit";
+
 /**
  * Encodes a Uint8Array to a Base64-encoded string.
  * @param byteArray - The Uint8Array to encode.
  * @returns A Base64-encoded string representing the byte array.
  */
 export function uint8ArrayToBase64(byteArray: Uint8Array): string {
-  const binary = byteArray.reduce((acc, byte) => {
-    acc += String.fromCharCode(byte);
-    return acc;
-  }, "");
-  return btoa(binary);
+  return bufferToBase64String(byteArray);
 }
 
 /**
@@ -17,10 +18,9 @@ export function uint8ArrayToBase64(byteArray: Uint8Array): string {
  * @returns A Uint8Array representing the decoded byte array.
  */
 export function base64ToUint8Array(base64: string): Uint8Array {
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
+  const bytes = base64StringToBuffer(base64);
+  if (bytes === null) {
+    throw new Error(`Invalid Base64 string: ${base64}`);
   }
   return bytes;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,9 +351,6 @@ catalogs:
     typescript-eslint:
       specifier: 8.41.0
       version: 8.41.0
-    url:
-      specifier: ^0.11.4
-      version: 0.11.4
     usb:
       specifier: ^2.16.0
       version: 2.17.0
@@ -1084,9 +1081,6 @@ importers:
       semver:
         specifier: 'catalog:'
         version: 7.7.2
-      url:
-        specifier: 'catalog:'
-        version: 0.11.4
       uuid:
         specifier: 'catalog:'
         version: 11.0.3
@@ -10936,9 +10930,6 @@ packages:
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
-  punycode@1.4.1:
-    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -12693,10 +12684,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  url@0.11.4:
-    resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
-    engines: {node: '>= 0.4'}
 
   usb@2.17.0:
     resolution: {integrity: sha512-UuFgrlglgDn5ll6d5l7kl3nDb2Yx43qLUGcDq+7UNLZLtbNug0HZBb2Xodhgx2JZB1LqvU+dOGqLEeYUeZqsHg==}
@@ -23787,8 +23774,6 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
-  punycode@1.4.1: {}
-
   punycode@2.3.1: {}
 
   pupa@3.1.0:
@@ -26039,11 +26024,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  url@0.11.4:
-    dependencies:
-      punycode: 1.4.1
-      qs: 6.14.1
 
   usb@2.17.0:
     dependencies:


### PR DESCRIPTION
### 📝 Description

#### 🔍 Context
After migrating `DmkNetworkClient` from `axios` to `fetch`, we hit several runtime-portability bugs because some Web/Node APIs aren't reliably available across our targets (Node, browsers, React Native/Hermes):
- [#1467 — Fix React Native compatibility in DmkNetworkClient](https://github.com/LedgerHQ/device-sdk-ts/pull/1467)
- [#1484 — Fix Android Manager API requests rejected with HTTP 400 due to trailing slash in query params](https://github.com/LedgerHQ/device-sdk-ts/pull/1484)

Until now there was no safeguard preventing this class of issue: nothing stopped a non-portable API (e.g. `URL`, `URLSearchParams`, `Buffer`, `AbortSignal.timeout`) from being used in shared code, so problems only surfaced at runtime on a specific platform. As the DMK is an SDK consumed across very different runtimes, we want to guarantee maximum compatibility and catch these APIs at lint time rather than in production.

#### 💡 Solution

This PR adds runtime-portability linting and fixes the production code paths that were already relying on non-portable APIs. The goal is to catch Node-only APIs and known React Native/Hermes pitfalls before they land in shared packages.

Fixes included in this PR:

#### `@ledgerhq/eslint-config-dsdk`

- Adds production-source restrictions for Node globals/imports (`Buffer`, `process`, Node built-ins including `url`, and bare built-in subpaths), problematic Web globals (`URL`, `URLSearchParams`, `Blob`, `FormData`, `ReadableStream`), non-portable `AbortSignal.timeout` / `AbortSignal.any` usage, and bare `atob` / `btoa` globals.
- Keeps Base64 work routed through the shared portable helpers by banning `atob` / `btoa` even in Node and Web runtime overrides.
- Adds runtime-specific opt-outs through `nodeRuntimeOverrides` and `webRuntimeOverrides` for Node-only packages/apps and browser app boundaries, without weakening shared runtime packages.
- Exempts test files from the runtime API restrictions so tests can keep using runtime-specific helpers and fixtures.

#### Runtime-specific apps and packages

- Applies `nodeRuntimeOverrides` to Node-only tooling/apps/packages such as `apps/clear-signing-tester`, `apps/ldmk-cli`, `packages/devtools/websocket-server`, `packages/mockserver-client`, `packages/speculos-device-controller`, `packages/tools/cal-interceptor`, `packages/tools/ldmk-tool`, and `packages/transport/node-hid`.
- Applies `webRuntimeOverrides` to browser app/UI boundaries such as `apps/sample` and `packages/devtools/ui`.

#### `@ledgerhq/device-management-kit`

- Aligns Base64 decoding/encoding around explicit runtime feature detection: `window.atob` / `window.btoa` in browsers, global `atob` / `btoa` in Hermes-like runtimes, and `Buffer` only as a Node fallback.
- Keeps `Base64String` as the single sanctioned place that touches bare `atob` / `btoa`, with scoped lint exceptions.
- Accepts MIME-style Base64 whitespace during decoding, so native encoders that emit line breaks do not break shared decoding. This complements the RN HID Android bridge fix that now uses `Base64.NO_WRAP` at the source.
- Removes `DmkRequestConfig.signal` and the now-dead `DmkNetworkClientError.isAbort` field.
- Replaces `AbortSignal.timeout` / `AbortSignal.any` usage with portable `AbortController` + `setTimeout` timeout handling, including cleanup tests.
- Replaces Node `url` formatting in the secure-channel WebSocket client with the portable `buildUrl` helper and removes the `url` dependency.
- Keeps browser-only log export usage of `Blob` / `URL.createObjectURL` explicit through targeted lint exceptions.

#### `@ledgerhq/device-signer-kit-bitcoin`

- Replaces empty `Buffer.from([])` fallbacks with `new Uint8Array()` in transaction extraction.

#### `@ledgerhq/device-signer-kit-solana`

- Removes the Node `buffer` import from transaction parsing.
- Decodes compiled instruction data through DMK Base64 utilities, with a regression test for base64 instruction data.

#### `@ledgerhq/solana-tools`

- Encodes transaction bytes through DMK `bufferToBase64String` instead of `btoa` with a `Buffer` fallback.
- Moves onto the portable lint config because the package ships into the web sample app.

#### `@ledgerhq/device-transport-kit-react-native-hid`

- Delegates JS `base64Utils` encoding/decoding to the shared DMK `bufferToBase64String` / `base64StringToBuffer` helpers.
- Updates the Android/Kotlin bridge to encode successful native APDU responses with `Base64.NO_WRAP`, avoiding trailing line breaks in the Base64 string sent back to JavaScript.
- Keeps JS decoding tolerant of Base64 whitespace and adds a mapper regression test for native APDU responses that include a line break.

#### `apps/sample`

- Decodes/encodes identity key material through the DMK Base64 helpers in `crypto` utils instead of bare `atob` / `btoa`.
- Keeps `util.inspect` usage as an explicit lint exception because the app runtime provides the required polyfill for response rendering.

#### `apps/mobile`

- Keeps `util.inspect` usage as explicit lint exceptions because React Native provides the required polyfill for command/action response rendering.

### 🧪 Test plan

The point of these changes is **runtime portability**, so the shared Base64 and network paths should be exercised in **both** the web sample app and the **mobile app (Hermes)**.

#### Mobile app (React Native / Hermes) — primary portability target
- [x] **Android USB HID**: connect a Ledger device over USB HID, then run Get App & Version, Send command with a raw APDU, open an app, install an app.
  - Validates: native APDU response encoding (`Base64.NO_WRAP`) and `rn-hid` Base64 APDU encode/decode → DMK `Base64String` Hermes fallback (`atob`/`btoa` globals).
  - Expect: commands round-trip correctly; no `HidTransportSendApduUnknownError`; no crash; no `Buffer is not defined`.
- [x] Open the **Send command** and **Send device action** modals and run them.
  - Validates: `util.inspect` polyfill rendering.
  - Expect: the response payload renders fully.

#### Web sample app
- [x] **Connect a device and run Manager/device flows**: list installed apps with metadata, genuine check, and app install.
  - Validates: manager API requests and secure-channel WebSocket URL formatting. Expect: normal responses.
- [x] **Solana signer** → generate a USDC transaction (single and multiple transfers) and sign it; also clear-sign a Solana tx whose instructions carry base64 data.
  - Validates: `solana-tools` encoding, `signer-solana` parsing, DMK Base64 helpers in the browser. Expect: valid base64 message, correct clear-sign display, no `Buffer` errors in the console.
- [x] **Export logs** from the sidebar.
  - Validates: `WebLogsExporterLogger` (`Blob` + `URL.createObjectURL`). Expect: a `.json` file downloads and opens.
- [x] **Ledger Sync identity / connection** that builds a client identity.
  - Validates: sample `crypto` utils + Base64 helpers. Expect: identity round-trips and connects; no `atob`/`btoa`/`Buffer` errors.
- [x] **Run a device action** and open the response view.
  - Validates: `util.inspect` polyfill rendering. Expect: the inspected object renders.

#### Bitcoin signing (web sample app or device e2e)
- [x] Sign a **legacy** and a **segwit** BTC transaction.
  - Validates: `signer-btc` extraction with empty script/witness defaults (`new Uint8Array()`). Expect: the serialized raw transaction is byte-correct and broadcastable.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/DSDK-1215

- **Feature**: Runtime portability linting and fixes

### ✅ Checklist

- [x] **Covered by automatic tests**: Added/updated focused unit tests for base64 decoding (including whitespace-tolerant native output), RN HID APDU response mapping, Solana instruction decoding, network timeout handling, and secure-channel WebSocket URL formatting. Local Danger checks passed.
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date**: No documentation update needed; changes are lint/runtime behavior and package changesets.
- [x] **Impact of the changes:**
  - Shared/runtime packages now fail lint on non-portable Node APIs, Node built-in imports such as `url`, bare built-in subpaths, and selected problematic Web APIs.
  - Node-only and web app packages use explicit runtime overrides.
  - `DmkNetworkClient` no longer exposes request `signal` or the dead `isAbort` error field, and uses portable timeout handling.
  - Secure-channel WebSocket URL formatting no longer relies on the Node `url` package.
  - Signer BTC/Solana no longer rely on Node `Buffer` in the updated paths.
  - All Base64 encode/decode routes through the shared DMK helpers; bare `atob` / `btoa` are banned outside `Base64String`.
  - RN HID Android APDU responses are encoded without Base64 line wrapping and the JS bridge remains tolerant of wrapped native output.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.



