### PR TITLE
✨ (signer-solana) [DSDK-1146]: Add generic clear sign device action 🚧 WIP 🚧

### DIFF
--- a/.changeset/pink-mangos-sin.md
+++ b/.changeset/pink-mangos-sin.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/context-module": minor
+"@ledgerhq/device-signer-kit-solana": minor
+---
+
+Add Generic clear sign device action

--- a/packages/signer/context-module/src/modules/solana/instruction-info/domain/InstructionInfoContextLoader.test.ts
+++ b/packages/signer/context-module/src/modules/solana/instruction-info/domain/InstructionInfoContextLoader.test.ts
@@ -263,6 +263,44 @@ describe("InstructionInfoContextLoader", () => {
       ).toHaveLength(0);
     });
 
+    it("bundles CAL enum_variants into the SOLANA_INSTRUCTION_INFO payload (host decode cache)", async () => {
+      const loader = makeLoader();
+      const jupiter = makeJupiterRouteResult();
+      const descriptor = jupiter.descriptors["e517cb977ae3ad2a"];
+      if (!descriptor) throw new Error("fixture: descriptor must exist");
+      descriptor.enum_variants = {
+        swap: {
+          "46": {
+            variant_name: "raydiumCP",
+            data: "01_raydium_tlv",
+            signatures: { prod: "prodsig_v46", test: "testsig_v46" },
+          },
+        },
+      };
+      vi.spyOn(dataSource, "getInstructionInfo").mockResolvedValue(
+        Right(jupiter),
+      );
+
+      const result = await loader.load({
+        deviceModelId: DeviceModelId.NANO_X,
+        instructions: [
+          { programId: JUPITER_PROGRAM, discriminator: "e517cb977ae3ad2a" },
+        ],
+      });
+
+      const infoCtx = result.find(
+        (c) => c.type === ClearSignContextType.SOLANA_INSTRUCTION_INFO,
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((infoCtx as any).payload.enumVariants).toEqual([
+        {
+          enumId: "swap",
+          variantIndex: 46,
+          descriptor: { data: "01_raydium_tlv", signature: "prodsig_v46" },
+        },
+      ]);
+    });
+
     it("filters descriptors by requested discriminator", async () => {
       const loader = makeLoader();
       const result: InstructionInfoResult = {

--- a/packages/signer/context-module/src/modules/solana/instruction-info/domain/InstructionInfoContextLoader.ts
+++ b/packages/signer/context-module/src/modules/solana/instruction-info/domain/InstructionInfoContextLoader.ts
@@ -18,6 +18,7 @@ import {
 } from "@/modules/solana/instruction-info/data/InstructionInfoDto";
 import { instructionInfoTypes } from "@/modules/solana/instruction-info/di/instructionInfoTypes";
 import {
+  type SolanaInstructionEnumVariant,
   type SolanaInstructionInfoPayload,
   type SolanaInstructionSubstructure,
   SolanaInstructionSubstructureKind,
@@ -259,6 +260,24 @@ export class InstructionInfoContextLoader
       })),
     ];
 
+    // Flatten the CAL-bundled enum variants (keyed enumId to variantIndex) into
+    // a flat list. The signed TLV feeds the host's type-pool decode cache, the
+    // signature is best-effort (only needed when streaming the selected
+    // variant, not for decoding).
+    const enumVariants: SolanaInstructionEnumVariant[] = [];
+    for (const [enumId, variants] of Object.entries(dto.enum_variants ?? {})) {
+      for (const [variantIndex, variant] of Object.entries(variants)) {
+        enumVariants.push({
+          enumId,
+          variantIndex: Number(variantIndex),
+          descriptor: {
+            data: variant.data,
+            signature: this.pickSignature(variant.signatures) ?? "",
+          },
+        });
+      }
+    }
+
     const payload: SolanaInstructionInfoPayload = {
       programId: info.program_id,
       discriminator,
@@ -267,6 +286,7 @@ export class InstructionInfoContextLoader
         signature,
       },
       substructures,
+      enumVariants,
     };
 
     return {

--- a/packages/signer/context-module/src/modules/solana/model/SolanaClearSignContext.ts
+++ b/packages/signer/context-module/src/modules/solana/model/SolanaClearSignContext.ts
@@ -19,6 +19,7 @@ import {
 export type {
   SolanaAltResolutionPayload,
   SolanaEnumVariantPayload,
+  SolanaInstructionEnumVariant,
   SolanaInstructionInfoPayload,
   SolanaInstructionSubstructure,
   SolanaLifiInstructionMeta,

--- a/packages/signer/context-module/src/modules/solana/model/SolanaContextTypes.ts
+++ b/packages/signer/context-module/src/modules/solana/model/SolanaContextTypes.ts
@@ -37,17 +37,20 @@ export type SolanaTransactionDescriptorList = Record<
   SolanaTransactionDescriptor
 >;
 
-// TODO SOLANA TX-CHECK
-// IMPORTANT: do not widen this union with the new clear-signing context
-// types (SOLANA_INSTRUCTION_INFO, SOLANA_ENUM_VARIANT, SOLANA_TOKEN_INFO,
-// SOLANA_TOKEN_ACCOUNT_STATE, SOLANA_ALT_RESOLUTION) until the
-// downstream signer registry declares matching handlers. That registry
-// uses a required mapped type over this union, so widening here without
-// adding handlers breaks the signer build.
+// The signer registry (`provideContextRegistry.ts`) uses a required mapped
+// type over this union, so every member listed here MUST have a matching
+// provide handler in the signer. The generic clear-signing types below are
+// declared together with their handlers
 export type SolanaContextSuccessType =
   | ClearSignContextType.SOLANA_TOKEN
   | ClearSignContextType.SOLANA_LIFI
-  | ClearSignContextType.SOLANA_TRANSACTION_CHECK;
+  | ClearSignContextType.SOLANA_TRANSACTION_CHECK
+  | ClearSignContextType.SOLANA_INSTRUCTION_INFO
+  | ClearSignContextType.SOLANA_ENUM_VARIANT
+  | ClearSignContextType.SOLANA_TOKEN_INFO
+  | ClearSignContextType.SOLANA_TOKEN_ACCOUNT_STATE
+  | ClearSignContextType.SOLANA_ALT_RESOLUTION
+  | ClearSignContextType.SOLANA_TRUSTED_NAME;
 
 export type SolanaContextSuccess<
   T extends SolanaContextSuccessType = SolanaContextSuccessType,
@@ -65,6 +68,24 @@ export type SolanaLifiContextSuccess =
 
 export type SolanaTransactionCheckContextSuccess =
   ClearSignContextSuccess<ClearSignContextType.SOLANA_TRANSACTION_CHECK>;
+
+export type SolanaInstructionInfoContextSuccess =
+  ClearSignContextSuccess<ClearSignContextType.SOLANA_INSTRUCTION_INFO>;
+
+export type SolanaEnumVariantContextSuccess =
+  ClearSignContextSuccess<ClearSignContextType.SOLANA_ENUM_VARIANT>;
+
+export type SolanaTokenInfoContextSuccess =
+  ClearSignContextSuccess<ClearSignContextType.SOLANA_TOKEN_INFO>;
+
+export type SolanaTokenAccountStateContextSuccess =
+  ClearSignContextSuccess<ClearSignContextType.SOLANA_TOKEN_ACCOUNT_STATE>;
+
+export type SolanaAltResolutionContextSuccess =
+  ClearSignContextSuccess<ClearSignContextType.SOLANA_ALT_RESOLUTION>;
+
+export type SolanaTrustedNameContextSuccess =
+  ClearSignContextSuccess<ClearSignContextType.SOLANA_TRUSTED_NAME>;
 
 export type SolanaTokenContextResult =
   | SolanaTokenContextSuccess

--- a/packages/signer/context-module/src/modules/solana/model/SolanaPayloads.ts
+++ b/packages/signer/context-module/src/modules/solana/model/SolanaPayloads.ts
@@ -41,14 +41,29 @@ export type SolanaSignedDescriptor = {
 };
 
 /**
+ * One enum-variant descriptor bundled with an instruction descriptor by CAL.
+ * The signed TLV (`descriptor.data`) feeds the host-side type-pool decode
+ * cache, `enumId`/`variantIndex` identify which variant it describes (and let
+ * the host stream the selected variant's signed descriptor to the device).
+ */
+export type SolanaInstructionEnumVariant = {
+  enumId: string;
+  variantIndex: number;
+  descriptor: SolanaSignedDescriptor;
+};
+
+/**
  * Payload for ClearSignContextType.SOLANA_INSTRUCTION_INFO: one signed
- * INSTRUCTION_INFO descriptor plus its substructures.
+ * INSTRUCTION_INFO descriptor, its substructures, and the enum-variant
+ * descriptors CAL bundles for the program's enums (used to build the host
+ * decode cache).
  */
 export type SolanaInstructionInfoPayload = {
   programId: string;
   discriminator: string;
   instructionInfo: SolanaSignedDescriptor;
   substructures: SolanaInstructionSubstructure[];
+  enumVariants: SolanaInstructionEnumVariant[];
 };
 
 export enum SolanaInstructionSubstructureKind {

--- a/packages/signer/signer-solana/src/api/app-binder/SignTransactionDeviceActionTypes.ts
+++ b/packages/signer/signer-solana/src/api/app-binder/SignTransactionDeviceActionTypes.ts
@@ -1,7 +1,4 @@
-import {
-  type ContextModule,
-  type SolanaTransactionContextResultSuccess,
-} from "@ledgerhq/context-module";
+import { type ContextModule } from "@ledgerhq/context-module";
 import {
   type DeviceActionState,
   type ExecuteDeviceActionReturnType,
@@ -17,9 +14,8 @@ import { type SolanaTransactionOptionalConfig } from "@api/model/SolanaTransacti
 import { type Transaction } from "@api/model/Transaction";
 import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
 import { type BlockhashService } from "@internal/app-binder/services/BlockhashService";
-import { type TxInspectorResult } from "@internal/app-binder/services/TransactionInspector";
 
-import { type DelayedSignDAStateStep } from "./DelayedSignTransactionDeviceActionTypes";
+import { type SigningOperationsDAStateStep } from "./SigningOperationsDeviceActionTypes";
 
 export const signTransactionDAStateSteps = Object.freeze({
   OPEN_APP: "signer.sol.steps.openApp",
@@ -28,15 +24,30 @@ export const signTransactionDAStateSteps = Object.freeze({
   WEB3_CHECKS_OPT_IN_RESULT: "signer.sol.steps.web3ChecksOptInResult",
   INSPECT_TRANSACTION: "signer.sol.steps.inspectTransaction",
   GET_PUB_KEY: "signer.sol.steps.getPubKey",
-  BUILD_TRANSACTION_CONTEXT: "signer.sol.steps.buildTransactionContext",
-  PROVIDE_TRANSACTION_CONTEXT: "signer.sol.steps.provideTransactionContext",
+  BUILD_SHALLOW_CLEAR_SIGN_CONTEXT:
+    "signer.sol.steps.buildShallowClearSignContext",
+  PROVIDE_SHALLOW_CLEAR_SIGN_CONTEXT:
+    "signer.sol.steps.provideShallowClearSignContext",
+  BUILD_GENERIC_CLEAR_SIGN_CONTEXT:
+    "signer.sol.steps.buildGenericClearSignContext",
+  PROVIDE_GENERIC_CLEAR_SIGN_CONTEXT:
+    "signer.sol.steps.provideGenericClearSignContext",
+  PROMPT_UI_DISPLAY: "signer.sol.steps.promptUiDisplay",
   SIGN_TRANSACTION: "signer.sol.steps.signTransaction",
   DELAYED_SIGN: "signer.sol.steps.delayedSign",
 } as const);
 
+/**
+ * Which clear-signing path produced the signature.
+ * `full` = device ran the merge engine
+ * `srfc39-only` = partial CAL coverage, device auto-rendered per-instruction without merge
+ * `none` = blind/legacy fallback (no instruction recognised or capability absent).
+ */
+export type ClearSignMode = "full" | "srfc39-only" | "none";
+
 export type SignTransactionDAStateStep =
   | (typeof signTransactionDAStateSteps)[keyof typeof signTransactionDAStateSteps]
-  | DelayedSignDAStateStep;
+  | SigningOperationsDAStateStep;
 
 export type SignTransactionDAOutput = Signature;
 
@@ -81,9 +92,9 @@ export type SignTransactionDAInternalState = {
   readonly error: SignTransactionDAError | null;
   readonly signature: Signature | null;
   readonly appConfig: AppConfiguration | null;
-  readonly solanaTransactionContext: SolanaTransactionContextResultSuccess | null;
-  readonly inspectorResult: TxInspectorResult | null;
-  readonly signerAddress: string | null;
+  // Set when the generic clear-sign path armed the device, so the terminal
+  // sign skips its own preview.
+  readonly clearSignArmed: boolean;
 };
 
 export type SignTransactionDAReturnType = ExecuteDeviceActionReturnType<

--- a/packages/signer/signer-solana/src/api/app-binder/SigningOperationsDeviceActionTypes.ts
+++ b/packages/signer/signer-solana/src/api/app-binder/SigningOperationsDeviceActionTypes.ts
@@ -12,50 +12,56 @@ import { type UserInputType } from "@api/model/TransactionResolutionContext";
 import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
 import { type BlockhashService } from "@internal/app-binder/services/BlockhashService";
 
-export const delayedSignDAStateSteps = Object.freeze({
+export const signingOperationsDAStateSteps = Object.freeze({
   ZERO_BLOCKHASH: "signer.sol.steps.zeroBlockhash",
   PREVIEW_TRANSACTION: "signer.sol.steps.previewTransaction",
   FETCH_BLOCKHASH: "signer.sol.steps.fetchBlockhash",
   PATCH_TRANSACTION: "signer.sol.steps.patchTransaction",
   DELAYED_SIGN: "signer.sol.steps.delayedSign",
+  SIGN_TRANSACTION: "signer.sol.steps.signTransaction",
   FALLBACK_TO_NON_DELAYED_SIGN: "signer.sol.steps.fallbackToNonDelayedSign",
 } as const);
 
-export type DelayedSignDAStateStep =
-  (typeof delayedSignDAStateSteps)[keyof typeof delayedSignDAStateSteps];
+export type SigningOperationsDAStateStep =
+  (typeof signingOperationsDAStateSteps)[keyof typeof signingOperationsDAStateSteps];
 
-export type DelayedSignDAOutput = Signature;
+export type SigningOperationsDAOutput = Signature;
 
-export type DelayedSignDAInput = {
+export type SigningOperationsDAInput = {
   readonly derivationPath: string;
   readonly transaction: Uint8Array;
   readonly rpcUrl?: string;
   readonly fetchBlockhash?: () => Promise<Uint8Array>;
   readonly userInputType?: UserInputType;
   readonly blockhashService?: BlockhashService;
+  // When the device fingerprint is already armed (e.g. by generic clear-sign's
+  // PROMPT UI DISPLAY), skip the SIGN MESSAGE PREVIEW step and go straight to
+  // the blockhash refresh + SIGN MESSAGE DELAYED. Without a blockhash source the
+  // original transaction is signed as-is.
+  readonly alreadyArmed?: boolean;
 };
 
-export type DelayedSignDAError =
+export type SigningOperationsDAError =
   | OpenAppDAError
   | SendCommandInAppDAError<SolanaAppErrorCodes>;
 
-type DelayedSignDARequiredInteraction =
+type SigningOperationsDARequiredInteraction =
   | UserInteractionRequired
   | OpenAppDARequiredInteraction;
 
-export type DelayedSignDAIntermediateValue = {
-  requiredUserInteraction: DelayedSignDARequiredInteraction;
-  step: DelayedSignDAStateStep;
+export type SigningOperationsDAIntermediateValue = {
+  requiredUserInteraction: SigningOperationsDARequiredInteraction;
+  step: SigningOperationsDAStateStep;
 };
 
-export type DelayedSignDAState = DeviceActionState<
-  DelayedSignDAOutput,
-  DelayedSignDAError,
-  DelayedSignDAIntermediateValue
+export type SigningOperationsDAState = DeviceActionState<
+  SigningOperationsDAOutput,
+  SigningOperationsDAError,
+  SigningOperationsDAIntermediateValue
 >;
 
-export type DelayedSignDAInternalState = {
-  readonly error: DelayedSignDAError | null;
+export type SigningOperationsDAInternalState = {
+  readonly error: SigningOperationsDAError | null;
   readonly signature: Signature | null;
   readonly zeroedTransaction: Uint8Array | null;
   readonly freshBlockhash: Uint8Array | null;
@@ -63,8 +69,8 @@ export type DelayedSignDAInternalState = {
   readonly previewFallback: boolean;
 };
 
-export type DelayedSignDAReturnType = ExecuteDeviceActionReturnType<
-  DelayedSignDAOutput,
-  DelayedSignDAError,
-  DelayedSignDAIntermediateValue
+export type SigningOperationsDAReturnType = ExecuteDeviceActionReturnType<
+  SigningOperationsDAOutput,
+  SigningOperationsDAError,
+  SigningOperationsDAIntermediateValue
 >;

--- a/packages/signer/signer-solana/src/internal/app-binder/SolanaApplicationResolver.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/SolanaApplicationResolver.ts
@@ -1,18 +1,25 @@
 import {
   type AppConfig,
+  ApplicationChecker,
   type ApplicationResolver,
   DeviceModelId,
   type DeviceSessionState,
   DeviceSessionStateType,
+  type InternalApi,
   type ResolvedApp,
 } from "@ledgerhq/device-management-kit";
+
+import { type AppConfiguration } from "@api/model/AppConfiguration";
 
 import { APP_NAME } from "./constants";
 
 const DEFAULT_VERSION = "0.0.1";
 export const SOLANA_MIN_SPL_VERSION = "1.9.2";
 export const SOLANA_MIN_DELAYED_SIGNING_VERSION = "1.14.0";
-export const SOLANA_MIN_WEB3_CHECKS_VERSION = "1.15.0";
+// Placeholder
+export const SOLANA_MIN_WEB3_CHECKS_VERSION = "10.0.0";
+// Placeholder
+export const SOLANA_MIN_GENERIC_CLEAR_SIGN_VERSION = "10.0.0";
 
 export const SOLANA_FEATURES = {
   spl: {
@@ -34,7 +41,33 @@ export const SOLANA_FEATURES = {
     excludedModels: [] as DeviceModelId[],
     excludedApps: [] as string[],
   },
+  genericClearSign: {
+    minVersion: SOLANA_MIN_GENERIC_CLEAR_SIGN_VERSION,
+    excludedModels: [DeviceModelId.NANO_S],
+    excludedApps: ["Exchange"],
+  },
 } as const;
+
+/**
+ * Whether the connected Solana app supports a given feature, applying its
+ * minimum version plus device-model / orchestrating-app exclusions.
+ */
+export function isSolanaFeatureSupported(
+  internalApi: InternalApi,
+  feature: keyof typeof SOLANA_FEATURES,
+  appConfig: AppConfiguration,
+): boolean {
+  const { minVersion, excludedModels, excludedApps } = SOLANA_FEATURES[feature];
+  return new ApplicationChecker(
+    internalApi.getDeviceSessionState(),
+    appConfig,
+    new SolanaApplicationResolver(),
+  )
+    .withMinVersionInclusive(minVersion)
+    .excludeDeviceModels(...excludedModels)
+    .excludeApps(...excludedApps)
+    .check();
+}
 
 export class SolanaApplicationResolver implements ApplicationResolver {
   resolve(deviceState: DeviceSessionState, appConfig: AppConfig): ResolvedApp {

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/tokenRule.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/tokenRule.ts
@@ -28,8 +28,7 @@ import {
  *   TOKEN_INFO. The reference may be a mint directly, or — when a TX-derived
  *   MINT_ASSOC binding covers it — a token account whose bound mint is used
  *   instead. (The chain-only token-account case where no binding exists is out
- *   of scope: DMK has no RPC to resolve such a mint, mirroring the POC, which
- *   only resolves it from on-chain balances.)
+ *   of scope: DMK has no RPC to resolve such a mint from on-chain balances.)
  *
  * `mintBindings` maps a token-account address to its TX-derived mint address.
  */

--- a/packages/signer/signer-solana/src/internal/app-binder/command/utils/apduChunking.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/utils/apduChunking.test.ts
@@ -3,6 +3,7 @@ import { APDU_MAX_PAYLOAD } from "@ledgerhq/device-management-kit";
 import {
   assertChunkSize,
   buildChunkP2,
+  frameClearSignPayload,
   P2_EXTEND,
   P2_MORE,
 } from "./apduChunking";
@@ -79,6 +80,34 @@ describe("apduChunking", () => {
         expect(e._tag).toBe("ChunkTooLargeError");
         expect(e.message).toMatch(/INS=0x25/);
       }
+    });
+  });
+
+  describe("frameClearSignPayload", () => {
+    it("prepends a 2-byte big-endian length of the TLV", () => {
+      expect(frameClearSignPayload(new Uint8Array([0xaa, 0xbb]))).toStrictEqual(
+        new Uint8Array([0x00, 0x02, 0xaa, 0xbb]),
+      );
+    });
+
+    it("counts the type byte in the length and places it first (substructures)", () => {
+      expect(
+        frameClearSignPayload(new Uint8Array([0xcc, 0xdd]), 0x01),
+      ).toStrictEqual(new Uint8Array([0x00, 0x03, 0x01, 0xcc, 0xdd]));
+    });
+
+    it("encodes lengths > 255 across both prefix bytes", () => {
+      const tlv = new Uint8Array(258).fill(0x7);
+      const framed = frameClearSignPayload(tlv);
+      expect(framed[0]).toBe(0x01);
+      expect(framed[1]).toBe(0x02);
+      expect(framed.length).toBe(260);
+    });
+
+    it("handles an empty TLV", () => {
+      expect(frameClearSignPayload(new Uint8Array([]))).toStrictEqual(
+        new Uint8Array([0x00, 0x00]),
+      );
     });
   });
 });

--- a/packages/signer/signer-solana/src/internal/app-binder/command/utils/apduChunking.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/utils/apduChunking.ts
@@ -29,3 +29,33 @@ export function assertChunkSize(payload: Uint8Array, ins: number): void {
     throw new ChunkTooLargeError(payload.length, ins);
   }
 }
+
+/**
+ * Prepend the 2-byte big-endian length prefix the generic clear-signing PROVIDE
+ * commands expect (`INSTRUCTION_INFO` 0x24, `INSTRUCTION_SUBSTRUCTURE` 0x25,
+ * `ENUM_VARIANT` 0x26, `TOKEN_INFO` 0x22, `TOKEN_ACCOUNT_STATE` 0x27,
+ * `ALT_RESOLUTION` 0x28, `TRUSTED_NAME` 0x21). The length covers everything
+ * after the prefix; the framed payload is then split with {@link buildChunkP2}
+ * so the prefix lands in the first chunk. When `typeByte` is provided
+ * (substructures) it is the first byte of the body and counted in the length.
+ *
+ * Note: the chunking itself is unchanged from every other Solana command, this
+ * only adds the per-command length prefix, which the generic preview / prompt /
+ * delayed APDUs do not use.
+ */
+export function frameClearSignPayload(
+  tlv: Uint8Array,
+  typeByte?: number,
+): Uint8Array {
+  const bodyLength = tlv.length + (typeByte === undefined ? 0 : 1);
+  const framed = new Uint8Array(2 + bodyLength);
+  framed[0] = (bodyLength >>> 8) & 0xff;
+  framed[1] = bodyLength & 0xff;
+  let offset = 2;
+  if (typeByte !== undefined) {
+    framed[offset] = typeByte & 0xff;
+    offset += 1;
+  }
+  framed.set(tlv, offset);
+  return framed;
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/GenericClearSignDeviceAction.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/GenericClearSignDeviceAction.test.ts
@@ -1,0 +1,212 @@
+import { type ContextModule } from "@ledgerhq/context-module";
+import {
+  CommandResultFactory,
+  type DeviceActionState,
+  DeviceActionStatus,
+  DeviceModelId,
+  DeviceSessionStateType,
+  DeviceStatus,
+} from "@ledgerhq/device-management-kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SolanaAppCommandError } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+
+import { makeDeviceActionInternalApiMock } from "./__test-utils__/makeInternalApi";
+import {
+  type GenericClearSignDAError,
+  type GenericClearSignDAInput,
+  type GenericClearSignDAIntermediateValue,
+  type GenericClearSignDAOutput,
+  GenericClearSignDeviceAction,
+} from "./GenericClearSignDeviceAction";
+
+const defaultDerivation = "44'/501'/0'/0'";
+const exampleTx = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+const contextModuleStub = { getContexts: vi.fn() } as unknown as ContextModule;
+
+let apiMock: ReturnType<typeof makeDeviceActionInternalApiMock>;
+let buildMock: ReturnType<typeof vi.fn>;
+let provideMock: ReturnType<typeof vi.fn>;
+let promptUiDisplayMock: ReturnType<typeof vi.fn>;
+
+function extractDeps() {
+  return {
+    buildGenericClearSignContext: buildMock,
+    provideGenericClearSignContext: provideMock,
+    promptUiDisplay: promptUiDisplayMock,
+  };
+}
+
+const input: GenericClearSignDAInput = {
+  derivationPath: defaultDerivation,
+  transaction: exampleTx,
+  contextModule: contextModuleStub,
+};
+
+function run(
+  onComplete: (
+    states: DeviceActionState<
+      GenericClearSignDAOutput,
+      GenericClearSignDAError,
+      GenericClearSignDAIntermediateValue
+    >[],
+  ) => void,
+  onError: (e: unknown) => void,
+) {
+  const action = new GenericClearSignDeviceAction({ input });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps() as any);
+  const { observable } = action._execute(apiMock);
+  const states: DeviceActionState<
+    GenericClearSignDAOutput,
+    GenericClearSignDAError,
+    GenericClearSignDAIntermediateValue
+  >[] = [];
+  observable.subscribe({
+    next: (s) => states.push(s),
+    error: onError,
+    complete: () => onComplete(states),
+  });
+}
+
+describe("GenericClearSignDeviceAction", () => {
+  beforeEach(() => {
+    apiMock = makeDeviceActionInternalApiMock();
+    apiMock.getDeviceSessionState.mockReturnValue({
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Solana", version: "1.18.0" },
+      deviceModelId: DeviceModelId.NANO_X,
+      isSecureConnectionAllowed: true,
+    });
+    buildMock = vi.fn().mockResolvedValue({
+      mode: "full",
+      poolContexts: [],
+      instructionInfoContexts: [],
+    });
+    provideMock = vi.fn().mockResolvedValue(undefined);
+    promptUiDisplayMock = vi
+      .fn()
+      .mockResolvedValue(CommandResultFactory({ data: undefined }));
+  });
+
+  it("build (recognised) → provide → prompt approved → armed", () =>
+    new Promise<void>((resolve, reject) => {
+      run((states) => {
+        try {
+          expect(buildMock).toHaveBeenCalled();
+          expect(provideMock).toHaveBeenCalled();
+          expect(promptUiDisplayMock).toHaveBeenCalled();
+          const last = states[states.length - 1]!;
+          expect(last.status).toBe(DeviceActionStatus.Completed);
+          expect(
+            last.status === DeviceActionStatus.Completed && last.output,
+          ).toBe("armed");
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      }, reject);
+    }));
+
+  it("build mode none → degraded (no provide, no prompt)", () =>
+    new Promise<void>((resolve, reject) => {
+      buildMock.mockResolvedValue({
+        mode: "none",
+        poolContexts: [],
+        instructionInfoContexts: [],
+      });
+      run((states) => {
+        try {
+          expect(provideMock).not.toHaveBeenCalled();
+          expect(promptUiDisplayMock).not.toHaveBeenCalled();
+          const last = states[states.length - 1]!;
+          expect(
+            last.status === DeviceActionStatus.Completed && last.output,
+          ).toBe("degraded");
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      }, reject);
+    }));
+
+  it("provide fails → degraded", () =>
+    new Promise<void>((resolve, reject) => {
+      provideMock.mockRejectedValue(new Error("stream boom"));
+      run((states) => {
+        try {
+          expect(promptUiDisplayMock).not.toHaveBeenCalled();
+          const last = states[states.length - 1]!;
+          expect(
+            last.status === DeviceActionStatus.Completed && last.output,
+          ).toBe("degraded");
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      }, reject);
+    }));
+
+  it("prompt non-cancel error → degraded", () =>
+    new Promise<void>((resolve, reject) => {
+      promptUiDisplayMock.mockResolvedValue(
+        CommandResultFactory({
+          error: new SolanaAppCommandError({
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ...({ errorCode: "6a80", message: "bad data" } as any),
+          }),
+        }),
+      );
+      run((states) => {
+        try {
+          const last = states[states.length - 1]!;
+          expect(
+            last.status === DeviceActionStatus.Completed && last.output,
+          ).toBe("degraded");
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      }, reject);
+    }));
+
+  it("prompt user cancel (6985) → error", () =>
+    new Promise<void>((resolve, reject) => {
+      promptUiDisplayMock.mockResolvedValue(
+        CommandResultFactory({
+          error: new SolanaAppCommandError({
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ...({ errorCode: "6985", message: "Canceled by user" } as any),
+          }),
+        }),
+      );
+      run((states) => {
+        try {
+          expect(states[states.length - 1]!.status).toBe(
+            DeviceActionStatus.Error,
+          );
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      }, reject);
+    }));
+
+  it("build throws → degraded", () =>
+    new Promise<void>((resolve, reject) => {
+      buildMock.mockRejectedValue(new Error("parse boom"));
+      run((states) => {
+        try {
+          const last = states[states.length - 1]!;
+          expect(
+            last.status === DeviceActionStatus.Completed && last.output,
+          ).toBe("degraded");
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      }, reject);
+    }));
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/GenericClearSignDeviceAction.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/GenericClearSignDeviceAction.ts
@@ -1,0 +1,394 @@
+import {
+  type ClearSignContext,
+  type ContextModule,
+} from "@ledgerhq/context-module";
+import {
+  type CommandResult,
+  type DeviceActionState,
+  type DeviceActionStateMachine,
+  type InternalApi,
+  isSuccessCommandResult,
+  type StateMachineTypes,
+  UserInteractionRequired,
+  XStateDeviceAction,
+} from "@ledgerhq/device-management-kit";
+import { Left, Right } from "purify-ts";
+import { assign, fromPromise, setup } from "xstate";
+
+import {
+  type ClearSignMode,
+  type SignTransactionDAError,
+  type SignTransactionDAStateStep,
+  signTransactionDAStateSteps,
+} from "@api/app-binder/SignTransactionDeviceActionTypes";
+import { PromptUiDisplayCommand } from "@internal/app-binder/command/PromptUiDisplayCommand";
+import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+import {
+  BuildGenericClearSignContextTask,
+  type GenericClearSignContext,
+} from "@internal/app-binder/task/BuildGenericClearSignContextTask";
+import { ProvideGenericClearSignContextTask } from "@internal/app-binder/task/ProvideGenericClearSignContextTask";
+
+/**
+ * Outcome of the generic clear-sign attempt. This machine prepares and arms the
+ * device but does not sign — the terminal SIGN MESSAGE DELAYED is run by the
+ * caller (shared with the legacy delayed-sign flow).
+ * - `Right("armed")` — descriptors streamed and PROMPT UI DISPLAY approved; the
+ *   device fingerprint is armed and ready for the terminal sign.
+ * - `Right("degraded")` — no instruction recognised or a best-effort step
+ *   failed; the caller should fall back to the legacy path.
+ * - `Left(error)` — the user cancelled; the caller must surface it.
+ */
+export type GenericClearSignDAOutput = "armed" | "degraded";
+
+export type GenericClearSignDAInput = {
+  readonly derivationPath: string;
+  readonly transaction: Uint8Array;
+  readonly contextModule: ContextModule;
+};
+
+export type GenericClearSignDAError = SignTransactionDAError;
+
+export type GenericClearSignDAIntermediateValue = {
+  requiredUserInteraction: UserInteractionRequired;
+  step: SignTransactionDAStateStep;
+};
+
+export type GenericClearSignDAInternalState = {
+  readonly error: GenericClearSignDAError | null;
+  readonly outcome: GenericClearSignDAOutput | null;
+  readonly mode: ClearSignMode | null;
+  readonly poolContexts: ClearSignContext[] | null;
+  readonly instructionInfoContexts: ClearSignContext[] | null;
+};
+
+export type GenericClearSignDAState = DeviceActionState<
+  GenericClearSignDAOutput,
+  GenericClearSignDAError,
+  GenericClearSignDAIntermediateValue
+>;
+
+export type MachineDependencies = {
+  readonly buildGenericClearSignContext: (arg0: {
+    input: { contextModule: ContextModule; transaction: Uint8Array };
+  }) => Promise<GenericClearSignContext>;
+  readonly provideGenericClearSignContext: (arg0: {
+    input: {
+      derivationPath: string;
+      transaction: Uint8Array;
+      poolContexts: ClearSignContext[];
+      instructionInfoContexts: ClearSignContext[];
+    };
+  }) => Promise<void>;
+  readonly promptUiDisplay: () => Promise<
+    CommandResult<void, SolanaAppErrorCodes>
+  >;
+};
+
+const USER_REJECTION_CODE: SolanaAppErrorCodes = "6985";
+
+/** A `6985` ("Canceled by user") is a user decision, not a clear-sign error. */
+function isUserCancelResult(
+  result: CommandResult<void, SolanaAppErrorCodes>,
+): boolean {
+  return (
+    !isSuccessCommandResult(result) &&
+    "errorCode" in result.error &&
+    result.error.errorCode === USER_REJECTION_CODE
+  );
+}
+
+/**
+ * Prepares a transaction for generic clear-signing and arms the device:
+ * `BuildContext` (host-side preparation) → `ProvideContext` (descriptor
+ * streaming) → `PromptUiDisplay` (user approval). Every step is best-effort: a
+ * failure resolves to `"degraded"` so the caller can fall back to the legacy
+ * path; only a user cancel surfaces as `Left(error)`. The terminal SIGN MESSAGE
+ * DELAYED is performed by the caller once this resolves to `"armed"`.
+ */
+export class GenericClearSignDeviceAction extends XStateDeviceAction<
+  GenericClearSignDAOutput,
+  GenericClearSignDAInput,
+  GenericClearSignDAError,
+  GenericClearSignDAIntermediateValue,
+  GenericClearSignDAInternalState
+> {
+  makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    GenericClearSignDAOutput,
+    GenericClearSignDAInput,
+    GenericClearSignDAError,
+    GenericClearSignDAIntermediateValue,
+    GenericClearSignDAInternalState
+  > {
+    type types = StateMachineTypes<
+      GenericClearSignDAOutput,
+      GenericClearSignDAInput,
+      GenericClearSignDAError,
+      GenericClearSignDAIntermediateValue,
+      GenericClearSignDAInternalState
+    >;
+
+    const {
+      buildGenericClearSignContext,
+      provideGenericClearSignContext,
+      promptUiDisplay,
+    } = this.extractDependencies(internalApi);
+
+    const logger = this.getLoggerFactory(internalApi)(
+      "GenericClearSignDeviceAction",
+    );
+
+    return setup({
+      types: {
+        input: {} as types["input"],
+        context: {} as types["context"],
+        output: {} as types["output"],
+      },
+      actors: {
+        buildGenericClearSignContext: fromPromise(buildGenericClearSignContext),
+        provideGenericClearSignContext: fromPromise(
+          provideGenericClearSignContext,
+        ),
+        promptUiDisplay: fromPromise(promptUiDisplay),
+      },
+      guards: {
+        // At least one instruction was recognised (CAL coverage), so there is
+        // something to clear-sign.
+        isContextRecognised: ({ event }) =>
+          (event as unknown as { output: GenericClearSignContext }).output
+            .mode !== "none",
+        isPromptApproved: ({ event }) =>
+          isSuccessCommandResult(
+            (
+              event as unknown as {
+                output: CommandResult<void, SolanaAppErrorCodes>;
+              }
+            ).output,
+          ),
+        isPromptUserCancel: ({ event }) =>
+          isUserCancelResult(
+            (
+              event as unknown as {
+                output: CommandResult<void, SolanaAppErrorCodes>;
+              }
+            ).output,
+          ),
+      },
+    }).createMachine({
+      id: "GenericClearSignDeviceAction",
+      initial: "BuildContext",
+      context: ({ input }) => ({
+        input,
+        intermediateValue: {
+          requiredUserInteraction: UserInteractionRequired.None,
+          step: signTransactionDAStateSteps.BUILD_GENERIC_CLEAR_SIGN_CONTEXT,
+        },
+        _internalState: {
+          error: null,
+          outcome: null,
+          mode: null,
+          poolContexts: null,
+          instructionInfoContexts: null,
+        },
+      }),
+      states: {
+        BuildContext: {
+          entry: assign({
+            intermediateValue: () => ({
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: signTransactionDAStateSteps.BUILD_GENERIC_CLEAR_SIGN_CONTEXT,
+            }),
+          }),
+          invoke: {
+            id: "buildGenericClearSignContext",
+            src: "buildGenericClearSignContext",
+            input: ({ context }) => ({
+              contextModule: context.input.contextModule,
+              transaction: context.input.transaction,
+            }),
+            onDone: [
+              {
+                target: "ProvideContext",
+                guard: "isContextRecognised",
+                actions: assign({
+                  _internalState: ({ event, context }) => ({
+                    ...context._internalState,
+                    mode: event.output.mode,
+                    poolContexts: event.output.poolContexts,
+                    instructionInfoContexts:
+                      event.output.instructionInfoContexts,
+                  }),
+                }),
+              },
+              {
+                target: "Degraded",
+                actions: assign({
+                  _internalState: ({ event, context }) => ({
+                    ...context._internalState,
+                    mode: event.output.mode,
+                  }),
+                }),
+              },
+            ],
+            onError: {
+              target: "Degraded",
+              actions: ({ event }) =>
+                logger.info(
+                  "[ClearSign] build failed; falling back to legacy",
+                  {
+                    data: { error: event.error },
+                  },
+                ),
+            },
+          },
+        },
+        ProvideContext: {
+          entry: assign({
+            intermediateValue: () => ({
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: signTransactionDAStateSteps.PROVIDE_GENERIC_CLEAR_SIGN_CONTEXT,
+            }),
+          }),
+          invoke: {
+            id: "provideGenericClearSignContext",
+            src: "provideGenericClearSignContext",
+            input: ({ context }) => ({
+              derivationPath: context.input.derivationPath,
+              transaction: context.input.transaction,
+              poolContexts: context._internalState.poolContexts ?? [],
+              instructionInfoContexts:
+                context._internalState.instructionInfoContexts ?? [],
+            }),
+            onDone: { target: "PromptUiDisplay" },
+            onError: {
+              target: "Degraded",
+              actions: ({ event }) =>
+                logger.info(
+                  "[ClearSign] descriptor streaming failed; falling back to legacy",
+                  { data: { error: event.error } },
+                ),
+            },
+          },
+        },
+        PromptUiDisplay: {
+          entry: assign({
+            intermediateValue: () => ({
+              requiredUserInteraction: UserInteractionRequired.SignTransaction,
+              step: signTransactionDAStateSteps.PROMPT_UI_DISPLAY,
+            }),
+          }),
+          invoke: {
+            id: "promptUiDisplay",
+            src: "promptUiDisplay",
+            onDone: [
+              {
+                // Approved: the device fingerprint is armed (over the message
+                // with the blockhash zeroed). The caller runs the terminal SIGN
+                // MESSAGE DELAYED; no 0x08 preview here — that would discard the
+                // armed clear-sign session.
+                target: "Armed",
+                guard: "isPromptApproved",
+              },
+              {
+                // User canceled: surface, do not re-prompt via legacy.
+                target: "Error",
+                guard: "isPromptUserCancel",
+                actions: assign({
+                  _internalState: ({ event, context }) =>
+                    isSuccessCommandResult(event.output)
+                      ? context._internalState
+                      : {
+                          ...context._internalState,
+                          error: event.output.error,
+                        },
+                }),
+              },
+              {
+                // Any other device error: degrade to legacy.
+                target: "Degraded",
+                actions: ({ event }) =>
+                  logger.info(
+                    "[ClearSign] PROMPT UI DISPLAY failed; falling back to legacy",
+                    { data: { output: event.output } },
+                  ),
+              },
+            ],
+            onError: {
+              target: "Degraded",
+              actions: ({ event }) =>
+                logger.info(
+                  "[ClearSign] PROMPT UI DISPLAY threw; falling back to legacy",
+                  { data: { error: event.error } },
+                ),
+            },
+          },
+        },
+        Armed: {
+          entry: assign({
+            _internalState: ({ context }) => ({
+              ...context._internalState,
+              outcome: "armed" as const,
+            }),
+          }),
+          type: "final",
+        },
+        Degraded: {
+          entry: assign({
+            _internalState: ({ context }) => ({
+              ...context._internalState,
+              outcome: "degraded" as const,
+            }),
+          }),
+          type: "final",
+        },
+        Error: { type: "final" },
+      },
+      output: ({ context }) => {
+        if (context._internalState.error)
+          return Left(context._internalState.error);
+        return Right(context._internalState.outcome ?? "degraded");
+      },
+    });
+  }
+
+  extractDependencies(internalApi: InternalApi): MachineDependencies {
+    const loggerFactory = this.getLoggerFactory(internalApi);
+
+    const buildGenericClearSignContext = async (arg0: {
+      input: { contextModule: ContextModule; transaction: Uint8Array };
+    }) =>
+      new BuildGenericClearSignContextTask(internalApi, {
+        contextModule: arg0.input.contextModule,
+        transaction: arg0.input.transaction,
+        deviceModelId: internalApi.getDeviceSessionState().deviceModelId,
+        loggerFactory,
+      }).run();
+
+    const provideGenericClearSignContext = async (arg0: {
+      input: {
+        derivationPath: string;
+        transaction: Uint8Array;
+        poolContexts: ClearSignContext[];
+        instructionInfoContexts: ClearSignContext[];
+      };
+    }) =>
+      new ProvideGenericClearSignContextTask(internalApi, {
+        derivationPath: arg0.input.derivationPath,
+        transaction: arg0.input.transaction,
+        poolContexts: arg0.input.poolContexts,
+        instructionInfoContexts: arg0.input.instructionInfoContexts,
+        loggerFactory,
+      }).run();
+
+    const promptUiDisplay = async () =>
+      internalApi.sendCommand(new PromptUiDisplayCommand());
+
+    return {
+      buildGenericClearSignContext,
+      provideGenericClearSignContext,
+      promptUiDisplay,
+    };
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/ShallowClearSignDeviceAction.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/ShallowClearSignDeviceAction.test.ts
@@ -1,0 +1,314 @@
+import {
+  CommandResultFactory,
+  type DeviceActionState,
+  DeviceActionStatus,
+  DeviceModelId,
+  DeviceSessionStateType,
+  DeviceStatus,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+import { Nothing } from "purify-ts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type AppConfiguration } from "@api/model/AppConfiguration";
+import { PublicKeyDisplayMode } from "@api/model/PublicKeyDisplayMode";
+import { SolanaTransactionTypes } from "@internal/app-binder/services/TransactionInspector";
+
+import { makeDeviceActionInternalApiMock } from "./__test-utils__/makeInternalApi";
+import {
+  type ShallowClearSignDAError,
+  type ShallowClearSignDAInput,
+  type ShallowClearSignDAIntermediateValue,
+  ShallowClearSignDeviceAction,
+} from "./ShallowClearSignDeviceAction";
+
+const defaultDerivation = "44'/501'/0'/0'";
+const exampleTx = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+
+const appConfig: AppConfiguration = {
+  blindSigningEnabled: true,
+  pubKeyDisplayMode: PublicKeyDisplayMode.LONG,
+  version: "1.10.0",
+  web3ChecksEnabled: false,
+  web3ChecksOptIn: false,
+};
+
+const contextModuleStub = { getContexts: vi.fn() } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+const shallowContext = {
+  tlvDescriptor: new Uint8Array([1]),
+  trustedNamePKICertificate: {
+    keyUsageNumber: 0,
+    payload: new Uint8Array([1]),
+  },
+  loadersResults: [],
+  contextErrorCount: 0,
+};
+
+let apiMock: ReturnType<typeof makeDeviceActionInternalApiMock>;
+let inspectMock: ReturnType<typeof vi.fn>;
+let getPubKeyMock: ReturnType<typeof vi.fn>;
+let buildMock: ReturnType<typeof vi.fn>;
+let provideMock: ReturnType<typeof vi.fn>;
+
+function extractDeps() {
+  return {
+    inspectTransaction: inspectMock,
+    getPubKey: getPubKeyMock,
+    buildShallowClearSignContext: buildMock,
+    provideShallowClearSignContext: provideMock,
+  };
+}
+
+function run(
+  input: ShallowClearSignDAInput,
+  onComplete: (
+    states: DeviceActionState<
+      void,
+      ShallowClearSignDAError,
+      ShallowClearSignDAIntermediateValue
+    >[],
+  ) => void,
+  onError: (e: unknown) => void,
+) {
+  const action = new ShallowClearSignDeviceAction({ input });
+  vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps() as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+  const { observable } = action._execute(apiMock);
+  const states: DeviceActionState<
+    void,
+    ShallowClearSignDAError,
+    ShallowClearSignDAIntermediateValue
+  >[] = [];
+  observable.subscribe({
+    next: (s) => states.push(s),
+    error: onError,
+    complete: () => onComplete(states),
+  });
+}
+
+const splInput: ShallowClearSignDAInput = {
+  derivationPath: defaultDerivation,
+  transaction: exampleTx,
+  contextModule: contextModuleStub,
+  appConfig,
+};
+
+describe("ShallowClearSignDeviceAction", () => {
+  beforeEach(() => {
+    apiMock = makeDeviceActionInternalApiMock();
+    apiMock.getDeviceSessionState.mockReturnValue({
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Solana", version: "1.10.0" },
+      deviceModelId: DeviceModelId.NANO_X,
+      isSecureConnectionAllowed: true,
+    });
+    inspectMock = vi.fn().mockResolvedValue({
+      transactionType: SolanaTransactionTypes.SPL,
+      data: { tokenAddress: null, createATA: false },
+    });
+    getPubKeyMock = vi
+      .fn()
+      .mockResolvedValue(CommandResultFactory({ data: "pk" }));
+    buildMock = vi.fn().mockResolvedValue(shallowContext);
+    provideMock = vi.fn().mockResolvedValue(Nothing);
+  });
+
+  it("SPL tx: inspect → getPubKey → build → provide → done", () =>
+    new Promise<void>((resolve, reject) => {
+      run(
+        splInput,
+        (states) => {
+          try {
+            expect(inspectMock).toHaveBeenCalled();
+            expect(getPubKeyMock).toHaveBeenCalled();
+            expect(buildMock).toHaveBeenCalled();
+            expect(provideMock).toHaveBeenCalled();
+            expect(states[states.length - 1]!.status).toBe(
+              DeviceActionStatus.Completed,
+            );
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        reject,
+      );
+    }));
+
+  it("SWAP tx: builds context like SPL", () =>
+    new Promise<void>((resolve, reject) => {
+      inspectMock.mockResolvedValue({
+        transactionType: SolanaTransactionTypes.SWAP,
+        data: { tokenAddress: null, createATA: false },
+      });
+      run(
+        splInput,
+        (states) => {
+          try {
+            expect(inspectMock).toHaveBeenCalled();
+            expect(getPubKeyMock).toHaveBeenCalled();
+            expect(buildMock).toHaveBeenCalled();
+            expect(provideMock).toHaveBeenCalled();
+            expect(states[states.length - 1]!.status).toBe(
+              DeviceActionStatus.Completed,
+            );
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        reject,
+      );
+    }));
+
+  it("inspect rejects → completes without building (blind fallback)", () =>
+    new Promise<void>((resolve, reject) => {
+      inspectMock.mockRejectedValue(new InvalidStatusWordError("insp"));
+      run(
+        splInput,
+        (states) => {
+          try {
+            expect(buildMock).not.toHaveBeenCalled();
+            expect(provideMock).not.toHaveBeenCalled();
+            expect(states[states.length - 1]!.status).toBe(
+              DeviceActionStatus.Completed,
+            );
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        reject,
+      );
+    }));
+
+  it("non-SPL standard tx with web3 unsupported (Nano X): skips build entirely", () =>
+    new Promise<void>((resolve, reject) => {
+      inspectMock.mockResolvedValue({
+        transactionType: SolanaTransactionTypes.STANDARD,
+      });
+      run(
+        splInput,
+        (states) => {
+          try {
+            // SPL supported → inspect runs, but STANDARD + no web3 → no build.
+            expect(inspectMock).toHaveBeenCalled();
+            expect(getPubKeyMock).not.toHaveBeenCalled();
+            expect(buildMock).not.toHaveBeenCalled();
+            expect(states[states.length - 1]!.status).toBe(
+              DeviceActionStatus.Completed,
+            );
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        reject,
+      );
+    }));
+
+  it("non-SPL standard tx but web3-checks supported (Flex): still builds context", () =>
+    new Promise<void>((resolve, reject) => {
+      apiMock.getDeviceSessionState.mockReturnValue({
+        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+        deviceStatus: DeviceStatus.CONNECTED,
+        installedApps: [],
+        currentApp: { name: "Solana", version: "1.15.0" },
+        deviceModelId: DeviceModelId.FLEX,
+        isSecureConnectionAllowed: true,
+      });
+      inspectMock.mockResolvedValue({
+        transactionType: SolanaTransactionTypes.STANDARD,
+      });
+      run(
+        // web3-checks needs both a supported model (Flex) and app version ≥ 1.15.
+        { ...splInput, appConfig: { ...appConfig, version: "1.15.0" } },
+        (states) => {
+          try {
+            // STANDARD → shouldBuildContext false, but web3 supported → build.
+            expect(inspectMock).toHaveBeenCalled();
+            expect(getPubKeyMock).toHaveBeenCalled();
+            expect(buildMock).toHaveBeenCalled();
+            expect(provideMock).toHaveBeenCalled();
+            expect(states[states.length - 1]!.status).toBe(
+              DeviceActionStatus.Completed,
+            );
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        reject,
+      );
+    }));
+
+  it("SPL unsupported (Nano S): skips inspect and completes", () =>
+    new Promise<void>((resolve, reject) => {
+      apiMock.getDeviceSessionState.mockReturnValue({
+        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+        deviceStatus: DeviceStatus.CONNECTED,
+        installedApps: [],
+        currentApp: { name: "Solana", version: "1.10.0" },
+        deviceModelId: DeviceModelId.NANO_S,
+        isSecureConnectionAllowed: true,
+      });
+      run(
+        splInput,
+        (states) => {
+          try {
+            expect(inspectMock).not.toHaveBeenCalled();
+            expect(buildMock).not.toHaveBeenCalled();
+            expect(states[states.length - 1]!.status).toBe(
+              DeviceActionStatus.Completed,
+            );
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        reject,
+      );
+    }));
+
+  it("build throws → completes without providing", () =>
+    new Promise<void>((resolve, reject) => {
+      buildMock.mockRejectedValue(new Error("build boom"));
+      run(
+        splInput,
+        (states) => {
+          try {
+            expect(buildMock).toHaveBeenCalled();
+            expect(provideMock).not.toHaveBeenCalled();
+            expect(states[states.length - 1]!.status).toBe(
+              DeviceActionStatus.Completed,
+            );
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        reject,
+      );
+    }));
+
+  it("provide rejects → still completes (blind fallback)", () =>
+    new Promise<void>((resolve, reject) => {
+      provideMock.mockRejectedValue(new Error("provide boom"));
+      run(
+        splInput,
+        (states) => {
+          try {
+            expect(provideMock).toHaveBeenCalled();
+            expect(states[states.length - 1]!.status).toBe(
+              DeviceActionStatus.Completed,
+            );
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        reject,
+      );
+    }));
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/ShallowClearSignDeviceAction.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/ShallowClearSignDeviceAction.ts
@@ -1,0 +1,394 @@
+import {
+  type ContextModule,
+  type SolanaTransactionContextResultSuccess,
+} from "@ledgerhq/context-module";
+import {
+  type CommandErrorResult,
+  type CommandResult,
+  type DeviceActionState,
+  type DeviceActionStateMachine,
+  type InternalApi,
+  isSuccessCommandResult,
+  type StateMachineTypes,
+  UnknownDAError,
+  UserInteractionRequired,
+  XStateDeviceAction,
+} from "@ledgerhq/device-management-kit";
+import { type Maybe, Right } from "purify-ts";
+import { assign, fromPromise, setup } from "xstate";
+
+import {
+  type SignTransactionDAError,
+  type SignTransactionDAStateStep,
+  signTransactionDAStateSteps,
+} from "@api/app-binder/SignTransactionDeviceActionTypes";
+import { type AppConfiguration } from "@api/model/AppConfiguration";
+import { type TransactionResolutionContext } from "@api/model/TransactionResolutionContext";
+import {
+  GetPubKeyCommand,
+  type GetPubKeyCommandResponse,
+} from "@internal/app-binder/command/GetPubKeyCommand";
+import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+import {
+  SolanaTransactionTypes,
+  TransactionInspector,
+  type TxInspectorResult,
+} from "@internal/app-binder/services/TransactionInspector";
+import { isSolanaFeatureSupported } from "@internal/app-binder/SolanaApplicationResolver";
+import {
+  BuildShallowClearSignContextTask,
+  type BuildShallowClearSignContextTaskArgs,
+  type ShallowClearSignContext,
+} from "@internal/app-binder/task/BuildShallowClearSignContextTask";
+import {
+  ProvideShallowClearSignContextTask,
+  type ProvideShallowClearSignContextTaskArgs,
+} from "@internal/app-binder/task/ProvideShallowClearSignContextTask";
+
+/**
+ * Best-effort outcome: this machine only streams legacy SPL / token descriptors
+ * to the device, it never signs. Any failure is swallowed (the caller signs
+ * blind), so the output is always `Right`.
+ */
+export type ShallowClearSignDAOutput = void;
+
+export type ShallowClearSignDAInput = {
+  readonly derivationPath: string;
+  readonly transaction: Uint8Array;
+  readonly contextModule: ContextModule;
+  readonly appConfig: AppConfiguration;
+  readonly rpcUrl?: string;
+  readonly resolutionContext?: TransactionResolutionContext;
+};
+
+export type ShallowClearSignDAError = SignTransactionDAError;
+
+export type ShallowClearSignDAIntermediateValue = {
+  requiredUserInteraction: UserInteractionRequired;
+  step: SignTransactionDAStateStep;
+};
+
+export type ShallowClearSignDAInternalState = {
+  readonly inspectorResult: TxInspectorResult | null;
+  readonly signerAddress: string | null;
+  readonly solanaTransactionContext: SolanaTransactionContextResultSuccess | null;
+};
+
+export type ShallowClearSignDAState = DeviceActionState<
+  ShallowClearSignDAOutput,
+  ShallowClearSignDAError,
+  ShallowClearSignDAIntermediateValue
+>;
+
+export type MachineDependencies = {
+  readonly inspectTransaction: (arg0: {
+    serializedTransaction: Uint8Array;
+    resolutionContext?: TransactionResolutionContext;
+    rpcUrl?: string;
+  }) => Promise<TxInspectorResult>;
+  readonly getPubKey: (arg0: {
+    input: { derivationPath: string; checkOnDevice: boolean };
+  }) => Promise<CommandResult<GetPubKeyCommandResponse, SolanaAppErrorCodes>>;
+  readonly buildShallowClearSignContext: (arg0: {
+    input: BuildShallowClearSignContextTaskArgs;
+  }) => Promise<ShallowClearSignContext>;
+  readonly provideShallowClearSignContext: (arg0: {
+    input: ProvideShallowClearSignContextTaskArgs;
+  }) => Promise<Maybe<CommandErrorResult<SolanaAppErrorCodes>>>;
+};
+
+/**
+ * Streams legacy SPL / token clear-sign descriptors to the device before
+ * signing: it inspects the transaction, and — when the app supports SPL or
+ * web3-checks — fetches the public key, builds the descriptor context and
+ * provides it. Every step is best-effort: a failure simply ends the machine so
+ * the caller falls back to blind signing.
+ */
+export class ShallowClearSignDeviceAction extends XStateDeviceAction<
+  ShallowClearSignDAOutput,
+  ShallowClearSignDAInput,
+  ShallowClearSignDAError,
+  ShallowClearSignDAIntermediateValue,
+  ShallowClearSignDAInternalState
+> {
+  makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    ShallowClearSignDAOutput,
+    ShallowClearSignDAInput,
+    ShallowClearSignDAError,
+    ShallowClearSignDAIntermediateValue,
+    ShallowClearSignDAInternalState
+  > {
+    type types = StateMachineTypes<
+      ShallowClearSignDAOutput,
+      ShallowClearSignDAInput,
+      ShallowClearSignDAError,
+      ShallowClearSignDAIntermediateValue,
+      ShallowClearSignDAInternalState
+    >;
+
+    const {
+      inspectTransaction,
+      getPubKey,
+      buildShallowClearSignContext,
+      provideShallowClearSignContext,
+    } = this.extractDependencies(internalApi);
+
+    return setup({
+      types: {
+        input: {} as types["input"],
+        context: {} as types["context"],
+        output: {} as types["output"],
+      },
+      actors: {
+        inspectTransaction: fromPromise(
+          ({
+            input,
+          }: {
+            input: {
+              serializedTransaction: Uint8Array;
+              resolutionContext?: TransactionResolutionContext;
+              rpcUrl?: string;
+            };
+          }) =>
+            inspectTransaction({
+              serializedTransaction: input.serializedTransaction,
+              resolutionContext: input.resolutionContext,
+              rpcUrl: input.rpcUrl,
+            }),
+        ),
+        getPubKey: fromPromise(getPubKey),
+        buildShallowClearSignContext: fromPromise(buildShallowClearSignContext),
+        provideShallowClearSignContext: fromPromise(
+          provideShallowClearSignContext,
+        ),
+      },
+      guards: {
+        isSPLSupported: ({ context }) =>
+          isSolanaFeatureSupported(internalApi, "spl", context.input.appConfig),
+        isWeb3ChecksSupported: ({ context }) =>
+          isSolanaFeatureSupported(
+            internalApi,
+            "web3Checks",
+            context.input.appConfig,
+          ),
+        shouldBuildContext: ({ context }) =>
+          context._internalState.inspectorResult?.transactionType ===
+            SolanaTransactionTypes.SPL ||
+          context._internalState.inspectorResult?.transactionType ===
+            SolanaTransactionTypes.SWAP,
+      },
+    }).createMachine({
+      id: "ShallowClearSignDeviceAction",
+      initial: "CheckSPLSupported",
+      context: ({ input }) => ({
+        input,
+        intermediateValue: {
+          requiredUserInteraction: UserInteractionRequired.None,
+          step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
+        },
+        _internalState: {
+          inspectorResult: null,
+          signerAddress: null,
+          solanaTransactionContext: null,
+        },
+      }),
+      states: {
+        CheckSPLSupported: {
+          always: [
+            { target: "InspectTransaction", guard: "isSPLSupported" },
+            { target: "CheckBuildNeeded" },
+          ],
+        },
+        InspectTransaction: {
+          entry: assign({
+            intermediateValue: () => ({
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
+            }),
+          }),
+          invoke: {
+            id: "inspectTransaction",
+            src: "inspectTransaction",
+            input: ({ context }) => ({
+              serializedTransaction: context.input.transaction,
+              resolutionContext: context.input.resolutionContext,
+              rpcUrl: context.input.rpcUrl,
+            }),
+            onDone: {
+              target: "CheckBuildNeeded",
+              actions: assign({
+                _internalState: ({ context, event }) => ({
+                  ...context._internalState,
+                  inspectorResult: event.output,
+                }),
+              }),
+            },
+            onError: { target: "Done" },
+          },
+        },
+        // Build the descriptor context when the inspected type needs it
+        // (SPL / SWAP) or when web3-checks are supported; otherwise skip.
+        CheckBuildNeeded: {
+          always: [
+            { target: "GetPubKey", guard: "shouldBuildContext" },
+            { target: "GetPubKey", guard: "isWeb3ChecksSupported" },
+            { target: "Done" },
+          ],
+        },
+        GetPubKey: {
+          entry: assign({
+            intermediateValue: () => ({
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: signTransactionDAStateSteps.GET_PUB_KEY,
+            }),
+          }),
+          invoke: {
+            id: "getPubKey",
+            src: "getPubKey",
+            input: ({ context }) => ({
+              derivationPath: context.input.derivationPath,
+              checkOnDevice: false,
+            }),
+            onDone: {
+              target: "BuildContext",
+              actions: assign({
+                _internalState: ({ event, context }) =>
+                  isSuccessCommandResult(event.output)
+                    ? {
+                        ...context._internalState,
+                        signerAddress: event.output.data,
+                      }
+                    : context._internalState,
+              }),
+            },
+            onError: { target: "BuildContext" },
+          },
+        },
+        BuildContext: {
+          entry: assign({
+            intermediateValue: () => ({
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: signTransactionDAStateSteps.BUILD_SHALLOW_CLEAR_SIGN_CONTEXT,
+            }),
+          }),
+          invoke: {
+            id: "buildShallowClearSignContext",
+            src: "buildShallowClearSignContext",
+            input: ({ context }) => {
+              const inspectorData =
+                context._internalState.inspectorResult?.data;
+              return {
+                contextModule: context.input.contextModule,
+                loggerFactory: this.getLoggerFactory(internalApi),
+                transactionBytes: context.input.transaction,
+                signerAddress: context._internalState.signerAddress,
+                options: {
+                  tokenAddress: inspectorData?.tokenAddress,
+                  createATA: inspectorData?.createATA,
+                  tokenInternalId:
+                    context.input.resolutionContext?.tokenInternalId,
+                  templateId: context.input.resolutionContext?.templateId,
+                },
+              };
+            },
+            onDone: {
+              target: "ProvideContext",
+              actions: assign({
+                _internalState: ({ event, context }) => ({
+                  ...context._internalState,
+                  solanaTransactionContext: {
+                    tlvDescriptor: event.output.tlvDescriptor,
+                    trustedNamePKICertificate:
+                      event.output.trustedNamePKICertificate,
+                    loadersResults: event.output.loadersResults,
+                    contextErrorCount: event.output.contextErrorCount,
+                  },
+                }),
+              }),
+            },
+            onError: { target: "Done" },
+          },
+        },
+        ProvideContext: {
+          entry: assign({
+            intermediateValue: () => ({
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: signTransactionDAStateSteps.PROVIDE_SHALLOW_CLEAR_SIGN_CONTEXT,
+            }),
+          }),
+          invoke: {
+            id: "provideShallowClearSignContext",
+            src: "provideShallowClearSignContext",
+            input: ({ context }) => {
+              if (!context._internalState.solanaTransactionContext) {
+                throw new UnknownDAError(
+                  "Solana transaction context is not available",
+                );
+              }
+              return {
+                ...context._internalState.solanaTransactionContext,
+                transactionBytes: context.input.transaction,
+                loggerFactory: this.getLoggerFactory(internalApi),
+              };
+            },
+            onDone: { target: "Done" },
+            onError: {
+              target: "Done",
+              actions: ({ event }) => {
+                this.logger?.error(
+                  "[ProvideShallowClearSignContext] Failed to provide transaction context, falling back to blind signing",
+                  { data: { error: event.error } },
+                );
+              },
+            },
+          },
+        },
+        Done: { type: "final" },
+      },
+      output: () => Right(undefined),
+    });
+  }
+
+  extractDependencies(internalApi: InternalApi): MachineDependencies {
+    const inspectTransaction = async (arg0: {
+      serializedTransaction: Uint8Array;
+      resolutionContext?: TransactionResolutionContext;
+      rpcUrl?: string;
+    }) =>
+      Promise.resolve(
+        new TransactionInspector(arg0.rpcUrl).inspectTransactionType(
+          arg0.serializedTransaction,
+          arg0.resolutionContext?.tokenAddress,
+          arg0.resolutionContext?.createATA,
+          arg0.resolutionContext?.templateId,
+        ),
+      );
+
+    const getPubKey = async (arg0: {
+      input: { derivationPath: string; checkOnDevice: boolean };
+    }) =>
+      internalApi.sendCommand(
+        new GetPubKeyCommand({
+          derivationPath: arg0.input.derivationPath,
+          checkOnDevice: arg0.input.checkOnDevice,
+        }),
+      );
+
+    const buildShallowClearSignContext = async (arg0: {
+      input: BuildShallowClearSignContextTaskArgs;
+    }) => new BuildShallowClearSignContextTask(internalApi, arg0.input).run();
+
+    const provideShallowClearSignContext = async (arg0: {
+      input: ProvideShallowClearSignContextTaskArgs;
+    }) => new ProvideShallowClearSignContextTask(internalApi, arg0.input).run();
+
+    return {
+      inspectTransaction,
+      getPubKey,
+      buildShallowClearSignContext,
+      provideShallowClearSignContext,
+    };
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceAction.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceAction.test.ts
@@ -6,12 +6,11 @@ import {
   DeviceModelId,
   DeviceSessionStateType,
   DeviceStatus,
-  InvalidStatusWordError,
-  UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
 import { Just, Nothing } from "purify-ts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { signingOperationsDAStateSteps } from "@api/app-binder/SigningOperationsDeviceActionTypes";
 import {
   type SignTransactionDAError,
   type SignTransactionDAInput,
@@ -21,1854 +20,546 @@ import {
 import { type AppConfiguration } from "@api/model/AppConfiguration";
 import { PublicKeyDisplayMode } from "@api/model/PublicKeyDisplayMode";
 import { SolanaAppCommandError } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
-import { testDeviceActionStates } from "@internal/app-binder/device-action/__test-utils__/testDeviceActionStates";
 import { SolanaTransactionTypes } from "@internal/app-binder/services/TransactionInspector";
-import {
-  SOLANA_MIN_DELAYED_SIGNING_VERSION,
-  SOLANA_MIN_SPL_VERSION,
-} from "@internal/app-binder/SolanaApplicationResolver";
-import { type SolanaBuildContextResult } from "@internal/app-binder/task/BuildTransactionContextTask";
+import { SOLANA_MIN_GENERIC_CLEAR_SIGN_VERSION } from "@internal/app-binder/SolanaApplicationResolver";
 
 import { makeDeviceActionInternalApiMock } from "./__test-utils__/makeInternalApi";
-import { DelayedSignTransactionDeviceAction } from "./DelayedSignTransactionDeviceAction";
+import { GenericClearSignDeviceAction } from "./GenericClearSignDeviceAction";
+import { ShallowClearSignDeviceAction } from "./ShallowClearSignDeviceAction";
+import { SigningOperationsDeviceAction } from "./SigningOperationsDeviceAction";
 import { SignTransactionDeviceAction } from "./SignTransactionDeviceAction";
+
+/**
+ * The parent is a thin orchestrator: setup (open app / config / web3 opt-in) →
+ * gate → generic clear-sign machine and/or shallow clear-sign machine → the
+ * (delayed) terminal-sign machine. These tests cover the orchestration only;
+ * each child machine's behaviour is covered by its own test file.
+ */
 
 const defaultDerivation = "44'/501'/0'/0'";
 const exampleTx = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+const signature = new Uint8Array([0xaa, 0xbb]);
+const armedSig = new Uint8Array([0x77, 0x88]);
 
-const defaultAppConfig: AppConfiguration = {
-  blindSigningEnabled: true,
-  pubKeyDisplayMode: PublicKeyDisplayMode.LONG,
-  version: "2.5.10",
-  web3ChecksEnabled: false,
-  web3ChecksOptIn: false,
-};
+// Below the generic-clear-sign min version → the gate routes to the shallow
+// path; still supports spl / delayed / web3.
+const legacyVersion = "1.15.5";
 
-const contextModuleStub: ContextModule = {
+const contextModuleStub = {
   getContexts: vi.fn(),
 } as unknown as ContextModule;
 
 let apiMock: ReturnType<typeof makeDeviceActionInternalApiMock>;
 let getAppConfigMock: ReturnType<typeof vi.fn>;
 let web3CheckOptInMock: ReturnType<typeof vi.fn>;
-let getPubKeyMock: ReturnType<typeof vi.fn>;
-let buildContextMock: ReturnType<typeof vi.fn>;
-let provideContextMock: ReturnType<typeof vi.fn>;
-let signMock: ReturnType<typeof vi.fn>;
-let inspectTransactionMock: ReturnType<typeof vi.fn>;
 
-function extractDeps() {
+// Generic child deps
+let buildGenericMock: ReturnType<typeof vi.fn>;
+let provideGenericMock: ReturnType<typeof vi.fn>;
+let promptUiDisplayMock: ReturnType<typeof vi.fn>;
+// Shallow child deps
+let inspectMock: ReturnType<typeof vi.fn>;
+let shallowGetPubKeyMock: ReturnType<typeof vi.fn>;
+let buildShallowMock: ReturnType<typeof vi.fn>;
+let provideShallowMock: ReturnType<typeof vi.fn>;
+// Delayed/terminal child deps
+let previewMock: ReturnType<typeof vi.fn>;
+let delayedSignMock: ReturnType<typeof vi.fn>;
+let signMock: ReturnType<typeof vi.fn>;
+let fetchBlockhashMock: ReturnType<typeof vi.fn>;
+let zeroBlockhashMock: ReturnType<typeof vi.fn>;
+let patchBlockhashMock: ReturnType<typeof vi.fn>;
+
+let parentSpy: ReturnType<typeof vi.spyOn>;
+let genericSpy: ReturnType<typeof vi.spyOn>;
+let shallowSpy: ReturnType<typeof vi.spyOn>;
+let delayedSpy: ReturnType<typeof vi.spyOn>;
+
+function appConfig(version: string): AppConfiguration {
   return {
-    getAppConfig: getAppConfigMock,
-    web3CheckOptIn: web3CheckOptInMock,
-    getPubKey: getPubKeyMock,
-    buildContext: buildContextMock,
-    provideContext: provideContextMock,
-    signTransaction: signMock,
-    inspectTransaction: inspectTransactionMock,
+    blindSigningEnabled: true,
+    pubKeyDisplayMode: PublicKeyDisplayMode.LONG,
+    version,
+    web3ChecksEnabled: false,
+    web3ChecksOptIn: false,
   };
 }
 
-describe("SignTransactionDeviceAction (Solana)", () => {
+function session(version: string, deviceModelId = DeviceModelId.NANO_X) {
+  return {
+    sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+    deviceStatus: DeviceStatus.CONNECTED,
+    installedApps: [],
+    currentApp: { name: "Solana", version },
+    deviceModelId,
+    isSecureConnectionAllowed: true,
+  };
+}
+
+function spyChildren() {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  genericSpy = vi
+    .spyOn(GenericClearSignDeviceAction.prototype, "extractDependencies")
+    .mockReturnValue({
+      buildGenericClearSignContext: buildGenericMock,
+      provideGenericClearSignContext: provideGenericMock,
+      promptUiDisplay: promptUiDisplayMock,
+    } as any) as any;
+  shallowSpy = vi
+    .spyOn(ShallowClearSignDeviceAction.prototype, "extractDependencies")
+    .mockReturnValue({
+      inspectTransaction: inspectMock,
+      getPubKey: shallowGetPubKeyMock,
+      buildShallowClearSignContext: buildShallowMock,
+      provideShallowClearSignContext: provideShallowMock,
+    } as any) as any;
+  delayedSpy = vi
+    .spyOn(SigningOperationsDeviceAction.prototype, "extractDependencies")
+    .mockReturnValue({
+      previewTransaction: previewMock,
+      delayedSignTransaction: delayedSignMock,
+      signTransaction: signMock,
+      fetchBlockhashFn: fetchBlockhashMock,
+      zeroBlockhashFn: zeroBlockhashMock,
+      patchBlockhashFn: patchBlockhashMock,
+    } as any) as any;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+}
+
+function run(
+  input: SignTransactionDAInput,
+  onComplete: (
+    states: DeviceActionState<
+      Uint8Array,
+      SignTransactionDAError,
+      SignTransactionDAIntermediateValue
+    >[],
+  ) => void,
+  onError: (e: unknown) => void,
+) {
+  const action = new SignTransactionDeviceAction({ input });
+  parentSpy = vi.spyOn(action, "extractDependencies").mockReturnValue({
+    getAppConfig: getAppConfigMock,
+    web3CheckOptIn: web3CheckOptInMock,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any) as unknown as ReturnType<typeof vi.spyOn>;
+  const { observable } = action._execute(apiMock);
+  const states: DeviceActionState<
+    Uint8Array,
+    SignTransactionDAError,
+    SignTransactionDAIntermediateValue
+  >[] = [];
+  observable.subscribe({
+    next: (s) => states.push(s),
+    error: onError,
+    complete: () => onComplete(states),
+  });
+}
+
+const baseInput: SignTransactionDAInput = {
+  derivationPath: defaultDerivation,
+  transaction: exampleTx,
+  transactionOptions: { skipOpenApp: true },
+  contextModule: contextModuleStub,
+};
+const withRpc: SignTransactionDAInput = {
+  ...baseInput,
+  solanaRPCURL: "https://api.devnet.solana.com",
+};
+
+// The ordered list of distinct steps a consumer observes. Consecutive repeats
+// (the Pending re-emitted at each child-machine boundary) are collapsed: they
+// carry the same step, so the meaningful contract is the step progression.
+function stepSequence(
+  states: DeviceActionState<
+    Uint8Array,
+    SignTransactionDAError,
+    SignTransactionDAIntermediateValue
+  >[],
+): string[] {
+  const steps: string[] = [];
+  for (const s of states) {
+    if (s.status !== DeviceActionStatus.Pending) continue;
+    const step = s.intermediateValue.step;
+    if (steps[steps.length - 1] !== step) steps.push(step);
+  }
+  return steps;
+}
+
+describe("SignTransactionDeviceAction (Solana) – orchestration", () => {
   beforeEach(() => {
     apiMock = makeDeviceActionInternalApiMock();
-    getAppConfigMock = vi.fn();
+    apiMock.getDeviceSessionState.mockReturnValue(session(legacyVersion));
+    getAppConfigMock = vi
+      .fn()
+      .mockResolvedValue(
+        CommandResultFactory({ data: appConfig(legacyVersion) }),
+      );
     web3CheckOptInMock = vi
       .fn()
       .mockResolvedValue(CommandResultFactory({ data: { enabled: true } }));
-    getPubKeyMock = vi.fn().mockResolvedValue(
-      CommandResultFactory({
-        data: "So1anaSignerPubKey111111111111111111111111111",
-      }),
-    );
-    buildContextMock = vi.fn();
-    provideContextMock = vi.fn();
-    signMock = vi.fn();
-    inspectTransactionMock = vi.fn().mockResolvedValue({
-      transactionType: SolanaTransactionTypes.SPL,
-      data: { tokenAddress: null, createATA: false },
+
+    // Generic child: degrades by default (no instruction recognised).
+    buildGenericMock = vi.fn().mockResolvedValue({
+      mode: "none",
+      poolContexts: [],
+      instructionInfoContexts: [],
     });
-  });
-
-  it("passes transactionOptions.solanaRPCURL to inspectTransaction when it overrides builder solanaRPCURL", () =>
-    new Promise<void>((resolve, reject) => {
-      apiMock.getDeviceSessionState.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.CONNECTED,
-        installedApps: [],
-        currentApp: { name: "Solana", version: "1.10.0" },
-        deviceModelId: DeviceModelId.NANO_X,
-        isSecureConnectionAllowed: true,
-      });
-
-      getAppConfigMock.mockResolvedValue(
-        CommandResultFactory({ data: { version: "1.10.0" } }),
-      );
-      inspectTransactionMock.mockImplementation(
-        async (arg: { rpcUrl?: string }) => {
-          expect(arg.rpcUrl).toBe("https://per-call.example.com");
-          return {
-            transactionType: SolanaTransactionTypes.STANDARD,
-          };
-        },
-      );
-
-      const signature = new Uint8Array([0xaa, 0xbb]);
-      signMock.mockResolvedValue(
-        CommandResultFactory({ data: Just(signature) }),
-      );
-
-      const input: SignTransactionDAInput = {
-        derivationPath: defaultDerivation,
-        transaction: exampleTx,
-        transactionOptions: {
-          skipOpenApp: true,
-          solanaRPCURL: "https://per-call.example.com",
-        },
-        solanaRPCURL: "https://builder.example.com",
-        contextModule: contextModuleStub,
-      };
-
-      const action = new SignTransactionDeviceAction({ input });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const expected = [
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_APP_CONFIG,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        { output: signature, status: DeviceActionStatus.Completed },
-      ] as DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[];
-
-      testDeviceActionStates(action, expected, apiMock, {
-        onDone: resolve,
-        onError: reject,
-      });
-    }));
-
-  it("happy path (skip open): getAppConfig -> inspect -> build -> provide -> sign", () =>
-    new Promise<void>((resolve, reject) => {
-      apiMock.getDeviceSessionState.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.CONNECTED,
-        installedApps: [],
-        currentApp: { name: "Solana", version: "1.10.0" },
-        deviceModelId: DeviceModelId.NANO_X,
-        isSecureConnectionAllowed: true,
-      });
-
-      getAppConfigMock.mockResolvedValue(
-        CommandResultFactory({ data: defaultAppConfig }),
-      );
-      inspectTransactionMock.mockResolvedValue({
-        transactionType: SolanaTransactionTypes.SPL,
-      });
-
-      const ctx: SolanaBuildContextResult = {
-        tlvDescriptor: new Uint8Array([1]),
-        trustedNamePKICertificate: {
-          keyUsageNumber: 0,
-          payload: new Uint8Array([0x01]),
-        },
-        loadersResults: [],
-        contextErrorCount: 0,
-      };
-      buildContextMock.mockResolvedValue(ctx);
-      provideContextMock.mockResolvedValue(Nothing);
-
-      const signature = new Uint8Array([0xaa, 0xbb]);
-      signMock.mockResolvedValue(
-        CommandResultFactory({ data: Just(signature) }),
-      );
-
-      const input: SignTransactionDAInput = {
-        derivationPath: defaultDerivation,
-        transaction: exampleTx,
-        transactionOptions: { skipOpenApp: true },
-        contextModule: contextModuleStub,
-      };
-
-      const action = new SignTransactionDeviceAction({
-        input,
-      });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const expected = [
-        // getAppConfig
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_APP_CONFIG,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // inspectTransaction
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // getPubKey
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_PUB_KEY,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // buildContext
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.BUILD_TRANSACTION_CONTEXT,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // provideContext
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.PROVIDE_TRANSACTION_CONTEXT,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // signTransaction
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // success
-        { output: signature, status: DeviceActionStatus.Completed },
-      ] as DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[];
-
-      testDeviceActionStates<
-        Uint8Array,
-        SignTransactionDAInput,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >(action, expected, apiMock, { onDone: resolve, onError: reject });
-    }));
-
-  it("inspectTransaction rejects, still signs (fallback)", () =>
-    new Promise<void>((resolve, reject) => {
-      apiMock.getDeviceSessionState.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.CONNECTED,
-        installedApps: [],
-        currentApp: { name: "Solana", version: "1.10.0" },
-        deviceModelId: DeviceModelId.NANO_X,
-        isSecureConnectionAllowed: true,
-      });
-
-      getAppConfigMock.mockResolvedValue(
-        CommandResultFactory({ data: defaultAppConfig }),
-      );
-
-      // InspectTransaction fails, machine transitions to SignTransaction
-      inspectTransactionMock.mockRejectedValue(
-        new InvalidStatusWordError("inspErr"),
-      );
-
-      const sig = new Uint8Array([0x11, 0x22]);
-      signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
-
-      const action = new SignTransactionDeviceAction({
-        input: {
-          derivationPath: defaultDerivation,
-          transaction: exampleTx,
-          transactionOptions: { skipOpenApp: true },
-          contextModule: contextModuleStub,
-        },
-      });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const expected = [
-        // getAppConfig
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_APP_CONFIG,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // inspectTransaction
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // signTransaction (fallback)
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // success
-        { output: sig, status: DeviceActionStatus.Completed },
-      ] as DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[];
-
-      testDeviceActionStates(action, expected, apiMock, {
-        onDone: () => {
-          // we should not try to build/provide context if inspection failed
-          expect(buildContextMock).not.toHaveBeenCalled();
-          expect(provideContextMock).not.toHaveBeenCalled();
-          resolve();
-        },
-        onError: reject,
-      });
-    }));
-
-  it("buildContext throws, still signs (fallback)", () =>
-    new Promise<void>((resolve, reject) => {
-      apiMock.getDeviceSessionState.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.CONNECTED,
-        installedApps: [],
-        currentApp: { name: "Solana", version: "1.10.0" },
-        deviceModelId: DeviceModelId.NANO_X,
-        isSecureConnectionAllowed: true,
-      });
-
-      getAppConfigMock.mockResolvedValue(
-        CommandResultFactory({ data: defaultAppConfig }),
-      );
-      inspectTransactionMock.mockResolvedValue({
-        transactionType: SolanaTransactionTypes.SPL,
-      });
-
-      // BuildContext fails, machine transitions to SignTransaction
-      buildContextMock.mockRejectedValue(new InvalidStatusWordError("bldErr"));
-
-      const sig = new Uint8Array([0xca, 0xfe]);
-      signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
-
-      const action = new SignTransactionDeviceAction({
-        input: {
-          derivationPath: defaultDerivation,
-          transaction: exampleTx,
-          transactionOptions: { skipOpenApp: true },
-          contextModule: contextModuleStub,
-        },
-      });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const expected = [
-        // getAppConfig
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_APP_CONFIG,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // inspectTransaction
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // getPubKey
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_PUB_KEY,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // buildContext (fails, but we still saw the pending step)
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.BUILD_TRANSACTION_CONTEXT,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // signTransaction (fallback)
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // success
-        { output: sig, status: DeviceActionStatus.Completed },
-      ] as DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[];
-
-      testDeviceActionStates<
-        Uint8Array,
-        SignTransactionDAInput,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >(action, expected, apiMock, { onDone: resolve, onError: reject });
-    }));
-
-  it("provideContext rejects, still signs (fallback)", () =>
-    new Promise<void>((resolve, reject) => {
-      apiMock.getDeviceSessionState.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.CONNECTED,
-        installedApps: [],
-        currentApp: { name: "Solana", version: "1.10.0" },
-        deviceModelId: DeviceModelId.NANO_X,
-        isSecureConnectionAllowed: true,
-      });
-
-      getAppConfigMock.mockResolvedValue(
-        CommandResultFactory({ data: defaultAppConfig }),
-      );
-      inspectTransactionMock.mockResolvedValue({
-        transactionType: SolanaTransactionTypes.SPL,
-      });
-
-      const ctx: SolanaBuildContextResult = {
-        tlvDescriptor: new Uint8Array([0x01]),
-        trustedNamePKICertificate: {
-          keyUsageNumber: 0,
-          payload: new Uint8Array([0x02]),
-        },
-        loadersResults: [],
-        contextErrorCount: 0,
-      };
-      buildContextMock.mockResolvedValue(ctx);
-
-      // ProvideContext rejects, machine transitions to SignTransaction
-      provideContextMock.mockRejectedValue(
-        new InvalidStatusWordError("provErr"),
-      );
-
-      const sig = new Uint8Array([0x33]);
-      signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
-
-      const action = new SignTransactionDeviceAction({
-        input: {
-          derivationPath: defaultDerivation,
-          transaction: exampleTx,
-          transactionOptions: { skipOpenApp: true },
-          contextModule: contextModuleStub,
-        },
-      });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const expected = [
-        // getAppConfig
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_APP_CONFIG,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // inspectTransaction
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // getPubKey
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_PUB_KEY,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // buildContext
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.BUILD_TRANSACTION_CONTEXT,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // provideContext
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.PROVIDE_TRANSACTION_CONTEXT,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // signTransaction (fallback)
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // success
-        { output: sig, status: DeviceActionStatus.Completed },
-      ] as DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[];
-
-      testDeviceActionStates(action, expected, apiMock, {
-        onDone: () => {
-          expect(buildContextMock).toHaveBeenCalledTimes(1);
-          expect(provideContextMock).toHaveBeenCalledTimes(1);
-          expect(signMock).toHaveBeenCalledTimes(1);
-          resolve();
-        },
-        onError: reject,
-      });
-    }));
-
-  it("failure in provideContext still signs", () =>
-    new Promise<void>((resolve, reject) => {
-      apiMock.getDeviceSessionState.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.CONNECTED,
-        installedApps: [],
-        currentApp: { name: "Solana", version: "1.10.0" },
-        deviceModelId: DeviceModelId.NANO_X,
-        isSecureConnectionAllowed: true,
-      });
-
-      getAppConfigMock.mockResolvedValue(
-        CommandResultFactory({ data: defaultAppConfig }),
-      );
-      inspectTransactionMock.mockResolvedValue({
-        transactionType: SolanaTransactionTypes.SPL,
-      });
-
-      buildContextMock.mockResolvedValue({
-        tlvDescriptor: new Uint8Array([2]),
-        trustedNamePKICertificate: {
-          keyUsageNumber: 0,
-          payload: new Uint8Array(),
-        },
-        loadersResults: [],
-        contextErrorCount: 0,
-      });
-      provideContextMock.mockResolvedValue(
-        Just(
-          CommandResultFactory({ error: new InvalidStatusWordError("ctxErr") }),
-        ),
-      );
-      const sig = new Uint8Array([0xfe]);
-      signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
-
-      const input: SignTransactionDAInput = {
-        derivationPath: defaultDerivation,
-        transaction: exampleTx,
-        transactionOptions: { skipOpenApp: true },
-        contextModule: contextModuleStub,
-      };
-
-      const action = new SignTransactionDeviceAction({
-        input,
-      });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const expected = [
-        // getAppConfig
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_APP_CONFIG,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // inspectTransaction
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // getPubKey
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_PUB_KEY,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // buildContext
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.BUILD_TRANSACTION_CONTEXT,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // provideContext (returns error but continues)
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.PROVIDE_TRANSACTION_CONTEXT,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // signTransaction
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // success
-        { output: sig, status: DeviceActionStatus.Completed },
-      ] as DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[];
-
-      testDeviceActionStates<
-        Uint8Array,
-        SignTransactionDAInput,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >(action, expected, apiMock, { onDone: resolve, onError: reject });
-    }));
-
-  it("swap path: SWAP type routes through build -> provide -> sign", () =>
-    new Promise<void>((resolve, reject) => {
-      apiMock.getDeviceSessionState.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.CONNECTED,
-        installedApps: [],
-        currentApp: { name: "Solana", version: "1.10.0" },
-        deviceModelId: DeviceModelId.NANO_X,
-        isSecureConnectionAllowed: true,
-      });
-
-      getAppConfigMock.mockResolvedValue(
-        CommandResultFactory({ data: defaultAppConfig }),
-      );
-      inspectTransactionMock.mockResolvedValue({
-        transactionType: SolanaTransactionTypes.SWAP,
-        data: {},
-      });
-
-      const ctx: SolanaBuildContextResult = {
-        tlvDescriptor: new Uint8Array([1]),
-        trustedNamePKICertificate: {
-          keyUsageNumber: 0,
-          payload: new Uint8Array([0x01]),
-        },
-        loadersResults: [],
-        contextErrorCount: 0,
-      };
-      buildContextMock.mockResolvedValue(ctx);
-      provideContextMock.mockResolvedValue(Nothing);
-
-      const signature = new Uint8Array([0xaa, 0xbb]);
-      signMock.mockResolvedValue(
-        CommandResultFactory({ data: Just(signature) }),
-      );
-
-      const input: SignTransactionDAInput = {
-        derivationPath: defaultDerivation,
-        transaction: exampleTx,
-        transactionOptions: {
-          skipOpenApp: true,
-          transactionResolutionContext: {
-            templateId: "swap-template-id",
-          },
-        },
-        contextModule: contextModuleStub,
-      };
-
-      const action = new SignTransactionDeviceAction({
-        input,
-      });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const expected = [
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_APP_CONFIG,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_PUB_KEY,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.BUILD_TRANSACTION_CONTEXT,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.PROVIDE_TRANSACTION_CONTEXT,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        { output: signature, status: DeviceActionStatus.Completed },
-      ] as DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[];
-
-      testDeviceActionStates<
-        Uint8Array,
-        SignTransactionDAInput,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >(action, expected, apiMock, {
-        onDone: () => {
-          expect(buildContextMock).toHaveBeenCalledTimes(1);
-          expect(provideContextMock).toHaveBeenCalledTimes(1);
-          resolve();
-        },
-        onError: reject,
-      });
-    }));
-
-  it("buildContext throws → error", () =>
-    new Promise<void>((resolve, reject) => {
-      apiMock.getDeviceSessionState.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.CONNECTED,
-        installedApps: [],
-        currentApp: { name: "Solana", version: "1.10.0" },
-        deviceModelId: DeviceModelId.NANO_X,
-        isSecureConnectionAllowed: true,
-      });
-
-      getAppConfigMock.mockResolvedValue(
-        CommandResultFactory({ data: defaultAppConfig }),
-      );
-      inspectTransactionMock.mockResolvedValue({
-        transactionType: SolanaTransactionTypes.SPL,
-      });
-
-      buildContextMock.mockRejectedValue(new InvalidStatusWordError("bldErr"));
-
-      const sig = new Uint8Array([0xab, 0xcd]);
-      signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
-
-      const input: SignTransactionDAInput = {
-        derivationPath: defaultDerivation,
-        transaction: exampleTx,
-        transactionOptions: { skipOpenApp: true },
-        contextModule: contextModuleStub,
-      };
-
-      const action = new SignTransactionDeviceAction({
-        input,
-      });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const expected = [
-        // getAppConfig
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_APP_CONFIG,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // inspectTransaction
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // getPubKey
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_PUB_KEY,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // buildContext (throws)
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.BUILD_TRANSACTION_CONTEXT,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // signTransaction (fallback)
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        // success
-        { output: sig, status: DeviceActionStatus.Completed },
-      ] as DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[];
-
-      testDeviceActionStates<
-        Uint8Array,
-        SignTransactionDAInput,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >(action, expected, apiMock, { onDone: resolve, onError: reject });
-    }));
-
-  it("delayed=true with missing config falls back to legacy sign", () =>
-    new Promise<void>((resolve, reject) => {
-      apiMock.getDeviceSessionState.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.CONNECTED,
-        installedApps: [],
-        currentApp: { name: "Solana", version: "1.10.0" },
-        deviceModelId: DeviceModelId.NANO_X,
-        isSecureConnectionAllowed: true,
-      });
-
-      getAppConfigMock.mockResolvedValue(
-        CommandResultFactory({ data: { version: "1.10.0" } }),
-      );
-      inspectTransactionMock.mockRejectedValue(
-        new InvalidStatusWordError("inspErr"),
-      );
-
-      const sig = new Uint8Array([0xdd, 0xee]);
-      signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
-
-      const input: SignTransactionDAInput = {
-        derivationPath: defaultDerivation,
-        transaction: exampleTx,
-        transactionOptions: {
-          skipOpenApp: true,
-          delayed: true,
-        },
-        contextModule: contextModuleStub,
-      };
-
-      const action = new SignTransactionDeviceAction({ input });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const expected = [
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_APP_CONFIG,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        { output: sig, status: DeviceActionStatus.Completed },
-      ] as DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[];
-
-      testDeviceActionStates(action, expected, apiMock, {
-        onDone: resolve,
-        onError: reject,
-      });
-    }));
-
-  it(`delayed=true with app version < ${SOLANA_MIN_DELAYED_SIGNING_VERSION} falls back to legacy sign`, () => {
-    const [major, minor, patch] = SOLANA_MIN_DELAYED_SIGNING_VERSION.split(
-      ".",
-    ).map(Number) as [number, number, number];
-    const belowDelayedVersion = `${major}.${minor - 1}.${patch}`;
-
-    return new Promise<void>((resolve, reject) => {
-      apiMock.getDeviceSessionState.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.CONNECTED,
-        installedApps: [],
-        currentApp: { name: "Solana", version: belowDelayedVersion },
-        deviceModelId: DeviceModelId.NANO_X,
-        isSecureConnectionAllowed: true,
-      });
-
-      getAppConfigMock.mockResolvedValue(
-        CommandResultFactory({ data: { version: "1.10.0" } }),
-      );
-      inspectTransactionMock.mockRejectedValue(
-        new InvalidStatusWordError("inspErr"),
-      );
-
-      const sig = new Uint8Array([0xaa, 0xbb]);
-      signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
-
-      const input: SignTransactionDAInput = {
-        derivationPath: defaultDerivation,
-        transaction: exampleTx,
-        transactionOptions: {
-          skipOpenApp: true,
-          delayed: true,
-        },
-        solanaRPCURL: "https://api.devnet.solana.com",
-        contextModule: contextModuleStub,
-      };
-
-      const action = new SignTransactionDeviceAction({ input });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const expected = [
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_APP_CONFIG,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        { output: sig, status: DeviceActionStatus.Completed },
-      ] as DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[];
-
-      testDeviceActionStates(action, expected, apiMock, {
-        onDone: resolve,
-        onError: reject,
-      });
-    });
-  });
-
-  it(`app version strictly below ${SOLANA_MIN_SPL_VERSION} skips SPL pipeline and signs directly`, () =>
-    new Promise<void>((resolve, reject) => {
-      apiMock.getDeviceSessionState.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.CONNECTED,
-        installedApps: [],
-        currentApp: { name: "Solana", version: "1.9.1" },
-        deviceModelId: DeviceModelId.NANO_X,
-        isSecureConnectionAllowed: true,
-      });
-
-      getAppConfigMock.mockResolvedValue(
-        CommandResultFactory({
-          data: { ...defaultAppConfig, version: "1.9.1" },
-        }),
-      );
-
-      const sig = new Uint8Array([0xa1, 0xb2]);
-      signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
-
-      const input: SignTransactionDAInput = {
-        derivationPath: defaultDerivation,
-        transaction: exampleTx,
-        transactionOptions: { skipOpenApp: true },
-        contextModule: contextModuleStub,
-      };
-
-      const action = new SignTransactionDeviceAction({ input });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const expected = [
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_APP_CONFIG,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        { output: sig, status: DeviceActionStatus.Completed },
-      ] as DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[];
-
-      testDeviceActionStates(action, expected, apiMock, {
-        onDone: () => {
-          expect(inspectTransactionMock).not.toHaveBeenCalled();
-          expect(buildContextMock).not.toHaveBeenCalled();
-          expect(provideContextMock).not.toHaveBeenCalled();
-          resolve();
-        },
-        onError: reject,
-      });
-    }));
-
-  it(`Nano S skips SPL pipeline regardless of app version`, () =>
-    new Promise<void>((resolve, reject) => {
-      apiMock.getDeviceSessionState.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.CONNECTED,
-        installedApps: [],
-        currentApp: { name: "Solana", version: "1.10.0" },
-        deviceModelId: DeviceModelId.NANO_S,
-        isSecureConnectionAllowed: true,
-      });
-
-      getAppConfigMock.mockResolvedValue(
-        CommandResultFactory({ data: { version: "1.10.0" } }),
-      );
-
-      const sig = new Uint8Array([0xc3, 0xd4]);
-      signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
-
-      const input: SignTransactionDAInput = {
-        derivationPath: defaultDerivation,
-        transaction: exampleTx,
-        transactionOptions: { skipOpenApp: true },
-        contextModule: contextModuleStub,
-      };
-
-      const action = new SignTransactionDeviceAction({ input });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const expected = [
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_APP_CONFIG,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        { output: sig, status: DeviceActionStatus.Completed },
-      ] as DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[];
-
-      testDeviceActionStates(action, expected, apiMock, {
-        onDone: () => {
-          expect(inspectTransactionMock).not.toHaveBeenCalled();
-          expect(buildContextMock).not.toHaveBeenCalled();
-          expect(provideContextMock).not.toHaveBeenCalled();
-          resolve();
-        },
-        onError: reject,
-      });
-    }));
-
-  it("delayed=false routes to legacy sign (unchanged behavior)", () =>
-    new Promise<void>((resolve, reject) => {
-      apiMock.getDeviceSessionState.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.CONNECTED,
-        installedApps: [],
-        currentApp: { name: "Solana", version: "1.10.0" },
-        deviceModelId: DeviceModelId.NANO_X,
-        isSecureConnectionAllowed: true,
-      });
-
-      getAppConfigMock.mockResolvedValue(
-        CommandResultFactory({ data: { version: "1.10.0" } }),
-      );
-      inspectTransactionMock.mockRejectedValue(
-        new InvalidStatusWordError("inspErr"),
-      );
-
-      const sig = new Uint8Array([0xff, 0x00]);
-      signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
-
-      const input: SignTransactionDAInput = {
-        derivationPath: defaultDerivation,
-        transaction: exampleTx,
-        transactionOptions: {
-          skipOpenApp: true,
-          delayed: false,
-        },
-        solanaRPCURL: "https://api.devnet.solana.com",
-        contextModule: contextModuleStub,
-      };
-
-      const action = new SignTransactionDeviceAction({ input });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const expected = [
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_APP_CONFIG,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        { output: sig, status: DeviceActionStatus.Completed },
-      ] as DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[];
-
-      testDeviceActionStates(action, expected, apiMock, {
-        onDone: resolve,
-        onError: reject,
-      });
-    }));
-
-  it("non-SPL web3checks-supported: inspects then routes to getPubKey -> build -> provide -> sign", () =>
-    new Promise<void>((resolve, reject) => {
-      apiMock.getDeviceSessionState.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.CONNECTED,
-        installedApps: [],
-        currentApp: { name: "Solana", version: "2.0.0" },
-        deviceModelId: DeviceModelId.FLEX,
-        isSecureConnectionAllowed: true,
-      });
-
-      getAppConfigMock.mockResolvedValue(
-        CommandResultFactory({
-          data: {
-            ...defaultAppConfig,
-            version: "2.0.0",
-            web3ChecksEnabled: true,
-            web3ChecksOptIn: true,
-          },
-        }),
-      );
-
-      inspectTransactionMock.mockResolvedValue({
-        transactionType: SolanaTransactionTypes.STANDARD,
-      });
-
-      buildContextMock.mockResolvedValue({
-        loadersResults: [],
-      });
-      provideContextMock.mockResolvedValue(Nothing);
-
-      const sig = new Uint8Array([0xaa, 0xbb]);
-      signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
-
-      const action = new SignTransactionDeviceAction({
-        input: {
-          derivationPath: defaultDerivation,
-          transaction: exampleTx,
-          transactionOptions: {
-            skipOpenApp: true,
-          },
-          contextModule: contextModuleStub,
-        },
-      });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const expected = [
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_APP_CONFIG,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_PUB_KEY,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.BUILD_TRANSACTION_CONTEXT,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.PROVIDE_TRANSACTION_CONTEXT,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        { output: sig, status: DeviceActionStatus.Completed },
-      ] as DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[];
-
-      testDeviceActionStates(action, expected, apiMock, {
-        onDone: () => {
-          expect(inspectTransactionMock).toHaveBeenCalledTimes(1);
-          expect(getPubKeyMock).toHaveBeenCalledTimes(1);
-          expect(buildContextMock).toHaveBeenCalledTimes(1);
-          expect(provideContextMock).toHaveBeenCalledTimes(1);
-          resolve();
-        },
-        onError: reject,
-      });
-    }));
-
-  it("non-SPL on unsupported device (NANO_X): skips GetPubKey/BuildContext and signs directly", () =>
-    new Promise<void>((resolve, reject) => {
-      apiMock.getDeviceSessionState.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.CONNECTED,
-        installedApps: [],
-        currentApp: { name: "Solana", version: "2.0.0" },
-        deviceModelId: DeviceModelId.NANO_X,
-        isSecureConnectionAllowed: true,
-      });
-
-      getAppConfigMock.mockResolvedValue(
-        CommandResultFactory({
-          data: {
-            ...defaultAppConfig,
-            version: "2.0.0",
-            web3ChecksEnabled: true,
-            web3ChecksOptIn: true,
-          },
-        }),
-      );
-
-      inspectTransactionMock.mockResolvedValue({
-        transactionType: SolanaTransactionTypes.STANDARD,
-      });
-
-      const sig = new Uint8Array([0xaa, 0xbb]);
-      signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
-
-      const action = new SignTransactionDeviceAction({
-        input: {
-          derivationPath: defaultDerivation,
-          transaction: exampleTx,
-          transactionOptions: {
-            skipOpenApp: true,
-          },
-          contextModule: contextModuleStub,
-        },
-      });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const expected = [
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_APP_CONFIG,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        { output: sig, status: DeviceActionStatus.Completed },
-      ] as DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[];
-
-      testDeviceActionStates(action, expected, apiMock, {
-        onDone: () => {
-          expect(inspectTransactionMock).toHaveBeenCalledTimes(1);
-          expect(getPubKeyMock).not.toHaveBeenCalled();
-          expect(buildContextMock).not.toHaveBeenCalled();
-          expect(provideContextMock).not.toHaveBeenCalled();
-          resolve();
-        },
-        onError: reject,
-      });
-    }));
-
-  it("Flex: Web3Checks opt-in runs before inspect when app requires it", () =>
-    new Promise<void>((resolve, reject) => {
-      apiMock.getDeviceSessionState.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.CONNECTED,
-        installedApps: [],
-        currentApp: { name: "Solana", version: "2.0.0" },
-        deviceModelId: DeviceModelId.FLEX,
-        isSecureConnectionAllowed: true,
-      });
-
-      getAppConfigMock.mockResolvedValue(
-        CommandResultFactory({
-          data: {
-            ...defaultAppConfig,
-            version: "2.0.0",
-            web3ChecksEnabled: false,
-            web3ChecksOptIn: false,
-          },
-        }),
-      );
-
-      web3CheckOptInMock.mockResolvedValue(
-        CommandResultFactory({ data: { enabled: true } }),
-      );
-
-      inspectTransactionMock.mockResolvedValue({
-        transactionType: SolanaTransactionTypes.STANDARD,
-        data: {},
-      });
-
-      buildContextMock.mockResolvedValue({
-        loadersResults: [],
-      });
-      provideContextMock.mockResolvedValue(Nothing);
-
-      const sig = new Uint8Array([0x01, 0x02]);
-      signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
-
-      const action = new SignTransactionDeviceAction({
-        input: {
-          derivationPath: defaultDerivation,
-          transaction: exampleTx,
-          transactionOptions: { skipOpenApp: true },
-          contextModule: contextModuleStub,
-        },
-      });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const expected = [
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_APP_CONFIG,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.Web3ChecksOptIn,
-            step: signTransactionDAStateSteps.WEB3_CHECKS_OPT_IN,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.WEB3_CHECKS_OPT_IN_RESULT,
-            result: true,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_PUB_KEY,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.BUILD_TRANSACTION_CONTEXT,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.PROVIDE_TRANSACTION_CONTEXT,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        { output: sig, status: DeviceActionStatus.Completed },
-      ] as DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[];
-
-      testDeviceActionStates<
-        Uint8Array,
-        SignTransactionDAInput,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >(action, expected, apiMock, {
-        onDone: () => {
-          expect(web3CheckOptInMock).toHaveBeenCalledTimes(1);
-          resolve();
-        },
-        onError: reject,
-      });
-    }));
-
-  it("Flex: Web3Checks opt-in command error proceeds without web3checks", () =>
-    new Promise<void>((resolve, reject) => {
-      apiMock.getDeviceSessionState.mockReturnValue({
-        sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-        deviceStatus: DeviceStatus.CONNECTED,
-        installedApps: [],
-        currentApp: { name: "Solana", version: "2.0.0" },
-        deviceModelId: DeviceModelId.FLEX,
-        isSecureConnectionAllowed: true,
-      });
-
-      getAppConfigMock.mockResolvedValue(
-        CommandResultFactory({
-          data: {
-            ...defaultAppConfig,
-            version: "2.0.0",
-            web3ChecksEnabled: false,
-            web3ChecksOptIn: false,
-          },
-        }),
-      );
-
-      web3CheckOptInMock.mockResolvedValue(
-        CommandResultFactory({
-          error: new InvalidStatusWordError("user declined opt-in"),
-        }),
-      );
-
-      inspectTransactionMock.mockResolvedValue({
-        transactionType: SolanaTransactionTypes.STANDARD,
-        data: {},
-      });
-
-      buildContextMock.mockResolvedValue({
-        loadersResults: [],
-      });
-      provideContextMock.mockResolvedValue(Nothing);
-
-      const sig = new Uint8Array([0x01, 0x02]);
-      signMock.mockResolvedValue(CommandResultFactory({ data: Just(sig) }));
-
-      const action = new SignTransactionDeviceAction({
-        input: {
-          derivationPath: defaultDerivation,
-          transaction: exampleTx,
-          transactionOptions: { skipOpenApp: true },
-          contextModule: contextModuleStub,
-        },
-      });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const expected = [
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_APP_CONFIG,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.Web3ChecksOptIn,
-            step: signTransactionDAStateSteps.WEB3_CHECKS_OPT_IN,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.WEB3_CHECKS_OPT_IN_RESULT,
-            result: false,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.GET_PUB_KEY,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.BUILD_TRANSACTION_CONTEXT,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.None,
-            step: signTransactionDAStateSteps.PROVIDE_TRANSACTION_CONTEXT,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        {
-          intermediateValue: {
-            requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-          },
-          status: DeviceActionStatus.Pending,
-        },
-        { output: sig, status: DeviceActionStatus.Completed },
-      ] as DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[];
-
-      testDeviceActionStates<
-        Uint8Array,
-        SignTransactionDAInput,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >(action, expected, apiMock, {
-        onDone: () => {
-          expect(web3CheckOptInMock).toHaveBeenCalledTimes(1);
-          resolve();
-        },
-        onError: reject,
-      });
-    }));
-});
-
-describe("SignTransactionDeviceAction – child machine integration", () => {
-  let childExtractDepsSpy: ReturnType<typeof vi.spyOn>;
-  let childPreviewMock: ReturnType<typeof vi.fn>;
-  let childDelayedSignMock: ReturnType<typeof vi.fn>;
-  let childFallbackSignMock: ReturnType<typeof vi.fn>;
-  let childFetchBlockhashMock: ReturnType<typeof vi.fn>;
-  let childZeroBlockhashMock: ReturnType<typeof vi.fn>;
-  let childPatchBlockhashMock: ReturnType<typeof vi.fn>;
-
-  const zeroedTx = new Uint8Array([0x00, 0x00, 0x00, 0x00]);
-  const patchedTx = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
-  const freshBlockhash = new Uint8Array(32).fill(0xab);
-  const delayedSig = new Uint8Array([0xcc, 0xdd]);
-
-  function childDeps() {
-    return {
-      previewTransaction: childPreviewMock,
-      delayedSignTransaction: childDelayedSignMock,
-      fallbackSignTransaction: childFallbackSignMock,
-      fetchBlockhashFn: childFetchBlockhashMock,
-      zeroBlockhashFn: childZeroBlockhashMock,
-      patchBlockhashFn: childPatchBlockhashMock,
-    };
-  }
-
-  function delayedInput(): SignTransactionDAInput {
-    return {
-      derivationPath: defaultDerivation,
-      transaction: exampleTx,
-      transactionOptions: {
-        skipOpenApp: true,
-        delayed: true,
-      },
-      solanaRPCURL: "https://api.devnet.solana.com",
-      contextModule: contextModuleStub,
-    };
-  }
-
-  beforeEach(() => {
-    apiMock = makeDeviceActionInternalApiMock();
-    apiMock.getDeviceSessionState.mockReturnValue({
-      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
-      deviceStatus: DeviceStatus.CONNECTED,
-      installedApps: [],
-      currentApp: { name: "Solana", version: "1.14.0" },
-      deviceModelId: DeviceModelId.NANO_X,
-      isSecureConnectionAllowed: true,
-    });
-
-    getAppConfigMock = vi
+    provideGenericMock = vi.fn().mockResolvedValue(undefined);
+    promptUiDisplayMock = vi
       .fn()
-      .mockResolvedValue(CommandResultFactory({ data: { version: "1.14.0" } }));
-    buildContextMock = vi.fn();
-    provideContextMock = vi.fn();
-    signMock = vi.fn();
-    inspectTransactionMock = vi
+      .mockResolvedValue(CommandResultFactory({ data: undefined }));
+
+    // Shallow child: provisions successfully by default.
+    inspectMock = vi
       .fn()
-      .mockRejectedValue(new InvalidStatusWordError("inspErr"));
+      .mockResolvedValue({ transactionType: SolanaTransactionTypes.STANDARD });
+    shallowGetPubKeyMock = vi
+      .fn()
+      .mockResolvedValue(CommandResultFactory({ data: "pk" }));
+    buildShallowMock = vi.fn().mockResolvedValue({
+      tlvDescriptor: new Uint8Array([1]),
+      trustedNamePKICertificate: null,
+      loadersResults: [],
+      contextErrorCount: 0,
+    });
+    provideShallowMock = vi.fn().mockResolvedValue(Nothing);
 
-    childPreviewMock = vi.fn();
-    childDelayedSignMock = vi.fn();
-    childFallbackSignMock = vi.fn();
-    childFetchBlockhashMock = vi.fn();
-    childZeroBlockhashMock = vi.fn().mockResolvedValue(zeroedTx);
-    childPatchBlockhashMock = vi.fn().mockResolvedValue(patchedTx);
+    // Terminal/delayed child: every path resolves to a signature.
+    zeroBlockhashMock = vi.fn().mockResolvedValue(exampleTx);
+    previewMock = vi
+      .fn()
+      .mockResolvedValue(CommandResultFactory({ data: Nothing }));
+    fetchBlockhashMock = vi
+      .fn()
+      .mockResolvedValue(new Uint8Array(32).fill(0xab));
+    patchBlockhashMock = vi.fn().mockResolvedValue(exampleTx);
+    delayedSignMock = vi
+      .fn()
+      .mockResolvedValue(CommandResultFactory({ data: Just(armedSig) }));
+    signMock = vi
+      .fn()
+      .mockResolvedValue(CommandResultFactory({ data: Just(signature) }));
 
-    childExtractDepsSpy = vi.spyOn(
-      DelayedSignTransactionDeviceAction.prototype,
-      "extractDependencies",
-    ) as unknown as ReturnType<typeof vi.spyOn>;
-    childExtractDepsSpy.mockReturnValue(childDeps());
+    spyChildren();
   });
 
   afterEach(() => {
-    childExtractDepsSpy.mockRestore();
+    parentSpy?.mockRestore();
+    genericSpy.mockRestore();
+    shallowSpy.mockRestore();
+    delayedSpy.mockRestore();
   });
 
-  it("child returns Right(signature) → parent completes with that signature", () =>
+  it("generic unavailable → shallow provisions → terminal one-shot sign (no RPC)", () =>
     new Promise<void>((resolve, reject) => {
-      childPreviewMock.mockResolvedValue(
-        CommandResultFactory({ data: Nothing }),
-      );
-      childFetchBlockhashMock.mockResolvedValue(freshBlockhash);
-      childDelayedSignMock.mockResolvedValue(
-        CommandResultFactory({ data: Just(delayedSig) }),
-      );
-
-      const action = new SignTransactionDeviceAction({
-        input: delayedInput(),
-      });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const { observable } = action._execute(apiMock);
-      const states: DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[] = [];
-
-      observable.subscribe({
-        next: (state) => states.push(state),
-        error: reject,
-        complete: () => {
+      run(
+        baseInput,
+        (states) => {
           try {
-            const last = states[states.length - 1]!;
-            expect(last.status).toBe(DeviceActionStatus.Completed);
-            expect(
-              last.status === DeviceActionStatus.Completed && last.output,
-            ).toEqual(delayedSig);
-            expect(signMock).not.toHaveBeenCalled();
-            resolve();
-          } catch (e) {
-            reject(e);
-          }
-        },
-      });
-    }));
-
-  it("child returns Left(UnknownDAError) → parent falls back to legacy sign", () =>
-    new Promise<void>((resolve, reject) => {
-      childPreviewMock.mockResolvedValue(
-        CommandResultFactory({ data: Nothing }),
-      );
-      childFetchBlockhashMock.mockRejectedValue(new Error("network error"));
-
-      const legacySig = new Uint8Array([0xee, 0xff]);
-      signMock.mockResolvedValue(
-        CommandResultFactory({ data: Just(legacySig) }),
-      );
-
-      const action = new SignTransactionDeviceAction({
-        input: delayedInput(),
-      });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const { observable } = action._execute(apiMock);
-      const states: DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[] = [];
-
-      observable.subscribe({
-        next: (state) => states.push(state),
-        error: reject,
-        complete: () => {
-          try {
-            const last = states[states.length - 1]!;
-            expect(last.status).toBe(DeviceActionStatus.Completed);
-            expect(
-              last.status === DeviceActionStatus.Completed && last.output,
-            ).toEqual(legacySig);
+            expect(buildGenericMock).not.toHaveBeenCalled();
+            expect(inspectMock).toHaveBeenCalled();
+            // No RPC → terminal one-shot (0x06), no delayed sign.
             expect(signMock).toHaveBeenCalled();
+            expect(delayedSignMock).not.toHaveBeenCalled();
+            const last = states[states.length - 1]!;
+            expect(last.status).toBe(DeviceActionStatus.Completed);
+            expect(
+              last.status === DeviceActionStatus.Completed && last.output,
+            ).toEqual(signature);
             resolve();
           } catch (e) {
             reject(e);
           }
         },
-      });
+        reject,
+      );
     }));
 
-  it("child returns Left(SolanaAppCommandError) for user rejection → parent errors", () =>
+  it("generic available + armed → terminal delayed sign (alreadyArmed, refreshed)", () =>
     new Promise<void>((resolve, reject) => {
-      childPreviewMock.mockResolvedValue(
+      apiMock.getDeviceSessionState.mockReturnValue(
+        session(SOLANA_MIN_GENERIC_CLEAR_SIGN_VERSION),
+      );
+      getAppConfigMock.mockResolvedValue(
+        CommandResultFactory({
+          data: appConfig(SOLANA_MIN_GENERIC_CLEAR_SIGN_VERSION),
+        }),
+      );
+      buildGenericMock.mockResolvedValue({
+        mode: "full",
+        poolContexts: [],
+        instructionInfoContexts: [],
+      });
+      run(
+        withRpc,
+        (states) => {
+          try {
+            expect(buildGenericMock).toHaveBeenCalled();
+            expect(promptUiDisplayMock).toHaveBeenCalled();
+            // Armed → terminal refreshes blockhash and delayed-signs (no preview).
+            expect(previewMock).not.toHaveBeenCalled();
+            expect(fetchBlockhashMock).toHaveBeenCalled();
+            expect(delayedSignMock).toHaveBeenCalled();
+            // Shallow path not taken.
+            expect(inspectMock).not.toHaveBeenCalled();
+            const last = states[states.length - 1]!;
+            expect(last.status).toBe(DeviceActionStatus.Completed);
+            expect(
+              last.status === DeviceActionStatus.Completed && last.output,
+            ).toEqual(armedSig);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        reject,
+      );
+    }));
+
+  it("generic degraded → shallow → terminal", () =>
+    new Promise<void>((resolve, reject) => {
+      apiMock.getDeviceSessionState.mockReturnValue(
+        session(SOLANA_MIN_GENERIC_CLEAR_SIGN_VERSION),
+      );
+      getAppConfigMock.mockResolvedValue(
+        CommandResultFactory({
+          data: appConfig(SOLANA_MIN_GENERIC_CLEAR_SIGN_VERSION),
+        }),
+      );
+      // buildGenericMock default → mode "none" → degraded.
+      run(
+        withRpc,
+        (states) => {
+          try {
+            expect(buildGenericMock).toHaveBeenCalled();
+            expect(inspectMock).toHaveBeenCalled(); // shallow ran
+            // RPC present + not armed → terminal does the legacy delayed flow.
+            expect(previewMock).toHaveBeenCalled();
+            expect(delayedSignMock).toHaveBeenCalled();
+            expect(states[states.length - 1]!.status).toBe(
+              DeviceActionStatus.Completed,
+            );
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        reject,
+      );
+    }));
+
+  it("generic user cancel (6985) → error, no shallow / no terminal", () =>
+    new Promise<void>((resolve, reject) => {
+      apiMock.getDeviceSessionState.mockReturnValue(
+        session(SOLANA_MIN_GENERIC_CLEAR_SIGN_VERSION),
+      );
+      getAppConfigMock.mockResolvedValue(
+        CommandResultFactory({
+          data: appConfig(SOLANA_MIN_GENERIC_CLEAR_SIGN_VERSION),
+        }),
+      );
+      buildGenericMock.mockResolvedValue({
+        mode: "full",
+        poolContexts: [],
+        instructionInfoContexts: [],
+      });
+      promptUiDisplayMock.mockResolvedValue(
         CommandResultFactory({
           error: new SolanaAppCommandError({
-            errorCode: "6985",
-            message: "Canceled by user",
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ...({ errorCode: "6985", message: "Canceled by user" } as any),
           }),
         }),
       );
-
-      const action = new SignTransactionDeviceAction({
-        input: delayedInput(),
-      });
-      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
-
-      const { observable } = action._execute(apiMock);
-      const states: DeviceActionState<
-        Uint8Array,
-        SignTransactionDAError,
-        SignTransactionDAIntermediateValue
-      >[] = [];
-
-      observable.subscribe({
-        next: (state) => states.push(state),
-        error: reject,
-        complete: () => {
+      run(
+        withRpc,
+        (states) => {
           try {
-            const last = states[states.length - 1]!;
-            expect(last.status).toBe(DeviceActionStatus.Error);
+            expect(inspectMock).not.toHaveBeenCalled();
+            expect(delayedSignMock).not.toHaveBeenCalled();
             expect(signMock).not.toHaveBeenCalled();
+            expect(states[states.length - 1]!.status).toBe(
+              DeviceActionStatus.Error,
+            );
             resolve();
           } catch (e) {
             reject(e);
           }
         },
+        reject,
+      );
+    }));
+
+  it("terminal sign failure → error", () =>
+    new Promise<void>((resolve, reject) => {
+      signMock.mockResolvedValue(
+        CommandResultFactory({
+          error: new SolanaAppCommandError({
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ...({ errorCode: "6f01", message: "sign failed" } as any),
+          }),
+        }),
+      );
+      run(
+        baseInput,
+        (states) => {
+          try {
+            expect(signMock).toHaveBeenCalled();
+            expect(states[states.length - 1]!.status).toBe(
+              DeviceActionStatus.Error,
+            );
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        reject,
+      );
+    }));
+
+  it("getAppConfig error → error", () =>
+    new Promise<void>((resolve, reject) => {
+      getAppConfigMock.mockResolvedValue(
+        CommandResultFactory({
+          error: new SolanaAppCommandError({
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ...({ errorCode: "6e00", message: "no app config" } as any),
+          }),
+        }),
+      );
+      run(
+        baseInput,
+        (states) => {
+          try {
+            expect(inspectMock).not.toHaveBeenCalled();
+            expect(states[states.length - 1]!.status).toBe(
+              DeviceActionStatus.Error,
+            );
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        reject,
+      );
+    }));
+
+  it("runs Web3Checks opt-in before clear-sign when the app requires it", () =>
+    new Promise<void>((resolve, reject) => {
+      // Flex supports web3-checks; opt-in not yet done.
+      apiMock.getDeviceSessionState.mockReturnValue(
+        session(legacyVersion, DeviceModelId.FLEX),
+      );
+      getAppConfigMock.mockResolvedValue(
+        CommandResultFactory({
+          data: {
+            ...appConfig(legacyVersion),
+            web3ChecksEnabled: false,
+            web3ChecksOptIn: false,
+          },
+        }),
+      );
+      run(
+        baseInput,
+        (states) => {
+          try {
+            expect(web3CheckOptInMock).toHaveBeenCalled();
+            // Opt-in must precede the terminal sign in the emitted sequence.
+            const steps = stepSequence(states);
+            const optInIdx = steps.indexOf(
+              signTransactionDAStateSteps.WEB3_CHECKS_OPT_IN,
+            );
+            const signIdx = steps.indexOf(
+              signingOperationsDAStateSteps.SIGN_TRANSACTION,
+            );
+            expect(optInIdx).toBeGreaterThanOrEqual(0);
+            expect(signIdx).toBeGreaterThan(optInIdx);
+            expect(states[states.length - 1]!.status).toBe(
+              DeviceActionStatus.Completed,
+            );
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        reject,
+      );
+    }));
+
+  // End-to-end emitted-step-sequence contracts (the progression a consumer sees).
+  it("e2e sequence: legacy SPL path with RPC → shallow provisioning then delayed terminal", () =>
+    new Promise<void>((resolve, reject) => {
+      inspectMock.mockResolvedValue({
+        transactionType: SolanaTransactionTypes.SPL,
+        data: { tokenAddress: null, createATA: false },
       });
+      run(
+        withRpc,
+        (states) => {
+          try {
+            expect(stepSequence(states)).toEqual([
+              signTransactionDAStateSteps.GET_APP_CONFIG,
+              signTransactionDAStateSteps.INSPECT_TRANSACTION,
+              signTransactionDAStateSteps.GET_PUB_KEY,
+              signTransactionDAStateSteps.BUILD_SHALLOW_CLEAR_SIGN_CONTEXT,
+              signTransactionDAStateSteps.PROVIDE_SHALLOW_CLEAR_SIGN_CONTEXT,
+              signingOperationsDAStateSteps.ZERO_BLOCKHASH,
+              signingOperationsDAStateSteps.PREVIEW_TRANSACTION,
+              signingOperationsDAStateSteps.FETCH_BLOCKHASH,
+              signingOperationsDAStateSteps.PATCH_TRANSACTION,
+              signingOperationsDAStateSteps.DELAYED_SIGN,
+            ]);
+            const last = states[states.length - 1]!;
+            expect(last.status).toBe(DeviceActionStatus.Completed);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        reject,
+      );
+    }));
+
+  it("e2e sequence: generic clear-sign armed → terminal refresh + delayed sign", () =>
+    new Promise<void>((resolve, reject) => {
+      apiMock.getDeviceSessionState.mockReturnValue(
+        session(SOLANA_MIN_GENERIC_CLEAR_SIGN_VERSION),
+      );
+      getAppConfigMock.mockResolvedValue(
+        CommandResultFactory({
+          data: appConfig(SOLANA_MIN_GENERIC_CLEAR_SIGN_VERSION),
+        }),
+      );
+      buildGenericMock.mockResolvedValue({
+        mode: "full",
+        poolContexts: [],
+        instructionInfoContexts: [],
+      });
+      run(
+        withRpc,
+        (states) => {
+          try {
+            expect(stepSequence(states)).toEqual([
+              signTransactionDAStateSteps.GET_APP_CONFIG,
+              signTransactionDAStateSteps.BUILD_GENERIC_CLEAR_SIGN_CONTEXT,
+              signTransactionDAStateSteps.PROVIDE_GENERIC_CLEAR_SIGN_CONTEXT,
+              signTransactionDAStateSteps.PROMPT_UI_DISPLAY,
+              signingOperationsDAStateSteps.FETCH_BLOCKHASH,
+              signingOperationsDAStateSteps.PATCH_TRANSACTION,
+              signingOperationsDAStateSteps.DELAYED_SIGN,
+            ]);
+            const last = states[states.length - 1]!;
+            expect(last.status).toBe(DeviceActionStatus.Completed);
+            expect(
+              last.status === DeviceActionStatus.Completed && last.output,
+            ).toEqual(armedSig);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        },
+        reject,
+      );
     }));
 });

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceAction.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceAction.ts
@@ -1,6 +1,5 @@
+import { type ContextModule } from "@ledgerhq/context-module";
 import {
-  ApplicationChecker,
-  type CommandErrorResult,
   type CommandResult,
   type DeviceActionStateMachine,
   type InternalApi,
@@ -11,7 +10,7 @@ import {
   UserInteractionRequired,
   XStateDeviceAction,
 } from "@ledgerhq/device-management-kit";
-import { Left, type Maybe, Right } from "purify-ts";
+import { type Either, Left, Right } from "purify-ts";
 import { and, assign, fromPromise, setup } from "xstate";
 
 import {
@@ -24,17 +23,7 @@ import {
   signTransactionDAStateSteps,
 } from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { type AppConfiguration } from "@api/model/AppConfiguration";
-import { type Signature } from "@api/model/Signature";
-import {
-  type TransactionResolutionContext,
-  type UserInputType,
-} from "@api/model/TransactionResolutionContext";
 import { GetAppConfigurationCommand } from "@internal/app-binder/command/GetAppConfigurationCommand";
-import {
-  GetPubKeyCommand,
-  type GetPubKeyCommandResponse,
-} from "@internal/app-binder/command/GetPubKeyCommand";
-import { SignTransactionCommand } from "@internal/app-binder/command/SignTransactionCommand";
 import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
 import {
   Web3CheckOptInCommand,
@@ -42,26 +31,17 @@ import {
 } from "@internal/app-binder/command/Web3CheckOptInCommand";
 import { APP_NAME } from "@internal/app-binder/constants";
 import {
-  SolanaTransactionTypes,
-  TransactionInspector,
-} from "@internal/app-binder/services/TransactionInspector";
-import { type TxInspectorResult } from "@internal/app-binder/services/TransactionInspector";
-import {
-  SOLANA_FEATURES,
-  SolanaApplicationResolver,
+  isSolanaFeatureSupported,
+  type SOLANA_FEATURES,
 } from "@internal/app-binder/SolanaApplicationResolver";
-import {
-  BuildTransactionContextTask,
-  type BuildTransactionContextTaskArgs,
-  type SolanaBuildContextResult,
-} from "@internal/app-binder/task/BuildTransactionContextTask";
-import {
-  ProvideSolanaTransactionContextTask,
-  type ProvideSolanaTransactionContextTaskArgs,
-} from "@internal/app-binder/task/ProvideTransactionContextTask";
-import { SignDataTask } from "@internal/app-binder/task/SendSignDataTask";
 
-import { DelayedSignTransactionDeviceAction } from "./DelayedSignTransactionDeviceAction";
+import {
+  type GenericClearSignDAError,
+  type GenericClearSignDAOutput,
+  GenericClearSignDeviceAction,
+} from "./GenericClearSignDeviceAction";
+import { ShallowClearSignDeviceAction } from "./ShallowClearSignDeviceAction";
+import { SigningOperationsDeviceAction } from "./SigningOperationsDeviceAction";
 
 /**
  * Per-sign `transactionOptions.solanaRPCURL` overrides the builder default
@@ -80,29 +60,6 @@ export type MachineDependencies = {
   readonly web3CheckOptIn: () => Promise<
     CommandResult<Web3CheckOptInCommandResponse, SolanaAppErrorCodes>
   >;
-  readonly getPubKey: (arg0: {
-    input: {
-      derivationPath: string;
-      checkOnDevice: boolean;
-    };
-  }) => Promise<CommandResult<GetPubKeyCommandResponse, SolanaAppErrorCodes>>;
-  readonly buildContext: (arg0: {
-    input: BuildTransactionContextTaskArgs;
-  }) => Promise<SolanaBuildContextResult>;
-  readonly provideContext: (arg0: {
-    input: ProvideSolanaTransactionContextTaskArgs;
-  }) => Promise<Maybe<CommandErrorResult<SolanaAppErrorCodes>>>;
-  readonly inspectTransaction: (arg0: {
-    serializedTransaction: Uint8Array;
-    resolutionContext?: TransactionResolutionContext;
-    rpcUrl?: string;
-  }) => Promise<TxInspectorResult>;
-  readonly signTransaction: (arg0: {
-    input: {
-      derivationPath: string;
-      serializedTransaction: Uint8Array;
-    };
-  }) => Promise<CommandResult<Maybe<Signature>, SolanaAppErrorCodes>>;
 };
 
 export class SignTransactionDeviceAction extends XStateDeviceAction<
@@ -129,15 +86,8 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
       SignTransactionDAInternalState
     >;
 
-    const {
-      signTransaction,
-      getAppConfig,
-      web3CheckOptIn,
-      getPubKey,
-      buildContext,
-      provideContext,
-      inspectTransaction,
-    } = this.extractDependencies(internalApi);
+    const { getAppConfig, web3CheckOptIn } =
+      this.extractDependencies(internalApi);
 
     const logger = this.getLoggerFactory(internalApi)(
       "SignTransactionDeviceAction",
@@ -146,19 +96,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
     const isSupported = (
       feature: keyof typeof SOLANA_FEATURES,
       appConfig: AppConfiguration,
-    ): boolean => {
-      const { minVersion, excludedModels, excludedApps } =
-        SOLANA_FEATURES[feature];
-      return new ApplicationChecker(
-        internalApi.getDeviceSessionState(),
-        appConfig,
-        new SolanaApplicationResolver(),
-      )
-        .withMinVersionInclusive(minVersion)
-        .excludeDeviceModels(...excludedModels)
-        .excludeApps(...excludedApps)
-        .check();
-    };
+    ): boolean => isSolanaFeatureSupported(internalApi, feature, appConfig);
 
     return setup({
       types: {
@@ -172,27 +110,22 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
         }).makeStateMachine(internalApi),
         getAppConfig: fromPromise(getAppConfig),
         web3CheckOptIn: fromPromise(web3CheckOptIn),
-        getPubKey: fromPromise(getPubKey),
-        inspectTransaction: fromPromise(
-          ({
-            input,
-          }: {
-            input: {
-              serializedTransaction: Uint8Array;
-              resolutionContext?: TransactionResolutionContext;
-              rpcUrl?: string;
-            };
-          }) =>
-            inspectTransaction({
-              serializedTransaction: input.serializedTransaction,
-              resolutionContext: input.resolutionContext,
-              rpcUrl: input.rpcUrl,
-            }),
-        ),
-        buildContext: fromPromise(buildContext),
-        provideContext: fromPromise(provideContext),
-        signTransaction: fromPromise(signTransaction),
-        delayedSignStateMachine: new DelayedSignTransactionDeviceAction({
+        genericClearSignStateMachine: new GenericClearSignDeviceAction({
+          input: {
+            derivationPath: "",
+            transaction: new Uint8Array(),
+            contextModule: undefined as unknown as ContextModule,
+          },
+        }).makeStateMachine(internalApi),
+        shallowClearSignStateMachine: new ShallowClearSignDeviceAction({
+          input: {
+            derivationPath: "",
+            transaction: new Uint8Array(),
+            contextModule: undefined as unknown as ContextModule,
+            appConfig: undefined as unknown as AppConfiguration,
+          },
+        }).makeStateMachine(internalApi),
+        signingOperationsStateMachine: new SigningOperationsDeviceAction({
           input: {
             derivationPath: "",
             transaction: new Uint8Array(),
@@ -205,27 +138,32 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
           context.input.transactionOptions?.skipOpenApp || false,
         isSPLSupported: ({ context }) =>
           isSupported("spl", context._internalState.appConfig!),
-        isDelayedRequested: ({ context }) =>
-          context.input.transactionOptions?.delayed === true,
-        isDelayedWithConfigAndSupported: ({ context }) =>
-          context.input.transactionOptions?.delayed === true &&
-          !!(
-            resolveSolanaRpcUrl(context.input) ||
-            context.input.transactionOptions?.fetchBlockhash
-          ) &&
-          isSupported("delayedSigning", context._internalState.appConfig!),
-        shouldBuildContext: ({ context }) =>
-          context._internalState.inspectorResult?.transactionType ===
-            SolanaTransactionTypes.SPL ||
-          context._internalState.inspectorResult?.transactionType ===
-            SolanaTransactionTypes.SWAP,
         isWeb3ChecksSupported: ({ context }) =>
           isSupported("web3Checks", context._internalState.appConfig!),
-        hasSignature: ({ context }) =>
-          context._internalState.signature !== null,
+        // Generic clear-signing terminates via SIGN MESSAGE DELAYED (0x09) on
+        // the original message, so it only needs the capability bit — no RPC /
+        // blockhash prerequisite.
+        isGenericClearSignAvailable: ({ context }) =>
+          isSupported("genericClearSign", context._internalState.appConfig!),
         shouldOptIn: ({ context }) =>
           !context._internalState.appConfig!.web3ChecksEnabled &&
           !context._internalState.appConfig!.web3ChecksOptIn,
+        // Generic clear-sign child armed the device (Right("armed")).
+        isGenericClearSignArmed: ({ event }) => {
+          const output = (
+            event as unknown as {
+              output: Either<GenericClearSignDAError, GenericClearSignDAOutput>;
+            }
+          ).output;
+          return output.isRight() && output.unsafeCoerce() === "armed";
+        },
+        // Generic clear-sign child surfaced a user cancel (Left).
+        isGenericClearSignCancelled: ({ event }) =>
+          (
+            event as unknown as {
+              output: Either<GenericClearSignDAError, GenericClearSignDAOutput>;
+            }
+          ).output.isLeft(),
       },
       actions: {
         assignErrorFromEvent: assign({
@@ -238,20 +176,9 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
             ),
           }),
         }),
-        logDelayedFallbackWarning: ({ context }) => {
-          const hasConfig = !!(
-            resolveSolanaRpcUrl(context.input) ||
-            context.input.transactionOptions?.fetchBlockhash
-          );
-          logger.warn(
-            hasConfig
-              ? `delayed signing requires Solana app version >= ${SOLANA_FEATURES.delayedSigning.minVersion}; falling back to standard signing`
-              : "delayed signing requires a Solana RPC URL or a fetchBlockhash callback; falling back to standard signing",
-          );
-        },
       },
     }).createMachine({
-      /** @xstate-layout N4IgpgJg5mDOIC5QGUCWUB2AVATgQw1jwGMAXVAewwBEwA3VYsAQTMowDoBJDVcvADbJSeUmADEAbQAMAXUSgADhVh92CkAA9EAJgCMADg4BWAGw7jAGhABPRHr3SA7Bx0BONwGYALNOPfvUz1jHQBfUOs0TFwCIjYqWgYmVnIqbl5+IRExKT15JBBlVVSMDW0EfSMzC2s7BDdvHQ5pby9ff0DgsIiQKOx8QhISxMYWeM4AeUUwDGZFRRHk8fEIKjAOVAw6CgBrdYpp2fnhUTAAWRIAC02wGXylFTUqMsQnN1MON2lzK1tEN0MJicOicTlMoM8LXe4Ui6H6sSG7EWYxKHAAwpcwMQdlMZnMFvRRil2AAlOAAVwEpCkcg0RSepQK5T0nmMRmkwR+tX+3iMgVM0mc+j0OgM3Vh0QGcWGhKWqIxWJxh3xyOJVDJsEp1MkeTpjxKLwQLLZzU5NT+CAMeg4rTcBneLN8bx8MN6cJig3GqvGHAA4mBSPi0VQAGboFZrDZbXbrGCB+bBjBhqB3PXFdRM+wGUzeVymaq-OqOMWfe0BHyeNxOPSmV19D3SpGylHsP0BoOh8NgHA4Cg4DiKASiEN9gC2HDjHaT6FTBXpBszRuzuZ0+a5Fr0Hk+HjL2YsLNMtZ69aliISzbVnH98cUieTGq1CuxNPuhX1GdA5R0nh0TRapgMJxC3sBwmgMMVwU8QC3l5Yw63dU8vQvH1ryne8KSpJ8dlyV95w-LRdB-P9AkA4CEB8a0qxzYwnE8H5jW8eDJQRJCkhbNIeFgaYyAbM8MAjDB1k2bY9ijLisVIXjxlnB502eRdRS+Dgc2+c0i2kBoODBUUDA0ytqyPCV4U9GU2MvdJxJ4xCSnEbte37QdhzHMTuMk6z2Bkt85MZT9dHtaRlN8dc6kCALvDBbwzA0jTwqApjjMbc8zJ9ZgQzEHBONcl80wZQ0fyCLSKyA7kjRZa1+UFYFQLFeKpNMokUrS7tMoknCcoXXzyNXa1aO8Txio3SFjC0jwfD8AIghCWr3KShrUVS9KWrIKQdFw995M6-KeqKsiBSaSLIUMYwvgaUFppY+q5VbAAhclUAECBEzETRqVWQSoxE9YACM7oep6wBezy8I2gjyKcbMbQMPqBqLBxPA4HxzD0RpaKhQy3WYkym2S1Fbvux6qGe6k7L7Ach1IEccHHH78f+wHaTndafNB-qId5aGyOBAK3GMQ7aM3KD9HOrHZqutIAAVewYCAwDp17I2EmMByl1AZbloGmcNPrRQRr5gpA8EOHA1daOghoDDg48EIu7G5tbSWKGl2XCYB4me1JxyKecxQVbVl36bW7ytZ-IxK1Usi90+dwaLtAWxT0YXEpoZDUQdp25YfTDMWfDWg8XcKeYR47+rIhwgOaVoxo6SbxQxhK+O9VPfedjAicz0gsLaxm886gvhtZLwYfsQVcz15HvzjoWrcxpPG9bE8baoAShOjUTVBnvjc9yxdeZ0XN-AAoejVXIxVx0vSqxrROG5T+frZF-iSYc8nKfHdf6+khnZO3zrd-3kij6gXhkFZGjhwpWhzNfVids0gLwfu3TuW8OqgxjsNNwlRAGeAcAjMUTgOQjwAryKBl12KcDgUnBB2dsI6kDj-FBbw0EYNLqufuuDpCsnATWRiroMAUBlvAAo5Cb443wsDZm5QAC0pgSpSOaIKeRCiFFOGIbbMWnAeBqEECcMQ7V8LlEaCVRwhs3heErCCSErR0ZCOgWojguIjgEhESDMRWtBSfHDiVMsrhRpmNRpYlRotSHoiofYlUt91QYVILokGzJ-zKVIiVBoAV3CmPQX46E08P4kPMqhBMnYoDRPEfYfwRhB6lyhMpH8wIALHQtpbIydVVFBNybefJlDFSFMNDoIUrhDCALAVpGsgpi6XysffWe4T1GEFco05xmsFLGBFJ8Q+5SnC5lMPlap3xBYGACcnJxnAFrNWmRJTpi4sE1kKhzQxIo3CDIFH4Lwoy9lzzSHjP6-sondzoeUHwUMjYinKV4XpDyRkGU8C8yZHA06qxbkTM5m0PC5muRuBwPUfFpIsRkhpM19kwM4DCv2rdXbtOxAi0GB0Pg7RuYeI2EEtkbLFLszJsy8W2Oscglx+c7QfFFICwxe8jAshNqubZTLIUHI4By0kkSsLkvKMYXeJhDGQnhvoY6e9FU82cGMjeNignIHJMQJgsABHf2QeUAUtKoYlxVdIUOEEPC0QuW4CV+KOAAFF3Y4HlYgK1HwbWAL3vDMwkVumRV0ofcI4QgA */
+      /** @xstate-layout N4IgpgJg5mDOIC5QGUCWUB2AVATgQw1jwGMAXVAewwBEwA3VYsAQTMowDoBJDVcvADbJSeUmADEAbQAMAXUSgADhVh92CkAA9EARgDsAZg4AOAJzSAbAYAsOgKymdN08YA0IAJ67LxjnbvWxjoW-kGGxgC+Ee5omLgERGxUtAxMrORU3Lz8QiJiUjrySCDKqhkYGtoI+kZmljb2js5unojmRgbS1haG0o5OllEx6Nj4hCTlKYwsSZwA8opgGMyKilNps+IQVGAcqBh0FADWuxSLy6vComAAsiQAFvtgMkVKKmpUlYh6dgBMHL8bJ0LKY7AZOr87O4vAhjHpTCZfkEDHo+nprL8ekMQLFRgkJux1jNyhwFksVooAEpwACuAlIAGF7mBiEcpHINKUPhVilUdL9gn5TCjfr9rNJ+X8WjDzAi9AKDGLwb94RZrNjcfFxrMiel2KTzhTqbA6YzmayCq8Su9yl9qgKLEKRWKJZCkdDEEE-NIffLAX8LPUNSMtYlJvRpnrMgBxMCkCkMqgAM3QWx2ewOx12MHjq0TGBTUBenJt6l5uj9JmsBjhxjhdn0pg91S61gB1kCPT0aosxiRwbiYzDhIjGxJsdzinzhfEYBwOAoOA4igEoiTi4Athwcwnk+hi8Uubby9VK8Zq7X643m78fRwfT7+fCxQ2B3jteHUsT9RPdwX0MappMiybIHm8ZRlqAVQCuYHAWJClj8qYSpQq0LZ6HoHA2D2PpwuCphvqGBLJKO34xnGf6FoB9LARakiFCWEGfCeMHSHBCEWEhKHNt2dj3ghdh9FYgLGHYhFDsRNCkVGnC-nme5QNRZogVIvxWkekFaIgrHsYJnG-Mh1aoTCDQcKYvG9sYaIuJE0Q4iGEk6tJswcAA6mAABGBi0UcsALKQPBphguz7IcJwcAA7p53nmkc-k8GB1pMTyUHaRh-zdHCpjVtInSic2dZGH8gmoi4lmQuJ+JOV+MludFPl+YoAUYLO86Lsuq6kOuOBblFXk+fFGCJRpzGpQgKryhwmXwjleXGd4k3WGCOhWd29g-BYlUfiONUue5-WxY1zVKeImiwHkux4EmYg4AAFNIACU4iao5n6Rnt9WHYNSnDaWo1aQgiqQhwqqmNlxUqrlzaOAi1h6H2KLLZCK1bcOJG7SSPmxsFOCMAyAhgHgOC4sgNKrIuYgQOy6l-SlAMGBYgYg6YjM-NYoLSGC80IMh-yBgYwTwqJ5l2HoqOSbqLlY0sc54wTRMk2Tyg4JTlqMdydoM0zqo9AEHNc82elTd28F1qtnTouL1XvZjsXY7LxD44TxMjKT5Mq5Aqk08lmuM2xOts-rBjc90bFwyEZvgh2KpiXZL1VW9Y4-jLuOO-LLuYEFIWZuFMA43LzskxddzEI8wW-T7J4YmDJjooYir2DY0OdMbjNiuiGIqgRccOQnO028n+dp4XIxZxmYXZinBcK67xcPE89HexrVcGQicJw8qjfWM28FtuZjOBOY1borZwyDn36MD+RQ9OzPmfbMF49ZtuU-D3fGBXGIJdl88anq8eY1q5rzrpvME280J1n+PvUWDgVril+FbROZFZKv1vhnFqc4FxLhXGuTcL8b7pyLtcb+C8OSHlpnaIBtcN4NzATxeGAJMRWF7EqCUBhEH9yTpkZA9xBACAoBFNBuIx6hWfrAXhAh+GCMIbPYh89y5kPAsvMaxUdB+G6I4eEAtpB1m5kEXwDMXDaN7HoHQwQOGXy4ZwHhfCBFCNHpg9qOCup4PEbY6RI9MCf1uPI54iikrKIBqo9RIJGzaN0fQtixgQTw1FBiXRYse7n22pY5BHAsBzg3PsQQwiH7ZwnhwVQmB9hQDJPgcosBvEkIUUvABQTsqYWkBhdENhzxql+DxUEcFqyr26Bibs3cz7vjRlJDG+p44pIwEpHy1N-6aSqCEQUQIGbymMOCMEBVgZgjVNEkELNuixyGURa2ViOATJGdM2KatyGVzGosx0yyehInWQYehCJtkdkZn8YO0Soh2QwBQCAcANDnIls5OpI06ZVAALQWGbLC+8D4kXIrVBY0ZV9OA8DUDki6cz-pVAxM2HQlg2I1hmtIES61Bn2WSSMyWJIyQXDWOCzSkLNZ2EdICasAs-imIMKCAq-g-ABHgv0Wwok0X0v1Iyo0tIaKxTxVC7wFL7z2EEsEUWcNuzQwlMKjewozDNJ0JKll5FJzTnQIqu0OhxSYQbKLLogJ4agleWhYlxKTB1iaYZDsARDk0uGWCsZZrKIATlcpVkVqTw6GFP7FmoIBQrTWToIllg+LmRtaiTmqJlQmuDZwfaMUQJHR4FGsaYonAg1yhCBs2VGapv5feFm-K4lOA3nmjFdUDrFu+uGstAMDJmA4MS8GQRRSKnMgVbKZl4Z9H5KKJEgQO2nOlgQzxH8lYU0gP2qoUc+JjvZhKZC8E4VoX6Iw5EfY4nVmNUkwNJy0n21TvYzAO7EA1jWdQn4GEzD6HlAVOEJgwS3lwvG9hd7jlINqjYyRdiZGvpuYEglok+Iit3lYfoKa0ImzMsBroyF9BxOXWkjJPVslCBGG+hA-gGz3lncLMUBlXUwnhm2Qx0SNrBHMtS0FD7oO90mZckCVH4J-DMgKeUIQwHswKvoLCeyJQbXgvKYj0GaTECYLAeAiG6kLPlJhTEgR5QNxVMxz0oo-AM26PBYI-KzGqZcgAUTajgET+mAQ7OMwKUzzYlqYXDhytZ6q8Lqj+UAA */
       id: "SignTransactionDeviceAction",
       initial: "InitialState",
       context: ({ input }) => ({
@@ -264,9 +191,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
           error: null,
           signature: null,
           appConfig: null,
-          solanaTransactionContext: null,
-          inspectorResult: null,
-          signerAddress: null,
+          clearSignArmed: false,
         },
       }),
       states: {
@@ -296,7 +221,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
               }),
             },
             onDone: {
-              target: "CheckOpenAppDeviceActionResult",
+              target: "OpenAppResultCheck",
               actions: assign({
                 _internalState: ({ event, context }) =>
                   event.output.caseOf({
@@ -310,7 +235,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
             },
           },
         },
-        CheckOpenAppDeviceActionResult: {
+        OpenAppResultCheck: {
           always: [
             { target: "GetAppConfig", guard: "noInternalError" },
             { target: "Error" },
@@ -354,7 +279,12 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
                 "shouldOptIn",
               ]),
             },
-            { target: "CheckSPLSupported", guard: "noInternalError" },
+            // When web3-checks aren't run, still evaluate the clear-sign gate
+            // (the web3 opt-in path rejoins it after Web3ChecksOptInResult).
+            {
+              target: "CheckGenericClearSignSupported",
+              guard: "noInternalError",
+            },
             { target: "Error" },
           ],
         },
@@ -409,217 +339,127 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
               result: context._internalState.appConfig!.web3ChecksEnabled!,
             },
           })),
-          // Zero-delay self-transition: ensures the entry assign above is
-          // visible to onSnapshot observers before the machine moves on.
+          // Zero-delay transition: ensures the entry assign above is visible to
+          // onSnapshot observers before the machine moves on to the gate.
           after: {
             0: {
-              target: "PostWeb3ChecksOptIn",
+              target: "CheckGenericClearSignSupported",
             },
           },
         },
-        PostWeb3ChecksOptIn: {
+        CheckGenericClearSignSupported: {
           always: [
-            { target: "CheckSPLSupported", guard: "noInternalError" },
+            {
+              target: "GenericClearSign",
+              guard: and(["noInternalError", "isGenericClearSignAvailable"]),
+            },
+            { target: "ShallowClearSign", guard: "noInternalError" },
             { target: "Error" },
           ],
         },
-        CheckSPLSupported: {
-          always: [
-            { target: "InspectTransaction", guard: "isSPLSupported" },
-            { target: "CheckBuildNeeded" },
-          ],
-        },
-        InspectTransaction: {
-          entry: assign({
-            intermediateValue: () => ({
-              requiredUserInteraction: UserInteractionRequired.None,
-              step: signTransactionDAStateSteps.INSPECT_TRANSACTION,
-            }),
-          }),
+        // Generic clear-sign child: prepares + arms the device (no signing).
+        // `"armed"` → terminal sign; `"degraded"` → legacy shallow provisioning;
+        // `Left` → user cancel (surface).
+        GenericClearSign: {
           invoke: {
-            id: "inspectTransaction",
-            src: "inspectTransaction",
-
-            input: ({ context }) => ({
-              serializedTransaction: context.input.transaction,
-              resolutionContext:
-                context.input.transactionOptions?.transactionResolutionContext,
-              rpcUrl: resolveSolanaRpcUrl(context.input),
-            }),
-            onDone: {
-              target: "AfterInspect",
-              actions: assign({
-                _internalState: ({ context, event }) => ({
-                  ...context._internalState,
-                  inspectorResult: event.output,
-                }),
-              }),
-            },
-            onError: {
-              target: "CheckDelayed",
-            },
-          },
-        },
-        AfterInspect: {
-          always: [
-            { target: "GetPubKey", guard: "shouldBuildContext" },
-            { target: "CheckBuildNeeded" },
-          ],
-        },
-        CheckBuildNeeded: {
-          always: [
-            {
-              target: "GetPubKey",
-              guard: "isWeb3ChecksSupported",
-            },
-            { target: "CheckDelayed" },
-          ],
-        },
-        GetPubKey: {
-          entry: assign({
-            intermediateValue: () => ({
-              requiredUserInteraction: UserInteractionRequired.None,
-              step: signTransactionDAStateSteps.GET_PUB_KEY,
-            }),
-          }),
-          invoke: {
-            id: "getPubKey",
-            src: "getPubKey",
+            id: "genericClearSignStateMachine",
+            src: "genericClearSignStateMachine",
             input: ({ context }) => ({
               derivationPath: context.input.derivationPath,
-              checkOnDevice: false,
+              transaction: context.input.transaction,
+              contextModule: context.input.contextModule,
             }),
-            onDone: {
-              target: "BuildContext",
+            onSnapshot: {
               actions: assign({
-                _internalState: ({ event, context }) => {
-                  if (isSuccessCommandResult(event.output)) {
-                    return {
-                      ...context._internalState,
-                      signerAddress: event.output.data,
-                    };
-                  }
-                  return context._internalState;
-                },
+                intermediateValue: ({ event }) =>
+                  ({
+                    requiredUserInteraction:
+                      event.snapshot.context.intermediateValue
+                        .requiredUserInteraction,
+
+                    step: event.snapshot.context.intermediateValue
+                      .step as SignTransactionDAStateStep,
+                  }) as SignTransactionDAIntermediateValue,
               }),
             },
-            onError: {
-              target: "BuildContext",
-            },
-          },
-        },
-        BuildContext: {
-          entry: assign({
-            intermediateValue: () => ({
-              requiredUserInteraction: UserInteractionRequired.None,
-              step: signTransactionDAStateSteps.BUILD_TRANSACTION_CONTEXT,
-            }),
-          }),
-          invoke: {
-            id: "buildContext",
-            src: "buildContext",
-            input: ({ context }) => {
-              const inspectorData =
-                context._internalState.inspectorResult?.data;
-              return {
-                contextModule: context.input.contextModule,
-                loggerFactory: this.getLoggerFactory(internalApi),
-                transactionBytes: context.input.transaction,
-                signerAddress: context._internalState.signerAddress,
-                options: {
-                  tokenAddress: inspectorData?.tokenAddress,
-                  createATA: inspectorData?.createATA,
-                  tokenInternalId:
-                    context.input.transactionOptions
-                      ?.transactionResolutionContext?.tokenInternalId,
-                  templateId:
-                    context.input.transactionOptions
-                      ?.transactionResolutionContext?.templateId,
-                },
-              };
-            },
-            onDone: {
-              target: "ProvideContext",
-              actions: assign({
-                _internalState: ({ event, context }) => ({
-                  ...context._internalState,
-                  solanaTransactionContext: {
-                    tlvDescriptor: event.output.tlvDescriptor,
-                    trustedNamePKICertificate:
-                      event.output.trustedNamePKICertificate,
-                    loadersResults: event.output.loadersResults,
-                    contextErrorCount: event.output.contextErrorCount,
-                  },
+            onDone: [
+              {
+                // Armed: run the terminal sign (skips preview, refreshes the
+                // blockhash when possible).
+                target: "TerminalSign",
+                guard: "isGenericClearSignArmed",
+                actions: assign({
+                  _internalState: ({ context }) => ({
+                    ...context._internalState,
+                    clearSignArmed: true,
+                  }),
                 }),
+              },
+              {
+                // User cancel: surface, never fall back.
+                target: "Error",
+                guard: "isGenericClearSignCancelled",
+                actions: assign({
+                  _internalState: ({ event, context }) =>
+                    event.output.caseOf({
+                      Left: (error) => ({ ...context._internalState, error }),
+                      Right: () => context._internalState,
+                    }),
+                }),
+              },
+              // Degraded (`Right("degraded")`): fall back to the legacy path.
+              { target: "ShallowClearSign" },
+            ],
+            onError: {
+              target: "ShallowClearSign",
+              actions: ({ event }) =>
+                logger.info(
+                  "[ClearSign] generic clear-sign threw; falling back to legacy",
+                  { data: { error: event.error } },
+                ),
+            },
+          },
+        },
+        // Legacy SPL / token provisioning child (best-effort, never signs). It
+        // streams descriptors; control always proceeds to the terminal sign.
+        ShallowClearSign: {
+          invoke: {
+            id: "shallowClearSignStateMachine",
+            src: "shallowClearSignStateMachine",
+            input: ({ context }) => ({
+              derivationPath: context.input.derivationPath,
+              transaction: context.input.transaction,
+              contextModule: context.input.contextModule,
+              appConfig: context._internalState.appConfig!,
+              rpcUrl: resolveSolanaRpcUrl(context.input),
+              resolutionContext:
+                context.input.transactionOptions?.transactionResolutionContext,
+            }),
+            onSnapshot: {
+              actions: assign({
+                intermediateValue: ({ event }) =>
+                  ({
+                    requiredUserInteraction:
+                      event.snapshot.context.intermediateValue
+                        .requiredUserInteraction,
+
+                    step: event.snapshot.context.intermediateValue
+                      .step as SignTransactionDAStateStep,
+                  }) as SignTransactionDAIntermediateValue,
               }),
             },
-            onError: {
-              target: "CheckDelayed",
-            },
+            onDone: { target: "TerminalSign" },
+            onError: { target: "TerminalSign" },
           },
         },
-        ProvideContext: {
-          entry: assign({
-            intermediateValue: () => ({
-              requiredUserInteraction: UserInteractionRequired.None,
-              step: signTransactionDAStateSteps.PROVIDE_TRANSACTION_CONTEXT,
-            }),
-          }),
+        // Single terminal sign via the signing-operations machine.
+        // `clearSignArmed` (set by the generic path) skips its preview;
+        // otherwise the machine decides delayed-vs-one-shot from the blockhash
+        // source.
+        TerminalSign: {
           invoke: {
-            id: "provideContext",
-            src: "provideContext",
-            input: ({ context }) => {
-              if (!context._internalState.solanaTransactionContext) {
-                throw new UnknownDAError(
-                  "Solana transaction context is not available",
-                );
-              }
-              return {
-                ...context._internalState.solanaTransactionContext,
-                transactionBytes: context.input.transaction,
-                loggerFactory: this.getLoggerFactory(internalApi),
-              };
-            },
-            onDone: {
-              target: "CheckDelayed",
-            },
-            onError: {
-              target: "CheckDelayed",
-              actions: ({ event }) => {
-                this.logger?.error(
-                  "[ProvideContext] Failed to provide transaction context, falling back to blind signing",
-                  {
-                    data: { error: event.error },
-                  },
-                );
-              },
-            },
-          },
-        },
-        CheckDelayed: {
-          always: [
-            {
-              target: "InvokeDelayedSign",
-              guard: "isDelayedWithConfigAndSupported",
-            },
-            {
-              target: "SignTransaction",
-              guard: "isDelayedRequested",
-              actions: "logDelayedFallbackWarning",
-            },
-            { target: "SignTransaction" },
-          ],
-        },
-        InvokeDelayedSign: {
-          entry: assign({
-            intermediateValue: () => ({
-              requiredUserInteraction: UserInteractionRequired.None,
-              step: signTransactionDAStateSteps.DELAYED_SIGN,
-            }),
-          }),
-          invoke: {
-            id: "delayedSignStateMachine",
-            src: "delayedSignStateMachine",
+            id: "signingOperationsStateMachine",
+            src: "signingOperationsStateMachine",
             input: ({ context }) => ({
               derivationPath: context.input.derivationPath,
               transaction: context.input.transaction,
@@ -629,125 +469,33 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
                 context.input.transactionOptions?.transactionResolutionContext
                   ?.userInputType,
               blockhashService: context.input.blockhashService,
+              alreadyArmed: context._internalState.clearSignArmed,
             }),
             onSnapshot: {
-              actions: [
-                assign({
-                  intermediateValue: ({ event }) =>
-                    ({
-                      requiredUserInteraction:
-                        event.snapshot.context.intermediateValue
-                          .requiredUserInteraction,
-                      step: event.snapshot.context.intermediateValue
-                        .step as SignTransactionDAStateStep,
-                    }) as SignTransactionDAIntermediateValue,
-                }),
-                ({ event }) => {
-                  const stateValue =
-                    typeof event.snapshot.value === "string"
-                      ? event.snapshot.value
-                      : JSON.stringify(event.snapshot.value);
-                  this.logger?.debug(
-                    `[DelayedSign] Child state: ${stateValue}`,
-                    {
-                      data: {
-                        internalState: event.snapshot.context._internalState,
-                        intermediateValue:
-                          event.snapshot.context.intermediateValue,
-                      },
-                    },
-                  );
-                },
-              ],
-            },
-            onDone: {
-              target: "CheckDelayedResult",
               actions: assign({
-                _internalState: ({ event, context }) =>
-                  event.output.caseOf({
-                    Right: (signature: Uint8Array) => ({
-                      ...context._internalState,
-                      signature,
-                    }),
-                    Left: (error) => {
-                      if (error instanceof UnknownDAError) {
-                        this.logger?.debug(
-                          "Delayed signing failed, falling back to legacy signing",
-                          {
-                            data: {
-                              error: error.originalError?.message,
-                            },
-                          },
-                        );
-                        return context._internalState;
-                      }
-                      return {
-                        ...context._internalState,
-                        error,
-                      };
-                    },
-                  }),
+                intermediateValue: ({ event }) =>
+                  ({
+                    requiredUserInteraction:
+                      event.snapshot.context.intermediateValue
+                        .requiredUserInteraction,
+
+                    step: event.snapshot.context.intermediateValue
+                      .step as SignTransactionDAStateStep,
+                  }) as SignTransactionDAIntermediateValue,
               }),
-            },
-          },
-        },
-        CheckDelayedResult: {
-          always: [
-            { target: "SignTransactionResultCheck", guard: "hasSignature" },
-            { target: "SignTransaction", guard: "noInternalError" },
-            { target: "Error" },
-          ],
-        },
-        SignTransaction: {
-          entry: assign({
-            intermediateValue: {
-              requiredUserInteraction: UserInteractionRequired.SignTransaction,
-              step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-            },
-          }),
-          invoke: {
-            id: "signTransaction",
-            src: "signTransaction",
-            input: ({ context }) => {
-              return {
-                derivationPath: context.input.derivationPath,
-                serializedTransaction: context.input.transaction,
-                userInputType:
-                  context.input.transactionOptions?.transactionResolutionContext
-                    ?.userInputType,
-              };
             },
             onDone: {
               target: "SignTransactionResultCheck",
               actions: assign({
-                _internalState: ({ event, context }) => {
-                  if (!isSuccessCommandResult(event.output))
-                    return {
+                _internalState: ({ event, context }) =>
+                  event.output.caseOf<SignTransactionDAInternalState>({
+                    Right: (signature) => ({
                       ...context._internalState,
-                      error: event.output.error,
-                    };
-
-                  const data = event.output.data.extract();
-                  if (event.output.data.isJust() && data instanceof Uint8Array)
-                    return {
-                      ...context._internalState,
-                      signature: data,
-                    };
-
-                  return {
-                    ...context._internalState,
-                    error: new UnknownDAError("No Signature available"),
-                  };
-                },
-                intermediateValue: {
-                  requiredUserInteraction: UserInteractionRequired.None,
-                  step: signTransactionDAStateSteps.SIGN_TRANSACTION,
-                },
+                      signature,
+                    }),
+                    Left: (error) => ({ ...context._internalState, error }),
+                  }),
               }),
-            },
-            onError: {
-              target: "Error",
-              actions: "assignErrorFromEvent",
             },
           },
         },
@@ -777,69 +525,9 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
     const web3CheckOptIn = async () =>
       internalApi.sendCommand(new Web3CheckOptInCommand());
 
-    const getPubKey = async (arg0: {
-      input: {
-        derivationPath: string;
-        checkOnDevice: boolean;
-      };
-    }) =>
-      internalApi.sendCommand(
-        new GetPubKeyCommand({
-          derivationPath: arg0.input.derivationPath,
-          checkOnDevice: arg0.input.checkOnDevice,
-        }),
-      );
-
-    const buildContext = async (arg0: {
-      input: BuildTransactionContextTaskArgs;
-    }) => new BuildTransactionContextTask(internalApi, arg0.input).run();
-
-    const provideContext = async (arg0: {
-      input: ProvideSolanaTransactionContextTaskArgs;
-    }) =>
-      new ProvideSolanaTransactionContextTask(internalApi, arg0.input).run();
-
-    const inspectTransaction = async (arg0: {
-      serializedTransaction: Uint8Array;
-      resolutionContext?: TransactionResolutionContext;
-      rpcUrl?: string;
-    }) =>
-      Promise.resolve(
-        new TransactionInspector(arg0.rpcUrl).inspectTransactionType(
-          arg0.serializedTransaction,
-          arg0.resolutionContext?.tokenAddress,
-          arg0.resolutionContext?.createATA,
-          arg0.resolutionContext?.templateId,
-        ),
-      );
-
-    const signTransaction = async (arg0: {
-      input: {
-        derivationPath: string;
-        serializedTransaction: Uint8Array;
-        userInputType?: UserInputType;
-      };
-    }) =>
-      new SignDataTask(internalApi, {
-        commandFactory: (args) =>
-          new SignTransactionCommand({
-            serializedTransaction: args.chunkedData,
-            more: args.more,
-            extend: args.extend,
-            userInputType: arg0.input.userInputType,
-          }),
-        derivationPath: arg0.input.derivationPath,
-        sendingData: arg0.input.serializedTransaction,
-      }).run();
-
     return {
       getAppConfig,
       web3CheckOptIn,
-      getPubKey,
-      buildContext,
-      provideContext,
-      signTransaction,
-      inspectTransaction,
     };
   }
 }

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/SigningOperationsDeviceAction.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/SigningOperationsDeviceAction.test.ts
@@ -9,16 +9,16 @@ import { Just, Nothing } from "purify-ts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
-  type DelayedSignDAError,
-  type DelayedSignDAInput,
-  type DelayedSignDAIntermediateValue,
-  delayedSignDAStateSteps,
-} from "@api/app-binder/DelayedSignTransactionDeviceActionTypes";
+  type SigningOperationsDAError,
+  type SigningOperationsDAInput,
+  type SigningOperationsDAIntermediateValue,
+  signingOperationsDAStateSteps,
+} from "@api/app-binder/SigningOperationsDeviceActionTypes";
 import { SolanaAppCommandError } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
 
 import { makeDeviceActionInternalApiMock } from "./__test-utils__/makeInternalApi";
 import { testDeviceActionStates } from "./__test-utils__/testDeviceActionStates";
-import { DelayedSignTransactionDeviceAction } from "./DelayedSignTransactionDeviceAction";
+import { SigningOperationsDeviceAction } from "./SigningOperationsDeviceAction";
 
 const defaultDerivation = "44'/501'/0'/0'";
 const exampleTx = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
@@ -31,7 +31,7 @@ const patchedTx = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
 let apiMock: ReturnType<typeof makeDeviceActionInternalApiMock>;
 let previewMock: ReturnType<typeof vi.fn>;
 let delayedSignMock: ReturnType<typeof vi.fn>;
-let fallbackSignMock: ReturnType<typeof vi.fn>;
+let signMock: ReturnType<typeof vi.fn>;
 let fetchBlockhashMock: ReturnType<typeof vi.fn>;
 let zeroBlockhashMock: ReturnType<typeof vi.fn>;
 let patchBlockhashMock: ReturnType<typeof vi.fn>;
@@ -40,19 +40,19 @@ function extractDeps() {
   return {
     previewTransaction: previewMock,
     delayedSignTransaction: delayedSignMock,
-    fallbackSignTransaction: fallbackSignMock,
+    signTransaction: signMock,
     fetchBlockhashFn: fetchBlockhashMock,
     zeroBlockhashFn: zeroBlockhashMock,
     patchBlockhashFn: patchBlockhashMock,
   };
 }
 
-describe("DelayedSignTransactionDeviceAction", () => {
+describe("SigningOperationsDeviceAction", () => {
   beforeEach(() => {
     apiMock = makeDeviceActionInternalApiMock();
     previewMock = vi.fn();
     delayedSignMock = vi.fn();
-    fallbackSignMock = vi.fn();
+    signMock = vi.fn();
     fetchBlockhashMock = vi.fn();
     zeroBlockhashMock = vi.fn().mockResolvedValue(zeroedTx);
     patchBlockhashMock = vi.fn().mockResolvedValue(patchedTx);
@@ -66,68 +66,68 @@ describe("DelayedSignTransactionDeviceAction", () => {
         CommandResultFactory({ data: Just(exampleSignature) }),
       );
 
-      const input: DelayedSignDAInput = {
+      const input: SigningOperationsDAInput = {
         derivationPath: defaultDerivation,
         transaction: exampleTx,
         rpcUrl: "https://api.devnet.solana.com",
       };
 
-      const action = new DelayedSignTransactionDeviceAction({ input });
+      const action = new SigningOperationsDeviceAction({ input });
       vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
 
       const expected = [
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+            step: signingOperationsDAStateSteps.ZERO_BLOCKHASH,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+            step: signingOperationsDAStateSteps.PREVIEW_TRANSACTION,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.FETCH_BLOCKHASH,
+            step: signingOperationsDAStateSteps.FETCH_BLOCKHASH,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.PATCH_TRANSACTION,
+            step: signingOperationsDAStateSteps.PATCH_TRANSACTION,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.DELAYED_SIGN,
+            step: signingOperationsDAStateSteps.DELAYED_SIGN,
           },
           status: DeviceActionStatus.Pending,
         },
         { output: exampleSignature, status: DeviceActionStatus.Completed },
       ] as DeviceActionState<
         Uint8Array,
-        DelayedSignDAError,
-        DelayedSignDAIntermediateValue
+        SigningOperationsDAError,
+        SigningOperationsDAIntermediateValue
       >[];
 
       testDeviceActionStates<
         Uint8Array,
-        DelayedSignDAInput,
-        DelayedSignDAError,
-        DelayedSignDAIntermediateValue
+        SigningOperationsDAInput,
+        SigningOperationsDAError,
+        SigningOperationsDAIntermediateValue
       >(action, expected, apiMock, {
         onDone: () => {
           expect(previewMock).toHaveBeenCalledTimes(1);
           expect(delayedSignMock).toHaveBeenCalledTimes(1);
-          expect(fallbackSignMock).not.toHaveBeenCalled();
+          expect(signMock).not.toHaveBeenCalled();
           resolve();
         },
         onError: reject,
@@ -145,11 +145,11 @@ describe("DelayedSignTransactionDeviceAction", () => {
         }),
       );
       fetchBlockhashMock.mockResolvedValue(exampleBlockhash);
-      fallbackSignMock.mockResolvedValue(
+      signMock.mockResolvedValue(
         CommandResultFactory({ data: Just(exampleSignature) }),
       );
 
-      const action = new DelayedSignTransactionDeviceAction({
+      const action = new SigningOperationsDeviceAction({
         input: {
           derivationPath: defaultDerivation,
           transaction: exampleTx,
@@ -162,49 +162,49 @@ describe("DelayedSignTransactionDeviceAction", () => {
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+            step: signingOperationsDAStateSteps.ZERO_BLOCKHASH,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+            step: signingOperationsDAStateSteps.PREVIEW_TRANSACTION,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.FETCH_BLOCKHASH,
+            step: signingOperationsDAStateSteps.FETCH_BLOCKHASH,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.PATCH_TRANSACTION,
+            step: signingOperationsDAStateSteps.PATCH_TRANSACTION,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: delayedSignDAStateSteps.FALLBACK_TO_NON_DELAYED_SIGN,
+            step: signingOperationsDAStateSteps.FALLBACK_TO_NON_DELAYED_SIGN,
           },
           status: DeviceActionStatus.Pending,
         },
         { output: exampleSignature, status: DeviceActionStatus.Completed },
       ] as DeviceActionState<
         Uint8Array,
-        DelayedSignDAError,
-        DelayedSignDAIntermediateValue
+        SigningOperationsDAError,
+        SigningOperationsDAIntermediateValue
       >[];
 
       testDeviceActionStates(action, expected, apiMock, {
         onDone: () => {
           expect(delayedSignMock).not.toHaveBeenCalled();
-          expect(fallbackSignMock).toHaveBeenCalledTimes(1);
+          expect(signMock).toHaveBeenCalledTimes(1);
           resolve();
         },
         onError: reject,
@@ -222,7 +222,7 @@ describe("DelayedSignTransactionDeviceAction", () => {
         }),
       );
 
-      const action = new DelayedSignTransactionDeviceAction({
+      const action = new SigningOperationsDeviceAction({
         input: {
           derivationPath: defaultDerivation,
           transaction: exampleTx,
@@ -235,14 +235,14 @@ describe("DelayedSignTransactionDeviceAction", () => {
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+            step: signingOperationsDAStateSteps.ZERO_BLOCKHASH,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+            step: signingOperationsDAStateSteps.PREVIEW_TRANSACTION,
           },
           status: DeviceActionStatus.Pending,
         },
@@ -254,14 +254,14 @@ describe("DelayedSignTransactionDeviceAction", () => {
         },
       ] as DeviceActionState<
         Uint8Array,
-        DelayedSignDAError,
-        DelayedSignDAIntermediateValue
+        SigningOperationsDAError,
+        SigningOperationsDAIntermediateValue
       >[];
 
       testDeviceActionStates(action, expected, apiMock, {
         onDone: () => {
           expect(delayedSignMock).not.toHaveBeenCalled();
-          expect(fallbackSignMock).not.toHaveBeenCalled();
+          expect(signMock).not.toHaveBeenCalled();
           expect(fetchBlockhashMock).not.toHaveBeenCalled();
           resolve();
         },
@@ -280,7 +280,7 @@ describe("DelayedSignTransactionDeviceAction", () => {
         }),
       );
 
-      const action = new DelayedSignTransactionDeviceAction({
+      const action = new SigningOperationsDeviceAction({
         input: {
           derivationPath: defaultDerivation,
           transaction: exampleTx,
@@ -293,14 +293,14 @@ describe("DelayedSignTransactionDeviceAction", () => {
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+            step: signingOperationsDAStateSteps.ZERO_BLOCKHASH,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+            step: signingOperationsDAStateSteps.PREVIEW_TRANSACTION,
           },
           status: DeviceActionStatus.Pending,
         },
@@ -312,14 +312,14 @@ describe("DelayedSignTransactionDeviceAction", () => {
         },
       ] as DeviceActionState<
         Uint8Array,
-        DelayedSignDAError,
-        DelayedSignDAIntermediateValue
+        SigningOperationsDAError,
+        SigningOperationsDAIntermediateValue
       >[];
 
       testDeviceActionStates(action, expected, apiMock, {
         onDone: () => {
           expect(delayedSignMock).not.toHaveBeenCalled();
-          expect(fallbackSignMock).not.toHaveBeenCalled();
+          expect(signMock).not.toHaveBeenCalled();
           expect(fetchBlockhashMock).not.toHaveBeenCalled();
           resolve();
         },
@@ -335,11 +335,11 @@ describe("DelayedSignTransactionDeviceAction", () => {
         }),
       );
       fetchBlockhashMock.mockResolvedValue(exampleBlockhash);
-      fallbackSignMock.mockResolvedValue(
+      signMock.mockResolvedValue(
         CommandResultFactory({ data: Just(exampleSignature) }),
       );
 
-      const action = new DelayedSignTransactionDeviceAction({
+      const action = new SigningOperationsDeviceAction({
         input: {
           derivationPath: defaultDerivation,
           transaction: exampleTx,
@@ -352,60 +352,63 @@ describe("DelayedSignTransactionDeviceAction", () => {
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+            step: signingOperationsDAStateSteps.ZERO_BLOCKHASH,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+            step: signingOperationsDAStateSteps.PREVIEW_TRANSACTION,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.FETCH_BLOCKHASH,
+            step: signingOperationsDAStateSteps.FETCH_BLOCKHASH,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.PATCH_TRANSACTION,
+            step: signingOperationsDAStateSteps.PATCH_TRANSACTION,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: delayedSignDAStateSteps.FALLBACK_TO_NON_DELAYED_SIGN,
+            step: signingOperationsDAStateSteps.FALLBACK_TO_NON_DELAYED_SIGN,
           },
           status: DeviceActionStatus.Pending,
         },
         { output: exampleSignature, status: DeviceActionStatus.Completed },
       ] as DeviceActionState<
         Uint8Array,
-        DelayedSignDAError,
-        DelayedSignDAIntermediateValue
+        SigningOperationsDAError,
+        SigningOperationsDAIntermediateValue
       >[];
 
       testDeviceActionStates(action, expected, apiMock, {
         onDone: () => {
-          expect(fallbackSignMock).toHaveBeenCalledTimes(1);
+          expect(signMock).toHaveBeenCalledTimes(1);
           resolve();
         },
         onError: reject,
       });
     }));
 
-  it("fetch blockhash failure -> error", () =>
+  it("fetch blockhash failure -> signs the original tx (best-effort, no patch)", () =>
     new Promise<void>((resolve, reject) => {
       previewMock.mockResolvedValue(CommandResultFactory({ data: Nothing }));
       fetchBlockhashMock.mockRejectedValue(new Error("network error"));
+      delayedSignMock.mockResolvedValue(
+        CommandResultFactory({ data: Just(exampleSignature) }),
+      );
 
-      const action = new DelayedSignTransactionDeviceAction({
+      const action = new SigningOperationsDeviceAction({
         input: {
           derivationPath: defaultDerivation,
           transaction: exampleTx,
@@ -418,38 +421,51 @@ describe("DelayedSignTransactionDeviceAction", () => {
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+            step: signingOperationsDAStateSteps.ZERO_BLOCKHASH,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+            step: signingOperationsDAStateSteps.PREVIEW_TRANSACTION,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.FETCH_BLOCKHASH,
+            step: signingOperationsDAStateSteps.FETCH_BLOCKHASH,
           },
           status: DeviceActionStatus.Pending,
         },
         {
-          error: expect.objectContaining({
-            _tag: "UnknownDAError",
-          }),
-          status: DeviceActionStatus.Error,
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+            step: signingOperationsDAStateSteps.DELAYED_SIGN,
+          },
+          status: DeviceActionStatus.Pending,
         },
+        { output: exampleSignature, status: DeviceActionStatus.Completed },
       ] as DeviceActionState<
         Uint8Array,
-        DelayedSignDAError,
-        DelayedSignDAIntermediateValue
+        SigningOperationsDAError,
+        SigningOperationsDAIntermediateValue
       >[];
 
       testDeviceActionStates(action, expected, apiMock, {
-        onDone: resolve,
+        onDone: () => {
+          // No patch happened; the original transaction is signed.
+          expect(patchBlockhashMock).not.toHaveBeenCalled();
+          expect(delayedSignMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+              input: expect.objectContaining({
+                serializedTransaction: exampleTx,
+              }),
+            }),
+          );
+          resolve();
+        },
         onError: reject,
       });
     }));
@@ -467,7 +483,7 @@ describe("DelayedSignTransactionDeviceAction", () => {
         }),
       );
 
-      const action = new DelayedSignTransactionDeviceAction({
+      const action = new SigningOperationsDeviceAction({
         input: {
           derivationPath: defaultDerivation,
           transaction: exampleTx,
@@ -480,35 +496,35 @@ describe("DelayedSignTransactionDeviceAction", () => {
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+            step: signingOperationsDAStateSteps.ZERO_BLOCKHASH,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+            step: signingOperationsDAStateSteps.PREVIEW_TRANSACTION,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.FETCH_BLOCKHASH,
+            step: signingOperationsDAStateSteps.FETCH_BLOCKHASH,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.PATCH_TRANSACTION,
+            step: signingOperationsDAStateSteps.PATCH_TRANSACTION,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.DELAYED_SIGN,
+            step: signingOperationsDAStateSteps.DELAYED_SIGN,
           },
           status: DeviceActionStatus.Pending,
         },
@@ -520,8 +536,8 @@ describe("DelayedSignTransactionDeviceAction", () => {
         },
       ] as DeviceActionState<
         Uint8Array,
-        DelayedSignDAError,
-        DelayedSignDAIntermediateValue
+        SigningOperationsDAError,
+        SigningOperationsDAIntermediateValue
       >[];
 
       testDeviceActionStates(action, expected, apiMock, {
@@ -539,7 +555,7 @@ describe("DelayedSignTransactionDeviceAction", () => {
         CommandResultFactory({ data: Just(exampleSignature) }),
       );
 
-      const action = new DelayedSignTransactionDeviceAction({
+      const action = new SigningOperationsDeviceAction({
         input: {
           derivationPath: defaultDerivation,
           transaction: exampleTx,
@@ -565,43 +581,43 @@ describe("DelayedSignTransactionDeviceAction", () => {
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+            step: signingOperationsDAStateSteps.ZERO_BLOCKHASH,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.SignTransaction,
-            step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+            step: signingOperationsDAStateSteps.PREVIEW_TRANSACTION,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.FETCH_BLOCKHASH,
+            step: signingOperationsDAStateSteps.FETCH_BLOCKHASH,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.PATCH_TRANSACTION,
+            step: signingOperationsDAStateSteps.PATCH_TRANSACTION,
           },
           status: DeviceActionStatus.Pending,
         },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
-            step: delayedSignDAStateSteps.DELAYED_SIGN,
+            step: signingOperationsDAStateSteps.DELAYED_SIGN,
           },
           status: DeviceActionStatus.Pending,
         },
         { output: exampleSignature, status: DeviceActionStatus.Completed },
       ] as DeviceActionState<
         Uint8Array,
-        DelayedSignDAError,
-        DelayedSignDAIntermediateValue
+        SigningOperationsDAError,
+        SigningOperationsDAIntermediateValue
       >[];
 
       testDeviceActionStates(action, expected, apiMock, {
@@ -611,5 +627,169 @@ describe("DelayedSignTransactionDeviceAction", () => {
         },
         onError: reject,
       });
+    }));
+
+  it("alreadyArmed with RPC: skips the preview, refreshes the blockhash, delayed-signs", () =>
+    new Promise<void>((resolve, reject) => {
+      fetchBlockhashMock.mockResolvedValue(exampleBlockhash);
+      delayedSignMock.mockResolvedValue(
+        CommandResultFactory({ data: Just(exampleSignature) }),
+      );
+
+      const input: SigningOperationsDAInput = {
+        derivationPath: defaultDerivation,
+        transaction: exampleTx,
+        rpcUrl: "https://api.devnet.solana.com",
+        alreadyArmed: true,
+      };
+
+      const action = new SigningOperationsDeviceAction({ input });
+      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+
+      testDeviceActionStates(
+        action,
+        [
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: signingOperationsDAStateSteps.FETCH_BLOCKHASH,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: signingOperationsDAStateSteps.PATCH_TRANSACTION,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: signingOperationsDAStateSteps.DELAYED_SIGN,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          { output: exampleSignature, status: DeviceActionStatus.Completed },
+        ] as DeviceActionState<
+          Uint8Array,
+          SigningOperationsDAError,
+          SigningOperationsDAIntermediateValue
+        >[],
+        apiMock,
+        {
+          onDone: () => {
+            expect(previewMock).not.toHaveBeenCalled();
+            expect(zeroBlockhashMock).not.toHaveBeenCalled();
+            expect(fetchBlockhashMock).toHaveBeenCalledTimes(1);
+            expect(delayedSignMock).toHaveBeenCalledTimes(1);
+            resolve();
+          },
+          onError: reject,
+        },
+      );
+    }));
+
+  it("alreadyArmed without RPC: signs the original transaction (no preview, no fetch)", () =>
+    new Promise<void>((resolve, reject) => {
+      delayedSignMock.mockResolvedValue(
+        CommandResultFactory({ data: Just(exampleSignature) }),
+      );
+
+      const input: SigningOperationsDAInput = {
+        derivationPath: defaultDerivation,
+        transaction: exampleTx,
+        alreadyArmed: true,
+      };
+
+      const action = new SigningOperationsDeviceAction({ input });
+      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+
+      testDeviceActionStates(
+        action,
+        [
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: signingOperationsDAStateSteps.DELAYED_SIGN,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          { output: exampleSignature, status: DeviceActionStatus.Completed },
+        ] as DeviceActionState<
+          Uint8Array,
+          SigningOperationsDAError,
+          SigningOperationsDAIntermediateValue
+        >[],
+        apiMock,
+        {
+          onDone: () => {
+            expect(previewMock).not.toHaveBeenCalled();
+            expect(fetchBlockhashMock).not.toHaveBeenCalled();
+            expect(patchBlockhashMock).not.toHaveBeenCalled();
+            // Signs the original transaction as-is.
+            expect(delayedSignMock).toHaveBeenCalledWith(
+              expect.objectContaining({
+                input: expect.objectContaining({
+                  serializedTransaction: exampleTx,
+                }),
+              }),
+            );
+            resolve();
+          },
+          onError: reject,
+        },
+      );
+    }));
+
+  it("not armed, no RPC: primary one-shot sign (0x06, SIGN_TRANSACTION step)", () =>
+    new Promise<void>((resolve, reject) => {
+      signMock.mockResolvedValue(
+        CommandResultFactory({ data: Just(exampleSignature) }),
+      );
+
+      const input: SigningOperationsDAInput = {
+        derivationPath: defaultDerivation,
+        transaction: exampleTx,
+      };
+
+      const action = new SigningOperationsDeviceAction({ input });
+      vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+
+      testDeviceActionStates(
+        action,
+        [
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.SignTransaction,
+              step: signingOperationsDAStateSteps.SIGN_TRANSACTION,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          { output: exampleSignature, status: DeviceActionStatus.Completed },
+        ] as DeviceActionState<
+          Uint8Array,
+          SigningOperationsDAError,
+          SigningOperationsDAIntermediateValue
+        >[],
+        apiMock,
+        {
+          onDone: () => {
+            // No preview, no fetch/patch, no delayed sign — just the one-shot.
+            expect(previewMock).not.toHaveBeenCalled();
+            expect(fetchBlockhashMock).not.toHaveBeenCalled();
+            expect(delayedSignMock).not.toHaveBeenCalled();
+            expect(signMock).toHaveBeenCalledWith(
+              expect.objectContaining({
+                input: expect.objectContaining({
+                  serializedTransaction: exampleTx,
+                }),
+              }),
+            );
+            resolve();
+          },
+          onError: reject,
+        },
+      );
     }));
 });

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/SigningOperationsDeviceAction.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/SigningOperationsDeviceAction.ts
@@ -9,16 +9,16 @@ import {
   XStateDeviceAction,
 } from "@ledgerhq/device-management-kit";
 import { Left, type Maybe, Right } from "purify-ts";
-import { assign, fromPromise, setup } from "xstate";
+import { and, assign, fromPromise, setup } from "xstate";
 
 import {
-  type DelayedSignDAError,
-  type DelayedSignDAInput,
-  type DelayedSignDAIntermediateValue,
-  type DelayedSignDAInternalState,
-  type DelayedSignDAOutput,
-  delayedSignDAStateSteps,
-} from "@api/app-binder/DelayedSignTransactionDeviceActionTypes";
+  type SigningOperationsDAError,
+  type SigningOperationsDAInput,
+  type SigningOperationsDAIntermediateValue,
+  type SigningOperationsDAInternalState,
+  type SigningOperationsDAOutput,
+  signingOperationsDAStateSteps,
+} from "@api/app-binder/SigningOperationsDeviceActionTypes";
 import { type Signature } from "@api/model/Signature";
 import { type UserInputType } from "@api/model/TransactionResolutionContext";
 import { DelayedSignTransactionCommand } from "@internal/app-binder/command/DelayedSignTransactionCommand";
@@ -46,7 +46,7 @@ export type MachineDependencies = {
       userInputType?: UserInputType;
     };
   }) => Promise<CommandResult<Maybe<Signature>, SolanaAppErrorCodes>>;
-  readonly fallbackSignTransaction: (arg0: {
+  readonly signTransaction: (arg0: {
     input: {
       derivationPath: string;
       serializedTransaction: Uint8Array;
@@ -69,34 +69,52 @@ export type MachineDependencies = {
 
 const USER_REJECTION_CODE: SolanaAppErrorCodes = "6985";
 
-export class DelayedSignTransactionDeviceAction extends XStateDeviceAction<
-  DelayedSignDAOutput,
-  DelayedSignDAInput,
-  DelayedSignDAError,
-  DelayedSignDAIntermediateValue,
-  DelayedSignDAInternalState
+/** Fold a sign command result into the internal state (signature or error). */
+function applySignatureResult(
+  internalState: SigningOperationsDAInternalState,
+  result: CommandResult<Maybe<Signature>, SolanaAppErrorCodes>,
+): SigningOperationsDAInternalState {
+  if (!isSuccessCommandResult(result)) {
+    return { ...internalState, error: result.error };
+  }
+  const data = result.data.extract();
+  if (result.data.isJust() && data instanceof Uint8Array) {
+    return { ...internalState, signature: data };
+  }
+  return {
+    ...internalState,
+    error: new UnknownDAError("No signature available"),
+  };
+}
+
+export class SigningOperationsDeviceAction extends XStateDeviceAction<
+  SigningOperationsDAOutput,
+  SigningOperationsDAInput,
+  SigningOperationsDAError,
+  SigningOperationsDAIntermediateValue,
+  SigningOperationsDAInternalState
 > {
   makeStateMachine(
     internalApi: InternalApi,
   ): DeviceActionStateMachine<
-    DelayedSignDAOutput,
-    DelayedSignDAInput,
-    DelayedSignDAError,
-    DelayedSignDAIntermediateValue,
-    DelayedSignDAInternalState
+    SigningOperationsDAOutput,
+    SigningOperationsDAInput,
+    SigningOperationsDAError,
+    SigningOperationsDAIntermediateValue,
+    SigningOperationsDAInternalState
   > {
     type types = StateMachineTypes<
-      DelayedSignDAOutput,
-      DelayedSignDAInput,
-      DelayedSignDAError,
-      DelayedSignDAIntermediateValue,
-      DelayedSignDAInternalState
+      SigningOperationsDAOutput,
+      SigningOperationsDAInput,
+      SigningOperationsDAError,
+      SigningOperationsDAIntermediateValue,
+      SigningOperationsDAInternalState
     >;
 
     const {
       previewTransaction,
       delayedSignTransaction,
-      fallbackSignTransaction,
+      signTransaction,
       fetchBlockhashFn,
       zeroBlockhashFn,
       patchBlockhashFn,
@@ -111,7 +129,7 @@ export class DelayedSignTransactionDeviceAction extends XStateDeviceAction<
       actors: {
         previewTransaction: fromPromise(previewTransaction),
         delayedSignTransaction: fromPromise(delayedSignTransaction),
-        fallbackSignTransaction: fromPromise(fallbackSignTransaction),
+        signTransaction: fromPromise(signTransaction),
         fetchBlockhashFn: fromPromise(fetchBlockhashFn),
         zeroBlockhashFn: fromPromise(zeroBlockhashFn),
         patchBlockhashFn: fromPromise(patchBlockhashFn),
@@ -120,6 +138,9 @@ export class DelayedSignTransactionDeviceAction extends XStateDeviceAction<
         noInternalError: ({ context }) => context._internalState.error === null,
         isPreviewFallback: ({ context }) =>
           context._internalState.previewFallback,
+        isAlreadyArmed: ({ context }) => context.input.alreadyArmed === true,
+        hasBlockhashSource: ({ context }) =>
+          !!(context.input.rpcUrl || context.input.fetchBlockhash),
       },
       actions: {
         assignErrorFromEvent: assign({
@@ -134,13 +155,14 @@ export class DelayedSignTransactionDeviceAction extends XStateDeviceAction<
         }),
       },
     }).createMachine({
-      id: "DelayedSignTransactionDeviceAction",
-      initial: "ZeroBlockhash",
+      /** @xstate-layout N4IgpgJg5mDOIC5QGUCWUB2qNQPIAcwAnAQwBdUB7DWAETADdUBjMAQWYuoDoBRDMkQCeAYgDaABgC6iUPkqxUXDLJAAPRAEYArABZuADk0AmbRM0SA7NoDMANgCcDywBoQQxHd03udy85tjc20QuwBfMLc0TGw8QlJlOkYWdk4qDD4BYXFNGSQQeUVlVQ0EHX0jU3MrW0dnNw8EB2MDbhsDFu8nTRNtAwio9CwcAmJydKSmVg5lTMFRMWM8uQUldJKtPUNe6ut7J1d3LWMfEIcDJ2MvTQcb3QGQaOG4scT6KdTZ-nnxG2WC1bFfKlcrbKoWPZ1Q6NCwGfR2DotSzBOx9BwPJ6xUYJCbvFIzdLcABaxEoACEADaUZgAawAFiRYHSRBBqGBuNgGJQaeyAF6kynU+mMukAMQwkn+hTW1A2CEsfm4xl0Tm0zX8Bgk9SOCGVxm4EjVBgMyMsxk0ul0lgxQyx8XG1Em+LSPBJRHJVNpDKZImI7qI3HwFPIADNKEQALbcfnuwVekXiyWqaVA0ClBWWJUqhxq4warXQxBGbjZpwGGwSDoGbR5m0xEb2t7JaYujIABSIyTAAHcACqkGgkVsstkcjBcnmBztMHv9kiD1tJ-Ip9bArT2bTcZqaY12EwtDq6BqIGy6Vo2ByBC8OPxmzR157Yh00PEt2Ydrt9gewIfKX1Ef1A2DMgw0jKdPznBdlCXFYilXNN11RLdzV3fdjWVY9dROEsFW0Lw7HaOFywfO1XlxZtPkJD8Z27AAlOAAFcKTIABhOkwFpcRpGTQF4PULQNS3OFOm0HQaz0TDxO4TR-DqY1y3VEiGzIx1X0onhqNQHt6NgJjWPYzixFyHi4NlNcykE85dBEsTTCPHUNxLWx92Mc4rgtJSXhxVSKIJHhRTAMhmDpONhR9VkMHZTluXZENAuC0LvTFCVuOXXizIQ3UbC2QIjBknQ8rPSSJH1Woz10PCvC1atPKfJsPj8jIAqCkLPTC5k-XDIDQ3DKM4paxKExSqV0pUcyThyloeksAqeiKnVNXPKsdxCCQrVsWrG3IhrW24NtyGCyCf2HCKovHGLAwO1qhSSxNUtgmUxsy1zLW4SxKksGx-Gy8xMK8Hw-GcSsLmVC5rUiR5bWU7yX183b9pao7f3Sf9AKDHqwPwK7BqZO6RtMp7+N1BxXvekxPu+sxNEws8fBzGxNAZisJuIiHMWh58nTfKirp0vS2I4mkuPxx65RsbLNysfwJFPPxDQcP7FXOHMHGBnoL2MTaVNhnb315xjmIFwzjLSgmxYlg1LGl2XkTVTD3rsEsJDsPNrCIvdtC1mGufUjJ6GDIRICeEdIrHCd2QgMAA6DoYkcXe6ATN8yLwRQwpp3RnnDsTCSYcXxHCuZwrd0Lx0TZqGvM5tTGu4f2SEDiBg86gN0ZA3ruEj6PG9j79keoGDE9F5Ob1aZaM4vBV7YIt6CJl24L0qTXy-rSv6udWZg9OsOLsUTA4+ghOVwyomU9H9OjAn7OdQsazfGME5qy1F3bi9qu4Y3oZUa61vQKjXeMH3ukAeR9CalFPmnPKF8s6YXVpubQ1gzBrR0NNe4y9HxbR8rrQkooSAUgpAAIyHDSTeo5oqThDLgghRCnjANGmLEeECehQMngtPCb1NAe0tH0AiBhwhoNIt7auu0cF4MIbSJuAFv7AV-twChojqFDFoUnTK4Cx7MKvo0F2m5mjOBMJWWm71X5r25jwPmhsDJCyUUPTK3gZqW01Izc0zQ1owNdtwEIQQ+hWAqhWPhgwV51W2uvQkZj9KCxyCLVMRNbGaHseYQINwgj2UaDeR2ZpbgtCspeC4EQIYYEoJHeA+R2aryCSYwmIC5QAFoNGIBqUYspvs5jCBMtY6JxgYHizaEaXRMkSol3Bv49B2sfY1zdB6G6IpWlRNKLoEwbRVZqhkucY0FVklFk3BWJwEhDQyxltlBpmDgkaWnFpL885jpRMqeZc4sTLyWEtNZZZN4FY6nvpmFoXg9AVl4SVE4hydbHPbKc7SBswm0mmXxEEapNz5SMPAzU71vCYS+hIaSNwNSohaM7PxkMAkYMBeU7gzUEptSSpC4+IJlZbmdjoS8JcpavMaGYR2st7BYrhNYe8-CObGKaQjQ6vdWwUtAYgUwn03ovLBnoEwNgaYmhnhWUSmpPkPIBaM+G+tdLmMFiKsWHDMzORMBVHcpd1kID8PqVELtLXZQRJadVQjZh1wbk8PVyc8L6g6O9c0hpPr2CnrEk4Ks9lGFuLikpgSjlErdabNpYC1R51RBYLUJVKxMq0GtR23h76HgpuLQZeLhmCPftgyhYjiFDHdSovc+g5kmBJo4F2c0-quTeinLUJdc1rUdaW0xYKjY0mre00w0ldCGktMicdBgc52IvH0ToWizCex5aU6NTTkAMWYKwWARSHozMQBVW4W4yzGjWs4PCriHnuJrOYIIFpjTtF7VgngvBJFEGHbMpZJ6VmahVNYWpCAWVCXEucEqokEQroiEAA */
+      id: "SigningOperationsDeviceAction",
+      initial: "Entry",
       context: ({ input }) => ({
         input,
         intermediateValue: {
           requiredUserInteraction: UserInteractionRequired.None,
-          step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+          step: signingOperationsDAStateSteps.ZERO_BLOCKHASH,
         },
         _internalState: {
           error: null,
@@ -152,11 +174,27 @@ export class DelayedSignTransactionDeviceAction extends XStateDeviceAction<
         },
       }),
       states: {
+        // Routes the four terminal cases:
+        // - armed + RPC source → refresh the blockhash, then SIGN DELAYED (0x09)
+        // - armed, no source    → SIGN DELAYED (0x09) on the original tx
+        // - not armed + source  → preview (0x08) to arm, refresh, then 0x09
+        // - not armed, no source → one-shot SIGN (0x06) on the original tx
+        Entry: {
+          always: [
+            {
+              target: "FetchBlockhash",
+              guard: and(["isAlreadyArmed", "hasBlockhashSource"]),
+            },
+            { target: "DelayedSign", guard: "isAlreadyArmed" },
+            { target: "ZeroBlockhash", guard: "hasBlockhashSource" },
+            { target: "Sign" },
+          ],
+        },
         ZeroBlockhash: {
           entry: assign({
             intermediateValue: () => ({
               requiredUserInteraction: UserInteractionRequired.None,
-              step: delayedSignDAStateSteps.ZERO_BLOCKHASH,
+              step: signingOperationsDAStateSteps.ZERO_BLOCKHASH,
             }),
           }),
           invoke: {
@@ -184,7 +222,7 @@ export class DelayedSignTransactionDeviceAction extends XStateDeviceAction<
           entry: assign({
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.SignTransaction,
-              step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+              step: signingOperationsDAStateSteps.PREVIEW_TRANSACTION,
             },
           }),
           invoke: {
@@ -219,7 +257,7 @@ export class DelayedSignTransactionDeviceAction extends XStateDeviceAction<
                 },
                 intermediateValue: {
                   requiredUserInteraction: UserInteractionRequired.None,
-                  step: delayedSignDAStateSteps.PREVIEW_TRANSACTION,
+                  step: signingOperationsDAStateSteps.PREVIEW_TRANSACTION,
                 },
               }),
             },
@@ -239,7 +277,7 @@ export class DelayedSignTransactionDeviceAction extends XStateDeviceAction<
           entry: assign({
             intermediateValue: () => ({
               requiredUserInteraction: UserInteractionRequired.None,
-              step: delayedSignDAStateSteps.FETCH_BLOCKHASH,
+              step: signingOperationsDAStateSteps.FETCH_BLOCKHASH,
             }),
           }),
           invoke: {
@@ -258,17 +296,16 @@ export class DelayedSignTransactionDeviceAction extends XStateDeviceAction<
                 }),
               }),
             },
-            onError: {
-              target: "Error",
-              actions: "assignErrorFromEvent",
-            },
+            // Best-effort refresh: a fetch failure signs the original blockhash
+            // (no patch) rather than aborting.
+            onError: { target: "PatchResultCheck" },
           },
         },
         PatchTransaction: {
           entry: assign({
             intermediateValue: () => ({
               requiredUserInteraction: UserInteractionRequired.None,
-              step: delayedSignDAStateSteps.PATCH_TRANSACTION,
+              step: signingOperationsDAStateSteps.PATCH_TRANSACTION,
             }),
           }),
           invoke: {
@@ -303,7 +340,7 @@ export class DelayedSignTransactionDeviceAction extends XStateDeviceAction<
           entry: assign({
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.None,
-              step: delayedSignDAStateSteps.DELAYED_SIGN,
+              step: signingOperationsDAStateSteps.DELAYED_SIGN,
             },
           }),
           invoke: {
@@ -311,31 +348,17 @@ export class DelayedSignTransactionDeviceAction extends XStateDeviceAction<
             src: "delayedSignTransaction",
             input: ({ context }) => ({
               derivationPath: context.input.derivationPath,
-              serializedTransaction: context._internalState.patchedTransaction!,
+              // Armed without a blockhash source: sign the original transaction.
+              serializedTransaction:
+                context._internalState.patchedTransaction ??
+                context.input.transaction,
               userInputType: context.input.userInputType,
             }),
             onDone: {
               target: "ResultCheck",
               actions: assign({
-                _internalState: ({ event, context }) => {
-                  if (!isSuccessCommandResult(event.output))
-                    return {
-                      ...context._internalState,
-                      error: event.output.error,
-                    };
-
-                  const data = event.output.data.extract();
-                  if (event.output.data.isJust() && data instanceof Uint8Array)
-                    return {
-                      ...context._internalState,
-                      signature: data,
-                    };
-
-                  return {
-                    ...context._internalState,
-                    error: new UnknownDAError("No signature available"),
-                  };
-                },
+                _internalState: ({ event, context }) =>
+                  applySignatureResult(context._internalState, event.output),
               }),
             },
             onError: {
@@ -344,43 +367,61 @@ export class DelayedSignTransactionDeviceAction extends XStateDeviceAction<
             },
           },
         },
-        FallbackSign: {
+        // Primary one-shot sign (no blockhash refresh): the device shows the
+        // review and signs in a single pass (0x06).
+        Sign: {
           entry: assign({
             intermediateValue: {
               requiredUserInteraction: UserInteractionRequired.SignTransaction,
-              step: delayedSignDAStateSteps.FALLBACK_TO_NON_DELAYED_SIGN,
+              step: signingOperationsDAStateSteps.SIGN_TRANSACTION,
             },
           }),
           invoke: {
-            id: "fallbackSignTransaction",
-            src: "fallbackSignTransaction",
+            id: "signTransaction",
+            src: "signTransaction",
             input: ({ context }) => ({
               derivationPath: context.input.derivationPath,
-              serializedTransaction: context._internalState.patchedTransaction!,
+              serializedTransaction: context.input.transaction,
               userInputType: context.input.userInputType,
             }),
             onDone: {
               target: "ResultCheck",
               actions: assign({
-                _internalState: ({ event, context }) => {
-                  if (!isSuccessCommandResult(event.output))
-                    return {
-                      ...context._internalState,
-                      error: event.output.error,
-                    };
-
-                  const data = event.output.data.extract();
-                  if (event.output.data.isJust() && data instanceof Uint8Array)
-                    return {
-                      ...context._internalState,
-                      signature: data,
-                    };
-
-                  return {
-                    ...context._internalState,
-                    error: new UnknownDAError("No signature available"),
-                  };
-                },
+                _internalState: ({ event, context }) =>
+                  applySignatureResult(context._internalState, event.output),
+              }),
+            },
+            onError: {
+              target: "Error",
+              actions: "assignErrorFromEvent",
+            },
+          },
+        },
+        // Fallback sign (0x06): the 0x08 preview was unsupported, so we sign the
+        // (blockhash-patched) transaction non-delayed.
+        FallbackSign: {
+          entry: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.SignTransaction,
+              step: signingOperationsDAStateSteps.FALLBACK_TO_NON_DELAYED_SIGN,
+            },
+          }),
+          invoke: {
+            id: "fallbackSign",
+            src: "signTransaction",
+            input: ({ context }) => ({
+              derivationPath: context.input.derivationPath,
+              // No patch (fetch failed): sign the original tx.
+              serializedTransaction:
+                context._internalState.patchedTransaction ??
+                context.input.transaction,
+              userInputType: context.input.userInputType,
+            }),
+            onDone: {
+              target: "ResultCheck",
+              actions: assign({
+                _internalState: ({ event, context }) =>
+                  applySignatureResult(context._internalState, event.output),
               }),
             },
             onError: {
@@ -450,7 +491,7 @@ export class DelayedSignTransactionDeviceAction extends XStateDeviceAction<
         sendingData: arg0.input.serializedTransaction,
       }).run();
 
-    const fallbackSignTransaction = async (arg0: {
+    const signTransaction = async (arg0: {
       input: {
         derivationPath: string;
         serializedTransaction: Uint8Array;
@@ -502,7 +543,7 @@ export class DelayedSignTransactionDeviceAction extends XStateDeviceAction<
     return {
       previewTransaction,
       delayedSignTransaction,
-      fallbackSignTransaction,
+      signTransaction,
       fetchBlockhashFn,
       zeroBlockhashFn,
       patchBlockhashFn,

--- a/packages/signer/signer-solana/src/internal/app-binder/task/BuildGenericClearSignContextTask.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/BuildGenericClearSignContextTask.test.ts
@@ -1,0 +1,172 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  type ClearSignContext,
+  ClearSignContextType,
+  type ContextModule,
+} from "@ledgerhq/context-module";
+import {
+  CommandResultFactory,
+  DeviceModelId,
+} from "@ledgerhq/device-management-kit";
+import {
+  Keypair,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import { Buffer } from "buffer";
+import { Right } from "purify-ts";
+import { describe, expect, it, vi } from "vitest";
+
+import { instructionInfo as buildInstructionInfoTlv } from "@internal/app-binder/clear-sign/requirements/__tests__/fixtures/tlvBuilders";
+import { GetChallengeCommand } from "@internal/app-binder/command/GetChallengeCommand";
+import { DefaultBs58Encoder } from "@internal/app-binder/services/bs58Encoder";
+
+import {
+  BuildGenericClearSignContextTask,
+  COMPUTE_BUDGET_PROGRAM_ID,
+} from "./BuildGenericClearSignContextTask";
+
+const DUMMY_BLOCKHASH = DefaultBs58Encoder.encode(
+  new Uint8Array(32).fill(0xaa),
+);
+const KNOWN_PROGRAM = new PublicKey(
+  "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+);
+const UNKNOWN_PROGRAM = new PublicKey(
+  "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",
+);
+
+// Minimal-but-valid INSTRUCTION_INFO TLV so buildRequirements returns Right.
+const INFO_HEX = Buffer.from(
+  buildInstructionInfoTlv({ typePool: new Uint8Array([0x00]), rootType: 0 }),
+).toString("hex");
+
+function makeIx(programId: PublicKey, data: number[]): TransactionInstruction {
+  return new TransactionInstruction({
+    keys: [
+      {
+        pubkey: Keypair.generate().publicKey,
+        isSigner: false,
+        isWritable: true,
+      },
+    ],
+    programId,
+    data: Buffer.from(data),
+  });
+}
+
+function makeRawTx(ixs: TransactionInstruction[]): Uint8Array {
+  const payer = Keypair.generate();
+  const tx = new Transaction();
+  tx.recentBlockhash = DUMMY_BLOCKHASH;
+  tx.feePayer = payer.publicKey;
+  tx.add(...ixs);
+  tx.sign(payer);
+  return tx.serialize();
+}
+
+function instructionInfoContext(
+  programId: string,
+  discriminator: string,
+): ClearSignContext {
+  return {
+    type: ClearSignContextType.SOLANA_INSTRUCTION_INFO,
+    payload: {
+      programId,
+      discriminator,
+      instructionInfo: { data: INFO_HEX, signature: "00" },
+      substructures: [],
+      enumVariants: [],
+    },
+  } as any;
+}
+
+function makeTask(transaction: Uint8Array, infoContexts: ClearSignContext[]) {
+  const getContexts = vi.fn(async (_input: unknown, types: unknown) =>
+    (types as ClearSignContextType[]).includes(
+      ClearSignContextType.SOLANA_INSTRUCTION_INFO,
+    )
+      ? infoContexts
+      : [],
+  );
+  const contextModule = { getContexts } as unknown as ContextModule;
+  const api = {
+    sendCommand: vi.fn(async (cmd: unknown) =>
+      cmd instanceof GetChallengeCommand
+        ? CommandResultFactory({ data: { challenge: "deadbeef" } })
+        : CommandResultFactory({ data: undefined }),
+    ),
+  };
+  const task = new BuildGenericClearSignContextTask(api as any, {
+    contextModule,
+    transaction,
+    deviceModelId: DeviceModelId.STAX,
+    loggerFactory: () =>
+      ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      }) as any,
+    // Stub the enum decoder (the minimal fixture pool isn't real-decodable).
+    selectEnumVariants: () => Right([]),
+  });
+  return { task, getContexts };
+}
+
+describe("BuildGenericClearSignContextTask", () => {
+  it("returns mode `full` and a template when every non-ComputeBudget instruction is recognized", async () => {
+    const tx = makeRawTx([
+      makeIx(new PublicKey(COMPUTE_BUDGET_PROGRAM_ID), [0x02, 0x40, 0x42]),
+      makeIx(KNOWN_PROGRAM, [0x01, 0x02, 0xaa]),
+    ]);
+    const { task, getContexts } = makeTask(tx, [
+      instructionInfoContext(KNOWN_PROGRAM.toBase58(), "0102"),
+    ]);
+
+    const result = await task.run();
+
+    expect(result.mode).toBe("full");
+    expect(result.instructionInfoContexts).toHaveLength(1);
+    // ComputeBudget is never looked up in CAL.
+    expect(getContexts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instructions: [{ programId: KNOWN_PROGRAM.toBase58() }],
+      }),
+      [ClearSignContextType.SOLANA_INSTRUCTION_INFO],
+    );
+  });
+
+  it("returns mode `srfc39-only` when some instructions are unrecognized", async () => {
+    const tx = makeRawTx([
+      makeIx(KNOWN_PROGRAM, [0x01, 0x02]),
+      makeIx(UNKNOWN_PROGRAM, [0x09]),
+    ]);
+    const { task } = makeTask(tx, [
+      instructionInfoContext(KNOWN_PROGRAM.toBase58(), "0102"),
+    ]);
+
+    const result = await task.run();
+
+    expect(result.mode).toBe("srfc39-only");
+    expect(result.instructionInfoContexts).toHaveLength(1);
+  });
+
+  it("returns mode `none` when nothing is recognized", async () => {
+    const tx = makeRawTx([makeIx(UNKNOWN_PROGRAM, [0x09])]);
+    const { task } = makeTask(tx, []);
+
+    expect((await task.run()).mode).toBe("none");
+  });
+
+  it("returns mode `none` for a ComputeBudget-only tx without calling CAL", async () => {
+    const tx = makeRawTx([
+      makeIx(new PublicKey(COMPUTE_BUDGET_PROGRAM_ID), [0x02, 0x40, 0x42]),
+    ]);
+    const { task, getContexts } = makeTask(tx, []);
+
+    expect((await task.run()).mode).toBe("none");
+    expect(getContexts).not.toHaveBeenCalled();
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/task/BuildGenericClearSignContextTask.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/BuildGenericClearSignContextTask.ts
@@ -1,0 +1,411 @@
+import {
+  type ClearSignContext,
+  ClearSignContextType,
+  type ContextModule,
+  type SolanaInstructionInfoPayload,
+  type SolanaInstructionSubstructure,
+} from "@ledgerhq/context-module";
+import {
+  type DeviceModelId,
+  hexaStringToBuffer,
+  type InternalApi,
+  isSuccessCommandResult,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+
+import { type ClearSignMode } from "@api/app-binder/SignTransactionDeviceActionTypes";
+import {
+  buildEnumCache,
+  type VariantCache,
+} from "@internal/app-binder/clear-sign/idl-type-pool";
+import {
+  buildRequirements,
+  type BuildRequirementsOptions,
+  type InstructionDescriptor,
+  type MatchedInstruction,
+  type RequirementAccount,
+  type SubstructureDescriptor,
+  SubstructureKind,
+} from "@internal/app-binder/clear-sign/requirements";
+import { GetChallengeCommand } from "@internal/app-binder/command/GetChallengeCommand";
+import { type NormalizedMessage } from "@internal/app-binder/services/TransactionInspector";
+import { TransactionParser } from "@internal/app-binder/services/utils/TransactionParser";
+
+/**
+ * ComputeBudget program — a hardcoded allow-list skip. It has no CAL descriptor
+ * and is understood natively by the device: never looked up, never counted,
+ * never streamed. `setComputeUnitPrice` (priority fee) is a ComputeBudget
+ * instruction so it is covered by the same skip.
+ */
+export const COMPUTE_BUDGET_PROGRAM_ID =
+  "ComputeBudget111111111111111111111111111111";
+
+const DEFAULT_NETWORK = "solana-mainnet";
+const EMPTY_ENUM_CACHE: VariantCache = new Map();
+
+const SUBSTRUCTURE_KIND_BY_VALUE: Record<number, SubstructureKind> = {
+  [SubstructureKind.DISPLAY_FIELD]: SubstructureKind.DISPLAY_FIELD,
+  [SubstructureKind.VALUE_FLOW_PORT]: SubstructureKind.VALUE_FLOW_PORT,
+  [SubstructureKind.HIDE_RULE]: SubstructureKind.HIDE_RULE,
+  [SubstructureKind.ACCOUNT_RESET]: SubstructureKind.ACCOUNT_RESET,
+};
+
+/**
+ * Everything the device needs to clear-sign a transaction, gathered host-side.
+ * A `provide` step just streams these.
+ */
+export type GenericClearSignContext = {
+  /** `full` (merge) / `srfc39-only` (partial) / `none` (legacy fallback). */
+  readonly mode: ClearSignMode;
+  /** Phase A pool descriptors (token-info, enum-variant, trusted-name, token-account-state, alt-resolution). */
+  readonly poolContexts: ClearSignContext[];
+  /** Phase B templates: one SOLANA_INSTRUCTION_INFO per matched (programId, discriminator). */
+  readonly instructionInfoContexts: ClearSignContext[];
+};
+
+export type BuildGenericClearSignContextTaskArgs = {
+  readonly contextModule: ContextModule;
+  readonly transaction: Uint8Array;
+  readonly deviceModelId: DeviceModelId;
+  readonly loggerFactory: (tag: string) => LoggerPublisherService;
+  readonly network?: string;
+  /** Enum-variant decoder override; defaults to the real type-pool decoder. */
+  readonly selectEnumVariants?: BuildRequirementsOptions["selectEnumVariants"];
+};
+
+/**
+ * Groups the whole host-side preparation for generic clear-signing: parse the
+ * TX (raw ALT refs preserved), skip ComputeBudget, look up CAL
+ * `INSTRUCTION_INFO` per remaining program, match discriminators, build the
+ * requirement set, and fetch every satellite descriptor (challenge-bound ones
+ * bound to a single device challenge). The matching `provide` task only streams
+ * the result.
+ */
+export class BuildGenericClearSignContextTask {
+  private readonly logger: LoggerPublisherService;
+  private readonly network: string;
+
+  constructor(
+    private readonly api: InternalApi,
+    private readonly args: BuildGenericClearSignContextTaskArgs,
+  ) {
+    this.logger = args.loggerFactory("BuildGenericClearSignContextTask");
+    this.network = args.network ?? DEFAULT_NETWORK;
+  }
+
+  async run(): Promise<GenericClearSignContext> {
+    const none: GenericClearSignContext = {
+      mode: "none",
+      poolContexts: [],
+      instructionInfoContexts: [],
+    };
+
+    // --- Parse + CAL lookup + match (Stage 1) ---
+    const parsed = await new TransactionParser(undefined, {
+      preserveAltRefs: true,
+    })
+      .parse(this.args.transaction)
+      .run();
+    if (parsed.isLeft()) {
+      this.logger.warn("[run] parse failed; falling back to legacy", {
+        data: { error: parsed.extract() },
+      });
+      return none;
+    }
+    const message = parsed.unsafeCoerce().message;
+
+    const remaining = message.compiledInstructions
+      .map((ix) => ({
+        ix,
+        programId: this.programIdOf(message, ix.programIdIndex),
+      }))
+      .filter(({ programId }) => programId !== COMPUTE_BUDGET_PROGRAM_ID);
+    if (remaining.length === 0) return none;
+
+    const distinctProgramIds = Array.from(
+      new Set(remaining.map((r) => r.programId)),
+    );
+    const infoContexts = await this.args.contextModule.getContexts(
+      {
+        deviceModelId: this.args.deviceModelId,
+        instructions: distinctProgramIds.map((programId) => ({ programId })),
+        network: this.network,
+      },
+      [ClearSignContextType.SOLANA_INSTRUCTION_INFO],
+    );
+
+    const byProgram = new Map<
+      string,
+      { payload: SolanaInstructionInfoPayload; context: ClearSignContext }[]
+    >();
+    for (const context of infoContexts) {
+      if (context.type !== ClearSignContextType.SOLANA_INSTRUCTION_INFO)
+        continue;
+      const list = byProgram.get(context.payload.programId) ?? [];
+      list.push({ payload: context.payload, context });
+      byProgram.set(context.payload.programId, list);
+    }
+
+    const matched: MatchedInstruction[] = [];
+    const templateByKey = new Map<string, ClearSignContext>();
+    let unrecognized = 0;
+    for (const { ix, programId } of remaining) {
+      const candidate = (byProgram.get(programId) ?? []).find(({ payload }) =>
+        this.discriminatorMatches(payload.discriminator, ix.data),
+      );
+      const descriptor = candidate
+        ? this.toInstructionDescriptor(candidate.payload)
+        : null;
+      if (!candidate || !descriptor) {
+        unrecognized += 1;
+        continue;
+      }
+      matched.push({
+        instruction: {
+          programId,
+          accounts: this.toRequirementAccounts(message, ix.accountKeyIndexes),
+          data: ix.data,
+        },
+        descriptor,
+      });
+      templateByKey.set(
+        `${programId}:${candidate.payload.discriminator}`,
+        candidate.context,
+      );
+    }
+    if (matched.length === 0) return none;
+
+    const mode: ClearSignMode = unrecognized === 0 ? "full" : "srfc39-only";
+    const instructionInfoContexts = Array.from(templateByKey.values());
+
+    // --- Requirements (Stage 2) ---
+    const requirementsResult = buildRequirements(matched, {
+      selectEnumVariants: this.args.selectEnumVariants,
+    });
+    if (requirementsResult.isLeft()) {
+      this.logger.warn("[run] requirement build failed; falling back", {
+        data: { error: requirementsResult.extract() },
+      });
+      return none;
+    }
+    const requirements = requirementsResult.unsafeCoerce();
+
+    // --- Fetch satellites (Stage 3) ---
+    const poolContexts: ClearSignContext[] = [];
+    if (requirements.tokenInfos.length > 0) {
+      poolContexts.push(
+        ...(await this.fetch(
+          {
+            deviceModelId: this.args.deviceModelId,
+            mints: requirements.tokenInfos,
+            network: this.network,
+          },
+          ClearSignContextType.SOLANA_TOKEN_INFO,
+        )),
+      );
+    }
+    poolContexts.push(
+      ...this.selectedEnumVariants(
+        requirements.enumVariants,
+        instructionInfoContexts,
+      ),
+    );
+
+    const challenge = await this.getChallenge();
+    if (challenge !== undefined) {
+      for (const account of requirements.tokenAccountStates) {
+        poolContexts.push(
+          ...(await this.fetch(
+            {
+              deviceModelId: this.args.deviceModelId,
+              requests: [{ tokenAccount: account, challenge }],
+            },
+            ClearSignContextType.SOLANA_TOKEN_ACCOUNT_STATE,
+          )),
+        );
+      }
+      for (const alt of requirements.altResolutions) {
+        poolContexts.push(
+          ...(await this.fetch(
+            {
+              deviceModelId: this.args.deviceModelId,
+              requests: [
+                {
+                  altAddress: alt.altAddress,
+                  entryIndex: alt.entryIndex,
+                  challenge,
+                },
+              ],
+            },
+            ClearSignContextType.SOLANA_ALT_RESOLUTION,
+          )),
+        );
+      }
+      for (const address of requirements.trustedNames) {
+        poolContexts.push(
+          ...(await this.fetch(
+            {
+              deviceModelId: this.args.deviceModelId,
+              network: this.network,
+              // types/sources are not carried by the requirement set; left
+              // empty pending backend confirmation.
+              requests: [{ address, challenge, types: [], sources: [] }],
+            },
+            ClearSignContextType.SOLANA_TRUSTED_NAME,
+          )),
+        );
+      }
+    }
+
+    this.logger.debug("[run] built clear-sign context", {
+      data: {
+        mode,
+        templates: instructionInfoContexts.length,
+        pool: poolContexts.length,
+      },
+    });
+
+    return { mode, poolContexts, instructionInfoContexts };
+  }
+
+  /** Fetch contexts of `type`; ERROR / wrong-type contexts are dropped (satellites degrade). */
+  private async fetch<TInput>(
+    input: TInput,
+    type: ClearSignContextType,
+  ): Promise<ClearSignContext[]> {
+    const contexts = await this.args.contextModule.getContexts(input, [type]);
+    const usable = contexts.filter((c) => c.type === type);
+    if (usable.length === 0) {
+      this.logger.warn(
+        "[run] satellite fetch yielded no descriptor (degraded)",
+        {
+          data: { type },
+        },
+      );
+    }
+    return usable;
+  }
+
+  private async getChallenge(): Promise<string | undefined> {
+    const result = await this.api.sendCommand(new GetChallengeCommand());
+    if (!isSuccessCommandResult(result)) {
+      this.logger.warn(
+        "[run] GET CHALLENGE failed; skipping challenge-bound descriptors",
+      );
+      return undefined;
+    }
+    return result.data.challenge;
+  }
+
+  /** Build SOLANA_ENUM_VARIANT contexts for the selected variants from the bundled payloads. */
+  private selectedEnumVariants(
+    keys: readonly {
+      programId: string;
+      enumId: string;
+      variantIndex: number;
+    }[],
+    instructionInfoContexts: ClearSignContext[],
+  ): ClearSignContext[] {
+    const out: ClearSignContext[] = [];
+    for (const key of keys) {
+      for (const context of instructionInfoContexts) {
+        if (context.type !== ClearSignContextType.SOLANA_INSTRUCTION_INFO)
+          continue;
+        if (context.payload.programId !== key.programId) continue;
+        const variant = context.payload.enumVariants.find(
+          (v) => v.enumId === key.enumId && v.variantIndex === key.variantIndex,
+        );
+        if (variant) {
+          out.push({
+            type: ClearSignContextType.SOLANA_ENUM_VARIANT,
+            payload: {
+              programId: key.programId,
+              enumId: key.enumId,
+              variantIndex: key.variantIndex,
+              descriptor: variant.descriptor,
+            },
+            certificate: context.certificate,
+          });
+          break;
+        }
+      }
+    }
+    return out;
+  }
+
+  private programIdOf(message: NormalizedMessage, index: number): string {
+    return message.allKeys[index]?.toBase58() ?? "";
+  }
+
+  private discriminatorMatches(
+    discriminatorHex: string,
+    data: Uint8Array,
+  ): boolean {
+    const disc = hexaStringToBuffer(discriminatorHex);
+    if (!disc || disc.length === 0 || data.length < disc.length) return false;
+    for (let i = 0; i < disc.length; i++) {
+      if (data[i] !== disc[i]) return false;
+    }
+    return true;
+  }
+
+  private toInstructionDescriptor(
+    payload: SolanaInstructionInfoPayload,
+  ): InstructionDescriptor | null {
+    const instructionInfo = hexaStringToBuffer(payload.instructionInfo.data);
+    if (!instructionInfo) return null;
+    const substructures: SubstructureDescriptor[] = [];
+    for (const sub of payload.substructures) {
+      const mapped = this.toSubstructure(sub);
+      if (mapped) substructures.push(mapped);
+    }
+    return {
+      discriminator: payload.discriminator,
+      instructionInfo,
+      substructures,
+      enumCache: this.toEnumCache(payload.enumVariants),
+    };
+  }
+
+  private toEnumCache(
+    enumVariants: SolanaInstructionInfoPayload["enumVariants"],
+  ): VariantCache {
+    if (enumVariants.length === 0) return EMPTY_ENUM_CACHE;
+    const tlvs: Uint8Array[] = [];
+    for (const variant of enumVariants) {
+      const bytes = hexaStringToBuffer(variant.descriptor.data);
+      if (bytes) tlvs.push(bytes);
+    }
+    return buildEnumCache(tlvs).caseOf({
+      Left: () => EMPTY_ENUM_CACHE,
+      Right: (cache) => cache,
+    });
+  }
+
+  private toSubstructure(
+    sub: SolanaInstructionSubstructure,
+  ): SubstructureDescriptor | null {
+    const kind = SUBSTRUCTURE_KIND_BY_VALUE[sub.kind];
+    const data = hexaStringToBuffer(sub.data);
+    if (kind === undefined || !data) return null;
+    return { kind, data };
+  }
+
+  private toRequirementAccounts(
+    message: NormalizedMessage,
+    accountKeyIndexes: number[],
+  ): RequirementAccount[] {
+    return accountKeyIndexes.map((keyIdx) => {
+      const altRef = message.addressLookupRefs?.[keyIdx];
+      if (altRef) {
+        return {
+          altRef: {
+            altAddress: altRef.altAddress.toBase58(),
+            entryIndex: altRef.entryIndex,
+          },
+        };
+      }
+      return { address: message.allKeys[keyIdx]?.toBase58() };
+    });
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/task/BuildShallowClearSignContextTask.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/BuildShallowClearSignContextTask.test.ts
@@ -14,9 +14,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GetChallengeCommand } from "@internal/app-binder/command/GetChallengeCommand";
 
 import {
-  BuildTransactionContextTask,
-  type SolanaBuildContextResult,
-} from "./BuildTransactionContextTask";
+  BuildShallowClearSignContextTask,
+  type ShallowClearSignContext,
+} from "./BuildShallowClearSignContextTask";
 
 const mockLoggerFactory = () => ({
   debug: vi.fn(),
@@ -55,7 +55,7 @@ const trustedNameSuccessContext = {
 
 let apiMock: InternalApi;
 
-describe("BuildTransactionContextTask", () => {
+describe("BuildShallowClearSignContextTask", () => {
   beforeEach(() => {
     vi.resetAllMocks();
 
@@ -76,7 +76,7 @@ describe("BuildTransactionContextTask", () => {
       trustedNameSuccessContext,
     ]);
 
-    const task = new BuildTransactionContextTask(apiMock, defaultArgs);
+    const task = new BuildShallowClearSignContextTask(apiMock, defaultArgs);
     await task.run();
 
     expect(apiMock.sendCommand).toHaveBeenCalledWith(
@@ -89,7 +89,7 @@ describe("BuildTransactionContextTask", () => {
       trustedNameSuccessContext,
     ]);
 
-    const task = new BuildTransactionContextTask(apiMock, defaultArgs);
+    const task = new BuildShallowClearSignContextTask(apiMock, defaultArgs);
     await task.run();
 
     expect(contextModuleMock.getContexts).toHaveBeenCalledWith(
@@ -120,7 +120,7 @@ describe("BuildTransactionContextTask", () => {
       signerAddress: "So1anaSignerPubKey111111111111111111111111111",
     };
 
-    const task = new BuildTransactionContextTask(apiMock, argsWithSigner);
+    const task = new BuildShallowClearSignContextTask(apiMock, argsWithSigner);
     await task.run();
 
     expect(contextModuleMock.getContexts).toHaveBeenCalledWith(
@@ -140,10 +140,10 @@ describe("BuildTransactionContextTask", () => {
       trustedNameSuccessContext,
     ]);
 
-    const task = new BuildTransactionContextTask(apiMock, defaultArgs);
+    const task = new BuildShallowClearSignContextTask(apiMock, defaultArgs);
     const result = await task.run();
 
-    expect(result).toEqual<SolanaBuildContextResult>({
+    expect(result).toEqual<ShallowClearSignContext>({
       tlvDescriptor: trustedNamePayload,
       trustedNamePKICertificate: trustedNameCert,
       loadersResults: [],
@@ -162,7 +162,7 @@ describe("BuildTransactionContextTask", () => {
       txCheckContext,
     ]);
 
-    const task = new BuildTransactionContextTask(apiMock, defaultArgs);
+    const task = new BuildShallowClearSignContextTask(apiMock, defaultArgs);
     const result = await task.run();
 
     expect(result.loadersResults).toEqual([txCheckContext]);
@@ -186,7 +186,7 @@ describe("BuildTransactionContextTask", () => {
       lifiContext,
     ]);
 
-    const task = new BuildTransactionContextTask(apiMock, defaultArgs);
+    const task = new BuildShallowClearSignContextTask(apiMock, defaultArgs);
     const result = await task.run();
 
     expect(result.loadersResults).toEqual([tokenContext, lifiContext]);
@@ -199,7 +199,7 @@ describe("BuildTransactionContextTask", () => {
       }),
     );
 
-    const task = new BuildTransactionContextTask(apiMock, defaultArgs);
+    const task = new BuildShallowClearSignContextTask(apiMock, defaultArgs);
 
     await expect(task.run()).rejects.toThrow(
       "Failed to get challenge from device",
@@ -213,7 +213,7 @@ describe("BuildTransactionContextTask", () => {
       { type: ClearSignContextType.ERROR, error },
     ]);
 
-    const task = new BuildTransactionContextTask(apiMock, defaultArgs);
+    const task = new BuildShallowClearSignContextTask(apiMock, defaultArgs);
     const result = await task.run();
 
     expect(result.trustedNamePKICertificate).toEqual(trustedNameCert);
@@ -234,7 +234,10 @@ describe("BuildTransactionContextTask", () => {
       { type: ClearSignContextType.ERROR, error },
     ]);
 
-    const task = new BuildTransactionContextTask(apiMock, argsWithoutOwnerInfo);
+    const task = new BuildShallowClearSignContextTask(
+      apiMock,
+      argsWithoutOwnerInfo,
+    );
     const result = await task.run();
 
     expect(result.trustedNamePKICertificate).toBeUndefined();
@@ -253,20 +256,20 @@ describe("BuildTransactionContextTask", () => {
       },
     ]);
 
-    const task = new BuildTransactionContextTask(apiMock, defaultArgs);
+    const task = new BuildShallowClearSignContextTask(apiMock, defaultArgs);
 
     await expect(task.run()).rejects.toThrow(
-      "[SignerSolana] BuildTransactionContextTask: owner info was required but could not be resolved",
+      "[SignerSolana] BuildShallowClearSignContextTask: owner info was required but could not be resolved",
     );
   });
 
   it("throws when owner info is required but contextModule returns an empty array", async () => {
     (contextModuleMock.getContexts as any).mockResolvedValue([]);
 
-    const task = new BuildTransactionContextTask(apiMock, defaultArgs);
+    const task = new BuildShallowClearSignContextTask(apiMock, defaultArgs);
 
     await expect(task.run()).rejects.toThrow(
-      "[SignerSolana] BuildTransactionContextTask: owner info was required but could not be resolved",
+      "[SignerSolana] BuildShallowClearSignContextTask: owner info was required but could not be resolved",
     );
   });
 });

--- a/packages/signer/signer-solana/src/internal/app-binder/task/BuildShallowClearSignContextTask.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/BuildShallowClearSignContextTask.ts
@@ -15,9 +15,9 @@ import {
 import { type TransactionResolutionContext } from "@api/model/TransactionResolutionContext";
 import { GetChallengeCommand } from "@internal/app-binder/command/GetChallengeCommand";
 
-export type { SolanaTransactionContextResultSuccess as SolanaBuildContextResult };
+export type { SolanaTransactionContextResultSuccess as ShallowClearSignContext };
 
-export type BuildTransactionContextTaskArgs = {
+export type BuildShallowClearSignContextTaskArgs = {
   readonly contextModule: ContextModule;
   readonly options: TransactionResolutionContext;
   readonly transactionBytes: Uint8Array;
@@ -25,17 +25,17 @@ export type BuildTransactionContextTaskArgs = {
   readonly loggerFactory: (tag: string) => LoggerPublisherService;
 };
 
-export class BuildTransactionContextTask {
+export class BuildShallowClearSignContextTask {
   private readonly _logger: LoggerPublisherService;
   constructor(
     private readonly api: InternalApi,
-    private readonly args: BuildTransactionContextTaskArgs,
+    private readonly args: BuildShallowClearSignContextTaskArgs,
   ) {
-    this._logger = args.loggerFactory("BuildTransactionContextTask");
+    this._logger = args.loggerFactory("BuildShallowClearSignContextTask");
   }
 
   async run(): Promise<SolanaTransactionContextResultSuccess> {
-    this._logger.debug("[run] Starting BuildTransactionContextTask");
+    this._logger.debug("[run] Starting BuildShallowClearSignContextTask");
     const { contextModule, options } = this.args;
     const deviceState = this.api.getDeviceSessionState();
 
@@ -105,7 +105,7 @@ export class BuildTransactionContextTask {
     const ownerInfoRequired = !!(options.tokenAddress || options.createATA);
     if (ownerInfoRequired && trustedNameCtx === undefined) {
       throw new Error(
-        "[SignerSolana] BuildTransactionContextTask: owner info was required but could not be resolved",
+        "[SignerSolana] BuildShallowClearSignContextTask: owner info was required but could not be resolved",
       );
     }
 

--- a/packages/signer/signer-solana/src/internal/app-binder/task/ProvideGenericClearSignContextTask.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/ProvideGenericClearSignContextTask.test.ts
@@ -1,0 +1,115 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  type ClearSignContext,
+  ClearSignContextType,
+} from "@ledgerhq/context-module";
+import { CommandResultFactory } from "@ledgerhq/device-management-kit";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+import { ProvideInstructionInfoCommand } from "@internal/app-binder/command/ProvideInstructionInfoCommand";
+import { ProvideTLVTransactionInstructionDescriptorCommand } from "@internal/app-binder/command/ProvideTLVTransactionInstructionDescriptorCommand";
+import { SignMessageGenericPreviewCommand } from "@internal/app-binder/command/SignMessageGenericPreviewCommand";
+import { BlockhashService } from "@internal/app-binder/services/BlockhashService";
+
+import { ProvideGenericClearSignContextTask } from "./ProvideGenericClearSignContextTask";
+
+const cert = { payload: new Uint8Array([0xf0]), keyUsageNumber: 11 } as const;
+const success = CommandResultFactory({ data: undefined });
+
+function tokenInfoContext(): ClearSignContext {
+  return {
+    type: ClearSignContextType.SOLANA_TOKEN_INFO,
+    payload: { mint: "M", descriptor: { data: "aabb", signature: "cc" } },
+    certificate: cert,
+  } as any;
+}
+
+function instructionInfoContext(): ClearSignContext {
+  return {
+    type: ClearSignContextType.SOLANA_INSTRUCTION_INFO,
+    payload: {
+      programId: "P",
+      discriminator: "0102",
+      instructionInfo: { data: "aabb", signature: "00" },
+      substructures: [],
+      enumVariants: [],
+    },
+    certificate: cert,
+  } as any;
+}
+
+function makeTask(
+  poolContexts: ClearSignContext[],
+  instructionInfoContexts: ClearSignContext[],
+) {
+  const api = { sendCommand: vi.fn().mockResolvedValue(success) };
+  const task = new ProvideGenericClearSignContextTask(api as any, {
+    derivationPath: "44'/501'/0'",
+    transaction: new Uint8Array([1, 2, 3]),
+    poolContexts,
+    instructionInfoContexts,
+    loggerFactory: () =>
+      ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }) as any,
+    normaliser: {} as any,
+  });
+  return { task, api };
+}
+
+describe("ProvideGenericClearSignContextTask", () => {
+  let api: { sendCommand: Mock };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it("streams GENERIC PREVIEW first, then Phase A pool, then Phase B templates", async () => {
+    const made = makeTask([tokenInfoContext()], [instructionInfoContext()]);
+    api = made.api;
+
+    await made.task.run();
+
+    const sent = api.sendCommand.mock.calls.map((c) => c[0]);
+    expect(sent[0]).toBeInstanceOf(SignMessageGenericPreviewCommand);
+    const previewIdx = 0;
+    const tokenIdx = sent.findIndex(
+      (c) => c instanceof ProvideTLVTransactionInstructionDescriptorCommand,
+    );
+    const infoIdx = sent.findIndex(
+      (c) => c instanceof ProvideInstructionInfoCommand,
+    );
+    expect(tokenIdx).toBeGreaterThan(previewIdx);
+    expect(infoIdx).toBeGreaterThan(tokenIdx); // Phase B after Phase A
+  });
+
+  it("streams the GENERIC PREVIEW with the blockhash zeroed", async () => {
+    const zeroed = new Uint8Array([9, 9, 9]);
+    const zeroSpy = vi
+      .spyOn(BlockhashService.prototype, "zeroBlockhash")
+      .mockReturnValue(zeroed);
+    const made = makeTask([], []);
+
+    await made.task.run();
+
+    expect(zeroSpy).toHaveBeenCalledWith(new Uint8Array([1, 2, 3]));
+    const preview = made.api.sendCommand.mock.calls
+      .map((c) => c[0])
+      .find((c) => c instanceof SignMessageGenericPreviewCommand) as any;
+    // The streamed payload is `[signers, pathCount, ...paths, ...tx]`; its tail
+    // is the zeroed transaction, not the original.
+    const msg: Uint8Array = preview.args.serializedMessage;
+    expect(Array.from(msg.slice(-3))).toEqual([9, 9, 9]);
+
+    zeroSpy.mockRestore();
+  });
+
+  it("aborts (throws) when the device rejects GENERIC PREVIEW", async () => {
+    const made = makeTask([], []);
+    made.api.sendCommand.mockResolvedValue(
+      CommandResultFactory({
+        error: { _tag: "E", errorCode: 0x6a80, message: "no" } as any,
+      }),
+    );
+
+    await expect(made.task.run()).rejects.toThrow(
+      "device rejected SIGN MESSAGE GENERIC PREVIEW",
+    );
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/task/ProvideGenericClearSignContextTask.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/ProvideGenericClearSignContextTask.ts
@@ -1,0 +1,125 @@
+import {
+  type ClearSignContext,
+  ClearSignContextType,
+  isSolanaContextSuccess,
+} from "@ledgerhq/context-module";
+import {
+  ByteArrayBuilder,
+  type InternalApi,
+  isSuccessCommandResult,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+import {
+  DerivationPathUtils,
+  SendCommandInChunksTask,
+} from "@ledgerhq/signer-utils";
+
+import { SignMessageGenericPreviewCommand } from "@internal/app-binder/command/SignMessageGenericPreviewCommand";
+import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+import { BlockhashService } from "@internal/app-binder/services/BlockhashService";
+import {
+  DefaultSolanaMessageNormaliser,
+  type SolanaMessageNormaliser,
+} from "@internal/app-binder/services/utils/DefaultSolanaMessageNormaliser";
+import { dispatchProvideContext } from "@internal/app-binder/task/context-providers/provideContextRegistry";
+import { type ProvideContextDeps } from "@internal/app-binder/task/context-providers/provideContextTypes";
+
+export type ProvideGenericClearSignContextTaskArgs = {
+  readonly derivationPath: string;
+  readonly transaction: Uint8Array;
+  /** Phase A pool descriptors, already fetched by the build task. */
+  readonly poolContexts: ClearSignContext[];
+  /** Phase B instruction templates, already fetched by the build task. */
+  readonly instructionInfoContexts: ClearSignContext[];
+  readonly loggerFactory: (tag: string) => LoggerPublisherService;
+  readonly normaliser?: SolanaMessageNormaliser;
+};
+
+/**
+ * Streams the pre-built generic clear-sign context to the device in the
+ * mandated order: `SIGN MESSAGE GENERIC PREVIEW` (0x0A) → Phase A pool → Phase B
+ * templates, stopping before `PROMPT UI DISPLAY` (a separate, user-interaction
+ * step). Per-descriptor provisioning is delegated to the shared
+ * {@link dispatchProvideContext} registry.
+ */
+export class ProvideGenericClearSignContextTask {
+  private readonly logger: LoggerPublisherService;
+  private readonly deps: ProvideContextDeps;
+
+  constructor(
+    private readonly api: InternalApi,
+    private readonly args: ProvideGenericClearSignContextTaskArgs,
+  ) {
+    this.logger = args.loggerFactory("ProvideGenericClearSignContextTask");
+    this.deps = {
+      api,
+      logger: this.logger,
+      normaliser: args.normaliser ?? new DefaultSolanaMessageNormaliser(),
+      transactionBytes: args.transaction,
+    };
+  }
+
+  async run(): Promise<void> {
+    await this.streamGenericPreview();
+    // Phase A pool, then Phase B templates. Order within Phase A is
+    // device-agnostic; templates come last so the device can run the merge.
+    for (const context of this.args.poolContexts) {
+      if (isSolanaContextSuccess(context)) {
+        await dispatchProvideContext(context, this.deps);
+      }
+    }
+    for (const context of this.args.instructionInfoContexts) {
+      if (context.type === ClearSignContextType.SOLANA_INSTRUCTION_INFO) {
+        await dispatchProvideContext(context, this.deps);
+      }
+    }
+  }
+
+  /** 0x0A — derivation path + serialized TX, chunked. No length prefix. */
+  private async streamGenericPreview(): Promise<void> {
+    // The device arms its fingerprint over the message with the blockhash
+    // zeroed, so the preview streams a zeroed-blockhash copy; the real (or
+    // freshly fetched) blockhash is supplied later at SIGN MESSAGE DELAYED.
+    // Best-effort: if the blockhash can't be located we stream the original
+    // (the device zeroes it anyway when computing the fingerprint).
+    let previewTransaction = this.args.transaction;
+    try {
+      previewTransaction = new BlockhashService().zeroBlockhash(
+        this.args.transaction,
+      );
+    } catch (error) {
+      this.logger.debug(
+        "[streamGenericPreview] could not zero blockhash; streaming original",
+        { data: { error } },
+      );
+    }
+
+    const paths = DerivationPathUtils.splitPath(this.args.derivationPath);
+    const builder = new ByteArrayBuilder(
+      previewTransaction.length + 2 + paths.length * 4,
+    );
+    builder.add8BitUIntToData(1); // number of signers
+    builder.add8BitUIntToData(paths.length);
+    paths.forEach((path) => builder.add32BitUIntToData(path));
+    builder.addBufferToData(previewTransaction);
+
+    const result = await new SendCommandInChunksTask<void, SolanaAppErrorCodes>(
+      this.api,
+      {
+        data: builder.build(),
+        commandFactory: (chunkArgs) =>
+          new SignMessageGenericPreviewCommand({
+            serializedMessage: chunkArgs.chunkedData,
+            isFirstChunk: !chunkArgs.extend,
+            hasMore: chunkArgs.more,
+          }),
+      },
+    ).run();
+
+    if (!isSuccessCommandResult(result)) {
+      throw new Error(
+        "[ProvideGenericClearSignContextTask] device rejected SIGN MESSAGE GENERIC PREVIEW",
+      );
+    }
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/task/ProvideShallowClearSignContextTask.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/ProvideShallowClearSignContextTask.test.ts
@@ -12,7 +12,7 @@ import { ProvideTLVDescriptorCommand } from "@internal/app-binder/command/Provid
 import { ProvideTLVTransactionInstructionDescriptorCommand } from "@internal/app-binder/command/ProvideTLVTransactionInstructionDescriptorCommand";
 import { ProvideWeb3CheckCommand } from "@internal/app-binder/command/ProvideWeb3CheckCommand";
 
-import { ProvideSolanaTransactionContextTask } from "./ProvideTransactionContextTask";
+import { ProvideShallowClearSignContextTask } from "./ProvideShallowClearSignContextTask";
 
 const mockLoggerFactory = () => ({
   debug: vi.fn(),
@@ -25,7 +25,7 @@ const mockLoggerFactory = () => ({
 const buildNormaliser = (message: any) =>
   ({ normaliseMessage: vi.fn(async () => message) }) as const;
 
-describe("ProvideSolanaTransactionContextTask", () => {
+describe("ProvideShallowClearSignContextTask", () => {
   let api: { sendCommand: Mock };
   const success = CommandResultFactory({ data: undefined });
 
@@ -60,7 +60,7 @@ describe("ProvideSolanaTransactionContextTask", () => {
         .mockResolvedValueOnce(success)
         .mockResolvedValueOnce(success);
 
-      const task = new ProvideSolanaTransactionContextTask(
+      const task = new ProvideShallowClearSignContextTask(
         api as any,
         {
           trustedNamePKICertificate: baseCert,
@@ -87,7 +87,7 @@ describe("ProvideSolanaTransactionContextTask", () => {
     });
 
     it("skips base context APDUs when trustedNamePKICertificate is missing", async () => {
-      const task = new ProvideSolanaTransactionContextTask(
+      const task = new ProvideShallowClearSignContextTask(
         api as any,
         {
           trustedNamePKICertificate: undefined,
@@ -107,7 +107,7 @@ describe("ProvideSolanaTransactionContextTask", () => {
     it("propagates errors thrown by sendCommand", async () => {
       api.sendCommand.mockRejectedValueOnce(new Error("transport fail"));
 
-      const task = new ProvideSolanaTransactionContextTask(
+      const task = new ProvideShallowClearSignContextTask(
         api as any,
         {
           trustedNamePKICertificate: baseCert,
@@ -124,7 +124,7 @@ describe("ProvideSolanaTransactionContextTask", () => {
 
   describe("loaders dispatch", () => {
     it("returns Nothing when loadersResults is empty", async () => {
-      const task = new ProvideSolanaTransactionContextTask(
+      const task = new ProvideShallowClearSignContextTask(
         api as any,
         {
           trustedNamePKICertificate: undefined,
@@ -142,7 +142,7 @@ describe("ProvideSolanaTransactionContextTask", () => {
     });
 
     it("skips ERROR loader results without sending APDUs", async () => {
-      const task = new ProvideSolanaTransactionContextTask(
+      const task = new ProvideShallowClearSignContextTask(
         api as any,
         {
           trustedNamePKICertificate: undefined,
@@ -171,7 +171,7 @@ describe("ProvideSolanaTransactionContextTask", () => {
         .mockResolvedValueOnce(success) // token cert
         .mockResolvedValueOnce(success); // token descriptor
 
-      const task = new ProvideSolanaTransactionContextTask(
+      const task = new ProvideShallowClearSignContextTask(
         api as any,
         {
           trustedNamePKICertificate: baseCert,
@@ -209,7 +209,7 @@ describe("ProvideSolanaTransactionContextTask", () => {
         .mockResolvedValueOnce(success) // tx-check cert
         .mockResolvedValueOnce(success); // descriptor chunk
 
-      const task = new ProvideSolanaTransactionContextTask(
+      const task = new ProvideShallowClearSignContextTask(
         api as any,
         {
           trustedNamePKICertificate: undefined,
@@ -248,7 +248,7 @@ describe("ProvideSolanaTransactionContextTask", () => {
         .mockResolvedValueOnce(success) // tx-check cert
         .mockResolvedValueOnce(success); // tx-check descriptor
 
-      const task = new ProvideSolanaTransactionContextTask(
+      const task = new ProvideShallowClearSignContextTask(
         api as any,
         {
           trustedNamePKICertificate: baseCert,
@@ -281,7 +281,7 @@ describe("ProvideSolanaTransactionContextTask", () => {
         .mockResolvedValueOnce(success) // tx-check cert
         .mockResolvedValueOnce(success); // tx-check descriptor
 
-      const task = new ProvideSolanaTransactionContextTask(
+      const task = new ProvideShallowClearSignContextTask(
         api as any,
         {
           trustedNamePKICertificate: undefined,

--- a/packages/signer/signer-solana/src/internal/app-binder/task/ProvideShallowClearSignContextTask.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/ProvideShallowClearSignContextTask.ts
@@ -15,28 +15,27 @@ import {
 } from "@internal/app-binder/services/utils/DefaultSolanaMessageNormaliser";
 
 import { dispatchProvideContext } from "./context-providers/provideContextRegistry";
-import { type SolanaBuildContextResult } from "./BuildTransactionContextTask";
+import { type ShallowClearSignContext } from "./BuildShallowClearSignContextTask";
 
-export type ProvideSolanaTransactionContextTaskArgs =
-  SolanaBuildContextResult & {
-    readonly transactionBytes: Uint8Array;
-    readonly loggerFactory: (tag: string) => LoggerPublisherService;
-    readonly normaliser?: SolanaMessageNormaliser;
-  };
+export type ProvideShallowClearSignContextTaskArgs = ShallowClearSignContext & {
+  readonly transactionBytes: Uint8Array;
+  readonly loggerFactory: (tag: string) => LoggerPublisherService;
+  readonly normaliser?: SolanaMessageNormaliser;
+};
 
-export class ProvideSolanaTransactionContextTask {
+export class ProvideShallowClearSignContextTask {
   private readonly _logger: LoggerPublisherService;
   private readonly _normaliser: SolanaMessageNormaliser;
   constructor(
     private readonly api: InternalApi,
-    private readonly args: ProvideSolanaTransactionContextTaskArgs,
+    private readonly args: ProvideShallowClearSignContextTaskArgs,
   ) {
-    this._logger = args.loggerFactory("ProvideSolanaTransactionContextTask");
+    this._logger = args.loggerFactory("ProvideShallowClearSignContextTask");
     this._normaliser = args.normaliser ?? new DefaultSolanaMessageNormaliser();
   }
 
   async run(): Promise<Maybe<CommandErrorResult<SolanaAppErrorCodes>>> {
-    this._logger.debug("[run] Starting ProvideSolanaTransactionContextTask");
+    this._logger.debug("[run] Starting ProvideShallowClearSignContextTask");
     const {
       tlvDescriptor,
       trustedNamePKICertificate,

--- a/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideAltResolutionContext.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideAltResolutionContext.test.ts
@@ -1,0 +1,79 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ClearSignContextType } from "@ledgerhq/context-module";
+import {
+  CommandResultFactory,
+  LoadCertificateCommand,
+} from "@ledgerhq/device-management-kit";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+import { ProvideAltResolutionCommand } from "@internal/app-binder/command/ProvideAltResolutionCommand";
+
+import { provideAltResolutionContext } from "./provideAltResolutionContext";
+import { type ProvideContextDeps } from "./provideContextTypes";
+
+const mockLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  subscribers: [],
+};
+const cert = { payload: new Uint8Array([0xf0]), keyUsageNumber: 2 } as const;
+const success = CommandResultFactory({ data: undefined });
+
+describe("provideAltResolutionContext", () => {
+  let api: { sendCommand: Mock };
+  let deps: ProvideContextDeps;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    api = { sendCommand: vi.fn() };
+    deps = {
+      api: api as any,
+      logger: mockLogger as any,
+      normaliser: {} as any,
+      transactionBytes: new Uint8Array(),
+    };
+  });
+
+  it("loads the certificate then streams the framed ALT_RESOLUTION (0x28)", async () => {
+    api.sendCommand.mockResolvedValue(success);
+
+    await provideAltResolutionContext(
+      {
+        type: ClearSignContextType.SOLANA_ALT_RESOLUTION as const,
+        payload: { descriptor: new Uint8Array([0xaa, 0xbb]) },
+        certificate: cert,
+      } as any,
+      deps,
+    );
+
+    expect(api.sendCommand.mock.calls[0]![0]).toBeInstanceOf(
+      LoadCertificateCommand,
+    );
+    const cmd = api.sendCommand.mock.calls[1]![0];
+    expect(cmd).toBeInstanceOf(ProvideAltResolutionCommand);
+    expect(cmd.args.payload).toStrictEqual(
+      new Uint8Array([0x00, 0x02, 0xaa, 0xbb]),
+    );
+  });
+
+  it("throws when the device rejects the descriptor", async () => {
+    api.sendCommand.mockResolvedValueOnce(success).mockResolvedValueOnce(
+      CommandResultFactory({
+        error: { _tag: "E", errorCode: 0x6a80, message: "no" } as any,
+      }),
+    );
+
+    await expect(
+      provideAltResolutionContext(
+        {
+          type: ClearSignContextType.SOLANA_ALT_RESOLUTION as const,
+          payload: { descriptor: new Uint8Array([0xaa, 0xbb]) },
+          certificate: cert,
+        } as any,
+        deps,
+      ),
+    ).rejects.toThrow("device rejected ALT_RESOLUTION");
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideAltResolutionContext.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideAltResolutionContext.ts
@@ -1,0 +1,52 @@
+import {
+  type ClearSignContextType,
+  type SolanaAltResolutionContextSuccess,
+} from "@ledgerhq/context-module";
+import { isSuccessCommandResult } from "@ledgerhq/device-management-kit";
+import { SendCommandInChunksTask } from "@ledgerhq/signer-utils";
+
+import { ProvideAltResolutionCommand } from "@internal/app-binder/command/ProvideAltResolutionCommand";
+import { frameClearSignPayload } from "@internal/app-binder/command/utils/apduChunking";
+import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+
+import { loadCertificate } from "./loadCertificate";
+import { type ProvideContextHandler } from "./provideContextTypes";
+
+/**
+ * Streams a challenge-bound `ALT_RESOLUTION` (0x28) descriptor. The caller must
+ * have issued a fresh `GET CHALLENGE` immediately before fetching it.
+ */
+export const provideAltResolutionContext: ProvideContextHandler<
+  ClearSignContextType.SOLANA_ALT_RESOLUTION
+> = async (result: SolanaAltResolutionContextSuccess, { api, logger }) => {
+  const { payload, certificate } = result;
+  if (!payload) return;
+
+  if (certificate) {
+    await loadCertificate(
+      api,
+      certificate,
+      "[SignerSolana] provideAltResolutionContext: failed to load ALT_RESOLUTION certificate",
+    );
+  }
+
+  logger.debug("[provideAltResolutionContext] Sending ALT_RESOLUTION");
+
+  const res = await new SendCommandInChunksTask<void, SolanaAppErrorCodes>(
+    api,
+    {
+      data: frameClearSignPayload(payload.descriptor),
+      commandFactory: (args) =>
+        new ProvideAltResolutionCommand({
+          payload: args.chunkedData,
+          isFirstChunk: !args.extend,
+          hasMore: args.more,
+        }),
+    },
+  ).run();
+  if (!isSuccessCommandResult(res)) {
+    throw new Error(
+      "[SignerSolana] provideAltResolutionContext: device rejected ALT_RESOLUTION",
+    );
+  }
+};

--- a/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideContextRegistry.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideContextRegistry.ts
@@ -4,13 +4,19 @@ import {
   type SolanaContextSuccessType,
 } from "@ledgerhq/context-module";
 
+import { provideAltResolutionContext } from "./provideAltResolutionContext";
 import {
   type ProvideContextDeps,
   type ProvideContextHandler,
 } from "./provideContextTypes";
+import { provideEnumVariantContext } from "./provideEnumVariantContext";
+import { provideInstructionInfoContext } from "./provideInstructionInfoContext";
 import { provideLifiContext } from "./provideLifiContext";
+import { provideTokenAccountStateContext } from "./provideTokenAccountStateContext";
 import { provideTokenContext } from "./provideTokenContext";
+import { provideTokenInfoContext } from "./provideTokenInfoContext";
 import { provideTransactionCheckContext } from "./provideTransactionCheckContext";
+import { provideTrustedNameContext } from "./provideTrustedNameContext";
 
 /**
  * Per-type provide pipeline: maps each success context type to its device-provision handler.
@@ -23,6 +29,14 @@ const PROVIDE_CONTEXT_REGISTRY: {
   [ClearSignContextType.SOLANA_LIFI]: provideLifiContext,
   [ClearSignContextType.SOLANA_TRANSACTION_CHECK]:
     provideTransactionCheckContext,
+  // Generic clear-signing descriptors
+  [ClearSignContextType.SOLANA_INSTRUCTION_INFO]: provideInstructionInfoContext,
+  [ClearSignContextType.SOLANA_ENUM_VARIANT]: provideEnumVariantContext,
+  [ClearSignContextType.SOLANA_TOKEN_INFO]: provideTokenInfoContext,
+  [ClearSignContextType.SOLANA_TOKEN_ACCOUNT_STATE]:
+    provideTokenAccountStateContext,
+  [ClearSignContextType.SOLANA_ALT_RESOLUTION]: provideAltResolutionContext,
+  [ClearSignContextType.SOLANA_TRUSTED_NAME]: provideTrustedNameContext,
 };
 
 type DiscriminatedSolanaContextSuccess = {

--- a/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideEnumVariantContext.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideEnumVariantContext.test.ts
@@ -1,0 +1,89 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ClearSignContextType } from "@ledgerhq/context-module";
+import {
+  CommandResultFactory,
+  LoadCertificateCommand,
+} from "@ledgerhq/device-management-kit";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+import { ProvideEnumVariantCommand } from "@internal/app-binder/command/ProvideEnumVariantCommand";
+
+import { type ProvideContextDeps } from "./provideContextTypes";
+import { provideEnumVariantContext } from "./provideEnumVariantContext";
+
+const mockLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  subscribers: [],
+};
+const cert = { payload: new Uint8Array([0xf0]), keyUsageNumber: 2 } as const;
+const success = CommandResultFactory({ data: undefined });
+
+describe("provideEnumVariantContext", () => {
+  let api: { sendCommand: Mock };
+  let deps: ProvideContextDeps;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    api = { sendCommand: vi.fn() };
+    deps = {
+      api: api as any,
+      logger: mockLogger as any,
+      normaliser: {} as any,
+      transactionBytes: new Uint8Array(),
+    };
+  });
+
+  it("loads the certificate then streams the framed ENUM_VARIANT (0x26)", async () => {
+    api.sendCommand.mockResolvedValue(success);
+
+    await provideEnumVariantContext(
+      {
+        type: ClearSignContextType.SOLANA_ENUM_VARIANT as const,
+        payload: {
+          programId: "P",
+          enumId: "swap",
+          variantIndex: 46,
+          descriptor: { data: "aabb", signature: "" },
+        },
+        certificate: cert,
+      } as any,
+      deps,
+    );
+
+    expect(api.sendCommand.mock.calls[0]![0]).toBeInstanceOf(
+      LoadCertificateCommand,
+    );
+    const cmd = api.sendCommand.mock.calls[1]![0];
+    expect(cmd).toBeInstanceOf(ProvideEnumVariantCommand);
+    expect(cmd.args.payload).toStrictEqual(
+      new Uint8Array([0x00, 0x02, 0xaa, 0xbb]),
+    );
+  });
+
+  it("throws when the device rejects the ENUM_VARIANT", async () => {
+    api.sendCommand.mockResolvedValueOnce(success).mockResolvedValueOnce(
+      CommandResultFactory({
+        error: { _tag: "E", errorCode: 0x6a80, message: "no" } as any,
+      }),
+    );
+
+    await expect(
+      provideEnumVariantContext(
+        {
+          type: ClearSignContextType.SOLANA_ENUM_VARIANT as const,
+          payload: {
+            programId: "P",
+            enumId: "swap",
+            variantIndex: 46,
+            descriptor: { data: "aabb", signature: "" },
+          },
+          certificate: cert,
+        } as any,
+        deps,
+      ),
+    ).rejects.toThrow("device rejected ENUM_VARIANT");
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideEnumVariantContext.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideEnumVariantContext.ts
@@ -1,0 +1,65 @@
+import {
+  type ClearSignContextType,
+  type SolanaEnumVariantContextSuccess,
+} from "@ledgerhq/context-module";
+import {
+  hexaStringToBuffer,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { SendCommandInChunksTask } from "@ledgerhq/signer-utils";
+
+import { ProvideEnumVariantCommand } from "@internal/app-binder/command/ProvideEnumVariantCommand";
+import { frameClearSignPayload } from "@internal/app-binder/command/utils/apduChunking";
+import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+
+import { loadCertificate } from "./loadCertificate";
+import { type ProvideContextHandler } from "./provideContextTypes";
+
+/** Streams the selected `ENUM_VARIANT` (0x26) descriptor. */
+export const provideEnumVariantContext: ProvideContextHandler<
+  ClearSignContextType.SOLANA_ENUM_VARIANT
+> = async (result: SolanaEnumVariantContextSuccess, { api, logger }) => {
+  const { payload, certificate } = result;
+  if (!payload) return;
+
+  if (certificate) {
+    await loadCertificate(
+      api,
+      certificate,
+      "[SignerSolana] provideEnumVariantContext: failed to load ENUM_VARIANT certificate",
+    );
+  }
+
+  const tlv = hexaStringToBuffer(payload.descriptor.data);
+  if (!tlv) {
+    throw new Error(
+      `[SignerSolana] provideEnumVariantContext: malformed ENUM_VARIANT for ${payload.programId}:${payload.enumId}:${payload.variantIndex}`,
+    );
+  }
+
+  logger.debug("[provideEnumVariantContext] Sending ENUM_VARIANT", {
+    data: {
+      programId: payload.programId,
+      enumId: payload.enumId,
+      variantIndex: payload.variantIndex,
+    },
+  });
+
+  const res = await new SendCommandInChunksTask<void, SolanaAppErrorCodes>(
+    api,
+    {
+      data: frameClearSignPayload(tlv),
+      commandFactory: (args) =>
+        new ProvideEnumVariantCommand({
+          payload: args.chunkedData,
+          isFirstChunk: !args.extend,
+          hasMore: args.more,
+        }),
+    },
+  ).run();
+  if (!isSuccessCommandResult(res)) {
+    throw new Error(
+      `[SignerSolana] provideEnumVariantContext: device rejected ENUM_VARIANT for ${payload.programId}:${payload.enumId}:${payload.variantIndex}`,
+    );
+  }
+};

--- a/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideInstructionInfoContext.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideInstructionInfoContext.test.ts
@@ -1,0 +1,100 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ClearSignContextType } from "@ledgerhq/context-module";
+import {
+  CommandResultFactory,
+  LoadCertificateCommand,
+} from "@ledgerhq/device-management-kit";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+import { ProvideInstructionInfoCommand } from "@internal/app-binder/command/ProvideInstructionInfoCommand";
+import { ProvideInstructionSubstructureCommand } from "@internal/app-binder/command/ProvideInstructionSubstructureCommand";
+
+import { type ProvideContextDeps } from "./provideContextTypes";
+import { provideInstructionInfoContext } from "./provideInstructionInfoContext";
+
+const mockLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  subscribers: [],
+};
+
+const cert = { payload: new Uint8Array([0xf0]), keyUsageNumber: 11 } as const;
+const success = CommandResultFactory({ data: undefined });
+
+function makeResult() {
+  return {
+    type: ClearSignContextType.SOLANA_INSTRUCTION_INFO as const,
+    payload: {
+      programId: "P",
+      discriminator: "0102",
+      instructionInfo: { data: "aabb", signature: "00" },
+      substructures: [
+        { kind: 0x00, data: "ccdd" },
+        { kind: 0x01, data: "ee" },
+      ],
+      enumVariants: [],
+    },
+    certificate: cert,
+  };
+}
+
+describe("provideInstructionInfoContext", () => {
+  let api: { sendCommand: Mock };
+  let deps: ProvideContextDeps;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    api = { sendCommand: vi.fn() };
+    deps = {
+      api: api as any,
+      logger: mockLogger as any,
+      normaliser: {} as any,
+      transactionBytes: new Uint8Array(),
+    };
+  });
+
+  it("loads the certificate, then streams INSTRUCTION_INFO and substructures (framed, in order)", async () => {
+    api.sendCommand.mockResolvedValue(success);
+
+    await provideInstructionInfoContext(makeResult() as any, deps);
+
+    expect(api.sendCommand).toHaveBeenCalledTimes(4);
+
+    expect(api.sendCommand.mock.calls[0]![0]).toBeInstanceOf(
+      LoadCertificateCommand,
+    );
+
+    const info = api.sendCommand.mock.calls[1]![0];
+    expect(info).toBeInstanceOf(ProvideInstructionInfoCommand);
+    expect(info.args.payload).toStrictEqual(
+      new Uint8Array([0x00, 0x02, 0xaa, 0xbb]),
+    );
+
+    const sub0 = api.sendCommand.mock.calls[2]![0];
+    expect(sub0).toBeInstanceOf(ProvideInstructionSubstructureCommand);
+    expect(sub0.args.payload).toStrictEqual(
+      new Uint8Array([0x00, 0x03, 0x00, 0xcc, 0xdd]),
+    );
+
+    const sub1 = api.sendCommand.mock.calls[3]![0];
+    expect(sub1.args.payload).toStrictEqual(
+      new Uint8Array([0x00, 0x02, 0x01, 0xee]),
+    );
+  });
+
+  it("throws when the device rejects the INSTRUCTION_INFO", async () => {
+    api.sendCommand
+      .mockResolvedValueOnce(success) // cert
+      .mockResolvedValueOnce(
+        CommandResultFactory({
+          error: { _tag: "E", errorCode: 0x6a80, message: "no" } as any,
+        }),
+      );
+
+    await expect(
+      provideInstructionInfoContext(makeResult() as any, deps),
+    ).rejects.toThrow("device rejected INSTRUCTION_INFO");
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideInstructionInfoContext.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideInstructionInfoContext.ts
@@ -1,0 +1,94 @@
+import {
+  type ClearSignContextType,
+  type SolanaInstructionInfoContextSuccess,
+} from "@ledgerhq/context-module";
+import {
+  hexaStringToBuffer,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { SendCommandInChunksTask } from "@ledgerhq/signer-utils";
+
+import { ProvideInstructionInfoCommand } from "@internal/app-binder/command/ProvideInstructionInfoCommand";
+import { ProvideInstructionSubstructureCommand } from "@internal/app-binder/command/ProvideInstructionSubstructureCommand";
+import { frameClearSignPayload } from "@internal/app-binder/command/utils/apduChunking";
+import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+
+import { loadCertificate } from "./loadCertificate";
+import { type ProvideContextHandler } from "./provideContextTypes";
+
+/**
+ * Streams a Phase-B instruction template: `PROVIDE INSTRUCTION INFO` (0x24)
+ * followed by its substructures (`PROVIDE INSTRUCTION SUBSTRUCTURE` 0x25) in
+ * the CAL-provided order, so the device's running SHA-256 matches the parent's
+ * `SUBSTRUCTURES_HASH`.
+ */
+export const provideInstructionInfoContext: ProvideContextHandler<
+  ClearSignContextType.SOLANA_INSTRUCTION_INFO
+> = async (result: SolanaInstructionInfoContextSuccess, { api, logger }) => {
+  const { payload, certificate } = result;
+  if (!payload) return;
+
+  if (certificate) {
+    await loadCertificate(
+      api,
+      certificate,
+      "[SignerSolana] provideInstructionInfoContext: failed to load INSTRUCTION_INFO certificate",
+    );
+  }
+
+  const label = `${payload.programId}:${payload.discriminator}`;
+  const infoBytes = hexaStringToBuffer(payload.instructionInfo.data);
+  if (!infoBytes) {
+    throw new Error(
+      `[SignerSolana] provideInstructionInfoContext: malformed INSTRUCTION_INFO for ${label}`,
+    );
+  }
+
+  logger.debug("[provideInstructionInfoContext] Sending INSTRUCTION_INFO", {
+    data: { label, substructures: payload.substructures.length },
+  });
+
+  const infoResult = await new SendCommandInChunksTask<
+    void,
+    SolanaAppErrorCodes
+  >(api, {
+    data: frameClearSignPayload(infoBytes),
+    commandFactory: (args) =>
+      new ProvideInstructionInfoCommand({
+        payload: args.chunkedData,
+        isFirstChunk: !args.extend,
+        hasMore: args.more,
+      }),
+  }).run();
+  if (!isSuccessCommandResult(infoResult)) {
+    throw new Error(
+      `[SignerSolana] provideInstructionInfoContext: device rejected INSTRUCTION_INFO for ${label}`,
+    );
+  }
+
+  for (const substructure of payload.substructures) {
+    const tlv = hexaStringToBuffer(substructure.data);
+    if (!tlv) {
+      throw new Error(
+        `[SignerSolana] provideInstructionInfoContext: malformed substructure (kind ${substructure.kind}) for ${label}`,
+      );
+    }
+    const subResult = await new SendCommandInChunksTask<
+      void,
+      SolanaAppErrorCodes
+    >(api, {
+      data: frameClearSignPayload(tlv, substructure.kind),
+      commandFactory: (args) =>
+        new ProvideInstructionSubstructureCommand({
+          payload: args.chunkedData,
+          isFirstChunk: !args.extend,
+          hasMore: args.more,
+        }),
+    }).run();
+    if (!isSuccessCommandResult(subResult)) {
+      throw new Error(
+        `[SignerSolana] provideInstructionInfoContext: device rejected substructure (kind ${substructure.kind}) for ${label}`,
+      );
+    }
+  }
+};

--- a/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideTokenAccountStateContext.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideTokenAccountStateContext.test.ts
@@ -1,0 +1,79 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ClearSignContextType } from "@ledgerhq/context-module";
+import {
+  CommandResultFactory,
+  LoadCertificateCommand,
+} from "@ledgerhq/device-management-kit";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+import { ProvideTokenAccountStateCommand } from "@internal/app-binder/command/ProvideTokenAccountStateCommand";
+
+import { type ProvideContextDeps } from "./provideContextTypes";
+import { provideTokenAccountStateContext } from "./provideTokenAccountStateContext";
+
+const mockLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  subscribers: [],
+};
+const cert = { payload: new Uint8Array([0xf0]), keyUsageNumber: 2 } as const;
+const success = CommandResultFactory({ data: undefined });
+
+describe("provideTokenAccountStateContext", () => {
+  let api: { sendCommand: Mock };
+  let deps: ProvideContextDeps;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    api = { sendCommand: vi.fn() };
+    deps = {
+      api: api as any,
+      logger: mockLogger as any,
+      normaliser: {} as any,
+      transactionBytes: new Uint8Array(),
+    };
+  });
+
+  it("loads the certificate then streams the framed TOKEN_ACCOUNT_STATE (0x27)", async () => {
+    api.sendCommand.mockResolvedValue(success);
+
+    await provideTokenAccountStateContext(
+      {
+        type: ClearSignContextType.SOLANA_TOKEN_ACCOUNT_STATE as const,
+        payload: { descriptor: new Uint8Array([0xaa, 0xbb]) },
+        certificate: cert,
+      } as any,
+      deps,
+    );
+
+    expect(api.sendCommand.mock.calls[0]![0]).toBeInstanceOf(
+      LoadCertificateCommand,
+    );
+    const cmd = api.sendCommand.mock.calls[1]![0];
+    expect(cmd).toBeInstanceOf(ProvideTokenAccountStateCommand);
+    expect(cmd.args.payload).toStrictEqual(
+      new Uint8Array([0x00, 0x02, 0xaa, 0xbb]),
+    );
+  });
+
+  it("throws when the device rejects the descriptor", async () => {
+    api.sendCommand.mockResolvedValueOnce(success).mockResolvedValueOnce(
+      CommandResultFactory({
+        error: { _tag: "E", errorCode: 0x6a80, message: "no" } as any,
+      }),
+    );
+
+    await expect(
+      provideTokenAccountStateContext(
+        {
+          type: ClearSignContextType.SOLANA_TOKEN_ACCOUNT_STATE as const,
+          payload: { descriptor: new Uint8Array([0xaa, 0xbb]) },
+          certificate: cert,
+        } as any,
+        deps,
+      ),
+    ).rejects.toThrow("device rejected TOKEN_ACCOUNT_STATE");
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideTokenAccountStateContext.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideTokenAccountStateContext.ts
@@ -1,0 +1,53 @@
+import {
+  type ClearSignContextType,
+  type SolanaTokenAccountStateContextSuccess,
+} from "@ledgerhq/context-module";
+import { isSuccessCommandResult } from "@ledgerhq/device-management-kit";
+import { SendCommandInChunksTask } from "@ledgerhq/signer-utils";
+
+import { ProvideTokenAccountStateCommand } from "@internal/app-binder/command/ProvideTokenAccountStateCommand";
+import { frameClearSignPayload } from "@internal/app-binder/command/utils/apduChunking";
+import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+
+import { loadCertificate } from "./loadCertificate";
+import { type ProvideContextHandler } from "./provideContextTypes";
+
+/**
+ * Streams a challenge-bound `TOKEN_ACCOUNT_STATE` (0x27) descriptor. The caller
+ * (stream task) must have issued a fresh `GET CHALLENGE` immediately before
+ * fetching this descriptor so its signature binds to the latest challenge.
+ */
+export const provideTokenAccountStateContext: ProvideContextHandler<
+  ClearSignContextType.SOLANA_TOKEN_ACCOUNT_STATE
+> = async (result: SolanaTokenAccountStateContextSuccess, { api, logger }) => {
+  const { payload, certificate } = result;
+  if (!payload) return;
+
+  if (certificate) {
+    await loadCertificate(
+      api,
+      certificate,
+      "[SignerSolana] provideTokenAccountStateContext: failed to load TOKEN_ACCOUNT_STATE certificate",
+    );
+  }
+
+  logger.debug("[provideTokenAccountStateContext] Sending TOKEN_ACCOUNT_STATE");
+
+  const res = await new SendCommandInChunksTask<void, SolanaAppErrorCodes>(
+    api,
+    {
+      data: frameClearSignPayload(payload.descriptor),
+      commandFactory: (args) =>
+        new ProvideTokenAccountStateCommand({
+          payload: args.chunkedData,
+          isFirstChunk: !args.extend,
+          hasMore: args.more,
+        }),
+    },
+  ).run();
+  if (!isSuccessCommandResult(res)) {
+    throw new Error(
+      "[SignerSolana] provideTokenAccountStateContext: device rejected TOKEN_ACCOUNT_STATE",
+    );
+  }
+};

--- a/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideTokenInfoContext.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideTokenInfoContext.test.ts
@@ -1,0 +1,80 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ClearSignContextType } from "@ledgerhq/context-module";
+import {
+  CommandResultFactory,
+  LoadCertificateCommand,
+} from "@ledgerhq/device-management-kit";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+import { ProvideTLVTransactionInstructionDescriptorCommand } from "@internal/app-binder/command/ProvideTLVTransactionInstructionDescriptorCommand";
+
+import { type ProvideContextDeps } from "./provideContextTypes";
+import { provideTokenInfoContext } from "./provideTokenInfoContext";
+
+const mockLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  subscribers: [],
+};
+const cert = { payload: new Uint8Array([0xf0]), keyUsageNumber: 2 } as const;
+const success = CommandResultFactory({ data: undefined });
+
+describe("provideTokenInfoContext", () => {
+  let api: { sendCommand: Mock };
+  let deps: ProvideContextDeps;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    api = { sendCommand: vi.fn() };
+    deps = {
+      api: api as any,
+      logger: mockLogger as any,
+      normaliser: {} as any,
+      transactionBytes: new Uint8Array(),
+    };
+  });
+
+  it("loads the certificate then sends TOKEN_INFO via dataHex/signatureHex", async () => {
+    api.sendCommand.mockResolvedValue(success);
+
+    await provideTokenInfoContext(
+      {
+        type: ClearSignContextType.SOLANA_TOKEN_INFO as const,
+        payload: { mint: "M", descriptor: { data: "aabb", signature: "cc" } },
+        certificate: cert,
+      } as any,
+      deps,
+    );
+
+    expect(api.sendCommand.mock.calls[0]![0]).toBeInstanceOf(
+      LoadCertificateCommand,
+    );
+    const cmd = api.sendCommand.mock.calls[1]![0];
+    expect(cmd).toBeInstanceOf(
+      ProvideTLVTransactionInstructionDescriptorCommand,
+    );
+    expect(cmd.args.dataHex).toBe("aabb");
+    expect(cmd.args.signatureHex).toBe("cc");
+  });
+
+  it("throws when the device rejects the descriptor", async () => {
+    api.sendCommand.mockResolvedValueOnce(success).mockResolvedValueOnce(
+      CommandResultFactory({
+        error: { _tag: "E", errorCode: 0x6a80, message: "no" } as any,
+      }),
+    );
+
+    await expect(
+      provideTokenInfoContext(
+        {
+          type: ClearSignContextType.SOLANA_TOKEN_INFO as const,
+          payload: { mint: "M", descriptor: { data: "aabb", signature: "cc" } },
+          certificate: cert,
+        } as any,
+        deps,
+      ),
+    ).rejects.toThrow("device rejected TOKEN_INFO");
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideTokenInfoContext.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideTokenInfoContext.ts
@@ -1,0 +1,42 @@
+import {
+  type ClearSignContextType,
+  type SolanaTokenInfoContextSuccess,
+} from "@ledgerhq/context-module";
+import { isSuccessCommandResult } from "@ledgerhq/device-management-kit";
+
+import { ProvideTLVTransactionInstructionDescriptorCommand } from "@internal/app-binder/command/ProvideTLVTransactionInstructionDescriptorCommand";
+
+import { loadCertificate } from "./loadCertificate";
+import { type ProvideContextHandler } from "./provideContextTypes";
+
+/** Streams a static `TOKEN_INFO` (0x22) descriptor for a mint. Not chunked. */
+export const provideTokenInfoContext: ProvideContextHandler<
+  ClearSignContextType.SOLANA_TOKEN_INFO
+> = async (result: SolanaTokenInfoContextSuccess, { api, logger }) => {
+  const { payload, certificate } = result;
+  if (!payload) return;
+
+  if (certificate) {
+    await loadCertificate(
+      api,
+      certificate,
+      "[SignerSolana] provideTokenInfoContext: failed to load TOKEN_INFO certificate",
+    );
+  }
+
+  logger.debug("[provideTokenInfoContext] Sending TOKEN_INFO", {
+    data: { mint: payload.mint },
+  });
+
+  const res = await api.sendCommand(
+    new ProvideTLVTransactionInstructionDescriptorCommand({
+      dataHex: payload.descriptor.data,
+      signatureHex: payload.descriptor.signature,
+    }),
+  );
+  if (!isSuccessCommandResult(res)) {
+    throw new Error(
+      `[SignerSolana] provideTokenInfoContext: device rejected TOKEN_INFO for mint ${payload.mint}`,
+    );
+  }
+};

--- a/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideTrustedNameContext.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideTrustedNameContext.test.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ClearSignContextType } from "@ledgerhq/context-module";
+import {
+  CommandResultFactory,
+  LoadCertificateCommand,
+} from "@ledgerhq/device-management-kit";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+import { ProvideTLVDescriptorCommand } from "@internal/app-binder/command/ProvideTLVDescriptorCommand";
+
+import { type ProvideContextDeps } from "./provideContextTypes";
+import { provideTrustedNameContext } from "./provideTrustedNameContext";
+
+const mockLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  subscribers: [],
+};
+const cert = { payload: new Uint8Array([0xf0]), keyUsageNumber: 2 } as const;
+const success = CommandResultFactory({ data: undefined });
+
+describe("provideTrustedNameContext", () => {
+  let api: { sendCommand: Mock };
+  let deps: ProvideContextDeps;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    api = { sendCommand: vi.fn() };
+    deps = {
+      api: api as any,
+      logger: mockLogger as any,
+      normaliser: {} as any,
+      transactionBytes: new Uint8Array(),
+    };
+  });
+
+  it("streams TRUSTED_NAME (0x21) framed with the 2-byte length prefix", async () => {
+    api.sendCommand.mockResolvedValue(success);
+
+    await provideTrustedNameContext(
+      {
+        type: ClearSignContextType.SOLANA_TRUSTED_NAME as const,
+        payload: new Uint8Array([0xaa, 0xbb]),
+        certificate: cert,
+      } as any,
+      deps,
+    );
+
+    expect(api.sendCommand.mock.calls[0]![0]).toBeInstanceOf(
+      LoadCertificateCommand,
+    );
+    const cmd = api.sendCommand.mock.calls[1]![0];
+    expect(cmd).toBeInstanceOf(ProvideTLVDescriptorCommand);
+    expect(cmd.args.payload).toStrictEqual(
+      new Uint8Array([0x00, 0x02, 0xaa, 0xbb]),
+    );
+  });
+
+  it("does nothing for an empty payload", async () => {
+    await provideTrustedNameContext(
+      {
+        type: ClearSignContextType.SOLANA_TRUSTED_NAME as const,
+        payload: new Uint8Array([]),
+        certificate: cert,
+      } as any,
+      deps,
+    );
+    expect(api.sendCommand).not.toHaveBeenCalled();
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideTrustedNameContext.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/context-providers/provideTrustedNameContext.ts
@@ -1,0 +1,54 @@
+import {
+  type ClearSignContextType,
+  type SolanaTrustedNameContextSuccess,
+} from "@ledgerhq/context-module";
+import { isSuccessCommandResult } from "@ledgerhq/device-management-kit";
+import { SendCommandInChunksTask } from "@ledgerhq/signer-utils";
+
+import { ProvideTLVDescriptorCommand } from "@internal/app-binder/command/ProvideTLVDescriptorCommand";
+import { frameClearSignPayload } from "@internal/app-binder/command/utils/apduChunking";
+import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+
+import { loadCertificate } from "./loadCertificate";
+import { type ProvideContextHandler } from "./provideContextTypes";
+
+/**
+ * Streams a challenge-bound `TRUSTED_NAME` (0x21) descriptor. Like the other
+ * Phase A descriptors, the payload carries the 2-byte BE length prefix the
+ * device expects. The caller must have issued a fresh `GET CHALLENGE`
+ * immediately before fetching it.
+ */
+export const provideTrustedNameContext: ProvideContextHandler<
+  ClearSignContextType.SOLANA_TRUSTED_NAME
+> = async (result: SolanaTrustedNameContextSuccess, { api, logger }) => {
+  const { payload, certificate } = result;
+  if (!payload || payload.length === 0) return;
+
+  if (certificate) {
+    await loadCertificate(
+      api,
+      certificate,
+      "[SignerSolana] provideTrustedNameContext: failed to load TRUSTED_NAME certificate",
+    );
+  }
+
+  logger.debug("[provideTrustedNameContext] Sending TRUSTED_NAME");
+
+  const res = await new SendCommandInChunksTask<void, SolanaAppErrorCodes>(
+    api,
+    {
+      data: frameClearSignPayload(payload),
+      commandFactory: (args) =>
+        new ProvideTLVDescriptorCommand({
+          payload: args.chunkedData,
+          isFirstChunk: !args.extend,
+          hasMore: args.more,
+        }),
+    },
+  ).run();
+  if (!isSuccessCommandResult(res)) {
+    throw new Error(
+      "[SignerSolana] provideTrustedNameContext: device rejected TRUSTED_NAME",
+    );
+  }
+};


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

  ### 📝 Description

Implements end-to-end **generic clear-signing** for Solana transactions and restructures `SignTransactionDeviceAction` into a thin orchestrator plus three single-responsibility child machines, with a single terminal-sign machine.

The device now renders a merged, descriptor-driven review for transactions whose instructions are covered by CAL (`full` / `srfc39-only`), gracefully degrades to the legacy SPL/token (“shallow”) path when generic clear-signing isn't possible, and blind-signs only as a last resort. Any clear-sign failure before approval degrades silently, only a user cancel (`6985`) surfaces.

**What it adds**

- **Streaming layer**
  - `BuildGenericClearSignContextTask` parses the tx (skips ComputeBudget), matches `INSTRUCTION_INFO` per program/discriminator in CAL, builds the requirement set, fetches satellite descriptors, returns `{ mode, poolContexts, instructionInfoContexts }`.
- `ProvideGenericClearSignContextTask` streams `SIGN MESSAGE GENERIC PREVIEW (0x0A)` => Phase A pool => Phase B templates via the shared `dispatchProvideContext` registry, zeroes the preview blockhash to match the armed fingerprint.
- Six new context-provider handlers + registry wiring: instruction-info, enum-variant, token-info, token-account-state, alt-resolution, trusted-name.
- `frameClearSignPayload` (`apduChunking`) `u16BE(len) ‖ [typeByte] ‖ TLV` framing for descriptor PROVIDE commands.
- **Device-action architecture** orchestrator + 3 child machines (diagrams below).
- **Supporting changes**
  - `SolanaApplicationResolver`: shared `isSolanaFeatureSupported` helper + `genericClearSign` capability/min-version.
  - `context-module`: `InstructionInfoContextLoader` flattens CAL `enum_variants`; payload/type widening + `enumVariants` field.
  - Renames for clarity: `DelayedSignTransactionDeviceAction to SigningOperationsDeviceAction`, `Build/ProvideTransactionContextTask to Build/ProvideShallowClearSignContextTask` (the legacy
  “transaction context” = the SPL/token *shallow* clear-sign path).

  #### Architecture
  
  `SignTransactionDeviceAction` (orchestrator)

  ```mermaid
  stateDiagram-v2
      [*] --> InitialState
      InitialState --> GetAppConfig: skipOpenApp
      InitialState --> OpenAppDeviceAction
      OpenAppDeviceAction --> OpenAppResultCheck
      OpenAppResultCheck --> GetAppConfig: noInternalError
      OpenAppResultCheck --> Error
      GetAppConfig --> GetAppConfigResultCheck
      GetAppConfig --> Error: onError
      GetAppConfigResultCheck --> Web3ChecksOptIn: web3 supported & shouldOptIn
      GetAppConfigResultCheck --> CheckGenericClearSignSupported: noInternalError
      Web3ChecksOptIn --> Web3ChecksOptInResult
      Web3ChecksOptInResult --> CheckGenericClearSignSupported: after(0)
      CheckGenericClearSignSupported --> GenericClearSign: isGenericClearSignAvailable
      CheckGenericClearSignSupported --> ShallowClearSign: noInternalError
      state "GenericClearSign (child)" as GenericClearSign
      GenericClearSign --> TerminalSign: Right(armed)
      GenericClearSign --> Error: Left (user cancel)
      GenericClearSign --> ShallowClearSign: Right(degraded) / onError
      state "ShallowClearSign (child)" as ShallowClearSign
      ShallowClearSign --> TerminalSign: onDone / onError
      state "TerminalSign (SigningOperations child)" as TerminalSign
      TerminalSign --> SignTransactionResultCheck
      SignTransactionResultCheck --> Success: noInternalError
      SignTransactionResultCheck --> Error
      Success --> [*]
      Error --> [*]
  ```

  `GenericClearSignDeviceAction` (prepare + arm, never signs)
  
  ```mermaid
  stateDiagram-v2
      [*] --> BuildContext
      BuildContext --> ProvideContext: isContextRecognised (mode ≠ none)
      BuildContext --> Degraded: mode = none / onError
      ProvideContext --> PromptUiDisplay: onDone
      ProvideContext --> Degraded: onError
      state "PromptUiDisplay (0x0B)" as PromptUiDisplay
      PromptUiDisplay --> Armed: isPromptApproved
      PromptUiDisplay --> Error: isPromptUserCancel (6985)
      PromptUiDisplay --> Degraded: other error / onError
      Armed --> [*]: Right("armed")
      Degraded --> [*]: Right("degraded")
      Error --> [*]: Left(error)
  ```

  `ShallowClearSignDeviceAction` (legacy SPL/token provisioning, best-effort, never signs)                                                                                             

  ```mermaid
  stateDiagram-v2
      [*] --> CheckSPLSupported
      CheckSPLSupported --> InspectTransaction: isSPLSupported                                                                                                                         
      CheckSPLSupported --> CheckBuildNeeded
      InspectTransaction --> CheckBuildNeeded: onDone
      InspectTransaction --> Done: onError
      CheckBuildNeeded --> GetPubKey: shouldBuildContext (SPL/SWAP)
      CheckBuildNeeded --> GetPubKey: isWeb3ChecksSupported
      CheckBuildNeeded --> Done
      GetPubKey --> BuildContext: onDone / onError
      BuildContext --> ProvideContext: onDone
      BuildContext --> Done: onError
      ProvideContext --> Done: onDone / onError
      Done --> [*]: Right (always)
  ```

  `SigningOperationsDeviceAction` (universal terminal sign)

  ```mermaid
  stateDiagram-v2
      [*] --> Entry
      Entry --> FetchBlockhash: alreadyArmed & hasBlockhashSource
      Entry --> DelayedSign: alreadyArmed (no source)
      Entry --> ZeroBlockhash: hasBlockhashSource (not armed)
      Entry --> Sign: not armed, no source
      ZeroBlockhash --> PreviewTransaction: onDone
      ZeroBlockhash --> Error: onError
      state "PreviewTransaction (0x08)" as PreviewTransaction
      PreviewTransaction --> PreviewResultCheck: onDone
      PreviewTransaction --> Error: onError
      PreviewResultCheck --> FetchBlockhash: noInternalError
      PreviewResultCheck --> Error
      FetchBlockhash --> PatchTransaction: onDone
      FetchBlockhash --> PatchResultCheck: onError (best-effort)
      PatchTransaction --> PatchResultCheck: onDone
      PatchTransaction --> Error: onError
      PatchResultCheck --> FallbackSign: isPreviewFallback
      PatchResultCheck --> DelayedSign
      state "DelayedSign (0x09)" as DelayedSign
      DelayedSign --> ResultCheck
      DelayedSign --> Error: onError
      state "Sign (0x06 one-shot)" as Sign
      Sign --> ResultCheck
      Sign --> Error: onError
      state "FallbackSign (0x06)" as FallbackSign
      FallbackSign --> ResultCheck
      FallbackSign --> Error: onError
      ResultCheck --> Success: noInternalError
      ResultCheck --> Error
      Success --> [*]
      Error --> [*]
  ```

  #### Behaviour & trade-offs

- Gating is capability-only; the generic build classifies coverage as `full` / `srfc39-only` / `none`, and `none` degrades to the shallow path.
- The terminal machine chooses delayed-with-refresh (`0x08`→`0x09`), armed delayed (`0x09`), or one-shot (`0x06`) from `alreadyArmed` + presence of a blockhash source. It absorbed the parent's old `CheckDelayed` + one-shot routing.
- **Blockhash refresh is the default** when an RPC source (`solanaRPCURL`/`fetchBlockhash`) is available — `delayed: true` is no longer required; fetch failures fall back to signing the original (best-effort).

- **JIRA or GitHub link**: [DSDK-1146](https://ledgerhq.atlassian.net/browse/DSDK-1146)

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[DSDK-1146]: https://ledgerhq.atlassian.net/browse/DSDK-1146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ