### PR TITLE
🐛 (sample) [NO-ISSUE]: Fix App Provider input not allowing empty value

### DIFF
--- a/apps/sample/src/components/SettingsView/AppProviderSetting.tsx
+++ b/apps/sample/src/components/SettingsView/AppProviderSetting.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Flex, Input } from "@ledgerhq/react-ui";
 
@@ -12,6 +12,11 @@ import { SettingBox } from "./SettingBox";
 export const AppProviderSetting: React.FC = () => {
   const appProvider = useSelector(selectAppProvider);
   const dispatch = useDispatch();
+  const [input, setInput] = useState(String(appProvider));
+
+  useEffect(() => {
+    setInput(String(appProvider));
+  }, [appProvider]);
 
   const setAppProviderFn = useCallback(
     (value: number) => {
@@ -22,6 +27,8 @@ export const AppProviderSetting: React.FC = () => {
 
   const onValueChange = useCallback(
     (value: string) => {
+      setInput(value);
+
       const parsed = parseInt(value, 10);
       if (!isNaN(parsed) && parsed >= 1) {
         setAppProviderFn(parsed);
@@ -35,7 +42,7 @@ export const AppProviderSetting: React.FC = () => {
       <Flex flex={1} flexDirection="column" alignItems="stretch">
         <Input
           renderLeft={<InputLabel>App Provider ID (must be ≥ 1)</InputLabel>}
-          value={String(appProvider)}
+          value={input}
           onChange={onValueChange}
           type="number"
           placeholder="Provider ID"


### PR DESCRIPTION
### 📝 Description

In the sample app settings, the **App Provider ID** input could not be cleared while editing.

Because the field read its value straight from the store (which always holds a valid number), deleting the last digit immediately put the old value back. So if it was `1` and you deleted it to type `81`, you ended up with `181`.

**Fix:** the input now keeps its own local text state, so it can be temporarily empty while you type. It only writes back to the store when the value is a valid provider ID (a number `≥ 1`). Empty / invalid input is no longer dispatched to the store.

This matches the existing pattern already used by the Polling Interval setting.


https://github.com/user-attachments/assets/146258d7-9914-405d-93fa-46bbb27c566c



### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Bugfix for the sample app settings.

### ✅ Checklist

- [ ] **Covered by automatic tests** — manual fix in the sample app UI (no test harness for this component).
- [ ] **Changeset is provided** — not needed, changes only affect `apps/sample` (not a published package).
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - The App Provider ID input in sample app settings can now be fully cleared while editing.
  - Only valid values (`≥ 1`) are persisted to the settings store.