### PR TITLE
🐛 (signer-zcash) [LIVE-32615]: Fix v4 GET_TRUSTED_INPUT framing and add NU6.2 branch id

### DIFF
--- a/.changeset/zcash-v4-trusted-input.md
+++ b/.changeset/zcash-v4-trusted-input.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/device-signer-kit-zcash": patch
+---
+
+Add NU6.2 consensus branch id and fix v4 GET_TRUSTED_INPUT framing
+
+

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.test.ts
@@ -7,6 +7,12 @@ import {
 } from "@ledgerhq/device-management-kit";
 
 import { GetTrustedInputCommand } from "@internal/app-binder/command/GetTrustedInputCommand";
+import { signTransactionFromLedgerWalletLogs20260615 } from "@internal/app-binder/task/__fixtures__/signTransactionFromLedgerWalletLogs2026-06-15";
+import {
+  getZcashBranchId,
+  serializeTransaction,
+  toInternalTransaction,
+} from "@internal/app-binder/task/utils/legacyTransactionUtils";
 
 import { GetTrustedInputTask } from "./GetTrustedInputTask";
 
@@ -124,6 +130,36 @@ describe("GetTrustedInputTask", () => {
     expect(bytesToHex(lastChunkData ?? new Uint8Array())).toBe(
       "000000000f000000000000000000000000000000000000",
     );
+  });
+
+  it("frames a v4/Sapling previous transaction with the input count right after the branch id (regression: 2026-06-15 device 6a80)", async () => {
+    vi.mocked(apiMock.sendCommand).mockResolvedValue(
+      CommandResultFactory({ data: makeSuccessResponse(0x01) }),
+    );
+
+    // Reproduce SignTransactionTask's prep for input[0]: the v4/Sapling prev tx
+    // with a (valid) consensus branch id attached, then serialized for GetTrustedInput.
+    const [legacyPrevTx, , , , branchHeight] =
+      signTransactionFromLedgerWalletLogs20260615.transactionArg.inputs[0]!;
+    const prevTx = toInternalTransaction(legacyPrevTx);
+    prevTx.consensusBranchId = getZcashBranchId(branchHeight);
+    const serialized = serializeTransaction(prevTx, prevTx.timestamp);
+
+    await new GetTrustedInputTask(apiMock, {
+      transaction: serialized,
+      indexLookup: 0,
+    }).run();
+
+    const firstChunkData = vi.mocked(apiMock.sendCommand).mock
+      .calls[0]?.[0] as GetTrustedInputCommand;
+    const header = bytesToHex(firstChunkData.getApdu().getRawApdu().slice(5));
+
+    // indexLookup(00000000) | version(04000080) | vgid(85202f89) | branchId | vin_count.
+    // The prev tx has 3 transparent inputs, so the count MUST be 03.
+    // Before the fix, serializeTransaction put locktime/expiry in the v4 header,
+    // so the chunker read the count off the locktime byte → "...f04dec4d00" (0 inputs)
+    // → the device misparsed the stream and returned 6a80.
+    expect(header).toBe("000000000400008085202f89f04dec4d03");
   });
 
   it("throws for malformed transaction input before sending any command", async () => {

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/SignTransactionTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/SignTransactionTask.test.ts
@@ -21,6 +21,7 @@ import {
   trustedInputHexFromLogs,
 } from "@internal/app-binder/task/__fixtures__/signTransactionFromLedgerWalletLogs2026-05-11";
 import { signTransactionFromLedgerWalletLogs20260512 } from "@internal/app-binder/task/__fixtures__/signTransactionFromLedgerWalletLogs2026-05-12";
+import { signTransactionFromLedgerWalletLogs20260615 } from "@internal/app-binder/task/__fixtures__/signTransactionFromLedgerWalletLogs2026-06-15";
 import { GetTrustedInputTask } from "@internal/app-binder/task/GetTrustedInputTask";
 import * as legacyTransactionUtils from "@internal/app-binder/task/utils/legacyTransactionUtils";
 
@@ -1266,5 +1267,108 @@ describe("SignTransactionTask", () => {
           .getRawApdu(),
       ).toString("hex"),
     ).toBe("e04800000b0000000000000100000000");
+  });
+
+  // NOTE: independent invariant — the *spending* tx header is always v5 (NU5)
+  // regardless of input versions. (The 2026-06-15 6a80 was a separate bug in the
+  // v4 *previous*-tx framing for GET_TRUSTED_INPUT; see GetTrustedInputTask.test.ts.)
+  it("pins the v5 (NU5) spending-transaction header even when the first input UTXO is a v4/Sapling transaction", async () => {
+    const getTrustedInputSpy = vi
+      .spyOn(GetTrustedInputTask.prototype, "run")
+      .mockResolvedValue(
+        DmkResultFactory({
+          data: {
+            statusCode: new Uint8Array([0x90, 0x00]),
+            data: new Uint8Array(64).fill(0x24),
+          },
+        }) as never,
+      );
+
+    vi.mocked(apiMock.sendCommand).mockImplementation((command: unknown) => {
+      if (command instanceof GetAddressCommand) {
+        return Promise.resolve(
+          CommandResultFactory({
+            data: {
+              publicKey: new Uint8Array(65).fill(0x04),
+              address: "t1sapling",
+              chainCode: new Uint8Array(32).fill(0x03),
+            },
+          }) as never,
+        );
+      }
+      if (
+        command instanceof StartUntrustedHashTransactionInputCommand ||
+        command instanceof ProvideOutputFullChangePathCommand ||
+        command instanceof HashOutputFullCommand
+      ) {
+        return Promise.resolve(
+          CommandResultFactory({
+            data: {
+              statusCode: new Uint8Array([0x90, 0x00]),
+              data: new Uint8Array([]),
+            },
+          }) as never,
+        );
+      }
+      if (command instanceof SignTransactionCommand) {
+        return Promise.resolve(
+          CommandResultFactory({
+            data: {
+              signature: new Uint8Array([0x30, 0x44, 0x02, 0x20, 0x01]),
+            },
+          }) as never,
+        );
+      }
+      if (command instanceof ZcashSaplingOutputCommitCommand) {
+        return Promise.resolve(
+          CommandResultFactory({ data: { committed: true } }) as never,
+        );
+      }
+      return Promise.reject(new Error("Unexpected command"));
+    });
+
+    const { transactionArg, regression } =
+      signTransactionFromLedgerWalletLogs20260615;
+
+    // Guard the fixture itself: the first input really is a v4/Sapling source tx,
+    // which is exactly the shape that produced 6a80 in the deployed build.
+    const firstInputSourceTx = transactionArg.inputs[0]![0];
+    expect(Buffer.from(firstInputSourceTx.version).toString("hex")).toBe(
+      regression.firstInputSourceVersionHex,
+    );
+    expect(
+      Buffer.from(firstInputSourceTx.nVersionGroupId!).toString("hex"),
+    ).toBe(regression.firstInputSourceVersionGroupIdHex);
+
+    try {
+      const result = await new SignTransactionTask(apiMock, {
+        transactionArg: { ...transactionArg },
+      }).run();
+
+      expect(isSuccessDmkResult(result)).toBe(true);
+
+      const startHashCommands = vi
+        .mocked(apiMock.sendCommand)
+        .mock.calls.map((call: SendCommandCall) => call[0])
+        .filter(
+          (c) => c instanceof StartUntrustedHashTransactionInputCommand,
+        ) as StartUntrustedHashTransactionInputCommand[];
+
+      // The first START is the global header carrying the spending-tx version.
+      const header = startHashCommands[0]!.getApdu().getRawApdu();
+      // APDU = [CLA, INS, P1, P2, Lc, version(4) | nVersionGroupId(4) | branchId(4) | count].
+      const version = Buffer.from(header.slice(5, 9)).toString("hex");
+      const versionGroupId = Buffer.from(header.slice(9, 13)).toString("hex");
+
+      // Must be pinned to v5 / NU5 — NOT inherited from the v4/Sapling input.
+      expect(version).toBe(regression.pinnedTransactionVersionHex);
+      expect(versionGroupId).toBe(regression.pinnedVersionGroupIdHex);
+      expect(version).not.toBe(regression.firstInputSourceVersionHex);
+      expect(versionGroupId).not.toBe(
+        regression.firstInputSourceVersionGroupIdHex,
+      );
+    } finally {
+      getTrustedInputSpy.mockRestore();
+    }
   });
 });

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/__fixtures__/signTransactionFromLedgerWalletLogs2026-06-15.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/__fixtures__/signTransactionFromLedgerWalletLogs2026-06-15.ts
@@ -1,0 +1,243 @@
+import {
+  type LegacyCreateTransactionArg,
+  type LegacyTransaction,
+} from "@api/model/CreateTransactionArg";
+
+/**
+ * Parsed from Ledger Wallet export (2026-06-15) — the send that FAILED with the
+ * Zcash app returning `6a80` (`IncorrectDataError` → `ZcashAppCommandError`).
+ *
+ * Root cause: coin selection (`Deepfirst`) ordered a pre-NU5, **v4 / Sapling**
+ * transparent UTXO (`c16f0e1f…`, 6 893 574 @ `t1VB78…`) as the **first** input.
+ * The failing APDU is **GET_TRUSTED_INPUT** (`INS 0x42`), NOT the spending-tx
+ * hash — the device choked while being streamed `inputs[0]`'s v4/Sapling
+ * *previous* transaction.
+ *
+ * `serializeTransaction` framed that v4 prev tx with the **v5 header layout**
+ * (`version|vgid|consensusBranchId|locktime|expiry` before the inputs). For v4
+ * the device (and the trusted-input chunker) expect `locktime`/`expiry` to trail
+ * the outputs, so the 8 extra header bytes shifted the input count onto the
+ * `locktime` byte → the chunker read **0 inputs** → the device misparsed the
+ * stream and returned `6a80`. Fixed in `serializeTransaction` (v4 branch).
+ *
+ * Decisive log evidence (hw / DMK channels):
+ * - logIndex 2944: `splitTransaction` of `inputs[0]` source tx — `0400008085202f89…`
+ *   (version `04000080` = v4, nVersionGroupId `85202f89` = Sapling).
+ * - logIndex 2945/2946: `splitTransaction` of `inputs[1]` source tx — `050000800a27a726…` (v5/NU5).
+ * - logIndex 2947: `createPaymentTransaction` — two transparent inputs, two keysets.
+ * - logIndex 2950: `GET_TRUSTED_INPUT` first APDU for the v4 prev tx, mis-framed
+ *   → `e042000011000000000400008085202f89f04dec4d00` (input count read as `00`).
+ * - logIndex 2964: device `<= 6a80`.
+ * - logIndex 2977: thrown via `DmkSignerZcash.mapError` (`ZcashAppCommandError`, 6a80).
+ *
+ * Contrast: the immediately preceding 2026-06-15 send (logIndex 707 / 959) spent
+ * two v5 change UTXOs whose v5 prev txs frame correctly, so it succeeded.
+ *
+ * There is no expected signed transaction. This vector pins the regression: a v4
+ * previous transaction must be framed for GET_TRUSTED_INPUT with the input count
+ * directly after the branch id (`…f04dec4d03`, three inputs) — exercised in
+ * `GetTrustedInputTask.test.ts`.
+ */
+
+export const ledgerWalletLogMeta = {
+  description:
+    "Ledger Wallet export 2026-06-15 — v4/Sapling prev tx mis-framed for GET_TRUSTED_INPUT → device 6a80",
+  splitTransactionV4InputLogIndex: 2944,
+  splitTransactionV5InputLogIndex: 2946,
+  createPaymentTransactionLogIndex: 2947,
+  failingTrustedInputApduLogIndex: 2950,
+  deviceErrorResponseLogIndex: 2964,
+  mappedErrorLogIndex: 2977,
+  zcashAppVersionFromGetVersion: "3.0.1",
+  /** Device error observed in the deployed (buggy) build. */
+  deviceError: { errorCode: "6a80", name: "IncorrectDataError" },
+  /**
+   * GET_TRUSTED_INPUT (`INS 0x42`) first APDU as built by the buggy
+   * `serializeTransaction` (logIndex 2950): after the indexLookup, the v4 header
+   * `04000080 85202f89 f04dec4d` is followed by `00` — the input count read off
+   * the injected `locktime` byte instead of the real `03`.
+   */
+  failingTrustedInputApduHex: "e042000011000000000400008085202f89f04dec4d00",
+} as const;
+
+/**
+ * `createPaymentTransaction` payload from logs (Buffer fields as hex for tests).
+ * Mirrors `@ledgerhq/hw-app-btc` `CreateTransactionArg` shape.
+ *
+ * `inputs[0]` is the **v4 / Sapling** UTXO that breaks the flow; `inputs[1]` is a
+ * normal v5 change UTXO.
+ */
+export const createPaymentTransactionArgsFromLogs = {
+  inputs: [
+    [
+      {
+        note: "v4/Sapling source tx (c16f0e1f…, t1VB78…) — the input that triggers 6a80; height 3363685",
+        versionHex: "04000080",
+        nVersionGroupIdHex: "85202f89",
+        consensusBranchIdHex: "f04dec4d",
+        nExpiryHeightHex: "00000000",
+        extraDataHex: "0000000000000000000000",
+        locktimeHex: "00000000",
+        inputs: [
+          {
+            prevoutHex:
+              "82408554fb2a500ebe031e6a0a0265d8f3068e14ebf1508b351bf60142388c3900000000",
+            scriptHex:
+              "47304402203ab7d1e8fadb344bf8c4903ec741b048498ab15568007757d2894b37c720de0b02201d94abd82f6974f9603359360ac13c4ff6c17fb729e0e2332358da1d94b91b03012102106a2dcaaac2ae3b24358a03f4264e05db420c5b090399bc23885fa02fef7716",
+            sequenceHex: "ffffffff",
+          },
+          {
+            prevoutHex:
+              "440461b63758819b115b4621886e158d7e7b1ccad87143b819abf4b6da095eac00000000",
+            scriptHex:
+              "47304402205f3161a994b848c63dc7b24836c68582b91649394f9134d651708f987c2e567e02204f15c5cd540d482c681217975e728dd0f26161bcf60239b48fe87e7c4148be8f012102106a2dcaaac2ae3b24358a03f4264e05db420c5b090399bc23885fa02fef7716",
+            sequenceHex: "ffffffff",
+          },
+          {
+            prevoutHex:
+              "f6bbd8b5f5413ff1405539c1d70ea1a4a053813e9d92be34ad21733d603564c401000000",
+            scriptHex:
+              "4830450221009ef05270bd4fcdd640a6bd7e2f6545a856b57118e7579c2a2d5e73981082f8f802201af78b51bcd3f99d64ad1f9f93273bc612953a3c3742d317c2cf719421b79d45012102106a2dcaaac2ae3b24358a03f4264e05db420c5b090399bc23885fa02fef7716",
+            sequenceHex: "ffffffff",
+          },
+        ],
+        outputs: [
+          {
+            amountHex: "0630690000000000",
+            scriptHex: "76a9147bf8c56b5c5c57e63e7d7cffffaeaa03e82f99ae88ac",
+          },
+          {
+            amountHex: "b0bf8b7200000000",
+            scriptHex: "76a9141634f5ff0b8f6603a17570436d6c12a91f4b1fed88ac",
+          },
+        ],
+      },
+      0,
+      null,
+      0xffffffff,
+      3363685,
+    ],
+    [
+      {
+        note: "v5/NU5 change source tx (79fa0041…, t1ZjWw…); height 3378711",
+        versionHex: "05000080",
+        nVersionGroupIdHex: "0a27a726",
+        consensusBranchIdHex: "30f33754",
+        nExpiryHeightHex: "00000000",
+        extraDataHex: "",
+        locktimeHex: "00000000",
+        inputs: [
+          {
+            prevoutHex:
+              "95c61cb6fbce43ca6e910a9e95b0faf8aa3edbd2356fbb6cffb0cef01a42223601000000",
+            scriptHex:
+              "47304402204f7ae09c4343f41eced53d4d9249cc133850a2a934103db6ac3834f97e51d1220220402ab9338e26c27d0d3d59cde3d2a662c8c59c58bb4610430ecc51244240e64e012102bcecf522cc89b8624d153c77b8db90a08d9cfb6e379be60173f7688d84483b60",
+            sequenceHex: "ffffffff",
+          },
+          {
+            prevoutHex:
+              "22d8ae584994e054232f6acfdbef0a1bf0b2d42030d8f5b776e6c423eec6de5801000000",
+            scriptHex:
+              "47304402205aa711418e1321a1f3b33983de533701a544e02ff5ae1027d5dd1558ef695edc02205ace391ca94ac96be8bd6072911f897f82924ee20635e899d0618824cf4f68b001210320e4aac1a4719a7e2d35ec9bb3a4b8122652dd59a3ed27cfef74bf358e0e7697",
+            sequenceHex: "ffffffff",
+          },
+        ],
+        outputs: [
+          {
+            amountHex: "808d5b0000000000",
+            scriptHex: "76a914126f2d54c9c72423f2ece862ee1f348a0120316a88ac",
+          },
+          {
+            amountHex: "e6c7210000000000",
+            scriptHex: "76a914adfa746f9d843cbde9c29c4445fed0da30ce20cd88ac",
+          },
+        ],
+      },
+      1,
+      null,
+      0xffffffff,
+      3378711,
+    ],
+  ],
+  associatedKeysets: ["44'/133'/0'/0/5", "44'/133'/0'/1/6"],
+  outputScriptHex:
+    "0178c68500000000001976a914126f2d54c9c72423f2ece862ee1f348a0120316a88ac",
+  blockHeight: 3378725,
+  sigHashType: 1,
+  expiryHeightHex: "00000000",
+  additionals: ["zcash", "sapling"] as const,
+} as const;
+
+const fixtureHexToBytes = (hex: string): Uint8Array => {
+  const clean = hex.replace(/^0x/i, "").replace(/\s+/g, "");
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+};
+
+const legacyPreviousTransactionFromLogInput = (
+  head: (typeof createPaymentTransactionArgsFromLogs.inputs)[number][0],
+): LegacyTransaction => ({
+  version: fixtureHexToBytes(head.versionHex),
+  nVersionGroupId: fixtureHexToBytes(head.nVersionGroupIdHex),
+  consensusBranchId: fixtureHexToBytes(head.consensusBranchIdHex),
+  nExpiryHeight: fixtureHexToBytes(head.nExpiryHeightHex),
+  ...(head.extraDataHex
+    ? { extraData: fixtureHexToBytes(head.extraDataHex) }
+    : {}),
+  locktime: fixtureHexToBytes(head.locktimeHex),
+  inputs: head.inputs.map((inp) => ({
+    prevout: fixtureHexToBytes(inp.prevoutHex),
+    script: fixtureHexToBytes(inp.scriptHex),
+    sequence: fixtureHexToBytes(inp.sequenceHex),
+  })),
+  outputs: head.outputs.map((out) => ({
+    amount: fixtureHexToBytes(out.amountHex),
+    script: fixtureHexToBytes(out.scriptHex),
+  })),
+});
+
+export const signTransactionFromLedgerWalletLogs20260615 = {
+  meta: {
+    capturedAt: "2026-06-15",
+    description:
+      "Ledger Wallet export — v4/Sapling UTXO selected first; deployed build emitted a v4 header and device returned 6a80.",
+  },
+  transactionArg: {
+    inputs: createPaymentTransactionArgsFromLogs.inputs.map((tuple) => {
+      const [head, outputIndex, script, sequence, branchHeight] = tuple;
+      return [
+        legacyPreviousTransactionFromLogInput(head),
+        outputIndex,
+        script,
+        sequence,
+        branchHeight,
+      ] as const;
+    }),
+    associatedKeysets: [
+      ...createPaymentTransactionArgsFromLogs.associatedKeysets,
+    ],
+    outputScriptHex: createPaymentTransactionArgsFromLogs.outputScriptHex,
+    blockHeight: createPaymentTransactionArgsFromLogs.blockHeight,
+    sigHashType: createPaymentTransactionArgsFromLogs.sigHashType,
+    additionals: [...createPaymentTransactionArgsFromLogs.additionals],
+    expiryHeight: fixtureHexToBytes(
+      createPaymentTransactionArgsFromLogs.expiryHeightHex,
+    ),
+  } satisfies LegacyCreateTransactionArg,
+
+  /**
+   * Regression expectations. The first input is v4/Sapling, but the signed
+   * transaction header sent to the device must be pinned to v5 (NU5).
+   */
+  regression: {
+    /** What the deployed build copied from `inputs[0]` source tx (the bug). */
+    firstInputSourceVersionHex: "04000080",
+    firstInputSourceVersionGroupIdHex: "85202f89",
+    /** What the START header MUST carry regardless of input versions. */
+    pinnedTransactionVersionHex: "05000080",
+    pinnedVersionGroupIdHex: "0a27a726",
+  },
+} as const;

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/utils/legacyTransactionUtils.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/utils/legacyTransactionUtils.test.ts
@@ -24,10 +24,10 @@ describe("getZcashBranchId", () => {
 
   it("returns latest branch id when block height is unknown", () => {
     expect(getZcashBranchId(undefined)).toEqual(
-      Uint8Array.of(0xf0, 0x4d, 0xec, 0x4d),
+      Uint8Array.of(0x30, 0xf3, 0x37, 0x54),
     );
     expect(getZcashBranchId(null)).toEqual(
-      Uint8Array.of(0xf0, 0x4d, 0xec, 0x4d),
+      Uint8Array.of(0x30, 0xf3, 0x37, 0x54),
     );
   });
 

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/utils/legacyTransactionUtils.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/utils/legacyTransactionUtils.test.ts
@@ -6,8 +6,12 @@ import {
   type InternalTransaction,
   parseOutputScriptsFromPaymentOutputBlob,
   resolveExpiryHeightBytes,
+  serializeTransaction,
   serializeTransactionOutputs,
 } from "./legacyTransactionUtils";
+
+const bytesToHex = (bytes: Uint8Array): string =>
+  Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 
 describe("getZcashDefaultTransactionVersion", () => {
   it("returns v5 transparent version constant", () => {
@@ -39,6 +43,15 @@ describe("getZcashBranchId", () => {
       Uint8Array.of(0xf0, 0x4d, 0xec, 0x4d),
     );
   });
+
+  it("switches from NU6.1 to NU6.2 branch id at activation height", () => {
+    expect(getZcashBranchId(3364599)).toEqual(
+      Uint8Array.of(0xf0, 0x4d, 0xec, 0x4d),
+    );
+    expect(getZcashBranchId(3364600)).toEqual(
+      Uint8Array.of(0x30, 0xf3, 0x37, 0x54),
+    );
+  });
 });
 
 describe("parseOutputScriptsFromPaymentOutputBlob", () => {
@@ -67,6 +80,68 @@ describe("parseOutputScriptsFromPaymentOutputBlob", () => {
     expect(parseOutputScriptsFromPaymentOutputBlob(Uint8Array.of(0x01))).toBe(
       null,
     );
+  });
+});
+
+describe("serializeTransaction v5 header", () => {
+  const v5Version = Uint8Array.of(0x05, 0x00, 0x00, 0x80);
+  const oneInput = {
+    inputs: [
+      {
+        prevout: Uint8Array.of(0xaa),
+        script: new Uint8Array(0),
+        sequence: Uint8Array.of(0xff, 0xff, 0xff, 0xff),
+      },
+    ],
+  };
+
+  it("normalizes an omitted locktime and expiry to 4 zero bytes so the input count is not shifted", () => {
+    const serialized = serializeTransaction({
+      version: v5Version,
+      ...oneInput,
+    } satisfies InternalTransaction);
+
+    // version(05000080) | locktime(00000000) | expiry(00000000) |
+    // vin_count(01) | prevout(aa) varint_script_len(00) sequence(ffffffff)
+    expect(bytesToHex(serialized)).toBe(
+      "05000080" + "00000000" + "00000000" + "01" + "aa00ffffffff",
+    );
+  });
+
+  it("normalizes an empty locktime to 4 zero bytes", () => {
+    const serialized = serializeTransaction({
+      version: v5Version,
+      locktime: new Uint8Array(0),
+      nExpiryHeight: Uint8Array.of(0x11, 0x22, 0x33, 0x44),
+      ...oneInput,
+    } satisfies InternalTransaction);
+
+    expect(bytesToHex(serialized)).toBe(
+      "05000080" + "00000000" + "11223344" + "01" + "aa00ffffffff",
+    );
+  });
+
+  it("passes through a 4-byte locktime and expiry unchanged", () => {
+    const serialized = serializeTransaction({
+      version: v5Version,
+      locktime: Uint8Array.of(0x0a, 0x0b, 0x0c, 0x0d),
+      nExpiryHeight: Uint8Array.of(0x11, 0x22, 0x33, 0x44),
+      ...oneInput,
+    } satisfies InternalTransaction);
+
+    expect(bytesToHex(serialized)).toBe(
+      "05000080" + "0a0b0c0d" + "11223344" + "01" + "aa00ffffffff",
+    );
+  });
+
+  it("throws when expiry width is neither empty nor 4 bytes", () => {
+    expect(() =>
+      serializeTransaction({
+        version: v5Version,
+        nExpiryHeight: Uint8Array.of(0x01, 0x02),
+        ...oneInput,
+      } satisfies InternalTransaction),
+    ).toThrow("expiryHeight must be 4 bytes (got 2)");
   });
 });
 

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/utils/legacyTransactionUtils.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/utils/legacyTransactionUtils.ts
@@ -20,6 +20,8 @@ export const OP_EQUALVERIFY = 0x88;
 export const OP_CHECKSIG = 0xac;
 
 const ZCASH_ACTIVATION_HEIGHTS = {
+  // https://z.cash/upgrade/nu6.2/
+  NU6_2: 3364600,
   NU6_1: 3146400,
   NU6: 2726400,
   NU5: 1687104,
@@ -220,6 +222,38 @@ export const serializeTransaction = (
     );
   });
 
+  const isTxV4 =
+    transaction.version.length >= 4 &&
+    (readUint32LE(transaction.version, 0) & 0x7fffffff) === 4;
+
+  if (isTxV4) {
+    // v4 (Sapling) GET_TRUSTED_INPUT framing expected by the Zcash device app:
+    //   version | nVersionGroupId | consensusBranchId | varint(vin) | inputs |
+    //   varint(vout) | outputs | <3 shielded routing counts> |
+    //   locktime | varint(4 + extraData) | nExpiryHeight | extraData
+    // Unlike v5, locktime/nExpiryHeight are NOT in the header — they trail the
+    // outputs. Emitting them in the header (v5 layout) shifts the input count
+    // onto the locktime byte, so the device reads 0 inputs and rejects the
+    // stream with 6a80 (IncorrectData).
+    const locktime = transaction.locktime || new Uint8Array(0);
+    const expiry = transaction.nExpiryHeight || new Uint8Array(0);
+    const extraData = transaction.extraData || new Uint8Array(0);
+
+    return concatUint8Arrays(
+      transaction.version,
+      transaction.nVersionGroupId || new Uint8Array(0),
+      transaction.consensusBranchId || new Uint8Array(0),
+      createVarint(transaction.inputs.length),
+      inputBuffer,
+      serializeTransactionOutputs(transaction),
+      new Uint8Array(3),
+      locktime,
+      createVarint(expiry.length + extraData.length),
+      expiry,
+      extraData,
+    );
+  }
+
   let outputBuffer: Uint8Array = serializeTransactionOutputs(transaction);
   if (transaction.outputs && transaction.locktime) {
     outputBuffer = concatUint8Arrays(
@@ -281,8 +315,11 @@ export const getZcashBranchId = (
   if (
     blockHeight === null ||
     blockHeight === undefined ||
-    blockHeight >= ZCASH_ACTIVATION_HEIGHTS.NU6_1
+    blockHeight >= ZCASH_ACTIVATION_HEIGHTS.NU6_2
   ) {
+    // NOTE: null and undefined should default to the latest version
+    return uint32ToBytesLE(0x5437f330);
+  } else if (blockHeight >= ZCASH_ACTIVATION_HEIGHTS.NU6_1) {
     return uint32ToBytesLE(0x4dec4df0);
   } else if (blockHeight >= ZCASH_ACTIVATION_HEIGHTS.NU6) {
     return uint32ToBytesLE(0xc8e71055);

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/utils/legacyTransactionUtils.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/utils/legacyTransactionUtils.ts
@@ -235,8 +235,11 @@ export const serializeTransaction = (
     // outputs. Emitting them in the header (v5 layout) shifts the input count
     // onto the locktime byte, so the device reads 0 inputs and rejects the
     // stream with 6a80 (IncorrectData).
-    const locktime = transaction.locktime || new Uint8Array(0);
-    const expiry = transaction.nExpiryHeight || new Uint8Array(0);
+    const locktime =
+      transaction.locktime && transaction.locktime.byteLength > 0
+        ? transaction.locktime
+        : new Uint8Array(4);
+    const expiry = resolveExpiryHeightBytes(transaction.nExpiryHeight);
     const extraData = transaction.extraData || new Uint8Array(0);
 
     return concatUint8Arrays(
@@ -263,13 +266,19 @@ export const serializeTransaction = (
     );
   }
 
+  const locktime =
+    transaction.locktime && transaction.locktime.byteLength > 0
+      ? transaction.locktime
+      : new Uint8Array(4);
+  const expiry = resolveExpiryHeightBytes(transaction.nExpiryHeight);
+
   return concatUint8Arrays(
     transaction.version,
     timestampOverride ?? transaction.timestamp ?? new Uint8Array(0),
     transaction.nVersionGroupId || new Uint8Array(0),
     transaction.consensusBranchId || new Uint8Array(0),
-    transaction.locktime || new Uint8Array(0),
-    transaction.nExpiryHeight || new Uint8Array(0),
+    locktime,
+    expiry,
     createVarint(transaction.inputs.length),
     inputBuffer,
     outputBuffer,


### PR DESCRIPTION
### 📝 Description

The Zcash device app rejected v4 (Sapling) transactions during the
`GET_TRUSTED_INPUT` exchange, returning `6a80` (IncorrectData).

**Previous behavior:** v4 transactions were serialized with the v5 layout,
placing `locktime` and `nExpiryHeight` in the header. This shifted the input
count onto the locktime byte, so the device read 0 inputs and aborted the stream.

**Fix:** v4 transactions are now serialized with the framing the device app
expects — `locktime` and `nExpiryHeight` trail the outputs rather than sitting
in the header:

    version | nVersionGroupId | consensusBranchId | varint(vin) | inputs |
    varint(vout) | outputs | <3 shielded routing counts> |
    locktime | varint(4 + extraData) | nExpiryHeight | extraData

This PR also adds the **NU6.2** consensus branch id and maps block heights at or
above the NU6.2 activation height (3,364,600) to it. `null`/`undefined` heights
default to the latest branch id.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32615](https://ledgerhq.atlassian.net/browse/LIVE-32615)
- **Feature**: Zcash shielded transaction signing — v4 trusted-input correctness
  and NU6.2 network upgrade support.

### ✅ Checklist

- [x] **Covered by automatic tests** — added cases in `SignTransactionTask.test.ts`,
  `GetTrustedInputTask.test.ts`, `legacyTransactionUtils.test.ts`, plus a real
  device-log fixture (`signTransactionFromLedgerWalletLogs2026-06-15.ts`). 107 tests pass.
- [x] **Changeset is provided** — `.changeset/zcash-v4-trusted-input.md` (patch,
  `@ledgerhq/device-signer-kit-zcash`).
- [x] **Documentation is up-to-date** — no public API change.
- [x] **Impact of the changes:**
  - v4 (Sapling) transactions now produce valid `GET_TRUSTED_INPUT` streams.
  - New NU6.2 branch id; QA should exercise signing across NU6.2 / NU6.1 / NU6 / NU5 boundaries.
  - No change to v5 transaction serialization.

[LIVE-32615]: https://ledgerhq.atlassian.net/browse/LIVE-32615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ