### PR TITLE
🐛 (dmk) [NO-ISSUE]: Fix device session polling interval applied at twice the configured value

### DIFF
--- a/.changeset/wild-pillows-jump.md
+++ b/.changeset/wild-pillows-jump.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Fix the device session refresher polling interval being applied at twice the configured value. The validated polling interval was multiplied by 2 before being passed to the timer, so a configured interval of 1000ms actually polled every 2000ms (and NANO_S devices every 4000ms). The interval is now used as-is, while the NANO_S minimum interval remains handled in `getValidPollingInterval`.

--- a/packages/device-management-kit/src/internal/device-session/model/DeviceSessionRefresher.test.ts
+++ b/packages/device-management-kit/src/internal/device-session/model/DeviceSessionRefresher.test.ts
@@ -163,7 +163,7 @@ describe("DeviceSessionRefresher", () => {
     // Trigger NEW_STATE event to start the refresher timer
     subject.next({ eventName: SessionEvents.NEW_STATE });
 
-    const timerInterval = validInterval * 2;
+    const timerInterval = validInterval;
 
     vi.advanceTimersByTime(timerInterval * 3);
 

--- a/packages/device-management-kit/src/internal/device-session/model/DeviceSessionRefresher.ts
+++ b/packages/device-management-kit/src/internal/device-session/model/DeviceSessionRefresher.ts
@@ -47,8 +47,10 @@ export class DeviceSessionRefresher {
     if (this._refresherOptions.isRefresherDisabled) return;
     if (this._refresherSubscription) return;
 
-    const pollingInterval =
-      this.getValidPollingInterval(this._refresherOptions, this._logger) * 2;
+    const pollingInterval = this.getValidPollingInterval(
+      this._refresherOptions,
+      this._logger,
+    );
 
     const isBusy$ = this._sessionEventDispatcher.listen().pipe(
       filter(


### PR DESCRIPTION
### 📝 Description

The device session refresher was polling **twice as slow** as configured.

**Problem:**
The validated polling interval was multiplied by `2` right before being passed to the timer. So a configured interval of `1000ms` actually polled every `2000ms`, and NANO_S devices (whose default is already `2×`) polled every `4000ms`.

This was a regression from a past refactor: originally only NANO_S devices doubled the interval, but the refactor applied the `× 2` to **all** devices.

**Fix:**
Use the validated polling interval as-is. The NANO_S "poll slower" behavior is preserved, because its minimum/default interval is still handled inside `getValidPollingInterval` (which returns `2×` the base interval for NANO_S).

| Device | Before | After |
| ------ | ------ | ----- |
| Default (configured 1000ms) | 2000ms | 1000ms |
| NANO_S (default) | 4000ms | 2000ms |

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Bugfix for the device session refresher polling interval.

### ✅ Checklist

- [x] **Covered by automatic tests** — updated the refresher timer-tick test; full `device-session` suite passes (90 tests).
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - Device session polling now happens at the configured interval instead of double.
  - NANO_S behavior is unchanged (still 2× the base interval).
  - QA should verify polling cadence in the logs for both default devices and NANO_S.