### PR TITLE
👷 (ci) [DSDK-1234]: Split health check into per-tool jobs and add sample integration tests

### DIFF
--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -18,8 +18,8 @@ jobs:
 
       - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@develop
 
-  health-check:
-    name: Run health check
+  prettier:
+    name: Run prettier
     needs: [build-libraries]
     runs-on: "ledgerhq-device-sdk"
     steps:
@@ -27,9 +27,35 @@ jobs:
 
       - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@develop
 
-      - name: Health check
-        id: health-check
-        run: pnpm health-check
+      - name: Prettier
+        id: prettier
+        run: pnpm prettier
+
+  lint:
+    name: Run lint
+    needs: [build-libraries]
+    runs-on: "ledgerhq-device-sdk"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@develop
+
+      - name: Lint
+        id: lint
+        run: pnpm lint
+
+  typecheck:
+    name: Run typecheck
+    needs: [build-libraries]
+    runs-on: "ledgerhq-device-sdk"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@develop
+
+      - name: Typecheck
+        id: typecheck
+        run: pnpm typecheck
 
   tests:
     name: Run unit tests
@@ -43,3 +69,19 @@ jobs:
       - name: Tests
         id: unit-tests
         run: pnpm test
+
+  health-check:
+    name: Run health check
+    # Aggregates the split checks and tests into a single required status so
+    # branch protection only needs to require "Run health check".
+    needs: [build-libraries, prettier, lint, typecheck, tests]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check results
+        run: |
+          if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
+            echo "One or more required checks failed."
+            exit 1
+          fi
+          echo "All required checks passed."

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -105,8 +105,8 @@ jobs:
       - name: Build apps
         run: pnpm build
 
-  health-check:
-    name: Run health check
+  prettier:
+    name: Run prettier
     needs: [build-libraries]
     runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
     steps:
@@ -114,9 +114,35 @@ jobs:
 
       - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@develop
 
-      - name: Health check
-        id: health-check
-        run: pnpm health-check
+      - name: Prettier
+        id: prettier
+        run: pnpm prettier
+
+  lint:
+    name: Run lint
+    needs: [build-libraries]
+    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@develop
+
+      - name: Lint
+        id: lint
+        run: pnpm lint
+
+  typecheck:
+    name: Run typecheck
+    needs: [build-libraries]
+    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@develop
+
+      - name: Typecheck
+        id: typecheck
+        run: pnpm typecheck
 
   tests:
     name: Run unit tests
@@ -138,6 +164,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  health-check:
+    name: Run health check
+    # Aggregates the split checks and tests into a single required status so
+    # branch protection only needs to require "Run health check".
+    needs: [build-libraries, prettier, lint, typecheck, tests]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check results
+        run: |
+          if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
+            echo "One or more required checks failed."
+            exit 1
+          fi
+          echo "All required checks passed."
 
   cs-tester:
     needs: [build-libraries, detect-changes]

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -85,7 +85,7 @@ jobs:
         run: pnpm danger:ci
 
   build-libraries:
-    name: Build libraries
+    name: Build libraries and apps
     needs: [setup]
     runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
     steps:
@@ -93,14 +93,13 @@ jobs:
 
       - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@develop
 
-  build-apps:
-    name: Build apps
-    needs: [build-libraries]
-    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@develop
+      # Cache the sample app production build so the sample-integration job can
+      # reuse it instead of rebuilding before the Playwright run.
+      - name: Cache sample app build
+        uses: actions/cache@v4
+        with:
+          path: apps/sample/.next
+          key: ${{ runner.os }}-sample-next-${{ github.sha }}
 
       - name: Build apps
         run: pnpm build
@@ -165,11 +164,44 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
+  sample-integration:
+    name: Run playwright
+    needs: [build-libraries]
+    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@develop
+
+      # Reuse the sample app build produced by build-libraries; start-servers.sh
+      # then skips the build and starts the prebuilt app directly.
+      - name: Restore sample app build
+        uses: actions/cache/restore@v4
+        with:
+          path: apps/sample/.next
+          key: ${{ runner.os }}-sample-next-${{ github.sha }}
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @ledgerhq/device-management-kit-sample exec playwright install --with-deps chromium
+
+      - name: Run sample Playwright tests
+        # The Playwright webServer (start-servers.sh) starts both the device mock
+        # server and the sample app, so neither is launched here.
+        run: pnpm --filter @ledgerhq/device-management-kit-sample test:playwright
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: sample-playwright-traces
+          path: apps/sample/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
   health-check:
     name: Run health check
     # Aggregates the split checks and tests into a single required status so
     # branch protection only needs to require "Run health check".
-    needs: [build-libraries, prettier, lint, typecheck, tests]
+    needs: [build-libraries, prettier, lint, typecheck, tests, sample-integration]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-22.04
     steps:

--- a/apps/sample/playwright.config.ts
+++ b/apps/sample/playwright.config.ts
@@ -18,7 +18,8 @@ export const config: PlaywrightTestConfig = {
   webServer: {
     command: `sh ${path.join(__dirname, "playwright/start-servers.sh")}`,
     port: 3000,
-    timeout: 120 * 1000,
+    // start-servers.sh now runs a production `next build` before `next start`.
+    timeout: 300 * 1000,
     reuseExistingServer: !process.env.CI,
   },
 };

--- a/apps/sample/playwright/start-servers.sh
+++ b/apps/sample/playwright/start-servers.sh
@@ -2,23 +2,63 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/../../.."
 
-# NOTE: the device mock server is expected to be started manually beforehand on
-# http://127.0.0.1:8080, e.g. `pnpm --filter @ledgerhq/device-mock-server serve`.
-# Each browser context (and each spec) provisions its own mock server session, so
-# no shared session/token is created here.
+# Each browser context (and each spec) provisions its own mock server session,
+# so no shared session/token is created here.
 
-echo "Starting sample app..."
-(cd "$SCRIPT_DIR/../../.." && pnpm --filter @ledgerhq/device-management-kit-sample dev:default-mock) &
-SAMPLE_APP_PID=$!
+# Fail fast instead of building. A production build is required (compile-on-demand
+# under `next dev` makes the first request to each route take ~25s+, tripping the
+# Playwright per-test timeout on slower/contended CI runners). The build is
+# expected to already exist: CI restores apps/sample/.next from the build job's
+# cache; locally, run `pnpm sample build` first.
+if [ ! -d "$REPO_ROOT/apps/sample/.next" ]; then
+  echo "Error: sample app is not built (apps/sample/.next is missing)." >&2
+  echo "Run 'pnpm sample build' before starting the Playwright servers." >&2
+  exit 1
+fi
 
-while ! nc -z localhost 3000; do
-  echo "Waiting for sample app to start..."
-  sleep 1
-done
-echo "Sample app is up!"
+# Track only the processes we start ourselves (space-separated PID list), so
+# servers that were already running (started manually or by CI) are left
+# untouched on cleanup.
+STARTED_PIDS=""
 
-# trap to kill the background process on script exit
-trap "kill $SAMPLE_APP_PID" EXIT
+cleanup() {
+  for pid in $STARTED_PIDS; do
+    kill "$pid" 2>/dev/null || true
+  done
+}
+trap cleanup EXIT
 
-wait $SAMPLE_APP_PID
+# Start a server only if its port is free; otherwise assume it is already running
+# and reuse it (without registering it for cleanup).
+#   maybe_start <name> <port> <command...>   (command runs from REPO_ROOT)
+maybe_start() {
+  name="$1"
+  port="$2"
+  shift 2
+  if nc -z 127.0.0.1 "$port" 2>/dev/null; then
+    echo "$name already running on port $port; reusing it."
+    return
+  fi
+  echo "Starting $name..."
+  (cd "$REPO_ROOT" && exec "$@") &
+  STARTED_PIDS="$STARTED_PIDS $!"
+  until nc -z 127.0.0.1 "$port" 2>/dev/null; do
+    echo "Waiting for $name on port $port..."
+    sleep 1
+  done
+  echo "$name is up!"
+}
+
+maybe_start "device mock server" 9752 pnpm --filter @ledgerhq/device-mock-server serve
+maybe_start "sample app" 3000 pnpm sample start
+
+# Stay in the foreground until Playwright tears the webServer down (which fires
+# the cleanup trap). Block on the servers we started, or idle if both were reused.
+if [ -n "$STARTED_PIDS" ]; then
+  # shellcheck disable=SC2086 # intentional word-splitting of the PID list
+  wait $STARTED_PIDS
+else
+  wait
+fi

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "test:watch": "turbo run test:watch",
     "test:coverage": "turbo run test:coverage",
     "typecheck": "turbo run typecheck",
-    "health-check": "turbo run health-check --output-logs=errors-only --continue",
     "dmk": "pnpm --filter @ledgerhq/device-management-kit",
     "devtools": "pnpm --filter @ledgerhq/device-management-kit-devtools",
     "speculos-device-controller": "pnpm --filter @ledgerhq/speculos-device-controller",

--- a/turbo.json
+++ b/turbo.json
@@ -41,9 +41,6 @@
     },
     "@ledgerhq/ledger-dmk-docs#typecheck": {
       "dependsOn": ["build", "^typecheck"]
-    },
-    "health-check": {
-      "dependsOn": ["build", "prettier", "lint", "typecheck"]
     }
   }
 }


### PR DESCRIPTION
### 📝 Description

Restructures the PR / merge-queue CI checks:

1. **Split the bundled `health-check` job** into independent jobs — `prettier`, `lint`, and `typecheck` — in both `pull_request.yml` and `merge_queue.yml`. They previously ran together under a single `pnpm health-check` (turbo) job, so one failure obscured the others. They now run in parallel and report per-check. The now-unused `health-check` root script and turbo task were removed.

2. **Added a `sample-integration` job** (PR checks only) running the sample app Playwright suite: installs chromium, starts the device mock server on port `9752`, then runs `test:playwright` (the playwright config boots the sample app on `:3000`). Traces are uploaded as an artifact on failure. These exercise the real UI against a **mock server** (not a real device), so they are UI integration tests rather than true e2e.

3. **Re-added an aggregate job named `Run health check`** that gates on `prettier`, `lint`, `typecheck`, `tests` and `sample-integration` (merge queue: without `sample-integration`). This keeps the existing required status check working after the split, so branch protection does not need to change.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1234](https://ledgerhq.atlassian.net/browse/DSDK-1234)
- **Feature**: Faster, more granular CI signal, plus integration coverage of the sample app.

### ✅ Checklist

- [x] **Covered by automatic tests** — adds CI execution of the existing sample Playwright suite.
- [ ] **Changeset is provided** — _Not needed: changes only affect CI workflows and root tooling config (no published packages)._
- [x] **Documentation is up-to-date** — no docs impacted.
- [ ] **Impact of the changes:**
  - CI only. QA focus: confirm the new `prettier` / `lint` / `typecheck` / `sample-integration` jobs and the `Run health check` aggregate gate correctly.

> [!NOTE]
> The required status check is still named **"Run health check"**, now satisfied by the aggregate job, so existing branch-protection / merge-queue rules keep working unchanged.

[DSDK-1234]: https://ledgerhq.atlassian.net/browse/DSDK-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ