### PR TITLE
✨ (solana-tools) [DSDK-1295]: Add ALT resolution

### DIFF
--- a/.changeset/thick-loops-kiss.md
+++ b/.changeset/thick-loops-kiss.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/solana-tools": minor
+---
+
+Add AltResolverService to resolve a transaction's address lookup tables over RPC

--- a/packages/tools/solana-tools/src/api/app-binder/CraftTransactionDeviceActionTypes.ts
+++ b/packages/tools/solana-tools/src/api/app-binder/CraftTransactionDeviceActionTypes.ts
@@ -8,6 +8,7 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { type SolanaAppErrorCodes } from "@ledgerhq/device-signer-kit-solana";
 
+import { type AltResolverService } from "@internal/services/AltResolverService";
 import { type TransactionFetcherService } from "@internal/services/TransactionFetcherService";
 
 export type CraftTransactionDAOutput = string;
@@ -19,6 +20,11 @@ export type CraftTransactionDAInput = {
   readonly rpcUrl?: string;
   readonly skipOpenApp?: boolean;
   readonly transactionFetcherService: TransactionFetcherService;
+  // Mirrors transactionFetcherService. Optional here so existing callers keep
+  // compiling; the wiring that resolves lookup tables passes it through.
+  readonly altResolverService?: AltResolverService;
+  // Optional explicit old to new address map, base58 keyed.
+  readonly replacements?: Readonly<Record<string, string>>;
 };
 
 export type CraftTransactionDAError =

--- a/packages/tools/solana-tools/src/internal/app-binder/device-action/CraftTransactionDeviceAction.ts
+++ b/packages/tools/solana-tools/src/internal/app-binder/device-action/CraftTransactionDeviceAction.ts
@@ -34,7 +34,12 @@ export type MachineDependencies = {
     input: { transactionSignature: string; rpcUrl?: string };
   }) => Promise<string>;
   readonly craftTransaction: (arg0: {
-    input: { publicKey: string; serialisedTransaction: string };
+    input: {
+      publicKey: string;
+      serialisedTransaction: string;
+      rpcUrl?: string;
+      replacements?: Readonly<Record<string, string>>;
+    };
   }) => Promise<string>;
 };
 

--- a/packages/tools/solana-tools/src/internal/services/AltResolverService.ts
+++ b/packages/tools/solana-tools/src/internal/services/AltResolverService.ts
@@ -1,0 +1,19 @@
+import {
+  type AddressLookupTableAccount,
+  type VersionedMessage,
+} from "@solana/web3.js";
+
+export interface AltResolverService {
+  /**
+   * Fetch the full lookup tables referenced by a v0 message, not just the
+   * subset of addresses a transaction happens to use.
+   *
+   * Legacy and no-ALT messages resolve to an empty array. Throws when a
+   * referenced table is missing or closed (the underlying lookup returns null),
+   * which is not recoverable.
+   */
+  resolveAddressLookupTables(
+    message: VersionedMessage,
+    rpcUrl?: string,
+  ): Promise<AddressLookupTableAccount[]>;
+}

--- a/packages/tools/solana-tools/src/internal/services/DefaultAltResolverService.test.ts
+++ b/packages/tools/solana-tools/src/internal/services/DefaultAltResolverService.test.ts
@@ -1,0 +1,177 @@
+import {
+  AddressLookupTableAccount,
+  Connection,
+  PublicKey,
+  type VersionedMessage,
+} from "@solana/web3.js";
+
+vi.mock("@solana/web3.js", async () => {
+  const actual = await vi.importActual("@solana/web3.js");
+  return {
+    ...actual,
+    Connection: vi.fn(),
+    AddressLookupTableAccount: class {
+      key: PublicKey;
+      state: unknown;
+      constructor(args: { key: PublicKey; state: unknown }) {
+        this.key = args.key;
+        this.state = args.state;
+      }
+      static deserialize = vi.fn();
+    },
+  };
+});
+
+import { DefaultAltResolverService } from "./DefaultAltResolverService";
+
+const tableKeyOne = new PublicKey(new Uint8Array(32).fill(1));
+const tableKeyTwo = new PublicKey(new Uint8Array(32).fill(2));
+
+function legacyMessage(): VersionedMessage {
+  return { version: "legacy" } as unknown as VersionedMessage;
+}
+
+function v0Message(tableKeys: PublicKey[]): VersionedMessage {
+  return {
+    version: 0,
+    addressTableLookups: tableKeys.map((accountKey) => ({
+      accountKey,
+      writableIndexes: [],
+      readonlyIndexes: [],
+    })),
+  } as unknown as VersionedMessage;
+}
+
+describe("DefaultAltResolverService", () => {
+  let getMultipleAccountsInfoMock: ReturnType<typeof vi.fn>;
+  let deserializeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getMultipleAccountsInfoMock = vi.fn();
+    vi.mocked(Connection).mockImplementation(
+      () =>
+        ({
+          getMultipleAccountsInfo: getMultipleAccountsInfoMock,
+        }) as unknown as Connection,
+    );
+    deserializeMock = vi.mocked(AddressLookupTableAccount.deserialize);
+  });
+
+  it("should return an empty array for a legacy message without hitting the RPC", async () => {
+    const service = new DefaultAltResolverService();
+
+    const result = await service.resolveAddressLookupTables(legacyMessage());
+
+    expect(result).toEqual([]);
+    expect(Connection).not.toHaveBeenCalled();
+  });
+
+  it("should return an empty array for a v0 message with no lookup tables", async () => {
+    const service = new DefaultAltResolverService();
+
+    const result = await service.resolveAddressLookupTables(v0Message([]));
+
+    expect(result).toEqual([]);
+    expect(Connection).not.toHaveBeenCalled();
+  });
+
+  it("should use the default RPC URL when none is provided", async () => {
+    getMultipleAccountsInfoMock.mockResolvedValue([
+      { data: new Uint8Array([1]) },
+    ]);
+    deserializeMock.mockReturnValue({ addresses: [] });
+    const service = new DefaultAltResolverService();
+
+    await service.resolveAddressLookupTables(v0Message([tableKeyOne]));
+
+    expect(Connection).toHaveBeenCalledWith(
+      "https://solana.coin.ledger.com",
+      "confirmed",
+    );
+  });
+
+  it("should use a custom RPC URL when provided", async () => {
+    getMultipleAccountsInfoMock.mockResolvedValue([
+      { data: new Uint8Array([1]) },
+    ]);
+    deserializeMock.mockReturnValue({ addresses: [] });
+    const service = new DefaultAltResolverService();
+
+    await service.resolveAddressLookupTables(
+      v0Message([tableKeyOne]),
+      "https://custom-rpc.example.com",
+    );
+
+    expect(Connection).toHaveBeenCalledWith(
+      "https://custom-rpc.example.com",
+      "confirmed",
+    );
+  });
+
+  it("should batch every referenced table into a single RPC request", async () => {
+    getMultipleAccountsInfoMock.mockResolvedValue([
+      { data: new Uint8Array([1]) },
+      { data: new Uint8Array([2]) },
+    ]);
+    deserializeMock.mockReturnValue({ addresses: [] });
+    const service = new DefaultAltResolverService();
+
+    await service.resolveAddressLookupTables(
+      v0Message([tableKeyOne, tableKeyTwo]),
+    );
+
+    expect(getMultipleAccountsInfoMock).toHaveBeenCalledTimes(1);
+    expect(getMultipleAccountsInfoMock).toHaveBeenCalledWith([
+      tableKeyOne,
+      tableKeyTwo,
+    ]);
+  });
+
+  it("should return the fully built tables aligned with the requested order", async () => {
+    const stateOne = { addresses: ["one"] };
+    const stateTwo = { addresses: ["two"] };
+    getMultipleAccountsInfoMock.mockResolvedValue([
+      { data: new Uint8Array([1]) },
+      { data: new Uint8Array([2]) },
+    ]);
+    deserializeMock.mockReturnValueOnce(stateOne).mockReturnValueOnce(stateTwo);
+    const service = new DefaultAltResolverService();
+
+    const result = await service.resolveAddressLookupTables(
+      v0Message([tableKeyOne, tableKeyTwo]),
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0]!.key).toBe(tableKeyOne);
+    expect(result[0]!.state).toBe(stateOne);
+    expect(result[1]!.key).toBe(tableKeyTwo);
+    expect(result[1]!.state).toBe(stateTwo);
+  });
+
+  it("should deserialize each table from its raw account data", async () => {
+    const data = new Uint8Array([9, 9, 9]);
+    getMultipleAccountsInfoMock.mockResolvedValue([{ data }]);
+    deserializeMock.mockReturnValue({ addresses: [] });
+    const service = new DefaultAltResolverService();
+
+    await service.resolveAddressLookupTables(v0Message([tableKeyOne]));
+
+    expect(deserializeMock).toHaveBeenCalledWith(data);
+  });
+
+  it("should throw a clear error when a referenced table is missing or closed", async () => {
+    getMultipleAccountsInfoMock.mockResolvedValue([
+      { data: new Uint8Array([1]) },
+      null,
+    ]);
+    deserializeMock.mockReturnValue({ addresses: [] });
+    const service = new DefaultAltResolverService();
+
+    await expect(
+      service.resolveAddressLookupTables(v0Message([tableKeyOne, tableKeyTwo])),
+    ).rejects.toThrow(
+      `Address lookup table not found or closed: ${tableKeyTwo.toBase58()}`,
+    );
+  });
+});

--- a/packages/tools/solana-tools/src/internal/services/DefaultAltResolverService.ts
+++ b/packages/tools/solana-tools/src/internal/services/DefaultAltResolverService.ts
@@ -1,0 +1,61 @@
+import {
+  AddressLookupTableAccount,
+  Connection,
+  type PublicKey,
+  type VersionedMessage,
+} from "@solana/web3.js";
+import { injectable } from "inversify";
+
+import { type AltResolverService } from "@internal/services/AltResolverService";
+
+const DEFAULT_RPC_URL = "https://solana.coin.ledger.com";
+
+@injectable()
+export class DefaultAltResolverService implements AltResolverService {
+  async resolveAddressLookupTables(
+    message: VersionedMessage,
+    rpcUrl?: string,
+  ): Promise<AddressLookupTableAccount[]> {
+    // Legacy messages cannot reference lookup tables. Their version is the
+    // string "legacy", whereas v0 messages report the number 0.
+    if (message.version === "legacy") {
+      return [];
+    }
+
+    const tableKeys = message.addressTableLookups.map(
+      (lookup) => lookup.accountKey,
+    );
+    if (tableKeys.length === 0) {
+      return [];
+    }
+
+    const connection = new Connection(rpcUrl ?? DEFAULT_RPC_URL, "confirmed");
+
+    // One batched request keeps every referenced table on the same RPC
+    // roundtrip. getMultipleAccountsInfo preserves the requested order, so the
+    // result aligns with tableKeys index by index.
+    const accountInfos = await connection.getMultipleAccountsInfo(tableKeys);
+
+    return tableKeys.map((key, index) => {
+      const accountInfo = accountInfos[index];
+      // A null account means the table was never created, was closed, or has
+      // been deactivated and garbage collected. The referenced addresses are
+      // gone, so the message can no longer be resolved or recompiled.
+      if (!accountInfo) {
+        throw new Error(
+          `Address lookup table not found or closed: ${key.toBase58()}`,
+        );
+      }
+
+      return this.buildLookupTableAccount(key, accountInfo.data);
+    });
+  }
+
+  private buildLookupTableAccount(
+    key: PublicKey,
+    data: Uint8Array,
+  ): AddressLookupTableAccount {
+    const state = AddressLookupTableAccount.deserialize(data);
+    return new AddressLookupTableAccount({ key, state });
+  }
+}

--- a/packages/tools/solana-tools/src/internal/services/TransactionCrafterService.ts
+++ b/packages/tools/solana-tools/src/internal/services/TransactionCrafterService.ts
@@ -7,8 +7,26 @@ import {
   TOKEN_2022_PROGRAM_ID,
   TOKEN_PROGRAM_ID,
 } from "@solana/spl-token";
-import { PublicKey } from "@solana/web3.js";
+import { type AddressLookupTableAccount, PublicKey } from "@solana/web3.js";
 import bs58 from "bs58";
+
+export type CraftOptions = {
+  /**
+   * base58 payer. When set, seeds auto-detect: the old payer maps to this
+   * payer, and the old payer's ATAs map to this payer's ATAs.
+   */
+  readonly payer?: string;
+  /**
+   * base58 old to new pairs, applied verbatim. Overrides any auto-detect entry
+   * on a key collision.
+   */
+  readonly replacements?: ReadonlyMap<string, string>;
+  /**
+   * Fully-resolved lookup tables from the resolver. Empty for legacy or no-ALT
+   * messages.
+   */
+  readonly addressLookupTableAccounts?: readonly AddressLookupTableAccount[];
+};
 
 type MessageDetection = {
   accountKeysStart: number;

--- a/packages/tools/solana-tools/src/internal/services/crafter/deserialize.test.ts
+++ b/packages/tools/solana-tools/src/internal/services/crafter/deserialize.test.ts
@@ -1,0 +1,125 @@
+import {
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+
+function toBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64");
+}
+
+function fromBase64(str: string): Uint8Array {
+  return new Uint8Array(Buffer.from(str, "base64"));
+}
+
+vi.mock("@ledgerhq/device-management-kit", () => ({
+  base64StringToBuffer: (value: string): Uint8Array | null => {
+    if (!value || !/^[A-Za-z0-9+/]*={0,2}$/.test(value)) return null;
+    return fromBase64(value);
+  },
+}));
+
+import { deserializeToMessage } from "./deserialize";
+
+const payer = new PublicKey("2cHm11EeTGQixAkyaqNRFczpi1XB1n6rK7bSwNiZbCdB");
+const recipient = new PublicKey("7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2");
+const recentBlockhash = "a3PD566oU2nE9JHwuC897aaT7ispdqaQ63Si6jzyKAg";
+
+function transferInstruction() {
+  return SystemProgram.transfer({
+    fromPubkey: payer,
+    toPubkey: recipient,
+    lamports: 1_000_000,
+  });
+}
+
+function buildLegacyMessageBytes(): Uint8Array {
+  const tx = new Transaction({ recentBlockhash, feePayer: payer });
+  tx.add(transferInstruction());
+  return new Uint8Array(tx.serializeMessage());
+}
+
+function buildLegacyTransactionBytes(): Uint8Array {
+  const tx = new Transaction({ recentBlockhash, feePayer: payer });
+  tx.add(transferInstruction());
+  tx.signatures = [{ publicKey: payer, signature: null }];
+  return new Uint8Array(
+    tx.serialize({ requireAllSignatures: false, verifySignatures: false }),
+  );
+}
+
+function buildV0MessageBytes(): Uint8Array {
+  const message = new TransactionMessage({
+    payerKey: payer,
+    recentBlockhash,
+    instructions: [transferInstruction()],
+  }).compileToV0Message();
+  return message.serialize();
+}
+
+function buildV0TransactionBytes(): Uint8Array {
+  const message = new TransactionMessage({
+    payerKey: payer,
+    recentBlockhash,
+    instructions: [transferInstruction()],
+  }).compileToV0Message();
+  return new VersionedTransaction(message).serialize();
+}
+
+describe("deserializeToMessage", () => {
+  it("deserializes a legacy message and round-trips it byte-for-byte", () => {
+    const bytes = buildLegacyMessageBytes();
+
+    const message = deserializeToMessage(toBase64(bytes));
+
+    expect(message.version).toBe("legacy");
+    expect(new Uint8Array(message.serialize())).toEqual(bytes);
+  });
+
+  it("deserializes a v0 message and round-trips it byte-for-byte", () => {
+    const bytes = buildV0MessageBytes();
+
+    const message = deserializeToMessage(toBase64(bytes));
+
+    expect(message.version).toBe(0);
+    expect(new Uint8Array(message.serialize())).toEqual(bytes);
+  });
+
+  it("returns the inner message of a full legacy transaction, dropping signatures", () => {
+    const txBytes = buildLegacyTransactionBytes();
+    const messageBytes = buildLegacyMessageBytes();
+
+    const message = deserializeToMessage(toBase64(txBytes));
+
+    expect(message.version).toBe("legacy");
+    expect(new Uint8Array(message.serialize())).toEqual(messageBytes);
+    expect(message.serialize().length).toBeLessThan(txBytes.length);
+  });
+
+  it("returns the inner message of a full v0 transaction, dropping signatures", () => {
+    const txBytes = buildV0TransactionBytes();
+    const messageBytes = buildV0MessageBytes();
+
+    const message = deserializeToMessage(toBase64(txBytes));
+
+    expect(message.version).toBe(0);
+    expect(new Uint8Array(message.serialize())).toEqual(messageBytes);
+    expect(message.serialize().length).toBeLessThan(txBytes.length);
+  });
+
+  it("throws on input that is not valid base64", () => {
+    expect(() => deserializeToMessage("!!!not base64!!!")).toThrow(
+      "Input is not a valid base64 string.",
+    );
+  });
+
+  it("throws on base64 that is neither a message nor a transaction", () => {
+    const garbage = toBase64(new Uint8Array([0xff, 0xff, 0xff, 0xff]));
+
+    expect(() => deserializeToMessage(garbage)).toThrow(
+      "Input is neither a valid serialized message nor a valid serialized transaction.",
+    );
+  });
+});

--- a/packages/tools/solana-tools/src/internal/services/crafter/deserialize.ts
+++ b/packages/tools/solana-tools/src/internal/services/crafter/deserialize.ts
@@ -1,0 +1,76 @@
+import { base64StringToBuffer } from "@ledgerhq/device-management-kit";
+import { VersionedMessage, VersionedTransaction } from "@solana/web3.js";
+
+/**
+ * Branch on the input kind and return the message to operate on.
+ *
+ * Accepts either a serialized VersionedMessage (legacy or v0) or a full
+ * serialized VersionedTransaction. For a full transaction the signatures are
+ * dropped and only `message` is returned: the craft path always recompiles
+ * into a fresh message, which carries no signatures.
+ *
+ * Detection is structural and confirmed by re-serialization. A candidate shape
+ * is accepted only when serializing it back produces the original bytes, which
+ * tells a bare message apart from a full transaction without guessing from the
+ * leading bytes alone.
+ *
+ * Throws when the input is not valid base64, or when it matches neither shape.
+ */
+export function deserializeToMessage(
+  transactionBase64: string,
+): VersionedMessage {
+  const bytes = base64StringToBuffer(transactionBase64);
+  if (bytes === null) {
+    throw new Error("Input is not a valid base64 string.");
+  }
+
+  const fromTransaction = tryDeserializeTransaction(bytes);
+  if (fromTransaction !== null) {
+    return fromTransaction;
+  }
+
+  const fromMessage = tryDeserializeMessage(bytes);
+  if (fromMessage !== null) {
+    return fromMessage;
+  }
+
+  throw new Error(
+    "Input is neither a valid serialized message nor a valid serialized transaction.",
+  );
+}
+
+function tryDeserializeTransaction(bytes: Uint8Array): VersionedMessage | null {
+  try {
+    const transaction = VersionedTransaction.deserialize(bytes);
+    if (bytesEqual(transaction.serialize(), bytes)) {
+      return transaction.message;
+    }
+  } catch {
+    // Not a full transaction, fall through to the bare-message branch.
+  }
+  return null;
+}
+
+function tryDeserializeMessage(bytes: Uint8Array): VersionedMessage | null {
+  try {
+    const message = VersionedMessage.deserialize(bytes);
+    if (bytesEqual(message.serialize(), bytes)) {
+      return message;
+    }
+  } catch {
+    // Not a bare message either.
+  }
+  return null;
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/tools/solana-tools/src/internal/services/di/servicesModule.ts
+++ b/packages/tools/solana-tools/src/internal/services/di/servicesModule.ts
@@ -1,5 +1,7 @@
 import { ContainerModule } from "inversify";
 
+import { type AltResolverService } from "@internal/services/AltResolverService";
+import { DefaultAltResolverService } from "@internal/services/DefaultAltResolverService";
 import { DefaultTransactionFetcherService } from "@internal/services/DefaultTransactionFetcherService";
 import { servicesTypes } from "@internal/services/di/servicesTypes";
 import { type TransactionFetcherService } from "@internal/services/TransactionFetcherService";
@@ -8,5 +10,8 @@ export const servicesModuleFactory = () =>
   new ContainerModule(({ bind }) => {
     bind<TransactionFetcherService>(servicesTypes.TransactionFetcherService).to(
       DefaultTransactionFetcherService,
+    );
+    bind<AltResolverService>(servicesTypes.AltResolverService).to(
+      DefaultAltResolverService,
     );
   });

--- a/packages/tools/solana-tools/src/internal/services/di/servicesTypes.ts
+++ b/packages/tools/solana-tools/src/internal/services/di/servicesTypes.ts
@@ -1,3 +1,4 @@
 export const servicesTypes = {
   TransactionFetcherService: Symbol.for("TransactionFetcherService"),
+  AltResolverService: Symbol.for("AltResolverService"),
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Adds `AltResolverService` the RPC-backed foundation that resolves a Solana transaction's Address Lookup Tables (ALTs) so the crafter can later operate on fully resolved account lists. This is Ticket 1 of the ALT-aware crafter work.

`DefaultAltResolverService.resolveAddressLookupTables(message, rpcUrl?)`:
  - Returns `[]` immediately for legacy messages and for v0 messages with no `addressTableLookups`, with no RPC call.
  - For v0 messages, collects the referenced table pubkeys and fetches them in a single batched `getMultipleAccountsInfo` request, deserialises each via `AddressLookupTableAccount.deserialize`, and returns the full `AddressLookupTableAccount[]` in the same order as requested.
  - Fetches the **full** tables (not just `getTransaction`'s `loadedAddresses`), because recompiling a crafted message needs every address in each table to keep untouched accounts in their table.
  - Throws a clear, non-recoverable error when a referenced table is missing or closed (the account lookup returns `null`).
  - Defaults `rpcUrl` to the same endpoint used by the transaction fetcher.

Bound in DI as `servicesTypes.AltResolverService` alongside the fetcher.

Note: this service does no decompile/recompile and is not yet wired into the craft path, that is the crafter engine (Ticket 2) and the wiring (Ticket 3).

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [DSDK-1295](https://ledgerhq.atlassian.net/browse/DSDK-1295)

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
