### PR TITLE
docs(speculos): fix import path in transport README

### DIFF
--- a/packages/transport/speculos/README.md
+++ b/packages/transport/speculos/README.md
@@ -46,7 +46,7 @@ import { DeviceManagementKitBuilder } from "@ledgerhq/device-management-kit";
 import {
   speculosTransportFactory,
   SpeculosTransport,
-} from "@ledgerhq/device-transport-speculos";
+} from "@ledgerhq/device-transport-kit-speculos";
 
 // Easy setup with the factory
 const dmk = new DeviceManagementKitBuilder()


### PR DESCRIPTION
## What
The `@ledgerhq/device-transport-kit-speculos` README's usage snippet imports from
`@ledgerhq/device-transport-speculos` (missing `-kit-`), which doesn't resolve. The
install line just above it uses the correct `@ledgerhq/device-transport-kit-speculos`,
so the README is internally inconsistent and copy-pasting the snippet fails.

## Fix
One-line doc fix: correct the import specifier to `@ledgerhq/device-transport-kit-speculos`.

## Context
Hit this while integrating Speculos for a hardware-in-the-loop signing flow (ETHGlobal
project). Still present on `develop` and in published `@ledgerhq/device-transport-kit-speculos@1.2.1`.
