### PR TITLE
✨ (devtools) [NO-ISSUE]: Add devtools session to mocks

### DIFF
--- a/.changeset/devtools-ui-mock-capture.md
+++ b/.changeset/devtools-ui-mock-capture.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit-devtools-ui": minor
+---
+
+Add a Mock Capture screen that records APDU exchanges from a live session, derives mock-server mocks from them, and lets you download the session export or push it directly to a running mock server for replay

--- a/.changeset/dmk-structured-apdu-exchange-logs.md
+++ b/.changeset/dmk-structured-apdu-exchange-logs.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Attach a structured APDU exchange payload (request + response + session id) to the device session APDU log, enabling consumers such as the DevTools dashboard to reconstruct exchanges without parsing log strings.

--- a/apps/devtools/src/renderer/index.html
+++ b/apps/devtools/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws://localhost:10001 ws://localhost:10002 ws://127.0.0.1:10001 ws://127.0.0.1:10002"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws://localhost:10001 ws://localhost:10002 ws://127.0.0.1:10001 ws://127.0.0.1:10002 http://localhost:* http://127.0.0.1:*"
     />
   </head>
 

--- a/packages/device-management-kit/src/api/utils/apduLogs.test.ts
+++ b/packages/device-management-kit/src/api/utils/apduLogs.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  APDU_EXCHANGE_LOG,
+  formatApduExchangeLog,
   formatApduReceivedLog,
   formatApduSendingLog,
   formatApduSentLog,
@@ -58,6 +60,49 @@ describe("apduLogs", () => {
         statusCode: Uint8Array.from([0x69, 0x85]),
       };
       expect(formatApduReceivedLog(apduResponse)).toBe("[exchange] <= 6985");
+    });
+  });
+
+  describe("formatApduExchangeLog", () => {
+    it("should keep the legacy received-log message and expose structured data", () => {
+      const apdu = Uint8Array.from([0xe0, 0x01, 0x00, 0x00, 0x04]);
+      const apduResponse = {
+        data: Uint8Array.from([0x01, 0x02, 0x03]),
+        statusCode: Uint8Array.from([0x90, 0x00]),
+      };
+
+      const { message, data } = formatApduExchangeLog(
+        "session-1",
+        apdu,
+        apduResponse,
+      );
+
+      expect(message).toBe(formatApduReceivedLog(apduResponse));
+      expect(message).toBe("[exchange] <= 0102039000");
+      expect(data).toEqual({
+        type: APDU_EXCHANGE_LOG,
+        sessionId: "session-1",
+        apdu: "e001000004",
+        response: "0102039000",
+      });
+    });
+
+    it("should concatenate empty data with the status word in the structured payload", () => {
+      const apdu = Uint8Array.from([0xb0, 0x01, 0x00, 0x00]);
+      const apduResponse = {
+        data: Uint8Array.from([]),
+        statusCode: Uint8Array.from([0x55, 0x15]),
+      };
+
+      const { message, data } = formatApduExchangeLog(
+        "session-2",
+        apdu,
+        apduResponse,
+      );
+
+      expect(message).toBe("[exchange] <= 5515");
+      expect(data.apdu).toBe("b0010000");
+      expect(data.response).toBe("5515");
     });
   });
 });

--- a/packages/device-management-kit/src/api/utils/apduLogs.ts
+++ b/packages/device-management-kit/src/api/utils/apduLogs.ts
@@ -25,3 +25,29 @@ export function formatApduSentLog(apdu: Uint8Array): string {
 export function formatApduReceivedLog(apduResponse: ApduResponse): string {
   return `[exchange] <= ${bufferToHexaString(apduResponse.data, false)}${bufferToHexaString(apduResponse.statusCode, false)}`;
 }
+
+export const APDU_EXCHANGE_LOG = "apdu-exchange";
+
+export type ApduExchangeLog = {
+  type: typeof APDU_EXCHANGE_LOG;
+  sessionId: string;
+  apdu: string;
+  response: string;
+};
+
+/**
+ * Formats the log message and builds the structured `data` payload for a completed APDU exchange
+ * (request + response).
+ */
+export function formatApduExchangeLog(
+  sessionId: string,
+  apdu: Uint8Array,
+  apduResponse: ApduResponse,
+): { message: string; data: ApduExchangeLog } {
+  const request = bufferToHexaString(apdu, false);
+  const response = `${bufferToHexaString(apduResponse.data, false)}${bufferToHexaString(apduResponse.statusCode, false)}`;
+  return {
+    message: formatApduReceivedLog(apduResponse),
+    data: { type: APDU_EXCHANGE_LOG, sessionId, apdu: request, response },
+  };
+}

--- a/packages/device-management-kit/src/internal/device-session/model/DeviceSession.ts
+++ b/packages/device-management-kit/src/internal/device-session/model/DeviceSession.ts
@@ -31,7 +31,7 @@ import {
 } from "@api/transport/model/Errors";
 import { type TransportConnectedDevice } from "@api/transport/model/TransportConnectedDevice";
 import {
-  formatApduReceivedLog,
+  formatApduExchangeLog,
   formatApduSendingLog,
 } from "@api/utils/apduLogs";
 import { DEVICE_SESSION_REFRESHER_DEFAULT_OPTIONS } from "@internal/device-session/data/DeviceSessionRefresherConst";
@@ -246,7 +246,12 @@ export class DeviceSession {
 
     return result
       .ifRight((response: ApduResponse) => {
-        this._logger.debug(formatApduReceivedLog(response));
+        const { message, data } = formatApduExchangeLog(
+          this._id,
+          rawApdu,
+          response,
+        );
+        this._logger.debug(message, { data });
         if (CommandUtils.isLockedDeviceResponse(response)) {
           this._sessionEventDispatcher.dispatch({
             eventName: SessionEvents.DEVICE_STATE_UPDATE_LOCKED,

--- a/packages/devtools/ui/package.json
+++ b/packages/devtools/ui/package.json
@@ -40,6 +40,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@ledgerhq/device-mockserver-client": "workspace:^",
     "@ledgerhq/react-ui": "catalog:",
     "@tanstack/react-table": "8.20.5",
     "@tanstack/react-virtual": "3.10.8",

--- a/packages/devtools/ui/src/Dashboard.tsx
+++ b/packages/devtools/ui/src/Dashboard.tsx
@@ -13,6 +13,7 @@ import { SplitView } from "./components/SplitView";
 import { useConnectorMessages } from "./hooks/useConnectorMessages";
 import { Inspector } from "./screens/inspector";
 import { Logger } from "./screens/logger";
+import { MockCapture } from "./screens/mock-capture";
 import { ErrorBoundary } from "./ErrorBoundary";
 
 const DashboardContainer = styled.div`
@@ -43,8 +44,13 @@ const Dashboard: React.FC<{ connector: Connector }> = ({ connector }) => {
     isInspectorConnected,
     providerValue,
     apduResponses,
+    apduExchanges,
+    isRecordingExchanges,
     sendMessage,
     clearLogs,
+    startRecordingExchanges,
+    stopRecordingExchanges,
+    clearRecordedExchanges,
     startListening,
     stopListening,
     startDiscovering,
@@ -86,12 +92,27 @@ const Dashboard: React.FC<{ connector: Connector }> = ({ connector }) => {
     />
   );
 
+  const mockCapture = (
+    <MockCapture
+      apduExchanges={apduExchanges}
+      isRecording={isRecordingExchanges}
+      isConnected={isLoggerConnected}
+      startRecording={startRecordingExchanges}
+      stopRecording={stopRecordingExchanges}
+      clearRecorded={clearRecordedExchanges}
+      sessionStates={sessionStates}
+      connectedDevices={connectedDevices}
+    />
+  );
+
   const content = (() => {
     switch (currentScreen) {
       case DashboardScreen.logs:
         return logger;
       case DashboardScreen.inspector:
         return inspector;
+      case DashboardScreen.mockCapture:
+        return mockCapture;
       case DashboardScreen.splitHorizontal:
         return (
           <SplitView direction="horizontal" first={logger} second={inspector} />

--- a/packages/devtools/ui/src/components/DashboardNavigationBar.tsx
+++ b/packages/devtools/ui/src/components/DashboardNavigationBar.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 export enum DashboardScreen {
   logs = "logs",
   inspector = "inspector",
+  mockCapture = "mockCapture",
   splitHorizontal = "splitHorizontal",
   splitVertical = "splitVertical",
 }
@@ -134,6 +135,14 @@ export const DashboardNavigationBar: React.FC<DashboardNavigationBarProps> = ({
         >
           <ConnectionIndicator $connected={isInspectorConnected} />
           Inspector
+        </NavButton>
+        <NavButton
+          $isActive={currentScreen === DashboardScreen.mockCapture}
+          $isConnected={isLoggerConnected}
+          onClick={() => onScreenChange(DashboardScreen.mockCapture)}
+        >
+          <ConnectionIndicator $connected={isLoggerConnected} />
+          Mock Capture
         </NavButton>
       </NavGroup>
 

--- a/packages/devtools/ui/src/hooks/connectorMessageHandlers.ts
+++ b/packages/devtools/ui/src/hooks/connectorMessageHandlers.ts
@@ -8,7 +8,34 @@ import { type DevToolsModule } from "@ledgerhq/device-management-kit-devtools-co
 
 import { mapConnectorMessageToLogData } from "../screens/logger/mapConnectorMessageToLogData";
 import { type LogData } from "../screens/logger/types";
-import { type ApduResponse } from "./useConnectorMessages";
+import { type ApduExchange, type ApduResponse } from "./useConnectorMessages";
+
+const APDU_EXCHANGE_LOG = "apdu-exchange";
+
+/**
+ * Extracts a structured APDU exchange from a log message, if the log carries
+ * the `apdu-exchange` payload emitted by DMK. Returns null otherwise.
+ */
+function tryExtractApduExchange(logData: LogData): ApduExchange | null {
+  const data = logData.payload;
+  if (
+    typeof data !== "object" ||
+    data === null ||
+    Array.isArray(data) ||
+    data["type"] !== APDU_EXCHANGE_LOG ||
+    typeof data["apdu"] !== "string" ||
+    typeof data["response"] !== "string"
+  ) {
+    return null;
+  }
+  return {
+    sessionId:
+      typeof data["sessionId"] === "string" ? data["sessionId"] : undefined,
+    apdu: data["apdu"],
+    response: data["response"],
+    timestamp: logData.timestamp,
+  };
+}
 
 /**
  * Handle module connected handshake message.
@@ -29,13 +56,20 @@ export function handleModuleConnected(
  * Handle log message. Returns true if message was a log, false otherwise.
  */
 export function handleLogMessage(
-  type: string,
   payload: string,
   setLogs: Dispatch<SetStateAction<LogData[]>>,
+  setApduExchanges: Dispatch<SetStateAction<ApduExchange[]>>,
+  isRecordingExchanges: boolean,
 ): boolean {
-  const logData = mapConnectorMessageToLogData({ type, payload });
+  const logData = mapConnectorMessageToLogData(payload);
   if (logData !== null) {
     setLogs((prev) => [...prev, logData]);
+    if (isRecordingExchanges) {
+      const exchange = tryExtractApduExchange(logData);
+      if (exchange !== null) {
+        setApduExchanges((prev) => [...prev, exchange]);
+      }
+    }
     return true;
   }
   return false;

--- a/packages/devtools/ui/src/hooks/useConnectorMessages.ts
+++ b/packages/devtools/ui/src/hooks/useConnectorMessages.ts
@@ -6,7 +6,7 @@
  * via the connector (WebSocket or Rozenite).
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type ConnectedDevice,
   type DeviceSessionState,
@@ -17,6 +17,7 @@ import {
   DEVTOOLS_MODULES,
   type DevToolsModule,
   INSPECTOR_MESSAGE_TYPES,
+  LOGGER_MESSAGE_TYPES,
   MODULE_CONNECTED_MESSAGE_TYPE,
 } from "@ledgerhq/device-management-kit-devtools-core";
 
@@ -49,6 +50,17 @@ export type ApduResponse = {
   error?: string;
 };
 
+/**
+ * A single APDU exchange (request + response) captured passively from the DMK
+ * logs of the host app. Used to derive mock-server mocks.
+ */
+export type ApduExchange = {
+  sessionId?: string;
+  apdu: string;
+  response: string;
+  timestamp: string;
+};
+
 export type ConnectorMessagesState = {
   receivedMessages: Message[];
   sentMessages: Message[];
@@ -63,8 +75,13 @@ export type ConnectorMessagesState = {
   isInspectorConnected: boolean;
   providerValue: number | null;
   apduResponses: Map<string, ApduResponse>;
+  apduExchanges: ApduExchange[];
+  isRecordingExchanges: boolean;
   sendMessage: (type: string, payload: string) => void;
   clearLogs: () => void;
+  startRecordingExchanges: () => void;
+  stopRecordingExchanges: () => void;
+  clearRecordedExchanges: () => void;
   startListening: () => void;
   stopListening: () => void;
   startDiscovering: () => void;
@@ -122,6 +139,9 @@ export function useConnectorMessages(
   const [apduResponses, setApduResponses] = useState<Map<string, ApduResponse>>(
     new Map(),
   );
+  const [apduExchanges, setApduExchanges] = useState<ApduExchange[]>([]);
+  const [isRecordingExchanges, setIsRecordingExchanges] = useState(false);
+  const isRecordingExchangesRef = useRef(false);
 
   // === Tracked Connector (keeps all sent messages in state) ===
   const trackedConnector: Connector = useMemo(
@@ -159,9 +179,13 @@ export function useConnectorMessages(
         case INSPECTOR_MESSAGE_TYPES.APDU_RESPONSE:
           handleApduResponse(payload, setApduResponses);
           break;
-        default:
-          // Try to handle as log message
-          handleLogMessage(type, payload, setLogs);
+        case LOGGER_MESSAGE_TYPES.ADD_LOG:
+          handleLogMessage(
+            payload,
+            setLogs,
+            setApduExchanges,
+            isRecordingExchangesRef.current,
+          );
           break;
       }
     });
@@ -211,6 +235,20 @@ export function useConnectorMessages(
     setLogs([]);
   }, []);
 
+  const startRecordingExchanges = useCallback(() => {
+    isRecordingExchangesRef.current = true;
+    setIsRecordingExchanges(true);
+  }, []);
+
+  const stopRecordingExchanges = useCallback(() => {
+    isRecordingExchangesRef.current = false;
+    setIsRecordingExchanges(false);
+  }, []);
+
+  const clearRecordedExchanges = useCallback(() => {
+    setApduExchanges([]);
+  }, []);
+
   // === Derived State ===
   const isLoggerConnected = connectedModules.has(DEVTOOLS_MODULES.LOGGER);
   const isInspectorConnected = connectedModules.has(
@@ -232,9 +270,14 @@ export function useConnectorMessages(
     isInspectorConnected,
     providerValue,
     apduResponses,
+    apduExchanges,
+    isRecordingExchanges,
     // Actions
     sendMessage: trackedConnector.sendMessage,
     clearLogs,
+    startRecordingExchanges,
+    stopRecordingExchanges,
+    clearRecordedExchanges,
     startListening,
     stopListening,
     startDiscovering,

--- a/packages/devtools/ui/src/screens/logger/mapConnectorMessageToLogData.ts
+++ b/packages/devtools/ui/src/screens/logger/mapConnectorMessageToLogData.ts
@@ -1,16 +1,8 @@
-import { LOGGER_MESSAGE_TYPES } from "@ledgerhq/device-management-kit-devtools-core";
-
 import type { DevToolsLog, LogData } from "./types";
 
-export function mapConnectorMessageToLogData(connectorMessage: {
-  type: string;
-  payload: string;
-}): LogData | null {
-  if (connectorMessage.type !== LOGGER_MESSAGE_TYPES.ADD_LOG) {
-    return null;
-  }
+export function mapConnectorMessageToLogData(payload: string): LogData | null {
   const { timestamp, tag, verbosity, message, payloadJSON } = JSON.parse(
-    connectorMessage.payload,
+    payload,
   ) as DevToolsLog;
   return {
     timestamp,

--- a/packages/devtools/ui/src/screens/mock-capture/deviceConfigFromSession.ts
+++ b/packages/devtools/ui/src/screens/mock-capture/deviceConfigFromSession.ts
@@ -1,0 +1,69 @@
+import {
+  type ConnectedDevice,
+  type DeviceSessionState,
+  DeviceSessionStateType,
+  StaticDeviceModelDataSource,
+} from "@ledgerhq/device-management-kit";
+import { type DeviceConfig } from "@ledgerhq/device-mockserver-client";
+
+type ConnectivityType = ConnectedDevice["type"];
+
+const DASHBOARD_APP_NAME = "BOLOS";
+const deviceModelDataSource = new StaticDeviceModelDataSource();
+
+function firmwareVersionFromState(state: DeviceSessionState): string {
+  if ("firmwareVersion" in state && state.firmwareVersion?.os) {
+    return state.firmwareVersion.os;
+  }
+  if ("currentApp" in state && state.currentApp?.name === DASHBOARD_APP_NAME) {
+    return state.currentApp.version;
+  }
+  return "";
+}
+
+/**
+ * Builds a partial mock-server device config from a DMK device session state.
+ *
+ * The mock server's `device_type` values match the `DeviceModelId` enum values
+ * (e.g. "nanoX", "stax"), so the model id is used directly. The `name` is the
+ * commercial model name (e.g. "Flex", "Gen 5"). The optional `connectivityType`
+ * ("USB" / "BLE") comes from the connected device. The `firmware_version` (SE
+ * version) is always present, defaulting to an empty string until the session
+ * is ready. The running app is only available once the session is ready.
+ */
+export function deviceConfigFromSession(
+  state?: DeviceSessionState,
+  connectivityType?: ConnectivityType,
+): Partial<DeviceConfig> {
+  if (!state) {
+    return {};
+  }
+
+  const firmwareVersion = firmwareVersionFromState(state);
+  const deviceModel = deviceModelDataSource.getDeviceModel({
+    id: state.deviceModelId,
+  });
+
+  const base: Partial<DeviceConfig> = {
+    name: deviceModel.productName,
+    device_type: state.deviceModelId,
+    ...(connectivityType ? { connectivity_type: connectivityType } : {}),
+    firmware_version: firmwareVersion,
+  };
+
+  if (state.sessionStateType === DeviceSessionStateType.Connected) {
+    return base;
+  }
+
+  return {
+    ...base,
+    // The dashboard (BOLOS) is not an installed app, so it is never listed.
+    ...(state.currentApp && state.currentApp.name !== DASHBOARD_APP_NAME
+      ? {
+          apps: [
+            { name: state.currentApp.name, version: state.currentApp.version },
+          ],
+        }
+      : {}),
+  };
+}

--- a/packages/devtools/ui/src/screens/mock-capture/generateSessionExport.test.ts
+++ b/packages/devtools/ui/src/screens/mock-capture/generateSessionExport.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import { type ApduExchange } from "../../hooks/useConnectorMessages";
+import {
+  generateMultiDeviceSessionExport,
+  generateSessionExport,
+} from "./generateSessionExport";
+
+const exchange = (apdu: string, response: string): ApduExchange => ({
+  apdu,
+  response,
+  sessionId: "session-1",
+  timestamp: "2026-06-29T00:00:00.000Z",
+});
+
+describe("generateSessionExport", () => {
+  it("creates one mock per unique APDU with the full APDU as prefix", () => {
+    const result = generateSessionExport([
+      exchange("e004000005", "deadbeef9000"),
+      exchange("e006000000", "9000"),
+    ]);
+
+    expect(result.devices).toHaveLength(1);
+    expect(result.devices[0]?.mocks).toEqual([
+      { prefix: "e004000005", responses: ["deadbeef9000"] },
+      { prefix: "e006000000", responses: ["9000"] },
+    ]);
+  });
+
+  it("accumulates differing responses for the same APDU in order", () => {
+    const result = generateSessionExport([
+      exchange("e004000000", "aa9000"),
+      exchange("e004000000", "6985"),
+      exchange("e004000000", "bb9000"),
+    ]);
+
+    expect(result.devices[0]?.mocks).toEqual([
+      { prefix: "e004000000", responses: ["aa9000", "6985", "bb9000"] },
+    ]);
+  });
+
+  it("collapses identical repeated responses to a single entry", () => {
+    const result = generateSessionExport([
+      exchange("e004000000", "aa9000"),
+      exchange("e004000000", "aa9000"),
+    ]);
+
+    expect(result.devices[0]?.mocks).toEqual([
+      { prefix: "e004000000", responses: ["aa9000"] },
+    ]);
+  });
+
+  it("lowercases prefixes and responses", () => {
+    const result = generateSessionExport([exchange("E004000000", "AA9000")]);
+
+    expect(result.devices[0]?.mocks).toEqual([
+      { prefix: "e004000000", responses: ["aa9000"] },
+    ]);
+  });
+
+  it("skips handshake APDUs by default", () => {
+    const result = generateSessionExport([
+      exchange("e001000000", "33000004deadbeef9000"),
+      exchange("b001000000", "0105424f4c4f539000"),
+      exchange("e004000000", "aa9000"),
+    ]);
+
+    expect(result.devices[0]?.mocks).toEqual([
+      { prefix: "e004000000", responses: ["aa9000"] },
+    ]);
+  });
+
+  it("includes handshake APDUs when requested", () => {
+    const result = generateSessionExport(
+      [
+        exchange("e001000000", "33000004deadbeef9000"),
+        exchange("e004000000", "aa9000"),
+      ],
+      {},
+      { includeHandshake: true },
+    );
+
+    expect(result.devices[0]?.mocks).toHaveLength(2);
+  });
+
+  it("attaches the provided device metadata", () => {
+    const result = generateSessionExport([exchange("e004000000", "aa9000")], {
+      name: "Captured Device",
+      device_type: "nanoX",
+      firmware_version: "2.2.3",
+    });
+
+    expect(result.devices[0]).toMatchObject({
+      name: "Captured Device",
+      device_type: "nanoX",
+      firmware_version: "2.2.3",
+    });
+  });
+
+  it("places name as the first key of the device", () => {
+    const result = generateSessionExport([exchange("e004000000", "aa9000")], {
+      device_type: "nanoX",
+      firmware_version: "2.2.3",
+      name: "Captured Device",
+    });
+
+    expect(Object.keys(result.devices[0]!)[0]).toBe("name");
+  });
+
+  it("produces an empty mocks list when there are no exchanges", () => {
+    const result = generateSessionExport([]);
+
+    expect(result.devices[0]?.mocks).toEqual([]);
+  });
+});
+
+describe("generateMultiDeviceSessionExport", () => {
+  it("keeps one device entry per group with its own mocks", () => {
+    const result = generateMultiDeviceSessionExport([
+      {
+        device: { name: "Device A", device_type: "flex" },
+        exchanges: [exchange("e004000000", "aa9000")],
+      },
+      {
+        device: { name: "Device B", device_type: "stax" },
+        exchanges: [exchange("e006000000", "bb9000")],
+      },
+    ]);
+
+    expect(result.devices).toHaveLength(2);
+    expect(result.devices[0]).toMatchObject({
+      name: "Device A",
+      device_type: "flex",
+      mocks: [{ prefix: "e004000000", responses: ["aa9000"] }],
+    });
+    expect(result.devices[1]).toMatchObject({
+      name: "Device B",
+      device_type: "stax",
+      mocks: [{ prefix: "e006000000", responses: ["bb9000"] }],
+    });
+  });
+
+  it("does not merge mocks across devices", () => {
+    const result = generateMultiDeviceSessionExport([
+      { device: { name: "A" }, exchanges: [exchange("e004000000", "aa9000")] },
+      { device: { name: "B" }, exchanges: [exchange("e004000000", "bb9000")] },
+    ]);
+
+    expect(result.devices[0]?.mocks).toEqual([
+      { prefix: "e004000000", responses: ["aa9000"] },
+    ]);
+    expect(result.devices[1]?.mocks).toEqual([
+      { prefix: "e004000000", responses: ["bb9000"] },
+    ]);
+  });
+});

--- a/packages/devtools/ui/src/screens/mock-capture/generateSessionExport.ts
+++ b/packages/devtools/ui/src/screens/mock-capture/generateSessionExport.ts
@@ -1,0 +1,124 @@
+import {
+  type DeviceConfig,
+  type MockConfig,
+  type SessionExport,
+} from "@ledgerhq/device-mockserver-client";
+
+import { type ApduExchange } from "../../hooks/useConnectorMessages";
+
+/**
+ * APDU prefixes the mock server synthesizes from device metadata when no
+ * explicit mock matches (GetOsVersion, GetAppAndVersion). They are excluded by
+ * default so the generated session relies on the device config for handshakes.
+ */
+const HANDSHAKE_PREFIXES = ["e0010000", "b0010000"];
+
+export type GenerateSessionExportOptions = {
+  /** Include the handshake APDUs (GetOsVersion / GetAppAndVersion) as mocks. */
+  includeHandshake?: boolean;
+};
+
+function isHandshake(prefix: string): boolean {
+  return HANDSHAKE_PREFIXES.some((handshake) => prefix.startsWith(handshake));
+}
+
+/**
+ * Collapses a list of responses to a single entry when they are all identical,
+ * keeping the ordered sequence otherwise (the mock server serves responses in
+ * order and loops once exhausted).
+ */
+function dedupeResponses(responses: string[]): string[] {
+  const allIdentical = responses.every((r) => r === responses[0]);
+  return allIdentical ? responses.slice(0, 1) : responses;
+}
+
+function buildMocks(
+  exchanges: ApduExchange[],
+  includeHandshake: boolean,
+): MockConfig[] {
+  const responsesByPrefix = new Map<string, string[]>();
+
+  for (const exchange of exchanges) {
+    const prefix = exchange.apdu.toLowerCase();
+    if (!includeHandshake && isHandshake(prefix)) {
+      continue;
+    }
+    const responses = responsesByPrefix.get(prefix) ?? [];
+    responses.push(exchange.response.toLowerCase());
+    responsesByPrefix.set(prefix, responses);
+  }
+
+  return [...responsesByPrefix.entries()].map(([prefix, responses]) => ({
+    prefix,
+    responses: dedupeResponses(responses),
+  }));
+}
+
+/**
+ * A device and the APDU exchanges captured from it, used to build one entry of
+ * the session export.
+ */
+export type DeviceCaptureGroup = {
+  device: Partial<DeviceConfig>;
+  exchanges: ApduExchange[];
+};
+
+/**
+ * Builds a single device config (metadata + derived mocks).
+ */
+function buildDeviceConfig(
+  device: Partial<DeviceConfig>,
+  exchanges: ApduExchange[],
+  includeHandshake: boolean,
+): Partial<DeviceConfig> {
+  const mocks = buildMocks(exchanges, includeHandshake);
+  const { name, ...rest } = device;
+  return {
+    ...(name !== undefined ? { name } : {}),
+    ...rest,
+    mocks,
+  };
+}
+
+/**
+ * Derives a mock-server session export from captured APDU exchanges.
+ *
+ * Each unique request APDU becomes a mock whose `prefix` is the full request
+ * hex (so the server matches it exactly), and whose `responses` replay the
+ * captured responses in order.
+ *
+ * @param exchanges Captured APDU exchanges.
+ * @param device Device metadata to attach (name, device_type, firmware...).
+ * @param options Generation options.
+ */
+export function generateSessionExport(
+  exchanges: ApduExchange[],
+  device: Partial<DeviceConfig> = {},
+  options: GenerateSessionExportOptions = {},
+): SessionExport {
+  return {
+    devices: [
+      buildDeviceConfig(device, exchanges, options.includeHandshake ?? false),
+    ],
+  };
+}
+
+/**
+ * Derives a mock-server session export from several devices, each with its own
+ * captured exchanges. Used when more than one device was active during the
+ * recording so each gets a distinct entry instead of being merged together.
+ *
+ * @param groups One device + its exchanges per connected device.
+ * @param options Generation options.
+ */
+export function generateMultiDeviceSessionExport(
+  groups: DeviceCaptureGroup[],
+  options: GenerateSessionExportOptions = {},
+): SessionExport {
+  const includeHandshake = options.includeHandshake ?? false;
+  return {
+    devices: groups.map(({ device, exchanges }) =>
+      buildDeviceConfig(device, exchanges, includeHandshake),
+    ),
+  };
+}

--- a/packages/devtools/ui/src/screens/mock-capture/index.tsx
+++ b/packages/devtools/ui/src/screens/mock-capture/index.tsx
@@ -1,0 +1,473 @@
+/**
+ * @file Mock Capture screen
+ *
+ * Records APDU exchanges captured passively from the host app DMK logs,
+ * derives mock-server mocks from them, and lets the user download the
+ * resulting session export or push it directly to a running mock server.
+ */
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  type ConnectedDevice,
+  type DeviceSessionState,
+} from "@ledgerhq/device-management-kit";
+import {
+  type DeviceApp,
+  MockClient,
+  type SessionExport,
+} from "@ledgerhq/device-mockserver-client";
+import styled from "styled-components";
+
+import { type ApduExchange } from "../../hooks/useConnectorMessages";
+import { NotConnectedMessage } from "../../shared/NotConnectedMessage";
+import { deviceConfigFromSession } from "./deviceConfigFromSession";
+import {
+  type DeviceCaptureGroup,
+  generateMultiDeviceSessionExport,
+} from "./generateSessionExport";
+
+const DEFAULT_MOCK_SERVER_URL = "http://127.0.0.1:8080";
+
+const MOCK_CAPTURE_CODE_EXAMPLE = `import { DevToolsLogger } from "@ledgerhq/device-management-kit-devtools-core";
+
+const dmk = new DeviceManagementKitBuilder()
+  .addLogger(new DevToolsLogger(connector))
+  .build();`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 24px;
+  overflow: auto;
+  height: 100%;
+`;
+
+const Section = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  background: #fff;
+`;
+
+const SectionTitle = styled.div`
+  font-size: 13px;
+  font-weight: 600;
+  color: #333;
+`;
+
+const Row = styled.div`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+`;
+
+const Field = styled.label`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: #666;
+  flex: 1;
+  min-width: 140px;
+`;
+
+const Input = styled.input`
+  padding: 6px 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 12px;
+
+  &:focus {
+    outline: none;
+    border-color: #2196f3;
+  }
+`;
+
+const Button = styled.button<{ $variant?: "primary" | "danger" | "neutral" }>`
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  color: white;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  background: ${({ $variant }) =>
+    $variant === "danger"
+      ? "#e53935"
+      : $variant === "neutral"
+        ? "#757575"
+        : "#2196f3"};
+
+  &:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+const RecordingDot = styled.span<{ $active: boolean }>`
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 6px;
+  background: ${({ $active }) => ($active ? "#fff" : "#bbb")};
+`;
+
+const Stat = styled.span`
+  font-size: 12px;
+  color: #555;
+`;
+
+const JsonEditor = styled.textarea`
+  margin: 0;
+  padding: 12px;
+  background: #1e1e1e;
+  color: #d4d4d4;
+  border: none;
+  border-radius: 4px;
+  font-size: 12px;
+  font-family: monospace;
+  min-height: 240px;
+  max-height: 480px;
+  overflow: auto;
+  white-space: pre;
+  resize: vertical;
+
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 1px #2196f3;
+  }
+`;
+
+const StatusMessage = styled.div<{ $error: boolean }>`
+  font-size: 12px;
+  padding: 8px;
+  border-radius: 4px;
+  background: ${({ $error }) => ($error ? "#ffebee" : "#e8f5e9")};
+  border: 1px solid ${({ $error }) => ($error ? "#ffcdd2" : "#c8e6c9")};
+  color: ${({ $error }) => ($error ? "#c62828" : "#2e7d32")};
+`;
+
+const Checkbox = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #666;
+  cursor: pointer;
+`;
+
+type MockCaptureProps = {
+  apduExchanges: ApduExchange[];
+  isRecording: boolean;
+  isConnected: boolean;
+  startRecording: () => void;
+  stopRecording: () => void;
+  clearRecorded: () => void;
+  sessionStates: Map<string, DeviceSessionState>;
+  connectedDevices: ConnectedDevice[];
+};
+
+type PushStatus = { error: boolean; message: string } | null;
+
+export const MockCapture: React.FC<MockCaptureProps> = ({
+  apduExchanges,
+  isRecording,
+  isConnected,
+  startRecording,
+  stopRecording,
+  clearRecorded,
+  sessionStates,
+  connectedDevices,
+}) => {
+  const [includeHandshake, setIncludeHandshake] = useState(false);
+  const [serverUrl, setServerUrl] = useState(DEFAULT_MOCK_SERVER_URL);
+  const [sessionToken, setSessionToken] = useState("");
+  const [isPushing, setIsPushing] = useState(false);
+  const [pushStatus, setPushStatus] = useState<PushStatus>(null);
+  const [detectedApps, setDetectedApps] = useState<Map<string, DeviceApp[]>>(
+    new Map(),
+  );
+  const [detectedFirmwareVersions, setDetectedFirmwareVersions] = useState<
+    Map<string, string>
+  >(new Map());
+
+  useEffect(() => {
+    for (const [sessionId, state] of sessionStates.entries()) {
+      const config = deviceConfigFromSession(state);
+      if (config.apps && config.apps.length > 0) {
+        const seenApps = config.apps;
+        setDetectedApps((prev) => {
+          const current = prev.get(sessionId) ?? [];
+          const merged = [...current];
+          for (const app of seenApps) {
+            if (
+              !merged.some(
+                (a) => a.name === app.name && a.version === app.version,
+              )
+            ) {
+              merged.push(app);
+            }
+          }
+          if (merged.length === current.length) return prev;
+          return new Map(prev).set(sessionId, merged);
+        });
+      }
+      if (config.firmware_version) {
+        const firmwareVersion = config.firmware_version;
+        setDetectedFirmwareVersions((prev) => {
+          if (prev.get(sessionId)) return prev;
+          return new Map(prev).set(sessionId, firmwareVersion);
+        });
+      }
+    }
+  }, [sessionStates]);
+
+  const handleClear = useCallback(() => {
+    clearRecorded();
+    setDetectedApps(new Map());
+    setDetectedFirmwareVersions(new Map());
+  }, [clearRecorded]);
+
+  // Group exchanges by the session (device) that performed them, preserving
+  // first-seen order, so each connected device gets its own export entry.
+  const captureGroups = useMemo<DeviceCaptureGroup[]>(() => {
+    const exchangesBySession = new Map<string, ApduExchange[]>();
+    for (const exchange of apduExchanges) {
+      const sessionId = exchange.sessionId ?? "";
+      const list = exchangesBySession.get(sessionId) ?? [];
+      list.push(exchange);
+      exchangesBySession.set(sessionId, list);
+    }
+
+    return [...exchangesBySession.entries()].map(([sessionId, exchanges]) => {
+      const state = sessionId ? sessionStates.get(sessionId) : undefined;
+      const connectivityType = sessionId
+        ? connectedDevices.find((device) => device.sessionId === sessionId)
+            ?.type
+        : undefined;
+      const base = deviceConfigFromSession(state, connectivityType);
+      const firmwareVersion = detectedFirmwareVersions.get(sessionId);
+      const apps = detectedApps.get(sessionId);
+      const device = {
+        ...base,
+        name: base.name || "Mocked device",
+        ...(firmwareVersion ? { firmware_version: firmwareVersion } : {}),
+        ...(apps && apps.length > 0 ? { apps } : {}),
+      };
+      return { device, exchanges };
+    });
+  }, [
+    apduExchanges,
+    sessionStates,
+    connectedDevices,
+    detectedApps,
+    detectedFirmwareVersions,
+  ]);
+
+  const sessionExport = useMemo(
+    () => generateMultiDeviceSessionExport(captureGroups, { includeHandshake }),
+    [captureGroups, includeHandshake],
+  );
+
+  const mockCount = sessionExport.devices.reduce(
+    (total, device) => total + (device.mocks?.length ?? 0),
+    0,
+  );
+
+  const generatedJson = useMemo(
+    () => JSON.stringify(sessionExport, null, 2),
+    [sessionExport],
+  );
+
+  // Editable JSON, kept in sync with the generated export until it changes
+  // (e.g. new exchanges captured or the handshake toggle flipped), at which
+  // point the editor is refreshed with the regenerated export.
+  const [editedJson, setEditedJson] = useState(generatedJson);
+  const lastGeneratedRef = useRef(generatedJson);
+  useEffect(() => {
+    if (generatedJson !== lastGeneratedRef.current) {
+      lastGeneratedRef.current = generatedJson;
+      setEditedJson(generatedJson);
+    }
+  }, [generatedJson]);
+
+  const jsonError = useMemo(() => {
+    try {
+      JSON.parse(editedJson);
+      return null;
+    } catch (error) {
+      return error instanceof Error ? error.message : "Invalid JSON";
+    }
+  }, [editedJson]);
+
+  const downloadJson = useCallback(() => {
+    const blob = new Blob([editedJson], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `mock-session-${new Date().toISOString()}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [editedJson]);
+
+  const pushToServer = useCallback(async () => {
+    setIsPushing(true);
+    setPushStatus(null);
+    try {
+      const parsedExport = JSON.parse(editedJson) as SessionExport;
+      const client = new MockClient(
+        serverUrl,
+        sessionToken ? { token: sessionToken } : {},
+      );
+      if (!sessionToken) {
+        await client.authenticate();
+      }
+      const result = await client.importSession(parsedExport);
+      const importedMocks = result.devices.reduce(
+        (total, device) => total + (device.mocks?.length ?? 0),
+        0,
+      );
+      setPushStatus({
+        error: false,
+        message: `Imported ${result.devices.length} device(s) with ${importedMocks} mock(s) to the mock server.`,
+      });
+    } catch (error) {
+      setPushStatus({
+        error: true,
+        message:
+          error instanceof Error ? error.message : "Failed to push session",
+      });
+    } finally {
+      setIsPushing(false);
+    }
+  }, [serverUrl, sessionToken, editedJson]);
+
+  if (!isConnected) {
+    return (
+      <NotConnectedMessage
+        title="Logger not connected"
+        description={
+          <>
+            Mock capture reads APDU exchanges from the DMK logs. Add{" "}
+            <code>DevToolsLogger</code> to your DMK builder to start capturing:
+          </>
+        }
+        codeExample={MOCK_CAPTURE_CODE_EXAMPLE}
+      />
+    );
+  }
+
+  const hasExchanges = apduExchanges.length > 0;
+
+  return (
+    <Container>
+      <Section>
+        <SectionTitle>Recording</SectionTitle>
+        <Row>
+          {isRecording ? (
+            <Button $variant="danger" onClick={stopRecording}>
+              <RecordingDot $active />
+              Stop
+            </Button>
+          ) : (
+            <Button $variant="primary" onClick={startRecording}>
+              <RecordingDot $active={false} />
+              Record
+            </Button>
+          )}
+          <Button
+            $variant="neutral"
+            onClick={handleClear}
+            disabled={!hasExchanges}
+          >
+            Clear
+          </Button>
+          <Stat>
+            {apduExchanges.length} exchange(s) captured, {mockCount} mock(s)
+            derived
+          </Stat>
+        </Row>
+        <Checkbox>
+          <input
+            type="checkbox"
+            checked={includeHandshake}
+            onChange={(e) => setIncludeHandshake(e.target.checked)}
+          />
+          Include handshake APDUs (GetOsVersion / GetAppAndVersion)
+        </Checkbox>
+      </Section>
+
+      <Section>
+        <SectionTitle>Generated session export</SectionTitle>
+        <Row>
+          <Button
+            onClick={downloadJson}
+            disabled={!hasExchanges || !!jsonError}
+          >
+            Download JSON
+          </Button>
+        </Row>
+        <JsonEditor
+          value={editedJson}
+          spellCheck={false}
+          onChange={(e) => setEditedJson(e.target.value)}
+        />
+        {jsonError && (
+          <StatusMessage $error>Invalid JSON: {jsonError}</StatusMessage>
+        )}
+      </Section>
+
+      <Section>
+        <SectionTitle>Push to mock server</SectionTitle>
+        <Row>
+          <Field>
+            Server URL
+            <Input
+              value={serverUrl}
+              onChange={(e) => setServerUrl(e.target.value)}
+            />
+          </Field>
+          <Field>
+            Session token
+            <Input
+              value={sessionToken}
+              placeholder="auto-provisioned if empty"
+              onChange={(e) => setSessionToken(e.target.value)}
+            />
+          </Field>
+        </Row>
+        <Row>
+          <Button
+            onClick={pushToServer}
+            disabled={!hasExchanges || isPushing || !!jsonError}
+          >
+            {isPushing ? "Pushing..." : "Push to mock server"}
+          </Button>
+        </Row>
+        {pushStatus && (
+          <StatusMessage $error={pushStatus.error}>
+            {pushStatus.message}
+          </StatusMessage>
+        )}
+      </Section>
+    </Container>
+  );
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -880,7 +880,7 @@ importers:
         version: 0.76.6
       '@react-native/metro-config':
         specifier: 'catalog:'
-        version: 0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))
+        version: 0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@react-native/typescript-config':
         specifier: 'catalog:'
         version: 0.76.6
@@ -1255,6 +1255,9 @@ importers:
 
   packages/devtools/ui:
     dependencies:
+      '@ledgerhq/device-mockserver-client':
+        specifier: workspace:^
+        version: link:../../mockserver-client
       '@ledgerhq/react-ui':
         specifier: 'catalog:'
         version: 0.45.0(@emotion/is-prop-valid@1.2.1)(@types/react@18.3.12)(embla-carousel@8.0.0-rc17)(react-dom@18.3.1(react@18.3.1))(react-native-svg@15.11.1(react-native@0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))(@react-native-community/cli-server-api@15.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@types/react@18.3.12)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1))(react-native@0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))(@react-native-community/cli-server-api@15.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@types/react@18.3.12)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
@@ -11141,10 +11144,6 @@ packages:
   purify-ts@2.1.0:
     resolution: {integrity: sha512-+KNUHV9FxB9BbjadFdvxa+LNJIaqZmSF7CQH5Rv6+f0rBzsxm9FEqrvkALQbWYJobAja2ZCbBDUY7O4fH2znMA==}
 
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
-    engines: {node: '>=0.6'}
-
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
@@ -16635,7 +16634,7 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
-  '@react-native/metro-config@0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))':
+  '@react-native/metro-config@0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
       '@react-native/js-polyfills': 0.76.6
       '@react-native/metro-babel-transformer': 0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))
@@ -16644,7 +16643,9 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 
@@ -18149,14 +18150,6 @@ snapshots:
       magic-string: 0.30.17
     optionalDependencies:
       vite: 7.1.6(@types/node@22.10.1)(jiti@1.21.6)(terser@5.43.1)(tsx@4.20.3)(yaml@2.7.0)
-
-  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@24.3.0)(jiti@1.21.6)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 7.1.6(@types/node@24.3.0)(jiti@1.21.6)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -24201,10 +24194,6 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  qs@6.14.1:
-    dependencies:
-      side-channel: 1.1.0
-
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
@@ -26720,7 +26709,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@24.3.0)(jiti@1.21.6)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))
+      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@22.10.1)(jiti@1.21.6)(terser@5.43.1)(tsx@4.20.3)(yaml@2.7.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4


### PR DESCRIPTION
### 📝 Description

This PR introduces a **Mock Capture** screen in the DevTools dashboard that turns a real device session into a ready-to-replay mock-server configuration.

While a device performs operations (connect, open app, sign, etc.), the DevTools logger passively records every APDU exchange (request + response) coming from the host app's DMK logs. The screen then derives mock-server mocks from those exchanges and the live session metadata, and lets you **download the session export as JSON** or **push it directly to a running mock server** for replay.

To make this reliable, the DMK now also emits a **structured APDU exchange log** (request, response, and session id) so consumers can reconstruct exchanges from the log payload instead of fragile string parsing.

**Key behaviors / advantages:**

- **Auto-derived device metadata**: commercial model name (`Flex`, `Stax`, `Gen 5`, …), `device_type`, `connectivity_type` (`USB`/`BLE`), and SE `firmware_version` are inferred from the live session.
- **Resilient firmware detection**: firmware version is read while on the dashboard (BOLOS) and persisted, so it isn't erased when you later open an app.
- **App accumulation**: switching apps automatically adds to the `apps` list; the dashboard (`BOLOS`) is filtered out as it is not an installed app.
- **Multi-device support**: when several devices are connected, exchanges are grouped per session so each device gets its own entry and mocks (no cross-device collision).
- **Optional handshake mocks**: a toggle includes/excludes the `GetOsVersion`/`GetAppAndVersion` handshake APDUs.
- **Editable JSON**: the export is shown in an editable black box; you can tweak it directly before download/push (with live JSON validation).
- **Direct push to mock server**: push a generated session directly to a running mock server.


**Result:**

https://github.com/user-attachments/assets/cd60043b-323a-41ca-89f1-9f24c8b51660

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Capture a live device session and convert it into mock-server mocks directly from the DevTools dashboard, streamlining the creation of deterministic, replayable test fixtures.

### ✅ Checklist

- [x] **Covered by automatic tests** — unit tests for the structured APDU exchange log (`apduLogs.test.ts`) and for session-export generation, including multi-device grouping and "name first" ordering (`generateSessionExport.test.ts`). The React screen (`index.tsx`) itself is not yet covered by component tests.
- [x] **Changeset is provided** — `@ledgerhq/device-management-kit-devtools-ui` (minor) and `@ledgerhq/device-management-kit` (patch).
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - New `Mock Capture` screen + nav entry in `@ledgerhq/device-management-kit-devtools-ui`.
  - New structured `apdu-exchange` log emitted by `DeviceSession` in `@ledgerhq/device-management-kit` (additive; existing string logs unchanged).
  - DevTools Electron CSP updated to permit local mock-server HTTP requests.
  - QA focus: recording start/stop/clear, JSON edit + validation, download, push to mock server (auth + session token paths), USB vs BLE connectivity, firmware detection across app switches, and multi-device capture.
