### PR TITLE
✨ (solana-tools) [DSDK-1296]: Crafter engine

### DIFF
--- a/.changeset/crafter-engine-alt-aware.md
+++ b/.changeset/crafter-engine-alt-aware.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/solana-tools": minor
+---
+
+Rewrite the transaction crafter to decompile, replace and recompile on real public keys instead of byte surgery.

--- a/packages/tools/solana-tools/src/api/app-binder/CraftTransactionDeviceActionTypes.ts
+++ b/packages/tools/solana-tools/src/api/app-binder/CraftTransactionDeviceActionTypes.ts
@@ -8,6 +8,7 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { type SolanaAppErrorCodes } from "@ledgerhq/device-signer-kit-solana";
 
+import { type AltResolverService } from "@internal/services/AltResolverService";
 import { type TransactionFetcherService } from "@internal/services/TransactionFetcherService";
 
 export type CraftTransactionDAOutput = string;
@@ -19,6 +20,11 @@ export type CraftTransactionDAInput = {
   readonly rpcUrl?: string;
   readonly skipOpenApp?: boolean;
   readonly transactionFetcherService: TransactionFetcherService;
+  // Mirrors transactionFetcherService. Optional here so existing callers keep
+  // compiling; the wiring that resolves lookup tables passes it through.
+  readonly altResolverService?: AltResolverService;
+  // Optional explicit old to new address map, base58 keyed.
+  readonly replacements?: Readonly<Record<string, string>>;
 };
 
 export type CraftTransactionDAError =

--- a/packages/tools/solana-tools/src/internal/app-binder/device-action/CraftTransactionDeviceAction.ts
+++ b/packages/tools/solana-tools/src/internal/app-binder/device-action/CraftTransactionDeviceAction.ts
@@ -344,10 +344,9 @@ export class CraftTransactionDeviceAction extends XStateDeviceAction<
       input: { publicKey: string; serialisedTransaction: string };
     }) => {
       const crafter = new TransactionCrafterService();
-      return crafter.getCraftedTransaction(
-        arg0.input.serialisedTransaction,
-        arg0.input.publicKey,
-      );
+      return crafter.getCraftedTransaction(arg0.input.serialisedTransaction, {
+        payer: arg0.input.publicKey,
+      });
     };
 
     return {

--- a/packages/tools/solana-tools/src/internal/app-binder/device-action/CraftTransactionDeviceAction.ts
+++ b/packages/tools/solana-tools/src/internal/app-binder/device-action/CraftTransactionDeviceAction.ts
@@ -34,7 +34,12 @@ export type MachineDependencies = {
     input: { transactionSignature: string; rpcUrl?: string };
   }) => Promise<string>;
   readonly craftTransaction: (arg0: {
-    input: { publicKey: string; serialisedTransaction: string };
+    input: {
+      publicKey: string;
+      serialisedTransaction: string;
+      rpcUrl?: string;
+      replacements?: Readonly<Record<string, string>>;
+    };
   }) => Promise<string>;
 };
 

--- a/packages/tools/solana-tools/src/internal/services/AltResolverService.ts
+++ b/packages/tools/solana-tools/src/internal/services/AltResolverService.ts
@@ -1,0 +1,19 @@
+import {
+  type AddressLookupTableAccount,
+  type VersionedMessage,
+} from "@solana/web3.js";
+
+export interface AltResolverService {
+  /**
+   * Fetch the full lookup tables referenced by a v0 message, not just the
+   * subset of addresses a transaction happens to use.
+   *
+   * Legacy and no-ALT messages resolve to an empty array. Throws when a
+   * referenced table is missing or closed (the underlying lookup returns null),
+   * which is not recoverable.
+   */
+  resolveAddressLookupTables(
+    message: VersionedMessage,
+    rpcUrl?: string,
+  ): Promise<AddressLookupTableAccount[]>;
+}

--- a/packages/tools/solana-tools/src/internal/services/TransactionCrafterService.test.ts
+++ b/packages/tools/solana-tools/src/internal/services/TransactionCrafterService.test.ts
@@ -1,4 +1,18 @@
-import { PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
+import {
+  getAssociatedTokenAddressSync,
+  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+} from "@solana/spl-token";
+import {
+  AddressLookupTableAccount,
+  ComputeBudgetProgram,
+  PublicKey,
+  SystemProgram,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
 
 function toBase64(bytes: Uint8Array): string {
   return Buffer.from(bytes).toString("base64");
@@ -18,7 +32,12 @@ vi.mock("@ledgerhq/device-management-kit", () => ({
   },
 }));
 
-import { TransactionCrafterService } from "./TransactionCrafterService";
+import {
+  type CraftOptions,
+  TransactionCrafterService,
+} from "./TransactionCrafterService";
+
+const BLOCKHASH = "a3PD566oU2nE9JHwuC897aaT7ispdqaQ63Si6jzyKAg";
 
 describe("TransactionCrafterService", () => {
   const crafter = new TransactionCrafterService();
@@ -32,111 +51,310 @@ describe("TransactionCrafterService", () => {
     "7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2",
   );
 
-  function buildLegacyMessageBase64(): string {
-    const tx = new Transaction({
-      recentBlockhash: "a3PD566oU2nE9JHwuC897aaT7ispdqaQ63Si6jzyKAg",
-      feePayer: oldPayer,
-    });
-    tx.add(
-      SystemProgram.transfer({
-        fromPubkey: oldPayer,
-        toPubkey: recipient,
-        lamports: 1_000_000,
-      }),
+  function craft(base64: string, options: CraftOptions): VersionedMessage {
+    return VersionedMessage.deserialize(
+      fromBase64(crafter.getCraftedTransaction(base64, options)),
     );
-    tx.signatures = [{ publicKey: oldPayer, signature: null }];
-    const msg = tx.serializeMessage();
-    return toBase64(msg);
   }
 
-  describe("getCraftedTransaction", () => {
+  function legacyTransferMessage(): string {
+    const message = new TransactionMessage({
+      payerKey: oldPayer,
+      recentBlockhash: BLOCKHASH,
+      instructions: [
+        SystemProgram.transfer({
+          fromPubkey: oldPayer,
+          toPubkey: recipient,
+          lamports: 1_000_000,
+        }),
+      ],
+    }).compileToLegacyMessage();
+    return toBase64(message.serialize());
+  }
+
+  describe("auto-detect mode", () => {
     it("should replace the payer in a legacy message", () => {
-      const original = buildLegacyMessageBase64();
-      const crafted = crafter.getCraftedTransaction(
-        original,
-        newPayer.toBase58(),
-      );
+      const crafted = craft(legacyTransferMessage(), {
+        payer: newPayer.toBase58(),
+      });
 
-      expect(crafted).not.toEqual(original);
-
-      const craftedBytes = fromBase64(crafted);
-      expect(craftedBytes.length).toBeGreaterThan(0);
-
-      const craftedHex = Buffer.from(craftedBytes).toString("hex");
-      const newPayerHex = Buffer.from(newPayer.toBytes()).toString("hex");
-      expect(craftedHex).toContain(newPayerHex);
-
-      const oldPayerHex = Buffer.from(oldPayer.toBytes()).toString("hex");
-      expect(craftedHex).not.toContain(oldPayerHex);
+      const keys = crafted.staticAccountKeys.map((k) => k.toBase58());
+      expect(keys).toContain(newPayer.toBase58());
+      expect(keys).not.toContain(oldPayer.toBase58());
     });
 
-    it("should preserve the recipient key", () => {
-      const original = buildLegacyMessageBase64();
-      const crafted = crafter.getCraftedTransaction(
-        original,
-        newPayer.toBase58(),
-      );
+    it("should preserve the recipient and the blockhash", () => {
+      const crafted = craft(legacyTransferMessage(), {
+        payer: newPayer.toBase58(),
+      });
 
-      const craftedBytes = fromBase64(crafted);
-      const craftedHex = Buffer.from(craftedBytes).toString("hex");
-      const recipientHex = Buffer.from(recipient.toBytes()).toString("hex");
-      expect(craftedHex).toContain(recipientHex);
+      const keys = crafted.staticAccountKeys.map((k) => k.toBase58());
+      expect(keys).toContain(recipient.toBase58());
+      expect(crafted.recentBlockhash).toBe(BLOCKHASH);
     });
 
+    it("should re-point the old payer's ATA to the new payer's ATA", () => {
+      const mint = new PublicKey(
+        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      );
+      const oldAta = getAssociatedTokenAddressSync(
+        mint,
+        oldPayer,
+        true,
+        TOKEN_PROGRAM_ID,
+      );
+      const newAta = getAssociatedTokenAddressSync(
+        mint,
+        newPayer,
+        true,
+        TOKEN_PROGRAM_ID,
+      );
+
+      const message = new TransactionMessage({
+        payerKey: oldPayer,
+        recentBlockhash: BLOCKHASH,
+        instructions: [
+          new TransactionInstruction({
+            programId: TOKEN_PROGRAM_ID,
+            keys: [
+              { pubkey: oldAta, isSigner: false, isWritable: true },
+              { pubkey: mint, isSigner: false, isWritable: false },
+              { pubkey: oldPayer, isSigner: true, isWritable: true },
+            ],
+            data: Buffer.from([3, 0, 0, 0, 0, 0, 0, 0, 0]),
+          }),
+        ],
+      }).compileToLegacyMessage();
+
+      const crafted = craft(toBase64(message.serialize()), {
+        payer: newPayer.toBase58(),
+      });
+
+      const keys = crafted.staticAccountKeys.map((k) => k.toBase58());
+      expect(keys).toContain(newAta.toBase58());
+      expect(keys).not.toContain(oldAta.toBase58());
+      // The mint is untouched.
+      expect(keys).toContain(mint.toBase58());
+    });
+
+    it("should re-point a TOKEN-2022 ATA", () => {
+      const mint = new PublicKey(
+        "9BcWFP4iAFmyT7QkpfRsTm6qkAxqYjZpFMDxZuTGZ6e9",
+      );
+      const oldAta = getAssociatedTokenAddressSync(
+        mint,
+        oldPayer,
+        true,
+        TOKEN_2022_PROGRAM_ID,
+      );
+      const newAta = getAssociatedTokenAddressSync(
+        mint,
+        newPayer,
+        true,
+        TOKEN_2022_PROGRAM_ID,
+      );
+
+      const message = new TransactionMessage({
+        payerKey: oldPayer,
+        recentBlockhash: BLOCKHASH,
+        instructions: [
+          new TransactionInstruction({
+            programId: TOKEN_2022_PROGRAM_ID,
+            keys: [
+              { pubkey: oldAta, isSigner: false, isWritable: true },
+              { pubkey: mint, isSigner: false, isWritable: false },
+              { pubkey: oldPayer, isSigner: true, isWritable: true },
+            ],
+            data: Buffer.from([3, 0, 0, 0, 0, 0, 0, 0, 0]),
+          }),
+        ],
+      }).compileToLegacyMessage();
+
+      const crafted = craft(toBase64(message.serialize()), {
+        payer: newPayer.toBase58(),
+      });
+
+      const keys = crafted.staticAccountKeys.map((k) => k.toBase58());
+      expect(keys).toContain(newAta.toBase58());
+      expect(keys).not.toContain(oldAta.toBase58());
+    });
+
+    it("should pass ComputeBudget instructions through untouched", () => {
+      const message = new TransactionMessage({
+        payerKey: oldPayer,
+        recentBlockhash: BLOCKHASH,
+        instructions: [
+          ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }),
+          SystemProgram.transfer({
+            fromPubkey: oldPayer,
+            toPubkey: recipient,
+            lamports: 1_000_000,
+          }),
+        ],
+      }).compileToLegacyMessage();
+
+      const crafted = craft(toBase64(message.serialize()), {
+        payer: newPayer.toBase58(),
+      });
+
+      const keys = crafted.staticAccountKeys.map((k) => k.toBase58());
+      expect(keys).toContain(ComputeBudgetProgram.programId.toBase58());
+      expect(keys).toContain(newPayer.toBase58());
+    });
+
+    it("should be idempotent when payer is unchanged", () => {
+      const original = legacyTransferMessage();
+      const crafted = crafter.getCraftedTransaction(original, {
+        payer: oldPayer.toBase58(),
+      });
+      expect(crafted).toBe(original);
+    });
+  });
+
+  describe("round-trip", () => {
+    it("should reproduce the message when there are no replacements", () => {
+      const original = legacyTransferMessage();
+      const crafted = crafter.getCraftedTransaction(original, {});
+      expect(crafted).toBe(original);
+    });
+  });
+
+  describe("explicit-map mode with ALTs", () => {
+    const programId = new PublicKey(
+      "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+    );
+    const altSupplied = new PublicKey(
+      "So11111111111111111111111111111111111111112",
+    );
+    const replacement = new PublicKey(
+      "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+    );
+
+    function lookupTable(): AddressLookupTableAccount {
+      return new AddressLookupTableAccount({
+        key: new PublicKey("HzMoc78z1VPHQwP1XQ3oM8oqkLW9bu2hZqScDpfEjBpd"),
+        state: {
+          // u64 max: an active (never deactivated) table.
+          deactivationSlot: 18446744073709551615n,
+          lastExtendedSlot: 0,
+          lastExtendedSlotStartIndex: 0,
+          authority: undefined,
+          addresses: [altSupplied],
+        },
+      });
+    }
+
+    function v0WithAltMessage(alt: AddressLookupTableAccount): string {
+      const message = new TransactionMessage({
+        payerKey: oldPayer,
+        recentBlockhash: BLOCKHASH,
+        instructions: [
+          new TransactionInstruction({
+            programId,
+            keys: [
+              { pubkey: oldPayer, isSigner: true, isWritable: true },
+              { pubkey: altSupplied, isSigner: false, isWritable: true },
+            ],
+            data: Buffer.from([]),
+          }),
+        ],
+      }).compileToV0Message([alt]);
+      return toBase64(message.serialize());
+    }
+
+    it("should promote a replaced ALT-supplied account into the static keys", () => {
+      const alt = lookupTable();
+      const original = VersionedMessage.deserialize(
+        fromBase64(v0WithAltMessage(alt)),
+      );
+      // Sanity check: the account is supplied via the lookup table, not static.
+      expect(original.staticAccountKeys.map((k) => k.toBase58())).not.toContain(
+        altSupplied.toBase58(),
+      );
+
+      const crafted = craft(v0WithAltMessage(alt), {
+        replacements: new Map([
+          [altSupplied.toBase58(), replacement.toBase58()],
+        ]),
+        addressLookupTableAccounts: [alt],
+      });
+
+      expect(crafted.version).toBe(0);
+      const staticKeys = crafted.staticAccountKeys.map((k) => k.toBase58());
+      expect(staticKeys).toContain(replacement.toBase58());
+
+      const decompiled = TransactionMessage.decompile(crafted, {
+        addressLookupTableAccounts: [alt],
+      });
+      const keys = decompiled.instructions[0]!.keys.map((k) =>
+        k.pubkey.toBase58(),
+      );
+      expect(keys).toContain(replacement.toBase58());
+      expect(keys).not.toContain(altSupplied.toBase58());
+    });
+
+    it("should let explicit pairs override auto-detect entries", () => {
+      const override = new PublicKey(
+        "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+      );
+      const crafted = craft(legacyTransferMessage(), {
+        payer: newPayer.toBase58(),
+        replacements: new Map([[oldPayer.toBase58(), override.toBase58()]]),
+      });
+
+      const keys = crafted.staticAccountKeys.map((k) => k.toBase58());
+      expect(keys).toContain(override.toBase58());
+      expect(keys).not.toContain(newPayer.toBase58());
+    });
+  });
+
+  describe("full transaction input", () => {
+    it("should drop signatures and emit the crafted message", () => {
+      const message = new TransactionMessage({
+        payerKey: oldPayer,
+        recentBlockhash: BLOCKHASH,
+        instructions: [
+          SystemProgram.transfer({
+            fromPubkey: oldPayer,
+            toPubkey: recipient,
+            lamports: 1_000_000,
+          }),
+        ],
+      }).compileToV0Message();
+      const transaction = new VersionedTransaction(message);
+
+      const crafted = craft(toBase64(transaction.serialize()), {
+        payer: newPayer.toBase58(),
+      });
+
+      const keys = crafted.staticAccountKeys.map((k) => k.toBase58());
+      expect(keys).toContain(newPayer.toBase58());
+      expect(keys).not.toContain(oldPayer.toBase58());
+    });
+  });
+
+  describe("errors", () => {
     it("should throw for invalid base64 input", () => {
       expect(() =>
-        crafter.getCraftedTransaction("!!!invalid!!!", newPayer.toBase58()),
+        crafter.getCraftedTransaction("!!!invalid!!!", {
+          payer: newPayer.toBase58(),
+        }),
       ).toThrow();
     });
 
-    it("should throw for invalid base58 payer key", () => {
-      const original = buildLegacyMessageBase64();
+    it("should throw for an invalid base58 payer key", () => {
       expect(() =>
-        crafter.getCraftedTransaction(original, "0OOO_not_base58"),
-      ).toThrow();
+        crafter.getCraftedTransaction(legacyTransferMessage(), {
+          payer: "0OOO_not_base58",
+        }),
+      ).toThrow("Failed to decode public key from base58.");
     });
 
     it("should throw for garbage binary input", () => {
       const garbage = toBase64(new Uint8Array([0, 1, 2, 3]));
       expect(() =>
-        crafter.getCraftedTransaction(garbage, newPayer.toBase58()),
+        crafter.getCraftedTransaction(garbage, { payer: newPayer.toBase58() }),
       ).toThrow();
-    });
-
-    it("should be idempotent when payer is the same", () => {
-      const original = buildLegacyMessageBase64();
-      const crafted = crafter.getCraftedTransaction(
-        original,
-        oldPayer.toBase58(),
-      );
-      expect(crafted).toEqual(original);
-    });
-  });
-
-  describe("decodeShortVec", () => {
-    it("should decode single-byte value", () => {
-      const bytes = new Uint8Array([5]);
-      const result = crafter.decodeShortVec(bytes, 0);
-      expect(result).toEqual({ length: 5, size: 1 });
-    });
-
-    it("should decode multi-byte value", () => {
-      const bytes = new Uint8Array([0x80, 0x01]);
-      const result = crafter.decodeShortVec(bytes, 0);
-      expect(result).toEqual({ length: 128, size: 2 });
-    });
-
-    it("should respect offset", () => {
-      const bytes = new Uint8Array([0xff, 3]);
-      const result = crafter.decodeShortVec(bytes, 1);
-      expect(result).toEqual({ length: 3, size: 1 });
-    });
-
-    it("should throw on overflow", () => {
-      const bytes = new Uint8Array([]);
-      expect(() => crafter.decodeShortVec(bytes, 0)).toThrow(
-        "shortvec decode overflow",
-      );
     });
   });
 });

--- a/packages/tools/solana-tools/src/internal/services/TransactionCrafterService.ts
+++ b/packages/tools/solana-tools/src/internal/services/TransactionCrafterService.ts
@@ -7,8 +7,26 @@ import {
   TOKEN_2022_PROGRAM_ID,
   TOKEN_PROGRAM_ID,
 } from "@solana/spl-token";
-import { PublicKey } from "@solana/web3.js";
+import { type AddressLookupTableAccount, PublicKey } from "@solana/web3.js";
 import bs58 from "bs58";
+
+export type CraftOptions = {
+  /**
+   * base58 payer. When set, seeds auto-detect: the old payer maps to this
+   * payer, and the old payer's ATAs map to this payer's ATAs.
+   */
+  readonly payer?: string;
+  /**
+   * base58 old to new pairs, applied verbatim. Overrides any auto-detect entry
+   * on a key collision.
+   */
+  readonly replacements?: ReadonlyMap<string, string>;
+  /**
+   * Fully-resolved lookup tables from the resolver. Empty for legacy or no-ALT
+   * messages.
+   */
+  readonly addressLookupTableAccounts?: readonly AddressLookupTableAccount[];
+};
 
 type MessageDetection = {
   accountKeysStart: number;

--- a/packages/tools/solana-tools/src/internal/services/TransactionCrafterService.ts
+++ b/packages/tools/solana-tools/src/internal/services/TransactionCrafterService.ts
@@ -1,14 +1,16 @@
-import {
-  base64StringToBuffer,
-  bufferToBase64String,
-} from "@ledgerhq/device-management-kit";
+import { bufferToBase64String } from "@ledgerhq/device-management-kit";
 import {
   getAssociatedTokenAddressSync,
   TOKEN_2022_PROGRAM_ID,
   TOKEN_PROGRAM_ID,
 } from "@solana/spl-token";
-import { type AddressLookupTableAccount, PublicKey } from "@solana/web3.js";
-import bs58 from "bs58";
+import {
+  type AddressLookupTableAccount,
+  PublicKey,
+  TransactionMessage,
+} from "@solana/web3.js";
+
+import { deserializeToMessage } from "./crafter/deserialize";
 
 export type CraftOptions = {
   /**
@@ -28,344 +30,186 @@ export type CraftOptions = {
   readonly addressLookupTableAccounts?: readonly AddressLookupTableAccount[];
 };
 
-type MessageDetection = {
-  accountKeysStart: number;
-  accountCount: number;
-  kind: "legacyMessage" | "v0Message";
-} | null;
-
-type TransactionDetection = {
-  accountKeysStart: number;
-  accountCount: number;
-  signatureSectionStart: number;
-  signatureCount: number;
-  kind: "legacyTx" | "v0Tx";
-} | null;
-
-const PUBLIC_KEY_LENGTH = 32;
+// Solana caps a serialized transaction at this many bytes. A crafted message is
+// never broadcast, but the device rejects anything over the limit, so promoting
+// too many ALT-supplied accounts to static keys is surfaced as a clear error.
+const PACKET_DATA_SIZE = 1232;
 const SIGNATURE_LENGTH = 64;
-const MAX_SIGNATURES = 64;
-const MAX_ACCOUNTS = 256;
 
 export class TransactionCrafterService {
+  /**
+   * Re-point the chosen accounts of a fetched transaction to new addresses and
+   * return the crafted message as base64.
+   *
+   * The input is either a serialized message or a full serialized transaction
+   * (signatures are dropped). The message is decompiled with the supplied
+   * lookup tables, the replacement set is applied on real public keys, and the
+   * message is recompiled. Replaced ALT-supplied accounts fall out of their
+   * tables and are promoted into the static keys; untouched accounts keep using
+   * their tables. The original recent blockhash is reused verbatim so that
+   * durable-nonce values are preserved.
+   *
+   * Synchronous and side-effect free: it never touches the network. Resolved
+   * lookup tables must be passed in via options.addressLookupTableAccounts.
+   */
   public getCraftedTransaction(
     transactionBase64: string,
-    newPayerBase58: string,
+    options: CraftOptions,
   ): string {
-    const rawInput = base64StringToBuffer(transactionBase64);
-    if (rawInput === null) {
-      throw new Error("Input is not a valid base64 string.");
+    const message = deserializeToMessage(transactionBase64);
+    const addressLookupTableAccounts = [
+      ...(options.addressLookupTableAccounts ?? []),
+    ];
+    const isLegacy = message.version === "legacy";
+
+    const txMessage = TransactionMessage.decompile(message, {
+      addressLookupTableAccounts,
+    });
+
+    const oldPayer = txMessage.payerKey;
+    const replacements = this.buildReplacements(txMessage, oldPayer, options);
+
+    for (const instruction of txMessage.instructions) {
+      for (const account of instruction.keys) {
+        const replacement = replacements.get(account.pubkey.toBase58());
+        if (replacement) {
+          // Only the address is swapped. The signer and writable flags are left
+          // untouched on purpose: decompile reconstructed them from the header
+          // and recompile recomputes the header and account ordering.
+          account.pubkey = replacement;
+        }
+      }
     }
 
-    let newPayer: Uint8Array;
-    try {
-      newPayer = bs58.decode(String(newPayerBase58).trim());
-    } catch {
-      throw new Error("Failed to decode public key from base58.");
+    const newPayer = replacements.get(oldPayer.toBase58());
+    if (newPayer) {
+      txMessage.payerKey = newPayer;
     }
 
-    if (newPayer.length !== PUBLIC_KEY_LENGTH) {
+    const crafted = isLegacy
+      ? txMessage.compileToLegacyMessage()
+      : txMessage.compileToV0Message(addressLookupTableAccounts);
+
+    const serialized = crafted.serialize();
+
+    // The full transaction is the message plus its signature section. Check it
+    // against the packet limit so an oversized craft fails here rather than on
+    // the device.
+    const transactionSize =
+      1 +
+      crafted.header.numRequiredSignatures * SIGNATURE_LENGTH +
+      serialized.length;
+    if (transactionSize > PACKET_DATA_SIZE) {
       throw new Error(
-        `Provided public key is not ${PUBLIC_KEY_LENGTH} bytes after base58 decode.`,
+        `Crafted transaction is ${transactionSize} bytes, over the ${PACKET_DATA_SIZE}-byte limit. Re-pointing fewer ALT-supplied accounts keeps more of them in their lookup tables.`,
       );
     }
 
-    const output = new Uint8Array(rawInput.length);
-    output.set(rawInput);
-
-    const transactionInfo = this.detectTransaction(rawInput);
-    if (transactionInfo) {
-      this.applyReplacements(
-        output,
-        rawInput,
-        transactionInfo.accountKeysStart,
-        transactionInfo.accountCount,
-        newPayer,
-      );
-      output.fill(
-        0,
-        transactionInfo.signatureSectionStart,
-        transactionInfo.signatureSectionStart +
-          transactionInfo.signatureCount * SIGNATURE_LENGTH,
-      );
-      return bufferToBase64String(output);
-    }
-
-    const msgInfo = this.detectMessage(rawInput);
-    if (msgInfo) {
-      this.applyReplacements(
-        output,
-        rawInput,
-        msgInfo.accountKeysStart,
-        msgInfo.accountCount,
-        newPayer,
-      );
-      return bufferToBase64String(output);
-    }
-
-    throw new Error(
-      "Input is neither a valid legacy/v0 message nor a legacy/v0 transaction.",
-    );
+    return bufferToBase64String(serialized);
   }
 
-  private applyReplacements(
-    output: Uint8Array,
-    rawInput: Uint8Array,
-    accountKeysStart: number,
-    accountCount: number,
-    newPayer: Uint8Array,
-  ): void {
-    const accountKeys: Uint8Array[] = [];
-    for (let i = 0; i < accountCount; i++) {
-      const start = accountKeysStart + i * PUBLIC_KEY_LENGTH;
-      accountKeys.push(rawInput.slice(start, start + PUBLIC_KEY_LENGTH));
+  private buildReplacements(
+    txMessage: TransactionMessage,
+    oldPayer: PublicKey,
+    options: CraftOptions,
+  ): Map<string, PublicKey> {
+    const replacements = new Map<string, PublicKey>();
+
+    // Auto-detect mode seeds the map from the payer: the old payer and its ATAs
+    // point at the new payer and its ATAs.
+    if (options.payer !== undefined) {
+      const newPayer = this.decodePublicKey(options.payer);
+      replacements.set(oldPayer.toBase58(), newPayer);
+      this.seedAtaReplacements(txMessage, oldPayer, newPayer, replacements);
     }
 
-    const oldPayerBytes = accountKeys[0]!;
-    const oldPayerPK = new PublicKey(oldPayerBytes);
-    const newPayerPK = new PublicKey(newPayer);
+    // Explicit pairs are applied verbatim and override auto-detect entries on a
+    // key collision. The caller supplies the new address directly, so any
+    // account (including user-seeded PDAs) can be re-pointed this way.
+    if (options.replacements) {
+      for (const [oldKey, newKey] of options.replacements) {
+        // Validate both ends so a bad pair fails here with a clear message.
+        this.decodePublicKey(oldKey);
+        replacements.set(oldKey, this.decodePublicKey(newKey));
+      }
+    }
 
-    const replacements: Map<number, Uint8Array> = new Map();
+    return replacements;
+  }
 
-    for (let i = 0; i < accountCount; i++) {
-      const offset = accountKeysStart + i * PUBLIC_KEY_LENGTH;
-      const key = accountKeys[i]!;
+  private seedAtaReplacements(
+    txMessage: TransactionMessage,
+    oldPayer: PublicKey,
+    newPayer: PublicKey,
+    replacements: Map<string, PublicKey>,
+  ): void {
+    const accounts = this.collectAccounts(txMessage);
 
-      if (this.bytesEqual(key, oldPayerBytes)) {
-        replacements.set(offset, newPayer);
+    for (const account of accounts) {
+      if (account.equals(oldPayer)) {
+        continue;
+      }
+      if (replacements.has(account.toBase58())) {
         continue;
       }
 
-      this.detectAndReplaceATA(
-        key,
-        offset,
-        accountKeys,
-        oldPayerPK,
-        newPayerPK,
-        replacements,
-      );
-    }
-
-    for (const [offset, bytes] of replacements) {
-      output.set(bytes, offset);
-    }
-  }
-
-  private detectAndReplaceATA(
-    key: Uint8Array,
-    offset: number,
-    accountKeys: Uint8Array[],
-    oldPayer: PublicKey,
-    newPayer: PublicKey,
-    replacements: Map<number, Uint8Array>,
-  ): void {
-    const keyPK = new PublicKey(key);
-    for (const candidateMintBytes of accountKeys) {
-      const candidateMint = new PublicKey(candidateMintBytes);
-      for (const tokenProgram of [TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID]) {
-        try {
-          const expectedATA = getAssociatedTokenAddressSync(
-            candidateMint,
-            oldPayer,
-            true,
-            tokenProgram,
-          );
-          if (expectedATA.equals(keyPK)) {
-            const newATA = getAssociatedTokenAddressSync(
-              candidateMint,
-              newPayer,
+      // Test every account as a candidate mint, for both token programs: an ATA
+      // of the old payer for a referenced mint is re-pointed to the new payer's
+      // ATA for that same mint.
+      for (const mint of accounts) {
+        for (const tokenProgram of [TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID]) {
+          try {
+            const oldAta = getAssociatedTokenAddressSync(
+              mint,
+              oldPayer,
               true,
               tokenProgram,
             );
-            replacements.set(offset, newATA.toBytes());
-            return;
+            if (oldAta.equals(account)) {
+              const newAta = getAssociatedTokenAddressSync(
+                mint,
+                newPayer,
+                true,
+                tokenProgram,
+              );
+              replacements.set(account.toBase58(), newAta);
+            }
+          } catch {
+            // Not a valid ATA derivation for this mint and token program.
           }
-        } catch {
-          /* not a valid derivation for this combo */
         }
       }
     }
   }
 
-  private bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
-    if (a.length !== b.length) return false;
-    for (let i = 0; i < a.length; i++) {
-      if (a[i] !== b[i]) return false;
-    }
-    return true;
-  }
+  private collectAccounts(txMessage: TransactionMessage): PublicKey[] {
+    const seen = new Set<string>();
+    const accounts: PublicKey[] = [];
 
-  decodeShortVec(
-    bytes: Uint8Array,
-    offset: number,
-  ): { length: number; size: number } {
-    let value = 0;
-    let size = 0;
-    let shift = 0;
-
-    while (true) {
-      const byte = bytes[offset + size];
-      if (byte === undefined) {
-        throw new Error("shortvec decode overflow");
+    const add = (publicKey: PublicKey): void => {
+      const key = publicKey.toBase58();
+      if (!seen.has(key)) {
+        seen.add(key);
+        accounts.push(publicKey);
       }
+    };
 
-      value |= (byte & 0x7f) << shift;
-      size += 1;
-
-      if ((byte & 0x80) === 0) {
-        break;
-      }
-
-      shift += 7;
-
-      if (shift >= 35) {
-        throw new Error("shortvec too long");
+    add(txMessage.payerKey);
+    for (const instruction of txMessage.instructions) {
+      add(instruction.programId);
+      for (const account of instruction.keys) {
+        add(account.pubkey);
       }
     }
 
-    return { length: value, size };
+    return accounts;
   }
 
-  private tryDecodeShortVec(
-    bytes: Uint8Array,
-    offset: number,
-  ): { length: number; size: number } | null {
+  private decodePublicKey(value: string): PublicKey {
     try {
-      return this.decodeShortVec(bytes, offset);
+      return new PublicKey(value.trim());
     } catch {
-      return null;
+      throw new Error("Failed to decode public key from base58.");
     }
-  }
-
-  private locatePayerInMessage(
-    bytes: Uint8Array,
-    messageOffset: number,
-    opts: { versioned: boolean },
-  ) {
-    let cursor = messageOffset;
-
-    if (opts.versioned) {
-      const versionByte = bytes[cursor];
-      if (versionByte === undefined || (versionByte & 0x80) === 0) return null;
-
-      const version = versionByte & 0x7f;
-      if (version !== 0) return null;
-
-      cursor += 1;
-    } else {
-      const first = bytes[cursor];
-      if (first === undefined) return null;
-
-      if ((first & 0x80) !== 0) return null;
-    }
-
-    if (cursor + 3 > bytes.length) return null;
-
-    const requiredSignatures = bytes[cursor];
-    const numReadonlySigned = bytes[cursor + 1];
-    const numReadonlyUnsigned = bytes[cursor + 2];
-
-    if (requiredSignatures === undefined) return null;
-
-    if (requiredSignatures < 1) return null;
-
-    cursor += 3;
-
-    const accountCountInfo = this.tryDecodeShortVec(bytes, cursor);
-    if (!accountCountInfo) return null;
-
-    const { length: accountCount, size: accountLenSize } = accountCountInfo;
-
-    if (accountCount < 1 || accountCount > MAX_ACCOUNTS) return null;
-
-    if (requiredSignatures > accountCount) return null;
-
-    cursor += accountLenSize;
-
-    const accountKeysStart = cursor;
-    const accountKeysBytes = accountCount * PUBLIC_KEY_LENGTH;
-
-    if (
-      accountKeysStart + accountKeysBytes + PUBLIC_KEY_LENGTH >
-      bytes.length
-    ) {
-      return null;
-    }
-
-    return {
-      payerOffset: accountKeysStart,
-      requiredSignatures,
-      numReadonlySigned,
-      numReadonlyUnsigned,
-      accountCount,
-    };
-  }
-
-  private locateMessageInfo(bytes: Uint8Array, messageOffset: number) {
-    const v0 = this.locatePayerInMessage(bytes, messageOffset, {
-      versioned: true,
-    });
-    if (v0) {
-      return {
-        accountKeysStart: v0.payerOffset,
-        accountCount: v0.accountCount,
-        kind: "v0" as const,
-      };
-    }
-
-    const legacy = this.locatePayerInMessage(bytes, messageOffset, {
-      versioned: false,
-    });
-    if (legacy) {
-      return {
-        accountKeysStart: legacy.payerOffset,
-        accountCount: legacy.accountCount,
-        kind: "legacy" as const,
-      };
-    }
-
-    return null;
-  }
-
-  private detectMessage(bytes: Uint8Array): MessageDetection {
-    const info = this.locateMessageInfo(bytes, 0);
-    if (!info) return null;
-    return {
-      accountKeysStart: info.accountKeysStart,
-      accountCount: info.accountCount,
-      kind: info.kind === "v0" ? "v0Message" : "legacyMessage",
-    };
-  }
-
-  private detectTransaction(bytes: Uint8Array): TransactionDetection {
-    let cursor = 0;
-
-    const signatureInfo = this.tryDecodeShortVec(bytes, cursor);
-    if (!signatureInfo) return null;
-
-    const { length: signatureCount, size: signatureLengthSize } = signatureInfo;
-
-    if (signatureCount < 1 || signatureCount > MAX_SIGNATURES) {
-      return null;
-    }
-
-    cursor += signatureLengthSize;
-
-    const signaturesStart = cursor;
-    const signaturesBytes = signatureCount * SIGNATURE_LENGTH;
-    const messageOffset = signaturesStart + signaturesBytes;
-
-    if (messageOffset > bytes.length) return null;
-
-    const info = this.locateMessageInfo(bytes, messageOffset);
-    if (!info) return null;
-
-    return {
-      accountKeysStart: info.accountKeysStart,
-      accountCount: info.accountCount,
-      signatureSectionStart: signaturesStart,
-      signatureCount,
-      kind: info.kind === "v0" ? "v0Tx" : "legacyTx",
-    };
   }
 }

--- a/packages/tools/solana-tools/src/internal/services/crafter/deserialize.test.ts
+++ b/packages/tools/solana-tools/src/internal/services/crafter/deserialize.test.ts
@@ -1,0 +1,125 @@
+import {
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+
+function toBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64");
+}
+
+function fromBase64(str: string): Uint8Array {
+  return new Uint8Array(Buffer.from(str, "base64"));
+}
+
+vi.mock("@ledgerhq/device-management-kit", () => ({
+  base64StringToBuffer: (value: string): Uint8Array | null => {
+    if (!value || !/^[A-Za-z0-9+/]*={0,2}$/.test(value)) return null;
+    return fromBase64(value);
+  },
+}));
+
+import { deserializeToMessage } from "./deserialize";
+
+const payer = new PublicKey("2cHm11EeTGQixAkyaqNRFczpi1XB1n6rK7bSwNiZbCdB");
+const recipient = new PublicKey("7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2");
+const recentBlockhash = "a3PD566oU2nE9JHwuC897aaT7ispdqaQ63Si6jzyKAg";
+
+function transferInstruction() {
+  return SystemProgram.transfer({
+    fromPubkey: payer,
+    toPubkey: recipient,
+    lamports: 1_000_000,
+  });
+}
+
+function buildLegacyMessageBytes(): Uint8Array {
+  const tx = new Transaction({ recentBlockhash, feePayer: payer });
+  tx.add(transferInstruction());
+  return new Uint8Array(tx.serializeMessage());
+}
+
+function buildLegacyTransactionBytes(): Uint8Array {
+  const tx = new Transaction({ recentBlockhash, feePayer: payer });
+  tx.add(transferInstruction());
+  tx.signatures = [{ publicKey: payer, signature: null }];
+  return new Uint8Array(
+    tx.serialize({ requireAllSignatures: false, verifySignatures: false }),
+  );
+}
+
+function buildV0MessageBytes(): Uint8Array {
+  const message = new TransactionMessage({
+    payerKey: payer,
+    recentBlockhash,
+    instructions: [transferInstruction()],
+  }).compileToV0Message();
+  return message.serialize();
+}
+
+function buildV0TransactionBytes(): Uint8Array {
+  const message = new TransactionMessage({
+    payerKey: payer,
+    recentBlockhash,
+    instructions: [transferInstruction()],
+  }).compileToV0Message();
+  return new VersionedTransaction(message).serialize();
+}
+
+describe("deserializeToMessage", () => {
+  it("deserializes a legacy message and round-trips it byte-for-byte", () => {
+    const bytes = buildLegacyMessageBytes();
+
+    const message = deserializeToMessage(toBase64(bytes));
+
+    expect(message.version).toBe("legacy");
+    expect(new Uint8Array(message.serialize())).toEqual(bytes);
+  });
+
+  it("deserializes a v0 message and round-trips it byte-for-byte", () => {
+    const bytes = buildV0MessageBytes();
+
+    const message = deserializeToMessage(toBase64(bytes));
+
+    expect(message.version).toBe(0);
+    expect(new Uint8Array(message.serialize())).toEqual(bytes);
+  });
+
+  it("returns the inner message of a full legacy transaction, dropping signatures", () => {
+    const txBytes = buildLegacyTransactionBytes();
+    const messageBytes = buildLegacyMessageBytes();
+
+    const message = deserializeToMessage(toBase64(txBytes));
+
+    expect(message.version).toBe("legacy");
+    expect(new Uint8Array(message.serialize())).toEqual(messageBytes);
+    expect(message.serialize().length).toBeLessThan(txBytes.length);
+  });
+
+  it("returns the inner message of a full v0 transaction, dropping signatures", () => {
+    const txBytes = buildV0TransactionBytes();
+    const messageBytes = buildV0MessageBytes();
+
+    const message = deserializeToMessage(toBase64(txBytes));
+
+    expect(message.version).toBe(0);
+    expect(new Uint8Array(message.serialize())).toEqual(messageBytes);
+    expect(message.serialize().length).toBeLessThan(txBytes.length);
+  });
+
+  it("throws on input that is not valid base64", () => {
+    expect(() => deserializeToMessage("!!!not base64!!!")).toThrow(
+      "Input is not a valid base64 string.",
+    );
+  });
+
+  it("throws on base64 that is neither a message nor a transaction", () => {
+    const garbage = toBase64(new Uint8Array([0xff, 0xff, 0xff, 0xff]));
+
+    expect(() => deserializeToMessage(garbage)).toThrow(
+      "Input is neither a valid serialized message nor a valid serialized transaction.",
+    );
+  });
+});

--- a/packages/tools/solana-tools/src/internal/services/crafter/deserialize.ts
+++ b/packages/tools/solana-tools/src/internal/services/crafter/deserialize.ts
@@ -1,0 +1,76 @@
+import { base64StringToBuffer } from "@ledgerhq/device-management-kit";
+import { VersionedMessage, VersionedTransaction } from "@solana/web3.js";
+
+/**
+ * Branch on the input kind and return the message to operate on.
+ *
+ * Accepts either a serialized VersionedMessage (legacy or v0) or a full
+ * serialized VersionedTransaction. For a full transaction the signatures are
+ * dropped and only `message` is returned: the craft path always recompiles
+ * into a fresh message, which carries no signatures.
+ *
+ * Detection is structural and confirmed by re-serialization. A candidate shape
+ * is accepted only when serializing it back produces the original bytes, which
+ * tells a bare message apart from a full transaction without guessing from the
+ * leading bytes alone.
+ *
+ * Throws when the input is not valid base64, or when it matches neither shape.
+ */
+export function deserializeToMessage(
+  transactionBase64: string,
+): VersionedMessage {
+  const bytes = base64StringToBuffer(transactionBase64);
+  if (bytes === null) {
+    throw new Error("Input is not a valid base64 string.");
+  }
+
+  const fromTransaction = tryDeserializeTransaction(bytes);
+  if (fromTransaction !== null) {
+    return fromTransaction;
+  }
+
+  const fromMessage = tryDeserializeMessage(bytes);
+  if (fromMessage !== null) {
+    return fromMessage;
+  }
+
+  throw new Error(
+    "Input is neither a valid serialized message nor a valid serialized transaction.",
+  );
+}
+
+function tryDeserializeTransaction(bytes: Uint8Array): VersionedMessage | null {
+  try {
+    const transaction = VersionedTransaction.deserialize(bytes);
+    if (bytesEqual(transaction.serialize(), bytes)) {
+      return transaction.message;
+    }
+  } catch {
+    // Not a full transaction, fall through to the bare-message branch.
+  }
+  return null;
+}
+
+function tryDeserializeMessage(bytes: Uint8Array): VersionedMessage | null {
+  try {
+    const message = VersionedMessage.deserialize(bytes);
+    if (bytesEqual(message.serialize(), bytes)) {
+      return message;
+    }
+  } catch {
+    // Not a bare message either.
+  }
+  return null;
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/tools/solana-tools/src/internal/services/di/servicesTypes.ts
+++ b/packages/tools/solana-tools/src/internal/services/di/servicesTypes.ts
@@ -1,3 +1,4 @@
 export const servicesTypes = {
   TransactionFetcherService: Symbol.for("TransactionFetcherService"),
+  AltResolverService: Symbol.for("AltResolverService"),
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Rewrites `TransactionCrafterService` so it stops doing byte surgery on the static account-keys array and instead operates on real `PublicKey`s: **deserialize => decompile => replace => recompile** via `@solana/web3.js`.

This is Ticket 2 of the ALT-aware crafter epic. The engine is **pure and synchronous**, it never touches the network. It receives already-resolved lookup tables through `CraftOptions.addressLookupTableAccounts` (the resolver and its wiring land in Tickets 1 and 3).

What changed:
  
  - **New signature** (frozen contract): `getCraftedTransaction(transactionBase64, CraftOptions)` replaces the old `getCraftedTransaction(tx, newPayerBase58)` positional form. `CraftOptions` carries `payer`, an explicit `replacements` map, and `addressLookupTableAccounts`.
  - **Input branching** via the shared `deserializeToMessage` helper: a bare serialised message or a full `VersionedTransaction` (signatures dropped).
  - **Auto-detect mode**: old payer to new payer, plus the old payer's ATAs to the new payer's ATAs, over the resolved account set, for both TOKEN and TOKEN-2022.
  - **Explicit-map mode**: caller-supplied `old to new` pairs applied verbatim, overriding auto-detect entries on a key collision, this also covers user-seeded PDAs, which cannot be auto-derived.
  - **ALT-supplied accounts**: a replaced address falls out of its lookup table and is promoted into the static keys on recompile, untouched accounts keep using their tables.
  - **Blockhash preserved verbatim** (durable-nonce safe). Signer/writable flags are left to `web3.js` (decompile reconstructs them, recompile recomputes the header), never set manually.
  - **Size guard**: throws a clear error when the crafted transaction exceeds the 1232-byte packet limit, instead of failing opaquely on the device.
  - Removes the manual shortvec/byte-offset parsing (`detectTransaction`/`detectMessage`/`applyReplacements`).

The only caller (`CraftTransactionDeviceAction`) is updated to the new options shape, full resolver + `replacements` wiring is Ticket 3.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [DSDK-1296](https://ledgerhq.atlassian.net/browse/DSDK-1296)

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
