### PR TITLE
🐛 (sample) [NO-ISSUE]: Debounce device reconnection instead of polling interval input

### DIFF
--- a/apps/sample/src/components/SettingsView/PollingIntervalSetting.tsx
+++ b/apps/sample/src/components/SettingsView/PollingIntervalSetting.tsx
@@ -3,20 +3,16 @@ import { useDispatch, useSelector } from "react-redux";
 import { Flex, Input } from "@ledgerhq/react-ui";
 
 import { InputLabel } from "@/components/InputLabel";
-import { useDebounce } from "@/hooks/useDebounce";
 import { selectPollingInterval } from "@/state/settings/selectors";
 import { setPollingInterval } from "@/state/settings/slice";
 
 import { ResetSettingCTA } from "./ResetSetting";
 import { SettingBox } from "./SettingBox";
 
-const DEBOUNCE_DELAY_MS = 500;
-
 export const PollingIntervalSetting: React.FC = () => {
   const pollingInterval = useSelector(selectPollingInterval);
   const dispatch = useDispatch();
   const [localValue, setLocalValue] = useState(String(pollingInterval));
-  const debouncedValue = useDebounce(localValue, DEBOUNCE_DELAY_MS);
 
   // Sync local value when redux state changes externally (e.g., reset)
   useEffect(() => {
@@ -30,16 +26,17 @@ export const PollingIntervalSetting: React.FC = () => {
     [dispatch],
   );
 
-  // Update redux state when debounced value changes
-  useEffect(() => {
-    const parsed = parseInt(debouncedValue, 10);
-    if (isNaN(parsed) || parsed === pollingInterval) return;
-    setPollingIntervalFn(parsed);
-  }, [debouncedValue, pollingInterval, setPollingIntervalFn]);
+  const onValueChange = useCallback(
+    (value: string) => {
+      setLocalValue(value);
 
-  const onValueChange = useCallback((value: string) => {
-    setLocalValue(value);
-  }, []);
+      const parsed = parseInt(value, 10);
+      if (!isNaN(parsed) && parsed >= 0) {
+        setPollingIntervalFn(parsed);
+      }
+    },
+    [setPollingIntervalFn],
+  );
 
   return (
     <SettingBox>

--- a/apps/sample/src/hooks/useUpdateConnectionsRefresherOptions.ts
+++ b/apps/sample/src/hooks/useUpdateConnectionsRefresherOptions.ts
@@ -1,18 +1,27 @@
 import { useEffect } from "react";
 import { useSelector } from "react-redux";
 
+import { useDebounce } from "@/hooks/useDebounce";
 import { useDmk } from "@/providers/DeviceManagementKitProvider";
 import { selectOrderedConnectedDevices } from "@/state/sessions/selectors";
 import { selectPollingInterval } from "@/state/settings/selectors";
 import { store } from "@/state/store";
 import { buildSessionRefresherOptions } from "@/utils/sessionRefresherOptions";
 
+const DEBOUNCE_DELAY_MS = 500;
+
 /**
  * Reconnects all connected devices when the polling interval setting changes.
+ * The polling interval is debounced so devices are not reconnected on every
+ * keystroke while the user is editing the setting.
  */
 export function useUpdateConnectionsRefresherOptions() {
   const dmk = useDmk();
   const pollingInterval = useSelector(selectPollingInterval);
+  const debouncedPollingInterval = useDebounce(
+    pollingInterval,
+    DEBOUNCE_DELAY_MS,
+  );
 
   useEffect(() => {
     // Read connected devices directly from store to avoid triggering
@@ -23,8 +32,9 @@ export function useUpdateConnectionsRefresherOptions() {
       dmk
         .reconnect({
           device: connectedDevice,
-          sessionRefresherOptions:
-            buildSessionRefresherOptions(pollingInterval),
+          sessionRefresherOptions: buildSessionRefresherOptions(
+            debouncedPollingInterval,
+          ),
         })
         .catch((error) => {
           console.error(
@@ -33,5 +43,5 @@ export function useUpdateConnectionsRefresherOptions() {
           );
         });
     });
-  }, [dmk, pollingInterval]);
+  }, [dmk, debouncedPollingInterval]);
 }


### PR DESCRIPTION
### 📝 Description

This fixes two issues with the **Polling Interval** setting in the sample app.

**Problem 1 — Reset didn't stick.**
Clicking "Reset" would briefly show the default value, then jump back to the previous one. The input debounced its writes to the store, so right after a reset the stale debounced value got written back, undoing the reset.


https://github.com/user-attachments/assets/8444d892-21b6-4950-9a9d-30b0d06760e4



**Problem 2 — Wrong place for the debounce.**
The debounce lived in the input, which made the store lag behind what you typed and caused the reset race above.

**Fix:**
- The input now writes to the store **immediately** (like the App Provider setting), so it stays responsive and reset works correctly. It also keeps a local text state so the field can be temporarily empty while editing.
- The debounce moved to `useUpdateConnectionsRefresherOptions`, where it actually matters: it now debounces the **device reconnection** so connected devices aren't reconnected on every keystroke.


https://github.com/user-attachments/assets/0c0c508a-2468-4cf5-b750-0f422c8cc65d



### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Bugfix for the sample app settings.

### ✅ Checklist

- [ ] **Covered by automatic tests** — manual fix in the sample app UI (no test harness for these components).
- [ ] **Changeset is provided** — not needed, changes only affect `apps/sample` (not a published package).
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - Polling Interval input writes to the store immediately and can be cleared while editing.
  - Reset now works reliably.
  - Device reconnection is debounced (500ms) so it no longer fires on every keystroke.