### PR TITLE
🥅 (web-hid) [LIVE-32292]: Catch WebHID close failures

### DIFF
--- a/.changeset/good-pans-melt.md
+++ b/.changeset/good-pans-melt.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-transport-kit-web-hid": patch
+---
+
+Catch asynchronous WebHID close failures during device disconnects.

--- a/packages/transport/web-hid/src/api/transport/WebHidApduSender.test.ts
+++ b/packages/transport/web-hid/src/api/transport/WebHidApduSender.test.ts
@@ -35,6 +35,7 @@ describe("WebHidApduSender", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockDevice.close = vi.fn().mockResolvedValue(undefined);
     const mockLoggerFactory = vi
       .fn()
       .mockReturnValue(mockLogger as unknown as LoggerPublisherService);
@@ -79,23 +80,33 @@ describe("WebHidApduSender", () => {
     expect(mockDevice.oninputreport).toBeDefined();
   });
 
-  it("should handle setup connection error", async () => {
+  it("GIVEN WebHID rejects open WHEN setting up the connection THEN it throws", async () => {
+    // GIVEN
     const error = new Error("Failed to open device");
     mockDevice.open = vi.fn().mockRejectedValue(error);
-    expect(webHidApduSender.setupConnection()).rejects.toThrowError();
+
+    // WHEN / THEN
+    await expect(webHidApduSender.setupConnection()).rejects.toThrowError();
   });
 
-  it("should close connection", () => {
+  it("WHEN closing the connection THEN it closes the WebHID device", () => {
+    // WHEN
     webHidApduSender.closeConnection();
+
+    // THEN
     expect(mockDevice.close).toHaveBeenCalled();
   });
 
-  it("should handle close connection error", () => {
+  it("GIVEN WebHID rejects close WHEN closing the connection THEN it logs the error", async () => {
+    // GIVEN
     const error = new Error("Failed to close device");
-    mockDevice.close = vi.fn().mockImplementation(() => {
-      throw error;
-    });
+    mockDevice.close = vi.fn().mockRejectedValue(error);
+
+    // WHEN
     webHidApduSender.closeConnection();
+    await Promise.resolve();
+
+    // THEN
     expect(mockLogger.error).toHaveBeenCalledWith(
       "Error while closing device",
       {

--- a/packages/transport/web-hid/src/api/transport/WebHidApduSender.ts
+++ b/packages/transport/web-hid/src/api/transport/WebHidApduSender.ts
@@ -155,12 +155,10 @@ export class WebHidApduSender
 
   public closeConnection() {
     this.logger.info("🔚 Disconnect");
-    try {
-      this.dependencies.device.close();
-    } catch (error) {
+    this.dependencies.device.close().catch((error) => {
       this.logger.error("Error while closing device", {
         data: { device: this.dependencies.device, error },
       });
-    }
+    });
   }
 }


### PR DESCRIPTION
### 📝 Description

Catch rejected `HIDDevice.close()` promises in the WebHID transport so browser state-change failures, such as `InvalidStateError` during device restart, are logged instead of surfacing as unhandled promise rejections.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-32292

- **Feature**: WebHID firmware update reconnect stability

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date** No documentation update needed for this bug fix.
- [x] **Impact of the changes:**
  - WebHID close failures are logged instead of escaping when `close()` rejects asynchronously.
  - QA should focus on Flex firmware update from onboarding and device restart/reconnect flows.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.