### PR TITLE
📝 (device-management-kit) [NO-ISSUE]: Remove outdated caution notice from README

### DIFF
--- a/packages/device-management-kit/README.md
+++ b/packages/device-management-kit/README.md
@@ -1,8 +1,5 @@
 # Device Management Kit Library Documentation
 
-> [!CAUTION]
-> This is still under development and we are free to make new interfaces which may lead to Device Management Kit breaking changes.
-
 - [Device Management Kit Library Documentation](#device-management-kit-library-documentation)
   - [Description](#description)
   - [Installation](#installation)


### PR DESCRIPTION
### 📝 Description

Removes an outdated caution notice from the Device Management Kit README that is no longer accurate or relevant.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]

### ✅ Checklist

- [ ] **Covered by automatic tests** <!-- N/A - documentation change -->
- [ ] **Changeset is provided** <!-- No changeset needed - changes only affect README documentation, not published package code -->
- [ ] **Documentation is up-to-date** <!-- This PR updates documentation -->
- [ ] **Impact of the changes:**
  - Removes outdated caution notice from `packages/device-management-kit/README.md`

---

### 🧐 Checklist for the PR Reviewers

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.