### PR TITLE
🐛 (device-management-kit) [LIVE-32728]: Allow recovery device status

### DIFF
--- a/.changeset/green-ravens-onboarded.md
+++ b/.changeset/green-ravens-onboarded.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Allow non-onboarded devices to pass the device status check by default, with an opt-out option for stricter consumers.

--- a/apps/sample/src/components/DeviceActionsView/AllDeviceActions.tsx
+++ b/apps/sample/src/components/DeviceActionsView/AllDeviceActions.tsx
@@ -169,9 +169,12 @@ export const AllDeviceActions: React.FC<{ sessionId: string }> = ({
         title: "Get device status",
         description:
           "Perform various checks on the device to determine its status",
-        executeDeviceAction: ({ unlockTimeout }, inspect) => {
+        executeDeviceAction: (
+          { unlockTimeout, allowNonOnboardedDevice },
+          inspect,
+        ) => {
           const deviceAction = new GetDeviceStatusDeviceAction({
-            input: { unlockTimeout },
+            input: { unlockTimeout, allowNonOnboardedDevice },
             inspect,
           });
           return dmk.executeDeviceAction({
@@ -179,7 +182,10 @@ export const AllDeviceActions: React.FC<{ sessionId: string }> = ({
             deviceAction,
           });
         },
-        initialValues: { unlockTimeout: UNLOCK_TIMEOUT },
+        initialValues: {
+          unlockTimeout: UNLOCK_TIMEOUT,
+          allowNonOnboardedDevice: true,
+        },
         deviceModelId,
       } satisfies DeviceActionProps<
         GetDeviceStatusDAOutput,

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.test.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.test.ts
@@ -478,6 +478,62 @@ describe("GetDeviceStatusDeviceAction", () => {
         );
       }));
 
+    it("GIVEN a non-onboarded device WHEN checking the device status THEN it returns the device status by default", () =>
+      new Promise<void>((resolve, reject) => {
+        // GIVEN
+        getDeviceSessionStateMock.mockReturnValue({
+          sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+          deviceStatus: DeviceStatus.CONNECTED,
+          currentApp: { name: "BOLOS", version: "1.0.0" },
+          installedApps: [],
+          deviceModelId: DeviceModelId.NANO_X,
+          isSecureConnectionAllowed: false,
+        });
+        getAppAndVersionMock.mockResolvedValue(
+          appAndVersionResult("BOLOS", "1.0.0"),
+        );
+        getOsVersionMock.mockResolvedValue(
+          osVersionCommandResult({
+            secureElementFlags: {
+              ...getOsVersionCommandResponseMockBuilder().secureElementFlags,
+              isOnboarded: false,
+            },
+          }),
+        );
+
+        const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
+          input: { unlockTimeout: undefined },
+        });
+
+        vi.spyOn(
+          getDeviceStateDeviceAction,
+          "extractDependencies",
+        ).mockReturnValue(extractDependenciesMock());
+
+        const expectedStates: Array<GetDeviceStatusDAState> = [
+          ...onboardCheckPendingStatesWithOsVersionFetch(),
+          {
+            status: DeviceActionStatus.Completed,
+            output: {
+              currentApp: "BOLOS",
+              currentAppVersion: "1.0.0",
+            },
+          },
+        ];
+
+        // WHEN
+        testDeviceActionStates(
+          getDeviceStateDeviceAction,
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          {
+            // THEN
+            onDone: resolve,
+            onError: reject,
+          },
+        );
+      }));
+
     it("should return the device status if the device is locked and the user unlocks the device", () =>
       new Promise<void>((resolve, reject) => {
         getDeviceSessionStateMock.mockReturnValue({
@@ -562,8 +618,9 @@ describe("GetDeviceStatusDeviceAction", () => {
   });
 
   describe("errors cases", () => {
-    it("should end in an error if the device is not onboarded", () =>
+    it("GIVEN a non-onboarded device and the non-onboarded allowance is disabled WHEN checking the device status THEN it returns a not-onboarded error", () =>
       new Promise<void>((resolve, reject) => {
+        // GIVEN
         getDeviceSessionStateMock.mockReturnValue({
           sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
           deviceStatus: DeviceStatus.CONNECTED,
@@ -587,7 +644,10 @@ describe("GetDeviceStatusDeviceAction", () => {
         );
 
         const getDeviceStateDeviceAction = new GetDeviceStatusDeviceAction({
-          input: { unlockTimeout: 500 },
+          input: {
+            unlockTimeout: 500,
+            allowNonOnboardedDevice: false,
+          },
         });
 
         vi.spyOn(
@@ -603,11 +663,13 @@ describe("GetDeviceStatusDeviceAction", () => {
           },
         ];
 
+        // WHEN
         testDeviceActionStates(
           getDeviceStateDeviceAction,
           expectedStates,
           makeDeviceActionInternalApiMock(),
           {
+            // THEN
             onDone: resolve,
             onError: reject,
           },

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.ts
@@ -156,7 +156,8 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
           const secureElementFlags =
             context._internalState.osVersionMetadata?.secureElementFlags;
           return (
-            allowNonOnboardedDevice && secureElementFlags?.isOnboarded === false
+            context.input.allowNonOnboardedDevice === true &&
+            secureElementFlags?.isOnboarded === false
           );
         },
         isDeviceLocked: ({ context }) => context._internalState.locked,

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/GetDeviceStatusDeviceAction.ts
@@ -117,6 +117,7 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
     } = this.extractDependencies(internalApi);
 
     const unlockTimeout = this.input.unlockTimeout ?? DEFAULT_UNLOCK_TIMEOUT_MS;
+    const allowNonOnboardedDevice = this.input.allowNonOnboardedDevice ?? true;
 
     const updateSessionFromOsVersion = (data: GetOsVersionResponse) => {
       const currentState = getDeviceSessionState();
@@ -135,6 +136,7 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
       types: {
         input: {
           unlockTimeout,
+          allowNonOnboardedDevice,
         } as types["input"],
         context: {} as types["context"],
         output: {} as types["output"],
@@ -150,6 +152,13 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
         isOnboardedFromOsVersion: ({ context }) =>
           context._internalState.osVersionMetadata?.secureElementFlags
             .isOnboarded === true,
+        isAllowedNonOnboardedDevice: ({ context }) => {
+          const secureElementFlags =
+            context._internalState.osVersionMetadata?.secureElementFlags;
+          return (
+            allowNonOnboardedDevice && secureElementFlags?.isOnboarded === false
+          );
+        },
         isDeviceLocked: ({ context }) => context._internalState.locked,
         hasError: ({ context }) => context._internalState.error !== null,
       },
@@ -202,6 +211,7 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
         return {
           input: {
             unlockTimeout: _.input.unlockTimeout,
+            allowNonOnboardedDevice: _.input.allowNonOnboardedDevice ?? true,
           },
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.None,
@@ -386,6 +396,10 @@ export class GetDeviceStatusDeviceAction extends XStateDeviceAction<
                   onboarded: true,
                 }),
               }),
+            },
+            {
+              guard: "isAllowedNonOnboardedDevice",
+              target: "Success",
             },
             {
               target: "Error",

--- a/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/types.ts
+++ b/packages/device-management-kit/src/api/device-action/os/GetDeviceStatus/types.ts
@@ -21,6 +21,7 @@ export type GetDeviceStatusDAOutput = {
 };
 export type GetDeviceStatusDAInput = {
   readonly unlockTimeout?: number;
+  readonly allowNonOnboardedDevice?: boolean;
 };
 
 export type GetDeviceStatusDAError =

--- a/packages/device-management-kit/src/api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction.test.ts
+++ b/packages/device-management-kit/src/api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction.test.ts
@@ -417,8 +417,9 @@ describe("OpenAppDeviceAction", () => {
   });
 
   describe("errors cases", () => {
-    it("should end in an error if the device is not onboarded", () =>
+    it("GIVEN a non-onboarded device WHEN opening an app THEN it blocks the app flow", () =>
       new Promise<void>((resolve, reject) => {
+        // GIVEN
         apiGetDeviceSessionStateMock.mockReturnValue({
           sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
           deviceStatus: DeviceStatus.CONNECTED,
@@ -454,11 +455,13 @@ describe("OpenAppDeviceAction", () => {
           },
         ];
 
+        // WHEN
         testDeviceActionStates(
           openAppDeviceAction,
           expectedStates,
           makeDeviceActionInternalApiMock(),
           {
+            // THEN
             onDone: resolve,
             onError: reject,
           },

--- a/packages/device-management-kit/src/api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction.ts
+++ b/packages/device-management-kit/src/api/device-action/os/OpenAppDeviceAction/OpenAppDeviceAction.ts
@@ -102,6 +102,7 @@ export class OpenAppDeviceAction extends XStateDeviceAction<
     const getDeviceStatusMachine = new GetDeviceStatusDeviceAction({
       input: {
         unlockTimeout,
+        allowNonOnboardedDevice: false,
       },
     }).makeStateMachine(internalApi);
 
@@ -199,6 +200,7 @@ export class OpenAppDeviceAction extends XStateDeviceAction<
             src: "getDeviceStatus",
             input: (_) => ({
               unlockTimeout: _.context.input.unlockTimeout,
+              allowNonOnboardedDevice: false,
             }),
             onSnapshot: {
               actions: assign({

--- a/packages/device-management-kit/src/api/device-action/os/OpenAppDeviceAction/types.ts
+++ b/packages/device-management-kit/src/api/device-action/os/OpenAppDeviceAction/types.ts
@@ -26,7 +26,10 @@ export type OpenAppDAStateStep =
 
 export type OpenAppDAOutput = void;
 
-export type OpenAppDAInput = GetDeviceStatusDAInput & {
+export type OpenAppDAInput = Omit<
+  GetDeviceStatusDAInput,
+  "allowNonOnboardedDevice"
+> & {
   readonly appName: string;
 };
 

--- a/packages/device-management-kit/src/api/device-action/os/OpenAppWithDependencies/types.ts
+++ b/packages/device-management-kit/src/api/device-action/os/OpenAppWithDependencies/types.ts
@@ -36,7 +36,10 @@ export type OpenAppWithDependenciesDAOutput = {
   installResult: InstallOrUpdateAppsDAOutput;
 };
 
-export type OpenAppWithDependenciesDAInput = GetDeviceStatusDAInput & {
+export type OpenAppWithDependenciesDAInput = Omit<
+  GetDeviceStatusDAInput,
+  "allowNonOnboardedDevice"
+> & {
   readonly application: ApplicationDependency;
   readonly dependencies: ApplicationDependency[];
   readonly requireLatestFirmware?: boolean;


### PR DESCRIPTION
### 📝 Description

#### Context
[device-sdk-ts PR #1521](https://github.com/LedgerHQ/device-sdk-ts/pull/1521) changed `GetDeviceStatusDeviceAction` to derive the onboarded state from `GetOsVersionCommand` and return `DeviceNotOnboardedError` for unseeded devices.
That stricter behavior broke existing flows (onboarding with Recover, in Ledger Wallet) because those flows use `GetDeviceStatusDeviceAction` with a non-onboarded device.

#### Solution

This PR fixes that by allowing non-onboarded devices to reach the success state by default when executing `GetDeviceStatusDeviceAction`, while exposing `allowNonOnboardedDevice: false` for consumers that explicitly need to keep blocking non-onboarded devices.

The option defaults to `true` to restore the previous DMK behavior for existing consumers and avoid introducing other breaking changes in flows that legitimately interact with non-onboarded devices.

OpenApp-like flows remain strict by design: `OpenAppDeviceAction` invokes the device status check with `allowNonOnboardedDevice: false`, and app-opening inputs do not expose this allowance because apps cannot be installed or opened on non-onboarded devices.

#### Get device status
https://github.com/user-attachments/assets/30f2bac8-bb3c-4fd4-894d-d56d9d9bff92

#### Open app
https://github.com/user-attachments/assets/c5a9a18d-fbc2-4517-8bec-d32d4e35d4ca




### ❓ Context

- **JIRA or GitHub link**: [LIVE-32728](https://ledgerhq.atlassian.net/browse/LIVE-32728)
- **Feature**: Recover restore flow / DMK device status
- **Snapshot**: https://github.com/LedgerHQ/device-sdk-ts/actions/runs/27678892914

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**: `.changeset/green-ravens-onboarded.md`
- [x] **Documentation is up-to-date**: No separate documentation update needed for this narrow device action option.
- [x] **Impact of the changes:**
  - Non-onboarded devices no longer fail `GetDeviceStatusDeviceAction` by default.
  - Consumers that need strict direct device status checks can pass `allowNonOnboardedDevice: false`.
  - OpenApp-like flows continue to block non-onboarded devices and do not expose the non-onboarded allowance.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.

[LIVE-32728]: https://ledgerhq.atlassian.net/browse/LIVE-32728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ