### PR TITLE
✨ (signer-zcash) [LIVE-31200]: Add PCZT Orchard shielded signing

### DIFF
--- a/.changeset/zcash-pczt-orchard-signing.md
+++ b/.changeset/zcash-pczt-orchard-signing.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-zcash": minor
+---
+
+Add PCZT Orchard shielded signing. A new `signPcztTransaction` method streams the PCZT bundle (header, transparent inputs/outputs, Orchard actions) to the device and returns the per-action Orchard `spendAuthSig`s and per-input transparent signatures. The legacy transparent `signTransaction` path is unchanged.

--- a/apps/docs/pages/docs/references/signers/zcash.mdx
+++ b/apps/docs/pages/docs/references/signers/zcash.mdx
@@ -329,7 +329,7 @@ type SignPcztTransactionResult = {
 };
 ```
 
-  There is no `bindingSig` in the result — it is computed host-side from `bsk = Σ rcv`. On `Pending`, `requiredUserInteraction` is `UserInteractionRequired.SignTransaction`.
+There is no `bindingSig` in the result — it is computed host-side from `bsk = Σ rcv`. On `Pending`, `requiredUserInteraction` is `UserInteractionRequired.SignTransaction`.
 
 - `cancel` A function to cancel the action on the Ledger device.
 

--- a/apps/docs/pages/docs/references/signers/zcash.mdx
+++ b/apps/docs/pages/docs/references/signers/zcash.mdx
@@ -18,7 +18,8 @@ This module provides the implementation of the Ledger zcash signer of the Device
    - [Get Address](#use-case-2-get-address)
    - [Get Full Viewing Key](#use-case-3-get-full-viewing-key)
    - [Sign Transaction](#use-case-4-sign-transaction)
-   - [Sign Message](#use-case-5-sign-message)
+   - [Sign PCZT Transaction](#use-case-5-sign-pczt-transaction)
+   - [Sign Message](#use-case-6-sign-message)
 5. [Observable Behavior](#-observable-behavior)
 6. [Example](#-example)
 
@@ -232,7 +233,109 @@ type Signature = {
 
 ---
 
-### Use Case 5: Sign Message
+### Use Case 5: Sign PCZT Transaction
+
+This method signs an Orchard **shielded** transaction expressed as a PCZT (Partially Constructed Zcash Transaction). The host (zcash-utils) builds the PCZT and passes the structured `PcztTransaction` to the signer, which streams the header, transparent inputs/outputs, and Orchard actions to the device. The device returns the raw per-action Orchard `spendAuthSig`s and per-input transparent signatures; the binding signature and final transaction assembly are computed host-side and never involve the device. The legacy transparent `signTransaction` path is unchanged.
+
+```typescript
+const { observable, cancel } = signerZcash.signPcztTransaction(
+  transaction,
+  options,
+);
+```
+
+#### **Parameters**
+
+- `transaction`
+
+  - **Required**
+  - **Type:** `PcztTransaction`
+  - The structured PCZT to sign. Transparent sections are always streamed (count `0` when empty); `orchardBundle` may be `null` (treated as an empty Orchard bundle). All multi-byte integer fields are little-endian on the wire, except derivation-path components (big-endian `Bip32Path`).
+
+    ```typescript
+    type PcztTransaction = {
+      global: PcztGlobal;
+      transparentInputs: PcztTransparentInput[];
+      transparentOutputs: PcztTransparentOutput[];
+      orchardBundle: PcztOrchardBundle | null;
+    };
+
+    type PcztGlobal = {
+      txVersion: number; // V5 = 5
+      versionGroupId: number;
+      consensusBranchId: number;
+      fallbackLockTime: number | null; // Option<u32>; null = absent
+      expiryHeight: number;
+      coinType: number; // 133 mainnet, 1 testnet
+      txModifiable: number;
+    };
+
+    type PcztBip32Derivation = {
+      signingPath: string;
+      pubkey: Uint8Array; // compressed secp256k1, 33 bytes
+      seedFingerprint?: Uint8Array; // ZIP-32, 32 bytes
+    };
+
+    type PcztTransparentInput = {
+      prevoutTxid: Uint8Array; // 32 bytes
+      prevoutIndex: number;
+      sequence: number | null; // Option<u32>; null = absent
+      value: bigint; // zatoshis
+      scriptPubKey: Uint8Array;
+      sighashType: number; // must be SIGHASH_ALL (0x01)
+      derivation: PcztBip32Derivation;
+    };
+
+    type PcztTransparentOutput = {
+      value: bigint; // zatoshis
+      scriptPubKey: Uint8Array;
+      derivation?: PcztBip32Derivation | null; // entry count 0 or 1
+    };
+
+    type PcztOrchardBundle = {
+      actions: PcztOrchardAction[];
+      flags: number;
+      valueBalance: bigint; // net value balance, zatoshis (signed)
+      anchor: Uint8Array; // commitment-tree anchor, 32 bytes
+    };
+    ```
+
+    Each `PcztOrchardAction` carries the spend and output halves of one Orchard action (value/nullifier/rk commitments, spent- and output-note fields, the host-supplied spend-auth randomizer `alpha`, the signing `signingPath`, and the randomized commitment value `rcv`). See the `PcztOrchardAction` type exported from `@ledgerhq/device-signer-kit-zcash` for the full field list.
+
+- `options`
+
+  - Optional
+  - Type: `TransactionOptions`
+
+    ```typescript
+    type TransactionOptions = {
+      skipOpenApp?: boolean;
+    };
+    ```
+
+  - `skipOpenApp`: An optional boolean indicating whether to skip opening the zcash app automatically (`true`) or not (`false`).
+
+#### **Returns**
+
+- `observable` Emits DeviceActionState updates. The final output is:
+
+```typescript
+type SignPcztTransactionResult = {
+  // one spendAuthSig per Orchard action, in action order
+  orchard: Array<{ spendAuthSig: Uint8Array }>; // RedPallas sig, 64 bytes each
+  // one signature per transparent input, in input order:
+  // DER-encoded secp256k1 signature + trailing sighash_type byte (0x01)
+  transparentInputSigs: Uint8Array[];
+};
+```
+
+  There is no `bindingSig` in the result — it is computed host-side from `bsk = Σ rcv`. On `Pending`, `requiredUserInteraction` is `UserInteractionRequired.SignTransaction`.
+
+- `cancel` A function to cancel the action on the Ledger device.
+
+---
+
+### Use Case 6: Sign Message
 
 This method allows users to sign a text string that is displayed on Ledger devices.
 

--- a/apps/sample/src/components/SignerZcashView/index.tsx
+++ b/apps/sample/src/components/SignerZcashView/index.tsx
@@ -618,6 +618,20 @@ const parseBigint = (value: string | number, fieldName: string): bigint => {
   }
 };
 
+const parseRequiredNumber = (
+  value: number | string | undefined | null,
+  fieldName: string,
+): number => {
+  if (value === undefined || value === null) {
+    throw new Error(`${fieldName} is required`);
+  }
+  const n = Number(value);
+  if (!Number.isFinite(n)) {
+    throw new Error(`Invalid number for ${fieldName}: ${String(value)}`);
+  }
+  return n;
+};
+
 const toNumberOrNull = (value: number | null | undefined): number | null =>
   value === null || value === undefined ? null : Number(value);
 
@@ -714,13 +728,19 @@ const parsePcztTransaction = (value: string): PcztTransaction => {
 
   const g = parsed.global ?? {};
   const global: PcztGlobal = {
-    txVersion: Number(g.txVersion),
-    versionGroupId: Number(g.versionGroupId),
-    consensusBranchId: Number(g.consensusBranchId),
+    txVersion: parseRequiredNumber(g.txVersion, "global.txVersion"),
+    versionGroupId: parseRequiredNumber(
+      g.versionGroupId,
+      "global.versionGroupId",
+    ),
+    consensusBranchId: parseRequiredNumber(
+      g.consensusBranchId,
+      "global.consensusBranchId",
+    ),
     fallbackLockTime: toNumberOrNull(g.fallbackLockTime),
-    expiryHeight: Number(g.expiryHeight),
-    coinType: Number(g.coinType),
-    txModifiable: Number(g.txModifiable),
+    expiryHeight: parseRequiredNumber(g.expiryHeight, "global.expiryHeight"),
+    coinType: parseRequiredNumber(g.coinType, "global.coinType"),
+    txModifiable: parseRequiredNumber(g.txModifiable, "global.txModifiable"),
   };
 
   const transparentInputs: PcztTransparentInput[] = (
@@ -730,14 +750,20 @@ const parsePcztTransaction = (value: string): PcztTransaction => {
       input.prevoutTxid,
       `transparentInputs[${i}].prevoutTxid`,
     ),
-    prevoutIndex: Number(input.prevoutIndex),
+    prevoutIndex: parseRequiredNumber(
+      input.prevoutIndex,
+      `transparentInputs[${i}].prevoutIndex`,
+    ),
     sequence: toNumberOrNull(input.sequence),
     value: parseBigint(input.value, `transparentInputs[${i}].value`),
     scriptPubKey: parseHexBytes(
       input.scriptPubKey,
       `transparentInputs[${i}].scriptPubKey`,
     ),
-    sighashType: Number(input.sighashType),
+    sighashType: parseRequiredNumber(
+      input.sighashType,
+      `transparentInputs[${i}].sighashType`,
+    ),
     derivation: parseDerivation(
       input.derivation,
       `transparentInputs[${i}].derivation`,
@@ -815,7 +841,10 @@ const parsePcztTransaction = (value: string): PcztTransaction => {
             rcv: parseHexBytes(action.rcv, `orchard[${i}].rcv`),
           }),
         ),
-        flags: Number(parsed.orchardBundle.flags),
+        flags: parseRequiredNumber(
+          parsed.orchardBundle.flags,
+          "orchardBundle.flags",
+        ),
         valueBalance: parseBigint(
           parsed.orchardBundle.valueBalance,
           "orchardBundle.valueBalance",

--- a/apps/sample/src/components/SignerZcashView/index.tsx
+++ b/apps/sample/src/components/SignerZcashView/index.tsx
@@ -15,9 +15,19 @@ import {
   type GetTrustedInputDAOutput,
   type LegacyCreateTransactionArg,
   type LegacyTransaction,
+  type PcztBip32Derivation,
+  type PcztGlobal,
+  type PcztOrchardAction,
+  type PcztOrchardBundle,
+  type PcztTransaction,
+  type PcztTransparentInput,
+  type PcztTransparentOutput,
   type SignMessageDAError,
   type SignMessageDAIntermediateValue,
   type SignMessageDAOutput,
+  type SignPcztTransactionDAError,
+  type SignPcztTransactionDAIntermediateValue,
+  type SignPcztTransactionDAOutput,
   type SignTransactionDAError,
   type SignTransactionDAIntermediateValue,
   type SignTransactionDAOutput,
@@ -518,6 +528,352 @@ const buildSignTransactionArg = (
   };
 };
 
+// --- PCZT (Orchard shielded) signing ---------------------------------------
+
+type SignPcztInput = {
+  pcztJson: string;
+  skipOpenApp: boolean;
+};
+
+const fillHex = (length: number, fill: number): string =>
+  fill.toString(16).padStart(2, "0").repeat(length);
+
+/**
+ * Default PCZT payload: the real Orchard→transparent vector from app-zcash
+ * `tests/standalone/test_pczt.py::test_pczt_sign_tx_v5_orchard_to_transparent_simple`
+ * (one Orchard spend into one transparent output). Unlike synthetic fill-byte
+ * fixtures — which the device accepts on the transparent path but rejects on the
+ * Orchard path (`0x6a80`, the Orchard notes are cryptographically validated) —
+ * this vector signs successfully on a real/Speculos device. With Speculos run as
+ * the functional tests do (`--deterministic-rng zcash-standalone-tests`), the
+ * returned `spendAuthSig` is exactly
+ * `c9c9c463…0820`.
+ */
+const DEFAULT_PCZT_JSON = JSON.stringify(
+  {
+    global: {
+      txVersion: 5,
+      versionGroupId: 0x26a7270a,
+      consensusBranchId: 0xc2d6d0b4,
+      fallbackLockTime: 0,
+      expiryHeight: 0,
+      coinType: 133,
+      txModifiable: 0,
+    },
+    transparentInputs: [],
+    transparentOutputs: [
+      {
+        value: "290000",
+        scriptPubKey: "76a914424242424242424242424242424242424242424288ac",
+        derivation: null,
+      },
+    ],
+    orchardBundle: {
+      actions: [
+        {
+          cvNet:
+            "24631b59abdde690d7e6b62cfeac6619efb7753dc873d9dbfdd4af58f0c50e98",
+          nullifier:
+            "2e552e9315c89ecbf8016a8dfaa325ef90dedc59df4b0a42e5ff5cee0bbed821",
+          // rk consistent with alpha = (1).to_bytes(32, "little")
+          rk: "e95982b73ab0c2137ec354cce448a75ef39ec0cbdf6907be6df3495297834f89",
+          spendRecipient:
+            "4a6414bb6f09e4a89469663a081fc2646c083708f552597d524b2f1812272e472d2b28f7414ece124ddf02",
+          spendValue: "300000",
+          spendRho:
+            "0400000000000000000000000000000000000000000000000000000000000000",
+          spendRseed:
+            "1800000000000000000000000000000000000000000000000000000000000000",
+          alpha:
+            "0100000000000000000000000000000000000000000000000000000000000000",
+          signingPath: "32'/133'/0'",
+          seedFingerprint: fillHex(32, 0x00),
+          cmx: "f4f6493954ecd47be87e5fdebb99db614dfaf1825717f23c4b0438688d831a04",
+          ephemeralKey: fillHex(32, 0x00),
+          encCiphertext: fillHex(580, 0x00),
+          outCiphertext: fillHex(80, 0x00),
+          recipient:
+            "ede3d2ce08c11d8c5c7bfe6814cedafd96c160c3d879cb270946f1ab6fdf442a15648d7c0b3c9fd052e20a",
+          value: "0",
+          rseed:
+            "2c00000000000000000000000000000000000000000000000000000000000000",
+          rcv: "4000000000000000000000000000000000000000000000000000000000000000",
+        },
+      ],
+      flags: 3,
+      valueBalance: "300000",
+      anchor:
+        "699c780066f179ff12b26a5ec5b1af3d418eb0eadec3d3b18f10c91d97b33109",
+    },
+  },
+  null,
+  2,
+);
+
+const parseBigint = (value: string | number, fieldName: string): bigint => {
+  try {
+    return BigInt(value);
+  } catch {
+    throw new Error(`Invalid integer for ${fieldName}`);
+  }
+};
+
+const toNumberOrNull = (value: number | null | undefined): number | null =>
+  value === null || value === undefined ? null : Number(value);
+
+const parseDerivation = (
+  raw: { signingPath: string; pubkey: string; seedFingerprint?: string },
+  prefix: string,
+): PcztBip32Derivation => ({
+  signingPath: raw.signingPath,
+  pubkey: parseHexBytes(raw.pubkey, `${prefix}.pubkey`),
+  ...(raw.seedFingerprint
+    ? {
+        seedFingerprint: parseHexBytes(
+          raw.seedFingerprint,
+          `${prefix}.seedFingerprint`,
+        ),
+      }
+    : {}),
+});
+
+type RawPcztDerivation = {
+  signingPath: string;
+  pubkey: string;
+  seedFingerprint?: string;
+};
+
+type RawPcztTransparentInput = {
+  prevoutTxid: string;
+  prevoutIndex: number | string;
+  sequence?: number | null;
+  value: number | string;
+  scriptPubKey: string;
+  sighashType: number | string;
+  derivation: RawPcztDerivation;
+};
+
+type RawPcztTransparentOutput = {
+  value: number | string;
+  scriptPubKey: string;
+  derivation?: RawPcztDerivation | null;
+};
+
+type RawPcztOrchardAction = {
+  cvNet: string;
+  nullifier: string;
+  rk: string;
+  spendRecipient: string;
+  spendValue: number | string;
+  spendRho: string;
+  spendRseed: string;
+  alpha: string;
+  signingPath: string;
+  seedFingerprint?: string;
+  cmx: string;
+  ephemeralKey: string;
+  encCiphertext: string;
+  outCiphertext: string;
+  recipient: string;
+  value: number | string;
+  rseed: string;
+  rcv: string;
+};
+
+type RawPcztJson = {
+  global?: {
+    txVersion?: number | string;
+    versionGroupId?: number | string;
+    consensusBranchId?: number | string;
+    fallbackLockTime?: number | null;
+    expiryHeight?: number | string;
+    coinType?: number | string;
+    txModifiable?: number | string;
+  };
+  transparentInputs?: RawPcztTransparentInput[];
+  transparentOutputs?: RawPcztTransparentOutput[];
+  orchardBundle?: {
+    actions?: RawPcztOrchardAction[];
+    flags: number | string;
+    valueBalance: number | string;
+    anchor: string;
+  } | null;
+};
+
+const parsePcztTransaction = (value: string): PcztTransaction => {
+  let parsed: RawPcztJson;
+  try {
+    parsed = JSON.parse(value) as RawPcztJson;
+  } catch (error) {
+    throw new Error(
+      `Invalid PCZT JSON: ${
+        error instanceof Error ? error.message : "parse error"
+      }`,
+    );
+  }
+
+  const g = parsed.global ?? {};
+  const global: PcztGlobal = {
+    txVersion: Number(g.txVersion),
+    versionGroupId: Number(g.versionGroupId),
+    consensusBranchId: Number(g.consensusBranchId),
+    fallbackLockTime: toNumberOrNull(g.fallbackLockTime),
+    expiryHeight: Number(g.expiryHeight),
+    coinType: Number(g.coinType),
+    txModifiable: Number(g.txModifiable),
+  };
+
+  const transparentInputs: PcztTransparentInput[] = (
+    parsed.transparentInputs ?? []
+  ).map((input, i) => ({
+    prevoutTxid: parseHexBytes(
+      input.prevoutTxid,
+      `transparentInputs[${i}].prevoutTxid`,
+    ),
+    prevoutIndex: Number(input.prevoutIndex),
+    sequence: toNumberOrNull(input.sequence),
+    value: parseBigint(input.value, `transparentInputs[${i}].value`),
+    scriptPubKey: parseHexBytes(
+      input.scriptPubKey,
+      `transparentInputs[${i}].scriptPubKey`,
+    ),
+    sighashType: Number(input.sighashType),
+    derivation: parseDerivation(
+      input.derivation,
+      `transparentInputs[${i}].derivation`,
+    ),
+  }));
+
+  const transparentOutputs: PcztTransparentOutput[] = (
+    parsed.transparentOutputs ?? []
+  ).map((output, i) => ({
+    value: parseBigint(output.value, `transparentOutputs[${i}].value`),
+    scriptPubKey: parseHexBytes(
+      output.scriptPubKey,
+      `transparentOutputs[${i}].scriptPubKey`,
+    ),
+    derivation: output.derivation
+      ? parseDerivation(
+          output.derivation,
+          `transparentOutputs[${i}].derivation`,
+        )
+      : null,
+  }));
+
+  const orchardBundle: PcztOrchardBundle | null = parsed.orchardBundle
+    ? {
+        actions: (parsed.orchardBundle.actions ?? []).map(
+          (action, i): PcztOrchardAction => ({
+            cvNet: parseHexBytes(action.cvNet, `orchard[${i}].cvNet`),
+            nullifier: parseHexBytes(
+              action.nullifier,
+              `orchard[${i}].nullifier`,
+            ),
+            rk: parseHexBytes(action.rk, `orchard[${i}].rk`),
+            spendRecipient: parseHexBytes(
+              action.spendRecipient,
+              `orchard[${i}].spendRecipient`,
+            ),
+            spendValue: parseBigint(
+              action.spendValue,
+              `orchard[${i}].spendValue`,
+            ),
+            spendRho: parseHexBytes(action.spendRho, `orchard[${i}].spendRho`),
+            spendRseed: parseHexBytes(
+              action.spendRseed,
+              `orchard[${i}].spendRseed`,
+            ),
+            alpha: parseHexBytes(action.alpha, `orchard[${i}].alpha`),
+            signingPath: action.signingPath,
+            ...(action.seedFingerprint
+              ? {
+                  seedFingerprint: parseHexBytes(
+                    action.seedFingerprint,
+                    `orchard[${i}].seedFingerprint`,
+                  ),
+                }
+              : {}),
+            cmx: parseHexBytes(action.cmx, `orchard[${i}].cmx`),
+            ephemeralKey: parseHexBytes(
+              action.ephemeralKey,
+              `orchard[${i}].ephemeralKey`,
+            ),
+            encCiphertext: parseHexBytes(
+              action.encCiphertext,
+              `orchard[${i}].encCiphertext`,
+            ),
+            outCiphertext: parseHexBytes(
+              action.outCiphertext,
+              `orchard[${i}].outCiphertext`,
+            ),
+            recipient: parseHexBytes(
+              action.recipient,
+              `orchard[${i}].recipient`,
+            ),
+            value: parseBigint(action.value, `orchard[${i}].value`),
+            rseed: parseHexBytes(action.rseed, `orchard[${i}].rseed`),
+            rcv: parseHexBytes(action.rcv, `orchard[${i}].rcv`),
+          }),
+        ),
+        flags: Number(parsed.orchardBundle.flags),
+        valueBalance: parseBigint(
+          parsed.orchardBundle.valueBalance,
+          "orchardBundle.valueBalance",
+        ),
+        anchor: parseHexBytes(
+          parsed.orchardBundle.anchor,
+          "orchardBundle.anchor",
+        ),
+      }
+    : null;
+
+  return { global, transparentInputs, transparentOutputs, orchardBundle };
+};
+
+const SIGN_PCZT_FORM_KEYS: (keyof SignPcztInput)[] = ["skipOpenApp"];
+
+const SignPcztForm = ({
+  initialValues,
+  onChange,
+  disabled,
+}: {
+  initialValues: SignPcztInput;
+  onChange: (values: SignPcztInput) => void;
+  disabled?: boolean;
+}) => {
+  const initialValuesRef = useRef(initialValues);
+  initialValuesRef.current = initialValues;
+
+  const formValues = Object.fromEntries(
+    SIGN_PCZT_FORM_KEYS.map((key) => [key, initialValues[key]]),
+  ) as Pick<SignPcztInput, (typeof SIGN_PCZT_FORM_KEYS)[number]>;
+
+  return (
+    <Flex flexDirection="column" rowGap={5}>
+      <Form
+        initialValues={formValues}
+        onChange={(values) =>
+          onChange({ ...initialValuesRef.current, ...values })
+        }
+        disabled={disabled}
+      />
+      <Flex flexDirection="column" rowGap={2}>
+        <InputHeader hint="Structured PCZT as JSON. Byte fields are hex strings; value/spendValue/valueBalance are decimal strings (zatoshis). Set orchardBundle to null for transparent-only. Defaults to the app-zcash public→private test fixture.">
+          PCZT (JSON)
+        </InputHeader>
+        <ResizableTextArea
+          value={initialValues.pcztJson}
+          onChange={(value) =>
+            onChange({ ...initialValuesRef.current, pcztJson: value })
+          }
+          initialHeight={260}
+          disabled={disabled}
+        />
+      </Flex>
+    </Flex>
+  );
+};
+
 export const SignerZcashView = ({ sessionId }: { sessionId: string }) => {
   const dmk = useDmk();
   const signer = useSignerZcash();
@@ -745,6 +1101,41 @@ export const SignerZcashView = ({ sessionId }: { sessionId: string }) => {
         },
         SignMessageDAError,
         SignMessageDAIntermediateValue
+      >,
+      {
+        title: "Sign PCZT Transaction",
+        description:
+          "Sign an Orchard shielded (PCZT) transaction. Returns one spendAuthSig per Orchard action plus one signature per transparent input; the binding signature and final assembly are host-side.",
+        executeDeviceAction: ({ pcztJson, skipOpenApp }) => {
+          if (!signer) {
+            throw new Error("Signer not initialized");
+          }
+          const transaction = parsePcztTransaction(pcztJson);
+          return signer.signPcztTransaction(transaction, { skipOpenApp });
+        },
+        initialValues: {
+          pcztJson: DEFAULT_PCZT_JSON,
+          skipOpenApp: false,
+        },
+        validateValues: (values) => {
+          try {
+            parsePcztTransaction(values.pcztJson);
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        InputValuesComponent: SignPcztForm,
+        labelSelector: {
+          pcztJson: "PCZT (JSON)",
+          skipOpenApp: "Skip open app",
+        },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        SignPcztTransactionDAOutput,
+        SignPcztInput,
+        SignPcztTransactionDAError,
+        SignPcztTransactionDAIntermediateValue
       >,
     ],
     [deviceModelId, signer],

--- a/packages/signer/signer-zcash/README.md
+++ b/packages/signer/signer-zcash/README.md
@@ -5,6 +5,7 @@ This module provides the implementation of the Ledger Zcash signer of the Device
 - Retrieving a transparent Zcash address for a given derivation path;
 - Retrieving a unified or Orchard full viewing key (ZIP-32 account path);
 - Signing a transparent Zcash payment transaction (Ledger Wallet / `hw-app-btc` compatible shape);
+- Signing an Orchard shielded (PCZT) transaction, returning per-action Orchard spend-authorization signatures and per-input transparent signatures;
 - Signing a message displayed on the device;
 - Fetching trusted inputs for previous transactions;
 - Retrieving the app configuration;
@@ -18,9 +19,10 @@ This module provides the implementation of the Ledger Zcash signer of the Device
    - [Get Address](#use-case-1-get-address)
    - [Get Full Viewing Key](#use-case-2-get-full-viewing-key)
    - [Sign Transaction](#use-case-3-sign-transaction)
-   - [Sign Message](#use-case-4-sign-message)
-   - [Get Trusted Input](#use-case-5-get-trusted-input)
-   - [Get App Configuration](#use-case-6-get-app-configuration)
+   - [Sign PCZT Transaction](#use-case-4-sign-pczt-transaction)
+   - [Sign Message](#use-case-5-sign-message)
+   - [Get Trusted Input](#use-case-6-get-trusted-input)
+   - [Get App Configuration](#use-case-7-get-app-configuration)
 5. [Observable Behavior](#observable-behavior)
 6. [Example](#example)
 7. [Development](#development)
@@ -263,7 +265,139 @@ On **Pending**, `requiredUserInteraction` is `UserInteractionRequired.SignTransa
 
 ---
 
-### Use Case 4: Sign Message
+### Use Case 4: Sign PCZT Transaction
+
+Sign an Orchard **shielded** transaction expressed as a PCZT (Partially Constructed Zcash Transaction). The host (zcash-utils) builds the PCZT and passes the structured `PcztTransaction` to the signer, which streams the header, transparent inputs/outputs, and Orchard actions to the device as the `PCZT_*` APDU sequence. The device returns the raw per-action Orchard `spendAuthSig`s and per-input transparent signatures; the **binding signature and final transaction assembly are host-side** (never involve the device). The legacy transparent [`signTransaction`](#use-case-3-sign-transaction) path is unchanged.
+
+```typescript
+import { type PcztTransaction } from "@ledgerhq/device-signer-kit-zcash";
+
+const transaction: PcztTransaction = {
+  global: {
+    txVersion: 5,
+    versionGroupId: 0x26a7270a,
+    consensusBranchId: 0xc2d6d0b4,
+    fallbackLockTime: 0, // Option<u32>; null encodes the absent tag
+    expiryHeight: 0,
+    coinType: 133, // 133 mainnet, 1 testnet
+    txModifiable: 0,
+  },
+  transparentInputs: [], // may be empty (streamed with count 0)
+  transparentOutputs: [],
+  orchardBundle: {
+    actions: [
+      /* PcztOrchardAction[] */
+    ],
+    flags: 0x03,
+    valueBalance: 0n,
+    anchor: orchardAnchor, // 32 bytes
+  },
+};
+
+const { observable, cancel } = signerZcash.signPcztTransaction(
+  transaction,
+  options,
+);
+```
+
+#### `PcztTransaction`
+
+All multi-byte integer fields are encoded little-endian on the wire, except derivation-path components (standard big-endian `Bip32Path`).
+
+```typescript
+type PcztTransaction = {
+  global: PcztGlobal;
+  transparentInputs: PcztTransparentInput[]; // count 0 when empty
+  transparentOutputs: PcztTransparentOutput[]; // count 0 when empty
+  orchardBundle: PcztOrchardBundle | null; // null = empty Orchard bundle
+};
+
+type PcztGlobal = {
+  txVersion: number; // V5 = 5
+  versionGroupId: number;
+  consensusBranchId: number;
+  fallbackLockTime: number | null; // Option<u32>; null = absent
+  expiryHeight: number;
+  coinType: number; // 133 mainnet, 1 testnet
+  txModifiable: number;
+};
+
+type PcztBip32Derivation = {
+  signingPath: string;
+  pubkey: Uint8Array; // compressed secp256k1, 33 bytes
+  seedFingerprint?: Uint8Array; // ZIP-32, 32 bytes (default 32 zero bytes)
+};
+
+type PcztTransparentInput = {
+  prevoutTxid: Uint8Array; // 32 bytes
+  prevoutIndex: number;
+  sequence: number | null; // Option<u32>; null = absent
+  value: bigint; // zatoshis
+  scriptPubKey: Uint8Array;
+  sighashType: number; // must be SIGHASH_ALL (0x01)
+  derivation: PcztBip32Derivation;
+};
+
+type PcztTransparentOutput = {
+  value: bigint; // zatoshis
+  scriptPubKey: Uint8Array;
+  derivation?: PcztBip32Derivation | null; // entry count 0 or 1
+};
+
+type PcztOrchardAction = {
+  cvNet: Uint8Array; // value commitment, 32 bytes
+  nullifier: Uint8Array; // spend nullifier, 32 bytes
+  rk: Uint8Array; // randomized verification key, 32 bytes
+  spendRecipient: Uint8Array; // raw Orchard address of spent note, 43 bytes
+  spendValue: bigint; // zatoshis
+  spendRho: Uint8Array; // 32 bytes
+  spendRseed: Uint8Array; // 32 bytes
+  alpha: Uint8Array; // spend-auth randomizer (Pallas scalar), 32 bytes; host→device only
+  signingPath: string; // ZIP-32 derivation path of the signing key
+  seedFingerprint?: Uint8Array; // 32 bytes (default 32 zero bytes)
+  cmx: Uint8Array; // note commitment x-coord, 32 bytes
+  ephemeralKey: Uint8Array; // 32 bytes
+  encCiphertext: Uint8Array;
+  outCiphertext: Uint8Array;
+  recipient: Uint8Array; // raw Orchard address of output note, 43 bytes
+  value: bigint; // output-note value, zatoshis
+  rseed: Uint8Array; // 32 bytes
+  rcv: Uint8Array; // randomized commitment value, 32 bytes (required)
+};
+
+type PcztOrchardBundle = {
+  actions: PcztOrchardAction[];
+  flags: number;
+  valueBalance: bigint; // net value balance, zatoshis (signed)
+  anchor: Uint8Array; // Orchard commitment-tree anchor, 32 bytes
+};
+```
+
+#### Parameters (options)
+
+```typescript
+type TransactionOptions = {
+  skipOpenApp?: boolean;
+};
+```
+
+#### Returns
+
+```typescript
+type SignPcztTransactionResult = {
+  // one spendAuthSig per Orchard action, in action order
+  orchard: Array<{ spendAuthSig: Uint8Array }>; // RedPallas sig, 64 bytes each
+  // one signature per transparent input, in input order:
+  // DER-encoded secp256k1 signature + trailing sighash_type byte (0x01)
+  transparentInputSigs: Uint8Array[];
+};
+```
+
+There is **no `bindingSig`** in the result: the binding signature is computed host-side from `bsk = Σ rcv`. On **Pending**, `requiredUserInteraction` is `UserInteractionRequired.SignTransaction` (user must approve on device).
+
+---
+
+### Use Case 5: Sign Message
 
 Sign a message displayed on the Ledger device.
 
@@ -279,7 +413,7 @@ const { observable, cancel } = signerZcash.signMessage(
 
 ---
 
-### Use Case 5: Get Trusted Input
+### Use Case 6: Get Trusted Input
 
 Low-level helper used internally by `signTransaction`; also exposed for debugging or custom flows.
 
@@ -295,7 +429,7 @@ const { observable, cancel } = signerZcash.getTrustedInput(
 
 ---
 
-### Use Case 6: Get App Configuration
+### Use Case 7: Get App Configuration
 
 ```typescript
 const { observable, cancel } = signerZcash.getAppConfig();

--- a/packages/signer/signer-zcash/src/api/SignerZcash.ts
+++ b/packages/signer/signer-zcash/src/api/SignerZcash.ts
@@ -3,10 +3,12 @@ import { type GetAppConfigDAReturnType } from "@api/app-binder/GetAppConfigDevic
 import { type GetFullViewingKeyDAReturnType } from "@api/app-binder/GetFullViewingKeyDeviceActionTypes";
 import { type GetTrustedInputDAReturnType } from "@api/app-binder/GetTrustedInputActionTypes";
 import { type SignMessageDAReturnType } from "@api/app-binder/SignMessageDeviceActionTypes";
+import { type SignPcztTransactionDAReturnType } from "@api/app-binder/SignPcztTransactionDeviceActionTypes";
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { type AddressOptions } from "@api/model/AddressOptions";
 import { type LegacyCreateTransactionArg } from "@api/model/CreateTransactionArg";
 import { type FullViewingKeyOptions } from "@api/model/FullViewingKeyOptions";
+import { type PcztTransaction } from "@api/model/PcztTransaction";
 import { type TransactionOptions } from "@api/model/TransactionOptions";
 
 export interface SignerZcash {
@@ -26,6 +28,16 @@ export interface SignerZcash {
     args: LegacyCreateTransactionArg,
     options?: TransactionOptions,
   ) => SignTransactionDAReturnType;
+
+  /**
+   * Signs an Orchard shielded (PCZT) transaction. Returns the raw per-action
+   * Orchard `spendAuthSig`s and per-input transparent signatures; the binding
+   * signature and final assembly are host-side (zcash-utils).
+   */
+  signPcztTransaction: (
+    transaction: PcztTransaction,
+    options?: TransactionOptions,
+  ) => SignPcztTransactionDAReturnType;
 
   signMessage: (
     derivationPath: string,

--- a/packages/signer/signer-zcash/src/api/app-binder/SignPcztTransactionDeviceActionTypes.ts
+++ b/packages/signer/signer-zcash/src/api/app-binder/SignPcztTransactionDeviceActionTypes.ts
@@ -1,0 +1,30 @@
+import {
+  type CommandErrorResult,
+  type ExecuteDeviceActionReturnType,
+  type OpenAppDAError,
+  type OpenAppDARequiredInteraction,
+  type UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import { type SignPcztTransactionResult } from "@api/model/PcztSignature";
+import { type ZcashErrorCodes } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+export type SignPcztTransactionDAOutput = SignPcztTransactionResult;
+
+export type SignPcztTransactionDAError =
+  | OpenAppDAError
+  | CommandErrorResult<ZcashErrorCodes>["error"];
+
+type SignPcztTransactionDARequiredInteraction =
+  | OpenAppDARequiredInteraction
+  | UserInteractionRequired.SignTransaction;
+
+export type SignPcztTransactionDAIntermediateValue = {
+  requiredUserInteraction: SignPcztTransactionDARequiredInteraction;
+};
+
+export type SignPcztTransactionDAReturnType = ExecuteDeviceActionReturnType<
+  SignPcztTransactionDAOutput,
+  SignPcztTransactionDAError,
+  SignPcztTransactionDAIntermediateValue
+>;

--- a/packages/signer/signer-zcash/src/api/index.ts
+++ b/packages/signer/signer-zcash/src/api/index.ts
@@ -25,6 +25,12 @@ export type {
   SignMessageDAOutput,
 } from "@api/app-binder/SignMessageDeviceActionTypes";
 export type {
+  SignPcztTransactionDAError,
+  SignPcztTransactionDAIntermediateValue,
+  SignPcztTransactionDAOutput,
+  SignPcztTransactionDAReturnType,
+} from "@api/app-binder/SignPcztTransactionDeviceActionTypes";
+export type {
   SignTransactionDAError,
   SignTransactionDAIntermediateValue,
   SignTransactionDAOutput,
@@ -40,5 +46,18 @@ export type {
   FullViewingKeyOptions,
   ZcashFullViewingKeyMode,
 } from "@api/model/FullViewingKeyOptions";
+export type {
+  OrchardActionSignature,
+  SignPcztTransactionResult,
+} from "@api/model/PcztSignature";
+export type {
+  PcztBip32Derivation,
+  PcztGlobal,
+  PcztOrchardAction,
+  PcztOrchardBundle,
+  PcztTransaction,
+  PcztTransparentInput,
+  PcztTransparentOutput,
+} from "@api/model/PcztTransaction";
 export * from "@api/SignerZcash";
 export * from "@api/SignerZcashBuilder";

--- a/packages/signer/signer-zcash/src/api/model/PcztSignature.ts
+++ b/packages/signer/signer-zcash/src/api/model/PcztSignature.ts
@@ -1,0 +1,37 @@
+/**
+ * Result types for PCZT (Orchard shielded) signing — DMK-02.
+ *
+ * These are intentionally distinct from the legacy transparent/ECDSA
+ * {@link Signature} (`{ r, s, v }`): the Orchard signature is a RedPallas
+ * spend-authorization signature returned by the device, incompatible with the
+ * `{ r, s, v }` shape, so the two never mix.
+ */
+
+/**
+ * Per-Orchard-action signature returned by the device.
+ *
+ * The device returns the RedPallas `spendAuthSig` only; `alpha` is a
+ * host-supplied PCZT field carried *to* the device and is never returned.
+ */
+export type OrchardActionSignature = {
+  /** RedPallas spend-authorization signature, 64 bytes. */
+  spendAuthSig: Uint8Array;
+};
+
+/**
+ * Result of {@link SignerZcash.signPcztTransaction}.
+ *
+ * No `bindingSig`: the binding signature is computed host-side (zcash-utils)
+ * from `bsk = Σ rcv` and never involves the device.
+ */
+export type SignPcztTransactionResult = {
+  /** One `spendAuthSig` per Orchard action, in action order. */
+  orchard: OrchardActionSignature[];
+  /**
+   * One signature per transparent input, in input order. Each entry is the
+   * raw device response for `INS_PCZT_SIGN_TRANSPARENT`: the DER-encoded
+   * secp256k1 signature followed by a single `sighash_type` byte (`0x01`,
+   * `SIGHASH_ALL`).
+   */
+  transparentInputSigs: Uint8Array[];
+};

--- a/packages/signer/signer-zcash/src/api/model/PcztSignature.ts
+++ b/packages/signer/signer-zcash/src/api/model/PcztSignature.ts
@@ -1,5 +1,5 @@
 /**
- * Result types for PCZT (Orchard shielded) signing — DMK-02.
+ * Result types for PCZT (Orchard shielded) signing.
  *
  * These are intentionally distinct from the legacy transparent/ECDSA
  * {@link Signature} (`{ r, s, v }`): the Orchard signature is a RedPallas

--- a/packages/signer/signer-zcash/src/api/model/PcztTransaction.ts
+++ b/packages/signer/signer-zcash/src/api/model/PcztTransaction.ts
@@ -1,6 +1,6 @@
 /**
  * Structured PCZT (Partially Constructed Zcash Transaction) input for
- * Orchard shielded signing — DMK-02.
+ * Orchard shielded signing.
  *
  * The shapes mirror, field-for-field, the compact PCZT subset the device
  * parses (see `LedgerHQ/app-zcash` `docs/PCZT_APDU.md`, branch `develop`).

--- a/packages/signer/signer-zcash/src/api/model/PcztTransaction.ts
+++ b/packages/signer/signer-zcash/src/api/model/PcztTransaction.ts
@@ -1,0 +1,121 @@
+/**
+ * Structured PCZT (Partially Constructed Zcash Transaction) input for
+ * Orchard shielded signing — DMK-02.
+ *
+ * The shapes mirror, field-for-field, the compact PCZT subset the device
+ * parses (see `LedgerHQ/app-zcash` `docs/PCZT_APDU.md`, branch `develop`).
+ * The host (zcash-utils) builds the PCZT and hands these structures to the
+ * signer, which serializes them into the `PCZT_*` APDU stream. All multi-byte
+ * integer fields are encoded little-endian on the wire, except derivation-path
+ * components, which use the standard big-endian `Bip32Path` encoding.
+ */
+
+/** PCZT header `common::Global` fields, sent once in `PCZT_HEADER`. */
+export type PcztGlobal = {
+  /** Transaction version (V5 = 5). */
+  txVersion: number;
+  versionGroupId: number;
+  consensusBranchId: number;
+  /** `fallback_lock_time Option<u32>`; `null` encodes the absent tag. */
+  fallbackLockTime: number | null;
+  expiryHeight: number;
+  /** BIP44 coin type (133 mainnet, 1 testnet). */
+  coinType: number;
+  txModifiable: number;
+};
+
+/** A `bip32_derivation` entry for a transparent input/output. */
+export type PcztBip32Derivation = {
+  signingPath: string;
+  /** Compressed secp256k1 public key, 33 bytes. */
+  pubkey: Uint8Array;
+  /** ZIP-32 seed fingerprint, 32 bytes. Defaults to 32 zero bytes if omitted. */
+  seedFingerprint?: Uint8Array;
+};
+
+/** A single `transparent::Input`. */
+export type PcztTransparentInput = {
+  /** Previous output txid, 32 bytes. */
+  prevoutTxid: Uint8Array;
+  prevoutIndex: number;
+  /** `sequence Option<u32>`; `null` encodes the absent tag. */
+  sequence: number | null;
+  /** Input value in zatoshis. */
+  value: bigint;
+  scriptPubKey: Uint8Array;
+  /** Must be `SIGHASH_ALL` (`0x01`). */
+  sighashType: number;
+  derivation: PcztBip32Derivation;
+};
+
+/** A single `transparent::Output`. */
+export type PcztTransparentOutput = {
+  /** Output value in zatoshis. */
+  value: bigint;
+  scriptPubKey: Uint8Array;
+  /** Optional `bip32_derivation` (entry count `0` or `1`). */
+  derivation?: PcztBip32Derivation | null;
+};
+
+/** A single `orchard::Action` (spend + output halves). */
+export type PcztOrchardAction = {
+  /** Value commitment, 32 bytes. */
+  cvNet: Uint8Array;
+  /** Spend nullifier, 32 bytes. */
+  nullifier: Uint8Array;
+  /** Randomized verification key, 32 bytes. */
+  rk: Uint8Array;
+  /** Raw Orchard payment address of the spent note, 43 bytes. */
+  spendRecipient: Uint8Array;
+  /** Spent-note value in zatoshis. */
+  spendValue: bigint;
+  /** Spend rho (ρ), 32 bytes. */
+  spendRho: Uint8Array;
+  /** Spend rseed, 32 bytes. */
+  spendRseed: Uint8Array;
+  /**
+   * Spend-authorization randomizer (Pallas scalar), 32 bytes. Host-supplied:
+   * carried to the device, never returned.
+   */
+  alpha: Uint8Array;
+  /** ZIP-32 derivation path of the signing key. */
+  signingPath: string;
+  /** ZIP-32 seed fingerprint, 32 bytes. Defaults to 32 zero bytes if omitted. */
+  seedFingerprint?: Uint8Array;
+  /** Note commitment x-coordinate, 32 bytes. */
+  cmx: Uint8Array;
+  /** Ephemeral key, 32 bytes. */
+  ephemeralKey: Uint8Array;
+  encCiphertext: Uint8Array;
+  outCiphertext: Uint8Array;
+  /** Raw Orchard payment address of the output note, 43 bytes. */
+  recipient: Uint8Array;
+  /** Output-note value in zatoshis. */
+  value: bigint;
+  /** Output rseed, 32 bytes. */
+  rseed: Uint8Array;
+  /** Randomized commitment value, 32 bytes (required by the device). */
+  rcv: Uint8Array;
+};
+
+/** The Orchard action bundle plus its trailer. */
+export type PcztOrchardBundle = {
+  actions: PcztOrchardAction[];
+  flags: number;
+  /** Net value balance in zatoshis (signed). */
+  valueBalance: bigint;
+  /** Orchard commitment-tree anchor, 32 bytes. */
+  anchor: Uint8Array;
+};
+
+/**
+ * Full structured PCZT to sign. The transparent sections are always streamed
+ * (count `0` when empty); `orchardBundle` may be `null`, treated as an empty
+ * Orchard bundle.
+ */
+export type PcztTransaction = {
+  global: PcztGlobal;
+  transparentInputs: PcztTransparentInput[];
+  transparentOutputs: PcztTransparentOutput[];
+  orchardBundle: PcztOrchardBundle | null;
+};

--- a/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.test.ts
+++ b/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.test.ts
@@ -17,6 +17,7 @@ import {
   zcashFvkP2FromMode,
 } from "@internal/app-binder/command/GetFullViewingKeyCommand";
 import { APP_NAME } from "@internal/app-binder/constants";
+import { privateToPrivateTransaction } from "@internal/app-binder/task/__fixtures__/pcztFixtures";
 
 import { DefaultSignerZcash } from "./DefaultSignerZcash";
 
@@ -146,6 +147,18 @@ describe("DefaultSignerZcash", () => {
       outputScriptHex: "00",
       additionals: ["zcash"],
     });
+
+    expect(dmk.executeDeviceAction).toHaveBeenCalled();
+  });
+
+  it("should call signPcztTransaction via device action", () => {
+    const dmk = {
+      executeDeviceAction: vi.fn(),
+    } as unknown as DeviceManagementKit;
+    const sessionId = {} as DeviceSessionId;
+    const signer = new DefaultSignerZcash({ dmk, sessionId });
+
+    signer.signPcztTransaction(privateToPrivateTransaction());
 
     expect(dmk.executeDeviceAction).toHaveBeenCalled();
   });

--- a/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.ts
+++ b/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.ts
@@ -9,10 +9,12 @@ import { type GetAppConfigDAReturnType } from "@api/app-binder/GetAppConfigDevic
 import { type GetFullViewingKeyDAReturnType } from "@api/app-binder/GetFullViewingKeyDeviceActionTypes";
 import { type GetTrustedInputDAReturnType } from "@api/app-binder/GetTrustedInputActionTypes";
 import { type SignMessageDAReturnType } from "@api/app-binder/SignMessageDeviceActionTypes";
+import { type SignPcztTransactionDAReturnType } from "@api/app-binder/SignPcztTransactionDeviceActionTypes";
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { type AddressOptions } from "@api/model/AddressOptions";
 import { type LegacyCreateTransactionArg } from "@api/model/CreateTransactionArg";
 import { type FullViewingKeyOptions } from "@api/model/FullViewingKeyOptions";
+import { type PcztTransaction } from "@api/model/PcztTransaction";
 import { type TransactionOptions } from "@api/model/TransactionOptions";
 import { type SignerZcash } from "@api/SignerZcash";
 import { makeContainer } from "@internal/di";
@@ -25,6 +27,7 @@ import { messageTypes } from "@internal/use-cases/message/di/messageTypes";
 import { type SignMessageUseCase } from "@internal/use-cases/message/SignMessageUseCase";
 import { transactionTypes } from "@internal/use-cases/transaction/di/transactionTypes";
 import { type GetTrustedInputUseCase } from "@internal/use-cases/transaction/GetTrustedInputUseCase";
+import { type SignPcztTransactionUseCase } from "@internal/use-cases/transaction/SignPcztTransactionUseCase";
 import { type SignTransactionUseCase } from "@internal/use-cases/transaction/SignTransactionUseCase";
 
 type DefaultSignerZcashConstructorArgs = {
@@ -70,6 +73,17 @@ export class DefaultSignerZcash implements SignerZcash {
     return this._container
       .get<SignTransactionUseCase>(transactionTypes.SignTransactionUseCase)
       .execute(args, options);
+  }
+
+  signPcztTransaction(
+    transaction: PcztTransaction,
+    options?: TransactionOptions,
+  ): SignPcztTransactionDAReturnType {
+    return this._container
+      .get<SignPcztTransactionUseCase>(
+        transactionTypes.SignPcztTransactionUseCase,
+      )
+      .execute(transaction, options);
   }
 
   signMessage(

--- a/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.test.ts
@@ -30,8 +30,10 @@ import {
 } from "@internal/app-binder/command/GetAddressCommand";
 import type { ZcashErrorCodes } from "@internal/app-binder/command/utils/zcashApplicationErrors";
 import { APP_NAME } from "@internal/app-binder/constants";
+import { privateToPrivateTransaction } from "@internal/app-binder/task/__fixtures__/pcztFixtures";
 import { GetFullViewingKeyTask } from "@internal/app-binder/task/GetFullViewingKeyTask";
 import { GetTrustedInputTask } from "@internal/app-binder/task/GetTrustedInputTask";
+import { SignPcztTransactionTask } from "@internal/app-binder/task/SignPcztTransactionTask";
 import { SignTransactionTask } from "@internal/app-binder/task/SignTransactionTask";
 import { ZcashAppBinder } from "@internal/app-binder/ZcashAppBinder";
 
@@ -366,6 +368,67 @@ describe("ZcashAppBinder", () => {
       });
 
       expect(result).toBe(expectedResult);
+    });
+  });
+
+  describe("signPcztTransaction", () => {
+    it("should call executeDeviceAction with CallTaskInAppDeviceAction and run SignPcztTransactionTask", async () => {
+      const sessionId = "test-session-id";
+      const expectedResult = {
+        observable: from([]),
+        cancel: vi.fn(),
+      };
+      const executeDeviceActionMock = vi.fn().mockReturnValue(expectedResult);
+      const dmkMock = {
+        executeDeviceAction: executeDeviceActionMock,
+      } as unknown as DeviceManagementKit;
+      const binder = new ZcashAppBinder(dmkMock, sessionId);
+      const runSpy = vi
+        .spyOn(SignPcztTransactionTask.prototype, "run")
+        .mockResolvedValue(
+          {} as unknown as Awaited<
+            ReturnType<typeof SignPcztTransactionTask.prototype.run>
+          >,
+        );
+
+      const result = binder.signPcztTransaction({
+        transaction: privateToPrivateTransaction(),
+      });
+
+      expect(executeDeviceActionMock).toHaveBeenCalledTimes(1);
+      const args = executeDeviceActionMock.mock
+        .calls[0]![0] as ExecuteDeviceActionTaskCallArgs;
+      expect(args.sessionId).toBe(sessionId);
+      expect(args.deviceAction).toBeInstanceOf(CallTaskInAppDeviceAction);
+      expect(args.deviceAction.input.appName).toBe(APP_NAME);
+      expect(args.deviceAction.input.requiredUserInteraction).toBe(
+        UserInteractionRequired.SignTransaction,
+      );
+      expect(args.deviceAction.input.skipOpenApp).toBe(false);
+      expect(result).toBe(expectedResult);
+
+      await args.deviceAction.input.task({} as InternalApi);
+      expect(runSpy).toHaveBeenCalledOnce();
+    });
+
+    it("should keep provided skipOpenApp value", () => {
+      const executeDeviceActionMock = vi.fn().mockReturnValue({
+        observable: from([]),
+        cancel: vi.fn(),
+      });
+      const dmkMock = {
+        executeDeviceAction: executeDeviceActionMock,
+      } as unknown as DeviceManagementKit;
+      const binder = new ZcashAppBinder(dmkMock, "sessionId");
+
+      binder.signPcztTransaction({
+        transaction: privateToPrivateTransaction(),
+        skipOpenApp: true,
+      });
+
+      const args = executeDeviceActionMock.mock
+        .calls[0]![0] as ExecuteDeviceActionTaskCallArgs;
+      expect(args.deviceAction.input.skipOpenApp).toBe(true);
     });
   });
 });

--- a/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.ts
@@ -13,9 +13,11 @@ import { type GetAppConfigDAReturnType } from "@api/app-binder/GetAppConfigDevic
 import { type GetFullViewingKeyDAReturnType } from "@api/app-binder/GetFullViewingKeyDeviceActionTypes";
 import { type GetTrustedInputDAReturnType } from "@api/app-binder/GetTrustedInputActionTypes";
 import { type SignMessageDAReturnType } from "@api/app-binder/SignMessageDeviceActionTypes";
+import { type SignPcztTransactionDAReturnType } from "@api/app-binder/SignPcztTransactionDeviceActionTypes";
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { type LegacyCreateTransactionArg } from "@api/model/CreateTransactionArg";
 import { type ZcashFullViewingKeyMode } from "@api/model/FullViewingKeyOptions";
+import { type PcztTransaction } from "@api/model/PcztTransaction";
 import { APP_NAME } from "@internal/app-binder/constants";
 import { externalTypes } from "@internal/externalTypes";
 
@@ -24,6 +26,7 @@ import { GetAppConfigCommand } from "./command/GetAppConfigCommand";
 import { SignMessageCommand } from "./command/SignMessageCommand";
 import { GetFullViewingKeyTask } from "./task/GetFullViewingKeyTask";
 import { GetTrustedInputTask } from "./task/GetTrustedInputTask";
+import { SignPcztTransactionTask } from "./task/SignPcztTransactionTask";
 import { SignTransactionTask } from "./task/SignTransactionTask";
 
 @injectable()
@@ -99,6 +102,26 @@ export class ZcashAppBinder {
         input: {
           task: async (internalApi: InternalApi) =>
             new SignTransactionTask(internalApi, args).run(),
+          appName: APP_NAME,
+          requiredUserInteraction: UserInteractionRequired.SignTransaction,
+          skipOpenApp: args.skipOpenApp ?? false,
+        },
+      }),
+    });
+  }
+
+  signPcztTransaction(args: {
+    transaction: PcztTransaction;
+    skipOpenApp?: boolean;
+  }): SignPcztTransactionDAReturnType {
+    return this.dmk.executeDeviceAction({
+      sessionId: this.sessionId,
+      deviceAction: new CallTaskInAppDeviceAction({
+        input: {
+          task: async (internalApi: InternalApi) =>
+            new SignPcztTransactionTask(internalApi, {
+              transaction: args.transaction,
+            }).run(),
           appName: APP_NAME,
           requiredUserInteraction: UserInteractionRequired.SignTransaction,
           skipOpenApp: args.skipOpenApp ?? false,

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/PcztBundleCommands.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/PcztBundleCommands.test.ts
@@ -58,6 +58,24 @@ describe("PCZT bundle commands", () => {
         .getRawApdu();
       expect(apduHex(apdu)).toBe("e053010002" + "0102");
     });
+
+    it("maps the success status word to a successful result", () => {
+      const result = new PcztTransparentInputCommand({
+        data: DATA,
+        p1: PCZT_P1.FIRST,
+        p2: PCZT_P2.CONTINUE,
+      }).parseResponse(success);
+      expect(isSuccessCommandResult(result)).toBe(true);
+    });
+
+    it("surfaces a device error status word", () => {
+      const result = new PcztTransparentInputCommand({
+        data: DATA,
+        p1: PCZT_P1.FIRST,
+        p2: PCZT_P2.CONTINUE,
+      }).parseResponse(rejected);
+      expect(isSuccessCommandResult(result)).toBe(false);
+    });
   });
 
   describe("PcztTransparentOutputCommand", () => {
@@ -70,6 +88,24 @@ describe("PCZT bundle commands", () => {
         .getApdu()
         .getRawApdu();
       expect(apduHex(apdu)).toBe("e054800002" + "0102");
+    });
+
+    it("maps the success status word to a successful result", () => {
+      const result = new PcztTransparentOutputCommand({
+        data: DATA,
+        p1: PCZT_P1.FIRST,
+        p2: PCZT_P2.CONTINUE,
+      }).parseResponse(success);
+      expect(isSuccessCommandResult(result)).toBe(true);
+    });
+
+    it("surfaces a device error status word", () => {
+      const result = new PcztTransparentOutputCommand({
+        data: DATA,
+        p1: PCZT_P1.FIRST,
+        p2: PCZT_P2.CONTINUE,
+      }).parseResponse(rejected);
+      expect(isSuccessCommandResult(result)).toBe(false);
     });
   });
 

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/PcztBundleCommands.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/PcztBundleCommands.test.ts
@@ -1,0 +1,97 @@
+import {
+  ApduResponse,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { describe, expect, it } from "vitest";
+
+import { PcztHeaderCommand } from "@internal/app-binder/command/PcztHeaderCommand";
+import { PcztOrchardActionCommand } from "@internal/app-binder/command/PcztOrchardActionCommand";
+import { PcztTransparentInputCommand } from "@internal/app-binder/command/PcztTransparentInputCommand";
+import { PcztTransparentOutputCommand } from "@internal/app-binder/command/PcztTransparentOutputCommand";
+import {
+  PCZT_P1,
+  PCZT_P2,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
+
+const DATA = Uint8Array.of(0x01, 0x02);
+const apduHex = (raw: Uint8Array): string => Buffer.from(raw).toString("hex");
+
+const success = new ApduResponse({
+  statusCode: Uint8Array.of(0x90, 0x00),
+  data: new Uint8Array(),
+});
+const rejected = new ApduResponse({
+  statusCode: Uint8Array.of(0x69, 0x85), // ConditionOfUseNotSatisfied
+  data: new Uint8Array(),
+});
+
+describe("PCZT bundle commands", () => {
+  describe("PcztHeaderCommand", () => {
+    it("builds INS 0x52 with P1_FIRST / P2_CONTINUE", () => {
+      const apdu = new PcztHeaderCommand({ data: DATA }).getApdu().getRawApdu();
+      expect(apduHex(apdu)).toBe("e052000002" + "0102");
+    });
+
+    it("maps the success status word to a successful result", () => {
+      const result = new PcztHeaderCommand({ data: DATA }).parseResponse(
+        success,
+      );
+      expect(isSuccessCommandResult(result)).toBe(true);
+    });
+
+    it("surfaces a device error status word", () => {
+      const result = new PcztHeaderCommand({ data: DATA }).parseResponse(
+        rejected,
+      );
+      expect(isSuccessCommandResult(result)).toBe(false);
+    });
+  });
+
+  describe("PcztTransparentInputCommand", () => {
+    it("builds INS 0x53 with the supplied P1/P2 framing", () => {
+      const apdu = new PcztTransparentInputCommand({
+        data: DATA,
+        p1: PCZT_P1.LAST,
+        p2: PCZT_P2.CONTINUE,
+      })
+        .getApdu()
+        .getRawApdu();
+      expect(apduHex(apdu)).toBe("e053010002" + "0102");
+    });
+  });
+
+  describe("PcztTransparentOutputCommand", () => {
+    it("builds INS 0x54 with the supplied P1/P2 framing", () => {
+      const apdu = new PcztTransparentOutputCommand({
+        data: DATA,
+        p1: PCZT_P1.NEXT,
+        p2: PCZT_P2.CONTINUE,
+      })
+        .getApdu()
+        .getRawApdu();
+      expect(apduHex(apdu)).toBe("e054800002" + "0102");
+    });
+  });
+
+  describe("PcztOrchardActionCommand", () => {
+    it("builds INS 0x56 and can carry the P2_FINISHED marker", () => {
+      const apdu = new PcztOrchardActionCommand({
+        data: DATA,
+        p1: PCZT_P1.LAST,
+        p2: PCZT_P2.FINISHED,
+      })
+        .getApdu()
+        .getRawApdu();
+      expect(apduHex(apdu)).toBe("e056010102" + "0102");
+    });
+
+    it("surfaces a device error status word", () => {
+      const result = new PcztOrchardActionCommand({
+        data: DATA,
+        p1: PCZT_P1.FIRST,
+        p2: PCZT_P2.CONTINUE,
+      }).parseResponse(rejected);
+      expect(isSuccessCommandResult(result)).toBe(false);
+    });
+  });
+});

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/PcztHeaderCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/PcztHeaderCommand.ts
@@ -11,7 +11,6 @@ import { CommandErrorHelper } from "@ledgerhq/signer-utils";
 import { Maybe } from "purify-ts";
 
 import {
-  PCZT_INS,
   PCZT_P1,
   PCZT_P2,
   ZCASH_CLA,
@@ -21,6 +20,12 @@ import {
   ZcashAppCommandErrorFactory,
   type ZcashErrorCodes,
 } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+/**
+ * `INS_PCZT_HEADER`: resets the tx context and opens a new PCZT payload. Sent
+ * exactly once. Mirrors `LedgerHQ/app-zcash` `src/consts.rs`.
+ */
+export const INS_PCZT_HEADER = 0x52;
 
 export type PcztHeaderCommandArgs = {
   /** Serialized `PCZT_HEADER` payload (magic + version + `common::Global`). */
@@ -43,7 +48,7 @@ export class PcztHeaderCommand
   getApdu(): Apdu {
     const apduArgs: ApduBuilderArgs = {
       cla: ZCASH_CLA,
-      ins: PCZT_INS.HEADER,
+      ins: INS_PCZT_HEADER,
       p1: PCZT_P1.FIRST,
       p2: PCZT_P2.CONTINUE,
     };

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/PcztHeaderCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/PcztHeaderCommand.ts
@@ -1,0 +1,60 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import {
+  PCZT_INS,
+  PCZT_P1,
+  PCZT_P2,
+  ZCASH_CLA,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import {
+  ZCASH_APP_ERRORS,
+  ZcashAppCommandErrorFactory,
+  type ZcashErrorCodes,
+} from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+export type PcztHeaderCommandArgs = {
+  /** Serialized `PCZT_HEADER` payload (magic + version + `common::Global`). */
+  data: Uint8Array;
+};
+
+/** `PCZT_HEADER` (`INS 0x52`): opens a new PCZT payload. Empty response. */
+export class PcztHeaderCommand
+  implements Command<void, PcztHeaderCommandArgs, ZcashErrorCodes>
+{
+  readonly name = "PcztHeader";
+
+  private readonly errorHelper = new CommandErrorHelper<void, ZcashErrorCodes>(
+    ZCASH_APP_ERRORS,
+    ZcashAppCommandErrorFactory,
+  );
+
+  constructor(private readonly args: PcztHeaderCommandArgs) {}
+
+  getApdu(): Apdu {
+    const apduArgs: ApduBuilderArgs = {
+      cla: ZCASH_CLA,
+      ins: PCZT_INS.HEADER,
+      p1: PCZT_P1.FIRST,
+      p2: PCZT_P2.CONTINUE,
+    };
+    return new ApduBuilder(apduArgs).addBufferToData(this.args.data).build();
+  }
+
+  parseResponse(
+    apduResponse: ApduResponse,
+  ): CommandResult<void, ZcashErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefault(CommandResultFactory({ data: undefined }));
+  }
+}

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/PcztOrchardActionCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/PcztOrchardActionCommand.ts
@@ -1,0 +1,69 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import {
+  PCZT_INS,
+  ZCASH_CLA,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import {
+  ZCASH_APP_ERRORS,
+  ZcashAppCommandErrorFactory,
+  type ZcashErrorCodes,
+} from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+export type PcztOrchardActionCommandArgs = {
+  /** One serialized packet of the Orchard action bundle. */
+  data: Uint8Array;
+  /** Packet framing: `PCZT_P1.FIRST` / `NEXT` / `LAST`. */
+  p1: number;
+  /**
+   * Bundle framing: `PCZT_P2.CONTINUE`, or `PCZT_P2.FINISHED` on the very last
+   * packet to finalize the PCZT (after which signing commands are accepted).
+   */
+  p2: number;
+};
+
+/**
+ * `PCZT_ORCHARD_ACTION` (`INS 0x56`): streams one packet of the Orchard action
+ * bundle. Always sent (count `0` when empty); the last packet carries
+ * `PCZT_P2.FINISHED`. Empty response.
+ */
+export class PcztOrchardActionCommand
+  implements Command<void, PcztOrchardActionCommandArgs, ZcashErrorCodes>
+{
+  readonly name = "PcztOrchardAction";
+
+  private readonly errorHelper = new CommandErrorHelper<void, ZcashErrorCodes>(
+    ZCASH_APP_ERRORS,
+    ZcashAppCommandErrorFactory,
+  );
+
+  constructor(private readonly args: PcztOrchardActionCommandArgs) {}
+
+  getApdu(): Apdu {
+    const apduArgs: ApduBuilderArgs = {
+      cla: ZCASH_CLA,
+      ins: PCZT_INS.ORCHARD_ACTION,
+      p1: this.args.p1,
+      p2: this.args.p2,
+    };
+    return new ApduBuilder(apduArgs).addBufferToData(this.args.data).build();
+  }
+
+  parseResponse(
+    apduResponse: ApduResponse,
+  ): CommandResult<void, ZcashErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefault(CommandResultFactory({ data: undefined }));
+  }
+}

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/PcztOrchardActionCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/PcztOrchardActionCommand.ts
@@ -10,15 +10,18 @@ import {
 import { CommandErrorHelper } from "@ledgerhq/signer-utils";
 import { Maybe } from "purify-ts";
 
-import {
-  PCZT_INS,
-  ZCASH_CLA,
-} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import { ZCASH_CLA } from "@internal/app-binder/command/utils/apduHeaderUtils";
 import {
   ZCASH_APP_ERRORS,
   ZcashAppCommandErrorFactory,
   type ZcashErrorCodes,
 } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+/**
+ * `INS_PCZT_ORCHARD_ACTION`: streams the Orchard action bundle (always sent,
+ * count 0 when empty). Mirrors `LedgerHQ/app-zcash` `src/consts.rs`.
+ */
+export const INS_PCZT_ORCHARD_ACTION = 0x56;
 
 export type PcztOrchardActionCommandArgs = {
   /** One serialized packet of the Orchard action bundle. */
@@ -52,7 +55,7 @@ export class PcztOrchardActionCommand
   getApdu(): Apdu {
     const apduArgs: ApduBuilderArgs = {
       cla: ZCASH_CLA,
-      ins: PCZT_INS.ORCHARD_ACTION,
+      ins: INS_PCZT_ORCHARD_ACTION,
       p1: this.args.p1,
       p2: this.args.p2,
     };

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/PcztTransparentInputCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/PcztTransparentInputCommand.ts
@@ -10,15 +10,18 @@ import {
 import { CommandErrorHelper } from "@ledgerhq/signer-utils";
 import { Maybe } from "purify-ts";
 
-import {
-  PCZT_INS,
-  ZCASH_CLA,
-} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import { ZCASH_CLA } from "@internal/app-binder/command/utils/apduHeaderUtils";
 import {
   ZCASH_APP_ERRORS,
   ZcashAppCommandErrorFactory,
   type ZcashErrorCodes,
 } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+/**
+ * `INS_PCZT_TRANSPARENT_INPUT`: streams the transparent input bundle (always
+ * sent, count 0 when empty). Mirrors `LedgerHQ/app-zcash` `src/consts.rs`.
+ */
+export const INS_PCZT_TRANSPARENT_INPUT = 0x53;
 
 export type PcztTransparentInputCommandArgs = {
   /** One serialized packet of the transparent-input bundle. */
@@ -48,7 +51,7 @@ export class PcztTransparentInputCommand
   getApdu(): Apdu {
     const apduArgs: ApduBuilderArgs = {
       cla: ZCASH_CLA,
-      ins: PCZT_INS.TRANSPARENT_INPUT,
+      ins: INS_PCZT_TRANSPARENT_INPUT,
       p1: this.args.p1,
       p2: this.args.p2,
     };

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/PcztTransparentInputCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/PcztTransparentInputCommand.ts
@@ -1,0 +1,65 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import {
+  PCZT_INS,
+  ZCASH_CLA,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import {
+  ZCASH_APP_ERRORS,
+  ZcashAppCommandErrorFactory,
+  type ZcashErrorCodes,
+} from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+export type PcztTransparentInputCommandArgs = {
+  /** One serialized packet of the transparent-input bundle. */
+  data: Uint8Array;
+  /** Packet framing: `PCZT_P1.FIRST` / `NEXT` / `LAST`. */
+  p1: number;
+  /** Bundle framing: `PCZT_P2.CONTINUE`. */
+  p2: number;
+};
+
+/**
+ * `PCZT_TRANSPARENT_INPUT` (`INS 0x53`): streams one packet of the transparent
+ * input bundle. Always sent (count `0` when empty). Empty response.
+ */
+export class PcztTransparentInputCommand
+  implements Command<void, PcztTransparentInputCommandArgs, ZcashErrorCodes>
+{
+  readonly name = "PcztTransparentInput";
+
+  private readonly errorHelper = new CommandErrorHelper<void, ZcashErrorCodes>(
+    ZCASH_APP_ERRORS,
+    ZcashAppCommandErrorFactory,
+  );
+
+  constructor(private readonly args: PcztTransparentInputCommandArgs) {}
+
+  getApdu(): Apdu {
+    const apduArgs: ApduBuilderArgs = {
+      cla: ZCASH_CLA,
+      ins: PCZT_INS.TRANSPARENT_INPUT,
+      p1: this.args.p1,
+      p2: this.args.p2,
+    };
+    return new ApduBuilder(apduArgs).addBufferToData(this.args.data).build();
+  }
+
+  parseResponse(
+    apduResponse: ApduResponse,
+  ): CommandResult<void, ZcashErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefault(CommandResultFactory({ data: undefined }));
+  }
+}

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/PcztTransparentOutputCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/PcztTransparentOutputCommand.ts
@@ -1,0 +1,65 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import {
+  PCZT_INS,
+  ZCASH_CLA,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import {
+  ZCASH_APP_ERRORS,
+  ZcashAppCommandErrorFactory,
+  type ZcashErrorCodes,
+} from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+export type PcztTransparentOutputCommandArgs = {
+  /** One serialized packet of the transparent-output bundle. */
+  data: Uint8Array;
+  /** Packet framing: `PCZT_P1.FIRST` / `NEXT` / `LAST`. */
+  p1: number;
+  /** Bundle framing: `PCZT_P2.CONTINUE`. */
+  p2: number;
+};
+
+/**
+ * `PCZT_TRANSPARENT_OUTPUT` (`INS 0x54`): streams one packet of the transparent
+ * output bundle. Always sent (count `0` when empty). Empty response.
+ */
+export class PcztTransparentOutputCommand
+  implements Command<void, PcztTransparentOutputCommandArgs, ZcashErrorCodes>
+{
+  readonly name = "PcztTransparentOutput";
+
+  private readonly errorHelper = new CommandErrorHelper<void, ZcashErrorCodes>(
+    ZCASH_APP_ERRORS,
+    ZcashAppCommandErrorFactory,
+  );
+
+  constructor(private readonly args: PcztTransparentOutputCommandArgs) {}
+
+  getApdu(): Apdu {
+    const apduArgs: ApduBuilderArgs = {
+      cla: ZCASH_CLA,
+      ins: PCZT_INS.TRANSPARENT_OUTPUT,
+      p1: this.args.p1,
+      p2: this.args.p2,
+    };
+    return new ApduBuilder(apduArgs).addBufferToData(this.args.data).build();
+  }
+
+  parseResponse(
+    apduResponse: ApduResponse,
+  ): CommandResult<void, ZcashErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefault(CommandResultFactory({ data: undefined }));
+  }
+}

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/PcztTransparentOutputCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/PcztTransparentOutputCommand.ts
@@ -10,15 +10,18 @@ import {
 import { CommandErrorHelper } from "@ledgerhq/signer-utils";
 import { Maybe } from "purify-ts";
 
-import {
-  PCZT_INS,
-  ZCASH_CLA,
-} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import { ZCASH_CLA } from "@internal/app-binder/command/utils/apduHeaderUtils";
 import {
   ZCASH_APP_ERRORS,
   ZcashAppCommandErrorFactory,
   type ZcashErrorCodes,
 } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+/**
+ * `INS_PCZT_TRANSPARENT_OUTPUT`: streams the transparent output bundle (always
+ * sent, count 0 when empty). Mirrors `LedgerHQ/app-zcash` `src/consts.rs`.
+ */
+export const INS_PCZT_TRANSPARENT_OUTPUT = 0x54;
 
 export type PcztTransparentOutputCommandArgs = {
   /** One serialized packet of the transparent-output bundle. */
@@ -48,7 +51,7 @@ export class PcztTransparentOutputCommand
   getApdu(): Apdu {
     const apduArgs: ApduBuilderArgs = {
       cla: ZCASH_CLA,
-      ins: PCZT_INS.TRANSPARENT_OUTPUT,
+      ins: INS_PCZT_TRANSPARENT_OUTPUT,
       p1: this.args.p1,
       p2: this.args.p2,
     };

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/SignPcztCommands.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/SignPcztCommands.test.ts
@@ -1,0 +1,95 @@
+import {
+  ApduResponse,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { describe, expect, it } from "vitest";
+
+import { SignPcztOrchardCommand } from "@internal/app-binder/command/SignPcztOrchardCommand";
+import { SignPcztTransparentCommand } from "@internal/app-binder/command/SignPcztTransparentCommand";
+
+const apduHex = (raw: Uint8Array): string => Buffer.from(raw).toString("hex");
+const response = (statusCode: number[], data: Uint8Array): ApduResponse =>
+  new ApduResponse({ statusCode: Uint8Array.from(statusCode), data });
+
+const OK = [0x90, 0x00];
+const REJECTED = [0x69, 0x85]; // ConditionOfUseNotSatisfied (signed before finalize)
+
+describe("SignPcztOrchardCommand", () => {
+  it("builds INS 0x57 with empty data and the action index in P2", () => {
+    const apdu = new SignPcztOrchardCommand({ actionIndex: 3 })
+      .getApdu()
+      .getRawApdu();
+    expect(apduHex(apdu)).toBe("e057000300");
+  });
+
+  it("parses a 64-byte spendAuthSig", () => {
+    const sig = new Uint8Array(64).fill(0xab);
+    const result = new SignPcztOrchardCommand({ actionIndex: 0 }).parseResponse(
+      response(OK, sig),
+    );
+    expect(isSuccessCommandResult(result)).toBe(true);
+    if (isSuccessCommandResult(result)) {
+      expect(result.data.spendAuthSig).toEqual(sig);
+    }
+  });
+
+  it("rejects a spendAuthSig of the wrong length", () => {
+    const result = new SignPcztOrchardCommand({ actionIndex: 0 }).parseResponse(
+      response(OK, new Uint8Array(63).fill(0xab)),
+    );
+    expect(isSuccessCommandResult(result)).toBe(false);
+  });
+
+  it("surfaces a device rejection", () => {
+    const result = new SignPcztOrchardCommand({ actionIndex: 0 }).parseResponse(
+      response(REJECTED, new Uint8Array()),
+    );
+    expect(isSuccessCommandResult(result)).toBe(false);
+  });
+});
+
+describe("SignPcztTransparentCommand", () => {
+  it("builds INS 0x55 with empty data and the input index in P2", () => {
+    const apdu = new SignPcztTransparentCommand({ inputIndex: 1 })
+      .getApdu()
+      .getRawApdu();
+    expect(apduHex(apdu)).toBe("e055000100");
+  });
+
+  it("parses a DER signature followed by a SIGHASH_ALL byte", () => {
+    const sig = Uint8Array.from([
+      0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01, 0x01,
+    ]);
+    const result = new SignPcztTransparentCommand({
+      inputIndex: 0,
+    }).parseResponse(response(OK, sig));
+    expect(isSuccessCommandResult(result)).toBe(true);
+    if (isSuccessCommandResult(result)) {
+      expect(result.data.signature).toEqual(sig);
+    }
+  });
+
+  it("rejects a trailing sighash byte that is not SIGHASH_ALL", () => {
+    const sig = Uint8Array.from([
+      0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01, 0x02,
+    ]);
+    const result = new SignPcztTransparentCommand({
+      inputIndex: 0,
+    }).parseResponse(response(OK, sig));
+    expect(isSuccessCommandResult(result)).toBe(false);
+  });
+
+  it("rejects a response too short to hold a signature + sighash", () => {
+    const result = new SignPcztTransparentCommand({
+      inputIndex: 0,
+    }).parseResponse(response(OK, Uint8Array.of(0x01)));
+    expect(isSuccessCommandResult(result)).toBe(false);
+  });
+
+  it("surfaces a device rejection", () => {
+    const result = new SignPcztTransparentCommand({
+      inputIndex: 0,
+    }).parseResponse(response(REJECTED, new Uint8Array()));
+    expect(isSuccessCommandResult(result)).toBe(false);
+  });
+});

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/SignPcztOrchardCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/SignPcztOrchardCommand.ts
@@ -13,7 +13,6 @@ import { Maybe } from "purify-ts";
 
 import { type OrchardActionSignature } from "@api/model/PcztSignature";
 import {
-  PCZT_INS,
   PCZT_P1,
   ZCASH_CLA,
 } from "@internal/app-binder/command/utils/apduHeaderUtils";
@@ -22,6 +21,12 @@ import {
   ZcashAppCommandErrorFactory,
   type ZcashErrorCodes,
 } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+/**
+ * `INS_PCZT_SIGN_ORCHARD`: signs one Orchard action. P2 = action index; returns
+ * `spendAuthSig[64]`. Mirrors `LedgerHQ/app-zcash` `src/consts.rs`.
+ */
+export const INS_PCZT_SIGN_ORCHARD = 0x57;
 
 /** RedPallas spend-authorization signature length. */
 const SPEND_AUTH_SIG_LENGTH = 64;
@@ -54,7 +59,7 @@ export class SignPcztOrchardCommand
   getApdu(): Apdu {
     const apduArgs: ApduBuilderArgs = {
       cla: ZCASH_CLA,
-      ins: PCZT_INS.SIGN_ORCHARD,
+      ins: INS_PCZT_SIGN_ORCHARD,
       p1: PCZT_P1.FIRST,
       p2: this.args.actionIndex,
     };

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/SignPcztOrchardCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/SignPcztOrchardCommand.ts
@@ -1,0 +1,81 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import { type OrchardActionSignature } from "@api/model/PcztSignature";
+import {
+  PCZT_INS,
+  PCZT_P1,
+  ZCASH_CLA,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import {
+  ZCASH_APP_ERRORS,
+  ZcashAppCommandErrorFactory,
+  type ZcashErrorCodes,
+} from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+/** RedPallas spend-authorization signature length. */
+const SPEND_AUTH_SIG_LENGTH = 64;
+
+export type SignPcztOrchardCommandArgs = {
+  /** Orchard action index to sign (carried in P2). */
+  actionIndex: number;
+};
+
+/**
+ * `PCZT_SIGN_ORCHARD` (`INS 0x57`, P2 = action index, empty data).
+ *
+ * Accepted only after the PCZT bundle is finalized; each action index is
+ * signable once. Returns the RedPallas `spendAuthSig[64]` only — `alpha` is a
+ * host-supplied PCZT field and is never returned.
+ */
+export class SignPcztOrchardCommand
+  implements
+    Command<OrchardActionSignature, SignPcztOrchardCommandArgs, ZcashErrorCodes>
+{
+  readonly name = "SignPcztOrchard";
+
+  private readonly errorHelper = new CommandErrorHelper<
+    OrchardActionSignature,
+    ZcashErrorCodes
+  >(ZCASH_APP_ERRORS, ZcashAppCommandErrorFactory);
+
+  constructor(private readonly args: SignPcztOrchardCommandArgs) {}
+
+  getApdu(): Apdu {
+    const apduArgs: ApduBuilderArgs = {
+      cla: ZCASH_CLA,
+      ins: PCZT_INS.SIGN_ORCHARD,
+      p1: PCZT_P1.FIRST,
+      p2: this.args.actionIndex,
+    };
+    return new ApduBuilder(apduArgs).build();
+  }
+
+  parseResponse(
+    apduResponse: ApduResponse,
+  ): CommandResult<OrchardActionSignature, ZcashErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      const spendAuthSig = new Uint8Array(apduResponse.data);
+      if (spendAuthSig.length !== SPEND_AUTH_SIG_LENGTH) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            `Expected ${SPEND_AUTH_SIG_LENGTH}-byte Orchard spendAuthSig, got ${spendAuthSig.length}`,
+          ),
+        });
+      }
+      return CommandResultFactory({ data: { spendAuthSig } });
+    });
+  }
+}

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/SignPcztTransparentCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/SignPcztTransparentCommand.ts
@@ -12,7 +12,6 @@ import { CommandErrorHelper } from "@ledgerhq/signer-utils";
 import { Maybe } from "purify-ts";
 
 import {
-  PCZT_INS,
   PCZT_P1,
   ZCASH_CLA,
 } from "@internal/app-binder/command/utils/apduHeaderUtils";
@@ -22,6 +21,12 @@ import {
   type ZcashErrorCodes,
 } from "@internal/app-binder/command/utils/zcashApplicationErrors";
 import { SIGHASH_ALL } from "@internal/app-binder/task/utils/legacyTransactionUtils";
+
+/**
+ * `INS_PCZT_SIGN_TRANSPARENT`: signs one transparent input. P2 = input index;
+ * returns DER sig + sighash byte. Mirrors `LedgerHQ/app-zcash` `src/consts.rs`.
+ */
+export const INS_PCZT_SIGN_TRANSPARENT = 0x55;
 
 export type SignPcztTransparentCommandArgs = {
   /** Transparent input index to sign (carried in P2). */
@@ -62,7 +67,7 @@ export class SignPcztTransparentCommand
   getApdu(): Apdu {
     const apduArgs: ApduBuilderArgs = {
       cla: ZCASH_CLA,
-      ins: PCZT_INS.SIGN_TRANSPARENT,
+      ins: INS_PCZT_SIGN_TRANSPARENT,
       p1: PCZT_P1.FIRST,
       p2: this.args.inputIndex,
     };

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/SignPcztTransparentCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/SignPcztTransparentCommand.ts
@@ -1,0 +1,99 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import {
+  PCZT_INS,
+  PCZT_P1,
+  ZCASH_CLA,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import {
+  ZCASH_APP_ERRORS,
+  ZcashAppCommandErrorFactory,
+  type ZcashErrorCodes,
+} from "@internal/app-binder/command/utils/zcashApplicationErrors";
+import { SIGHASH_ALL } from "@internal/app-binder/task/utils/legacyTransactionUtils";
+
+export type SignPcztTransparentCommandArgs = {
+  /** Transparent input index to sign (carried in P2). */
+  inputIndex: number;
+};
+
+export type SignPcztTransparentCommandResponse = {
+  /**
+   * Raw device response: DER-encoded secp256k1 signature followed by a single
+   * `sighash_type` byte (`SIGHASH_ALL` = `0x01`).
+   */
+  signature: Uint8Array;
+};
+
+/**
+ * `PCZT_SIGN_TRANSPARENT` (`INS 0x55`, P2 = input index, empty data).
+ *
+ * Accepted only after the PCZT bundle is finalized; each input index is
+ * signable once. Returns DER secp256k1 signature + `sighash_type` byte.
+ */
+export class SignPcztTransparentCommand
+  implements
+    Command<
+      SignPcztTransparentCommandResponse,
+      SignPcztTransparentCommandArgs,
+      ZcashErrorCodes
+    >
+{
+  readonly name = "SignPcztTransparent";
+
+  private readonly errorHelper = new CommandErrorHelper<
+    SignPcztTransparentCommandResponse,
+    ZcashErrorCodes
+  >(ZCASH_APP_ERRORS, ZcashAppCommandErrorFactory);
+
+  constructor(private readonly args: SignPcztTransparentCommandArgs) {}
+
+  getApdu(): Apdu {
+    const apduArgs: ApduBuilderArgs = {
+      cla: ZCASH_CLA,
+      ins: PCZT_INS.SIGN_TRANSPARENT,
+      p1: PCZT_P1.FIRST,
+      p2: this.args.inputIndex,
+    };
+    return new ApduBuilder(apduArgs).build();
+  }
+
+  parseResponse(
+    apduResponse: ApduResponse,
+  ): CommandResult<SignPcztTransparentCommandResponse, ZcashErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      const signature = new Uint8Array(apduResponse.data);
+      // DER signature (≥1 byte) + trailing sighash_type byte.
+      if (signature.length < 2) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            `Expected a transparent signature with a trailing sighash byte, got ${signature.length} bytes`,
+          ),
+        });
+      }
+      if (signature[signature.length - 1] !== SIGHASH_ALL) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            `Expected sighash_type SIGHASH_ALL (0x01), got 0x${signature[
+              signature.length - 1
+            ]!.toString(16)}`,
+          ),
+        });
+      }
+      return CommandResultFactory({ data: { signature } });
+    });
+  }
+}

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/utils/apduHeaderUtils.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/utils/apduHeaderUtils.ts
@@ -20,22 +20,6 @@ export const P2 = {
  * transparent P1/P2 above so the DMK-01 transparent path is untouched.
  */
 
-/** PCZT instruction opcodes (`INS_PCZT_*`). */
-export const PCZT_INS = {
-  /** Resets the tx context and opens a new PCZT payload. Sent exactly once. */
-  HEADER: 0x52,
-  /** Streams the transparent input bundle (always sent, count 0 when empty). */
-  TRANSPARENT_INPUT: 0x53,
-  /** Streams the transparent output bundle (always sent, count 0 when empty). */
-  TRANSPARENT_OUTPUT: 0x54,
-  /** Signs one transparent input. P2 = input index; DER sig + sighash byte. */
-  SIGN_TRANSPARENT: 0x55,
-  /** Streams the Orchard action bundle (always sent, count 0 when empty). */
-  ORCHARD_ACTION: 0x56,
-  /** Signs one Orchard action. P2 = action index; returns spendAuthSig[64]. */
-  SIGN_ORCHARD: 0x57,
-} as const;
-
 /** P1 packet-sequence framing for a single multi-packet PCZT bundle command. */
 export const PCZT_P1 = {
   /** First (or only) APDU packet of the command. */

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/utils/apduHeaderUtils.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/utils/apduHeaderUtils.ts
@@ -11,3 +11,51 @@ export const P2 = {
   SAPLING: 0x05,
   HASH_INPUT_CONTINUE: 0x80,
 } as const;
+
+/**
+ * PCZT (Partially Constructed Zcash Transaction) APDU framing.
+ *
+ * Source of truth: `LedgerHQ/app-zcash` (branch `develop`) `src/consts.rs`,
+ * `docs/APDU.md` and `docs/PCZT_APDU.md`. Kept separate from the legacy
+ * transparent P1/P2 above so the DMK-01 transparent path is untouched.
+ */
+
+/** PCZT instruction opcodes (`INS_PCZT_*`). */
+export const PCZT_INS = {
+  /** Resets the tx context and opens a new PCZT payload. Sent exactly once. */
+  HEADER: 0x52,
+  /** Streams the transparent input bundle (always sent, count 0 when empty). */
+  TRANSPARENT_INPUT: 0x53,
+  /** Streams the transparent output bundle (always sent, count 0 when empty). */
+  TRANSPARENT_OUTPUT: 0x54,
+  /** Signs one transparent input. P2 = input index; DER sig + sighash byte. */
+  SIGN_TRANSPARENT: 0x55,
+  /** Streams the Orchard action bundle (always sent, count 0 when empty). */
+  ORCHARD_ACTION: 0x56,
+  /** Signs one Orchard action. P2 = action index; returns spendAuthSig[64]. */
+  SIGN_ORCHARD: 0x57,
+} as const;
+
+/** P1 packet-sequence framing for a single multi-packet PCZT bundle command. */
+export const PCZT_P1 = {
+  /** First (or only) APDU packet of the command. */
+  FIRST: 0x00,
+  /** Continuation APDU packet. */
+  NEXT: 0x80,
+  /** Last APDU packet of the command. */
+  LAST: 0x01,
+} as const;
+
+/** P2 framing for PCZT bundle commands. */
+export const PCZT_P2 = {
+  /** More PCZT bundle commands may still follow. */
+  CONTINUE: 0x00,
+  /**
+   * Final PCZT data packet — valid only on the last packet of
+   * `ORCHARD_ACTION`. Signing commands are accepted only after this marker.
+   */
+  FINISHED: 0x01,
+} as const;
+
+/** Maximum APDU `data` payload for one PCZT packet (255 bytes). */
+export const PCZT_MAX_PACKET_SIZE = 255 as const;

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/utils/apduHeaderUtils.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/utils/apduHeaderUtils.ts
@@ -17,7 +17,7 @@ export const P2 = {
  *
  * Source of truth: `LedgerHQ/app-zcash` (branch `develop`) `src/consts.rs`,
  * `docs/APDU.md` and `docs/PCZT_APDU.md`. Kept separate from the legacy
- * transparent P1/P2 above so the DMK-01 transparent path is untouched.
+ * transparent P1/P2 above so the legacy transparent path is untouched.
  */
 
 /** P1 packet-sequence framing for a single multi-packet PCZT bundle command. */

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/utils/pcztSerializer.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/utils/pcztSerializer.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PCZT_MAX_PACKET_SIZE,
+  PCZT_P1,
+  PCZT_P2,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import {
+  pcztP1,
+  pcztP2,
+  serializeOrchardActions,
+  serializePcztHeader,
+  serializeTransparentInputs,
+  serializeTransparentOutputs,
+} from "@internal/app-binder/command/utils/pcztSerializer";
+import {
+  bytes,
+  bytesToHex,
+  hexToBytes,
+  ORCHARD_ENC_CIPHERTEXT_SIZE,
+  SAMPLE_GLOBAL,
+  SAMPLE_HEADER_HEX,
+  sampleOrchardBundle,
+  sampleTransparentInput,
+  sampleTransparentOutput,
+} from "@internal/app-binder/task/__fixtures__/pcztFixtures";
+import { concatUint8Arrays } from "@internal/utils/concatUint8Arrays";
+
+describe("pcztSerializer", () => {
+  describe("serializePcztHeader", () => {
+    it("serializes the header + globals byte-for-byte (little-endian)", () => {
+      expect(bytesToHex(serializePcztHeader(SAMPLE_GLOBAL))).toBe(
+        SAMPLE_HEADER_HEX,
+      );
+    });
+
+    it("encodes an absent fallback_lock_time as a single 0x00 tag", () => {
+      const hex = bytesToHex(
+        serializePcztHeader({ ...SAMPLE_GLOBAL, fallbackLockTime: null }),
+      );
+      // ...consensus_branch_id, then 0x00 (absent), then expiry_height...
+      expect(hex).toContain("b4d0d6c200" + "00000000");
+    });
+  });
+
+  describe("serializeTransparentInputs", () => {
+    it("emits only a CompactSize 0 count packet when empty", () => {
+      const packets = serializeTransparentInputs([]);
+      expect(packets).toHaveLength(1);
+      expect(bytesToHex(packets[0]!)).toBe("00");
+    });
+
+    it("serializes one input: count, small fields, script, sighash+bip32", () => {
+      const input = sampleTransparentInput();
+      const packets = serializeTransparentInputs([input]);
+
+      expect(packets).toHaveLength(4);
+      expect(bytesToHex(packets[0]!)).toBe("01");
+
+      // prevout(36) + sequence Option<u32>(present) + value u64 LE.
+      const expectedSmall = concatUint8Arrays(
+        bytes(32, 0x11),
+        hexToBytes("00000000"), // prevout_index 0
+        hexToBytes("01ffffffff"), // sequence present, 0xffffffff
+        hexToBytes("e803000000000000"), // value 1000 LE
+      );
+      expect(bytesToHex(packets[1]!)).toBe(bytesToHex(expectedSmall));
+
+      // script packet: CompactSize length + scriptPubKey (25 bytes -> 0x19).
+      expect(bytesToHex(packets[2]!)).toBe(
+        "19" + bytesToHex(input.scriptPubKey),
+      );
+
+      // sighash(0x01) + bip32: count(1) + pubkey[33] + fingerprint[32] + path.
+      const deriv = packets[3]!;
+      expect(deriv[0]).toBe(0x01); // sighash_type SIGHASH_ALL
+      expect(deriv[1]).toBe(0x01); // bip32 entry count
+      expect(bytesToHex(deriv.subarray(2, 35))).toBe(
+        bytesToHex(bytes(33, 0x02)),
+      );
+      // path "44'/133'/0'/0/0": len 5, then BE u32 components.
+      expect(bytesToHex(deriv.subarray(67))).toBe(
+        "05" + "8000002c" + "80000085" + "80000000" + "00000000" + "00000000",
+      );
+    });
+  });
+
+  describe("serializeTransparentOutputs", () => {
+    it("emits only a CompactSize 0 count packet when empty", () => {
+      const packets = serializeTransparentOutputs([]);
+      expect(packets).toHaveLength(1);
+      expect(bytesToHex(packets[0]!)).toBe("00");
+    });
+
+    it("serializes one output: count, value, script, empty bip32", () => {
+      const output = sampleTransparentOutput();
+      const packets = serializeTransparentOutputs([output]);
+
+      expect(packets).toHaveLength(4);
+      expect(bytesToHex(packets[0]!)).toBe("01");
+      expect(bytesToHex(packets[1]!)).toBe("8403000000000000"); // value 900 LE
+      expect(bytesToHex(packets[2]!)).toBe(
+        "19" + bytesToHex(output.scriptPubKey),
+      );
+      expect(bytesToHex(packets[3]!)).toBe("00"); // bip32 entry count 0 (no derivation)
+    });
+  });
+
+  describe("serializeOrchardActions", () => {
+    it("emits only a CompactSize 0 count packet when empty", () => {
+      const packets = serializeOrchardActions({
+        actions: [],
+        flags: 0,
+        valueBalance: 0n,
+        anchor: bytes(32, 0x00),
+      });
+      expect(packets).toHaveLength(1);
+      expect(bytesToHex(packets[0]!)).toBe("00");
+    });
+
+    it("serializes one action with the full packet sequence + trailer", () => {
+      const packets = serializeOrchardActions(sampleOrchardBundle());
+
+      // count + [spend, zip32, outputSmall, enc x3, out, metadata] + trailer.
+      expect(packets).toHaveLength(10);
+      expect(bytesToHex(packets[0]!)).toBe("01");
+
+      // spend small fields: cv|nullifier|rk|recipient|value8|rho|rseed|alpha.
+      const spend = packets[1]!;
+      expect(spend).toHaveLength(32 * 3 + 43 + 8 + 32 * 3);
+      expect(spend[32 * 3 + 43]).toBe(0x05); // spend_value first LE byte
+
+      // zip32: fingerprint[32] + path("44'/133'/0'": len 3 + 3 BE u32).
+      expect(bytesToHex(packets[2]!)).toBe(
+        bytesToHex(bytes(32, 0x00)) +
+          "03" +
+          "8000002c" +
+          "80000085" +
+          "80000000",
+      );
+
+      // every emitted packet stays within the APDU payload cap.
+      packets.forEach((packet) => {
+        expect(packet.length).toBeLessThanOrEqual(PCZT_MAX_PACKET_SIZE);
+      });
+    });
+
+    it("splits a large enc_ciphertext across multiple <=255B packets", () => {
+      const packets = serializeOrchardActions(sampleOrchardBundle());
+      // enc field occupies packets[4..6] (CompactSize 580 + 580 bytes = 583).
+      const encField = concatUint8Arrays(packets[4]!, packets[5]!, packets[6]!);
+      // strip the 3-byte CompactSize prefix (0xfd + u16 LE).
+      expect(bytesToHex(encField.subarray(0, 3))).toBe("fd4402");
+      expect(encField.length - 3).toBe(ORCHARD_ENC_CIPHERTEXT_SIZE);
+      expect(bytesToHex(encField.subarray(3))).toBe(
+        bytesToHex(bytes(ORCHARD_ENC_CIPHERTEXT_SIZE, 0xaa)),
+      );
+    });
+
+    it("encodes a negative value_balance with the sign flag set", () => {
+      const packets = serializeOrchardActions({
+        ...sampleOrchardBundle(),
+        valueBalance: -7n,
+      });
+      const trailer = packets[packets.length - 1]!;
+      // flags(1) + |value_sum| u64 LE + sign(1) + anchor[32].
+      expect(trailer[0]).toBe(0x02); // flags
+      expect(trailer[1]).toBe(0x07); // |−7| first LE byte
+      expect(trailer[9]).toBe(0x01); // negative sign flag
+    });
+  });
+
+  describe("framing", () => {
+    it("pcztP1 marks first / continuation / last packets", () => {
+      expect(pcztP1(0, 1)).toBe(PCZT_P1.FIRST);
+      expect(pcztP1(0, 3)).toBe(PCZT_P1.FIRST);
+      expect(pcztP1(1, 3)).toBe(PCZT_P1.NEXT);
+      expect(pcztP1(2, 3)).toBe(PCZT_P1.LAST);
+    });
+
+    it("pcztP2 sets FINISHED only on the final packet when requested", () => {
+      expect(pcztP2(2, 3, true)).toBe(PCZT_P2.FINISHED);
+      expect(pcztP2(1, 3, true)).toBe(PCZT_P2.CONTINUE);
+      expect(pcztP2(2, 3, false)).toBe(PCZT_P2.CONTINUE);
+    });
+  });
+});

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/utils/pcztSerializer.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/utils/pcztSerializer.ts
@@ -1,0 +1,247 @@
+import { ByteArrayBuilder } from "@ledgerhq/device-management-kit";
+import { DerivationPathUtils } from "@ledgerhq/signer-utils";
+
+import {
+  type PcztBip32Derivation,
+  type PcztGlobal,
+  type PcztOrchardBundle,
+  type PcztTransparentInput,
+  type PcztTransparentOutput,
+} from "@api/model/PcztTransaction";
+import {
+  PCZT_MAX_PACKET_SIZE,
+  PCZT_P1,
+  PCZT_P2,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import { createVarint } from "@internal/app-binder/task/utils/legacyTransactionUtils";
+import { concatUint8Arrays } from "@internal/utils/concatUint8Arrays";
+
+/**
+ * Byte-exact serialization of the compact PCZT subset the device parses.
+ *
+ * The field order, sizes and endianness mirror `LedgerHQ/app-zcash`
+ * (branch `develop`) `src/parser/pczt/{common,transparent,orchard}.rs` and the
+ * `docs/PCZT_APDU.md` contract. PCZT integer fields are little-endian;
+ * derivation-path components use the standard big-endian `Bip32Path` encoding.
+ *
+ * Each `serialize*` function returns the ordered list of *logical* packet
+ * payloads for one `PCZT_*` command. The task frames them into APDUs with
+ * {@link pcztP1}/{@link pcztP2}. Every logical packet is at most
+ * {@link PCZT_MAX_PACKET_SIZE} bytes; large `Vec<u8>` fields (script,
+ * ciphertext) are pre-split here.
+ */
+
+/** Default ZIP-32 seed fingerprint when the PCZT omits one (32 zero bytes). */
+const DEFAULT_SEED_FINGERPRINT = new Uint8Array(32);
+
+/** `path_len u8` followed by big-endian `u32` path components. */
+const packDerivationPath = (path: string): Uint8Array => {
+  const components = DerivationPathUtils.splitPath(path);
+  const builder = new ByteArrayBuilder();
+  builder.add8BitUIntToData(components.length);
+  components.forEach((component) => builder.add32BitUIntToData(component));
+  return builder.build();
+};
+
+/** `Option<u32>`: tag `0x00` (absent) or `0x01` + little-endian `u32`. */
+const optionalU32 = (value: number | null): Uint8Array => {
+  if (value === null) {
+    return Uint8Array.of(0x00);
+  }
+  const builder = new ByteArrayBuilder();
+  builder.add8BitUIntToData(0x01);
+  builder.add32BitUIntToData(value, false);
+  return builder.build();
+};
+
+/**
+ * A `bip32_derivation` packet:
+ * - CompactSize entry count (`0` when absent, else `1`)
+ * - if present: compressed pubkey `[33]` + seed fingerprint `[32]` + `Bip32Path`
+ */
+const bip32DerivationPacket = (
+  derivation: PcztBip32Derivation | null | undefined,
+): Uint8Array => {
+  if (!derivation) {
+    return createVarint(0);
+  }
+  return concatUint8Arrays(
+    createVarint(1),
+    derivation.pubkey,
+    derivation.seedFingerprint ?? DEFAULT_SEED_FINGERPRINT,
+    packDerivationPath(derivation.signingPath),
+  );
+};
+
+/** A `zip32_derivation` packet: seed fingerprint `[32]` + `Bip32Path` (no count). */
+const zip32DerivationPacket = (
+  signingPath: string,
+  seedFingerprint?: Uint8Array,
+): Uint8Array =>
+  concatUint8Arrays(
+    seedFingerprint ?? DEFAULT_SEED_FINGERPRINT,
+    packDerivationPath(signingPath),
+  );
+
+/**
+ * A length-prefixed `Vec<u8>` field, split into ≤ {@link PCZT_MAX_PACKET_SIZE}
+ * packets: first packet is `CompactSize length + bytes`, continuations are
+ * bytes only.
+ */
+const fieldPackets = (field: Uint8Array): Uint8Array[] =>
+  splitIntoPackets(concatUint8Arrays(createVarint(field.length), field));
+
+/** Split a logical payload into ≤ {@link PCZT_MAX_PACKET_SIZE} byte packets. */
+const splitIntoPackets = (payload: Uint8Array): Uint8Array[] => {
+  if (payload.length <= PCZT_MAX_PACKET_SIZE) {
+    return [payload];
+  }
+  const packets: Uint8Array[] = [];
+  for (
+    let offset = 0;
+    offset < payload.length;
+    offset += PCZT_MAX_PACKET_SIZE
+  ) {
+    packets.push(payload.subarray(offset, offset + PCZT_MAX_PACKET_SIZE));
+  }
+  return packets;
+};
+
+/** `PCZT_HEADER` payload: magic, PCZT version, then `common::Global`. */
+export const serializePcztHeader = (global: PcztGlobal): Uint8Array => {
+  const builder = new ByteArrayBuilder();
+  builder.addBufferToData(Uint8Array.of(0x50, 0x43, 0x5a, 0x54)); // "PCZT"
+  builder.add32BitUIntToData(1, false); // PCZT version
+  builder.add32BitUIntToData(global.txVersion, false);
+  builder.add32BitUIntToData(global.versionGroupId, false);
+  builder.add32BitUIntToData(global.consensusBranchId, false);
+  builder.addBufferToData(optionalU32(global.fallbackLockTime));
+  builder.add32BitUIntToData(global.expiryHeight, false);
+  builder.add32BitUIntToData(global.coinType, false);
+  builder.add8BitUIntToData(global.txModifiable);
+  return builder.build();
+};
+
+/** `PCZT_TRANSPARENT_INPUT` packet sequence. */
+export const serializeTransparentInputs = (
+  inputs: PcztTransparentInput[],
+): Uint8Array[] => {
+  const packets: Uint8Array[] = [createVarint(inputs.length)];
+
+  for (const input of inputs) {
+    const small = new ByteArrayBuilder();
+    small.addBufferToData(input.prevoutTxid);
+    small.add32BitUIntToData(input.prevoutIndex, false);
+    small.addBufferToData(optionalU32(input.sequence));
+    small.add64BitUIntToData(input.value, false);
+    packets.push(small.build());
+
+    packets.push(...fieldPackets(input.scriptPubKey));
+
+    packets.push(
+      concatUint8Arrays(
+        Uint8Array.of(input.sighashType),
+        bip32DerivationPacket(input.derivation),
+      ),
+    );
+  }
+
+  return packets;
+};
+
+/** `PCZT_TRANSPARENT_OUTPUT` packet sequence. */
+export const serializeTransparentOutputs = (
+  outputs: PcztTransparentOutput[],
+): Uint8Array[] => {
+  const packets: Uint8Array[] = [createVarint(outputs.length)];
+
+  for (const output of outputs) {
+    const value = new ByteArrayBuilder();
+    value.add64BitUIntToData(output.value, false);
+    packets.push(value.build());
+
+    packets.push(...fieldPackets(output.scriptPubKey));
+
+    packets.push(bip32DerivationPacket(output.derivation));
+  }
+
+  return packets;
+};
+
+/** `PCZT_ORCHARD_ACTION` packet sequence (including the trailer). */
+export const serializeOrchardActions = (
+  bundle: PcztOrchardBundle,
+): Uint8Array[] => {
+  const packets: Uint8Array[] = [createVarint(bundle.actions.length)];
+
+  if (bundle.actions.length === 0) {
+    return packets;
+  }
+
+  for (const action of bundle.actions) {
+    const spend = new ByteArrayBuilder();
+    spend.addBufferToData(action.cvNet);
+    spend.addBufferToData(action.nullifier);
+    spend.addBufferToData(action.rk);
+    spend.addBufferToData(action.spendRecipient);
+    spend.add64BitUIntToData(action.spendValue, false);
+    spend.addBufferToData(action.spendRho);
+    spend.addBufferToData(action.spendRseed);
+    spend.addBufferToData(action.alpha);
+    packets.push(spend.build());
+
+    packets.push(
+      zip32DerivationPacket(action.signingPath, action.seedFingerprint),
+    );
+
+    packets.push(concatUint8Arrays(action.cmx, action.ephemeralKey));
+
+    packets.push(...fieldPackets(action.encCiphertext));
+    packets.push(...fieldPackets(action.outCiphertext));
+
+    const metadata = new ByteArrayBuilder();
+    metadata.addBufferToData(action.recipient);
+    metadata.add64BitUIntToData(action.value, false);
+    metadata.addBufferToData(action.rseed);
+    metadata.addBufferToData(action.rcv);
+    packets.push(metadata.build());
+  }
+
+  const trailer = new ByteArrayBuilder();
+  const valueBalance = bundle.valueBalance;
+  trailer.add8BitUIntToData(bundle.flags);
+  trailer.add64BitUIntToData(
+    valueBalance < 0n ? -valueBalance : valueBalance,
+    false,
+  );
+  trailer.add8BitUIntToData(valueBalance < 0n ? 1 : 0);
+  trailer.addBufferToData(bundle.anchor);
+  packets.push(trailer.build());
+
+  return packets;
+};
+
+/**
+ * P1 framing for packet `index` of a `total`-packet command:
+ * `FIRST` for the first (or only) packet, `LAST` for the last, else `NEXT`.
+ */
+export const pcztP1 = (index: number, total: number): number => {
+  if (index === 0) {
+    return PCZT_P1.FIRST;
+  }
+  if (index === total - 1) {
+    return PCZT_P1.LAST;
+  }
+  return PCZT_P1.NEXT;
+};
+
+/**
+ * P2 framing: `FINISHED` only on the last packet of the final bundle command
+ * (`ORCHARD_ACTION`), otherwise `CONTINUE`.
+ */
+export const pcztP2 = (
+  index: number,
+  total: number,
+  finished: boolean,
+): number =>
+  finished && index === total - 1 ? PCZT_P2.FINISHED : PCZT_P2.CONTINUE;

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/utils/pcztSerializer.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/utils/pcztSerializer.ts
@@ -174,6 +174,14 @@ export const serializeOrchardActions = (
 ): Uint8Array[] => {
   const packets: Uint8Array[] = [createVarint(bundle.actions.length)];
 
+  // No trailer when there are zero actions: this is *not* a missing field. The
+  // device parser finalizes the Orchard bundle the moment it reads a count of 0
+  // (`app-zcash` `src/parser/pczt/orchard.rs`: `if action_count == 0 {
+  // finalize_orchard_actions(..) }`) and never reads flags/value_sum/anchor.
+  // The contract spells this out in `docs/PCZT_APDU.md`: "Bundle trailer
+  // packet, only when Orchard action count is greater than 0." Emitting a
+  // trailer here would leave unexpected bytes and fail the parser's group-end
+  // check on the transparent-only flow.
   if (bundle.actions.length === 0) {
     return packets;
   }
@@ -224,8 +232,16 @@ export const serializeOrchardActions = (
 /**
  * P1 framing for packet `index` of a `total`-packet command:
  * `FIRST` for the first (or only) packet, `LAST` for the last, else `NEXT`.
+ *
+ * A one-packet command (e.g. an empty section's count-0 packet) resolves to
+ * `FIRST`, never `LAST` — this is correct, not a missed case. `docs/PCZT_APDU.md`
+ * states "A one-packet command uses P1_FIRST", and the device only runs its
+ * "ended before all parsed" completeness check when the `LAST` flag is set
+ * (`app-zcash` `src/handlers/pczt.rs`), so a lone `FIRST` packet is accepted.
  */
 export const pcztP1 = (index: number, total: number): number => {
+  // `index === 0` is taken before the `index === total - 1` branch, so the
+  // single-packet case (index 0, total 1) intentionally returns FIRST.
   if (index === 0) {
     return PCZT_P1.FIRST;
   }

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.test.ts
@@ -7,10 +7,13 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { type PcztTransaction } from "@api/model/PcztTransaction";
-import {
-  PCZT_INS,
-  PCZT_P2,
-} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import { INS_PCZT_HEADER } from "@internal/app-binder/command/PcztHeaderCommand";
+import { INS_PCZT_ORCHARD_ACTION } from "@internal/app-binder/command/PcztOrchardActionCommand";
+import { INS_PCZT_TRANSPARENT_INPUT } from "@internal/app-binder/command/PcztTransparentInputCommand";
+import { INS_PCZT_TRANSPARENT_OUTPUT } from "@internal/app-binder/command/PcztTransparentOutputCommand";
+import { INS_PCZT_SIGN_ORCHARD } from "@internal/app-binder/command/SignPcztOrchardCommand";
+import { INS_PCZT_SIGN_TRANSPARENT } from "@internal/app-binder/command/SignPcztTransparentCommand";
+import { PCZT_P2 } from "@internal/app-binder/command/utils/apduHeaderUtils";
 import {
   privateToPrivateTransaction,
   privateToPublicTransaction,
@@ -67,19 +70,19 @@ describe("SignPcztTransactionTask", () => {
     const bundleIns = calls
       .filter((c) =>
         [
-          PCZT_INS.HEADER,
-          PCZT_INS.TRANSPARENT_INPUT,
-          PCZT_INS.TRANSPARENT_OUTPUT,
-          PCZT_INS.ORCHARD_ACTION,
+          INS_PCZT_HEADER,
+          INS_PCZT_TRANSPARENT_INPUT,
+          INS_PCZT_TRANSPARENT_OUTPUT,
+          INS_PCZT_ORCHARD_ACTION,
         ].includes(c.ins as never),
       )
       .map((c) => c.ins);
 
     // header first; the three bundle sections strictly increasing INS groups.
-    expect(bundleIns[0]).toBe(PCZT_INS.HEADER);
-    const firstInput = bundleIns.indexOf(PCZT_INS.TRANSPARENT_INPUT);
-    const firstOutput = bundleIns.indexOf(PCZT_INS.TRANSPARENT_OUTPUT);
-    const firstOrchard = bundleIns.indexOf(PCZT_INS.ORCHARD_ACTION);
+    expect(bundleIns[0]).toBe(INS_PCZT_HEADER);
+    const firstInput = bundleIns.indexOf(INS_PCZT_TRANSPARENT_INPUT);
+    const firstOutput = bundleIns.indexOf(INS_PCZT_TRANSPARENT_OUTPUT);
+    const firstOrchard = bundleIns.indexOf(INS_PCZT_ORCHARD_ACTION);
     expect(firstInput).toBeLessThan(firstOutput);
     expect(firstOutput).toBeLessThan(firstOrchard);
   });
@@ -88,7 +91,7 @@ describe("SignPcztTransactionTask", () => {
     await run(privateToPrivateTransaction());
 
     const orchardPackets = calls.filter(
-      (c) => c.ins === PCZT_INS.ORCHARD_ACTION,
+      (c) => c.ins === INS_PCZT_ORCHARD_ACTION,
     );
     const finished = orchardPackets.filter((c) => c.p2 === PCZT_P2.FINISHED);
     expect(finished).toHaveLength(1);
@@ -113,10 +116,12 @@ describe("SignPcztTransactionTask", () => {
       expect(result.data.transparentInputSigs).toHaveLength(0);
     }
     // SIGN_ORCHARD issued once, with P2 = action index 0.
-    const orchardSigns = calls.filter((c) => c.ins === PCZT_INS.SIGN_ORCHARD);
+    const orchardSigns = calls.filter(
+      (c) => c.ins === INS_PCZT_SIGN_ORCHARD,
+    );
     expect(orchardSigns).toHaveLength(1);
     expect(orchardSigns[0]!.p2).toBe(0);
-    expect(calls.some((c) => c.ins === PCZT_INS.SIGN_TRANSPARENT)).toBe(false);
+    expect(calls.some((c) => c.ins === INS_PCZT_SIGN_TRANSPARENT)).toBe(false);
   });
 
   it("collects one secp256k1 signature per transparent input", async () => {
@@ -131,7 +136,7 @@ describe("SignPcztTransactionTask", () => {
       expect(result.data.orchard).toHaveLength(0);
     }
     const transparentSigns = calls.filter(
-      (c) => c.ins === PCZT_INS.SIGN_TRANSPARENT,
+      (c) => c.ins === INS_PCZT_SIGN_TRANSPARENT,
     );
     expect(transparentSigns).toHaveLength(1);
     expect(transparentSigns[0]!.p2).toBe(0);
@@ -171,7 +176,7 @@ describe("SignPcztTransactionTask", () => {
     expect(isSuccessDmkResult(result)).toBe(false);
     // failed on the very first command (HEADER); nothing else streamed.
     expect(calls).toHaveLength(1);
-    expect(calls[0]!.ins).toBe(PCZT_INS.HEADER);
+    expect(calls[0]!.ins).toBe(INS_PCZT_HEADER);
   });
 
   it("surfaces a device rejection during Orchard signing", async () => {

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.test.ts
@@ -1,0 +1,193 @@
+import {
+  CommandResultFactory,
+  type InternalApi,
+  InvalidStatusWordError,
+  isSuccessDmkResult,
+} from "@ledgerhq/device-management-kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type PcztTransaction } from "@api/model/PcztTransaction";
+import {
+  PCZT_INS,
+  PCZT_P2,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import {
+  privateToPrivateTransaction,
+  privateToPublicTransaction,
+  publicToPrivateTransaction,
+  publicToPublicTransaction,
+} from "@internal/app-binder/task/__fixtures__/pcztFixtures";
+
+import { SignPcztTransactionTask } from "./SignPcztTransactionTask";
+
+type Call = { name: string; ins: number; p1: number; p2: number };
+
+/** Minimal shape of the commands the task sends, for inspection in the mock. */
+type CapturedCommand = {
+  name: string;
+  getApdu: () => { getRawApdu: () => Uint8Array };
+};
+
+describe("SignPcztTransactionTask", () => {
+  let apiMock: InternalApi;
+  let calls: Call[];
+
+  beforeEach(() => {
+    calls = [];
+    apiMock = { sendCommand: vi.fn() } as unknown as InternalApi;
+    vi.mocked(apiMock.sendCommand).mockImplementation((command: unknown) => {
+      const cmd = command as CapturedCommand;
+      const raw: Uint8Array = cmd.getApdu().getRawApdu();
+      calls.push({ name: cmd.name, ins: raw[1]!, p1: raw[2]!, p2: raw[3]! });
+      if (cmd.name === "SignPcztOrchard") {
+        // spendAuthSig keyed on the action index (P2) so order is verifiable.
+        return Promise.resolve(
+          CommandResultFactory({
+            data: { spendAuthSig: new Uint8Array(64).fill(raw[3]!) },
+          }),
+        );
+      }
+      if (cmd.name === "SignPcztTransparent") {
+        return Promise.resolve(
+          CommandResultFactory({
+            data: { signature: Uint8Array.of(0x30, raw[3]!, 0x01) },
+          }),
+        );
+      }
+      return Promise.resolve(CommandResultFactory({ data: undefined }));
+    });
+  });
+
+  const run = (transaction: PcztTransaction) =>
+    new SignPcztTransactionTask(apiMock, { transaction }).run();
+
+  it("streams HEADER, transparent in/out, then ORCHARD in fixed order", async () => {
+    await run(publicToPublicTransaction());
+
+    const bundleIns = calls
+      .filter((c) =>
+        [
+          PCZT_INS.HEADER,
+          PCZT_INS.TRANSPARENT_INPUT,
+          PCZT_INS.TRANSPARENT_OUTPUT,
+          PCZT_INS.ORCHARD_ACTION,
+        ].includes(c.ins as never),
+      )
+      .map((c) => c.ins);
+
+    // header first; the three bundle sections strictly increasing INS groups.
+    expect(bundleIns[0]).toBe(PCZT_INS.HEADER);
+    const firstInput = bundleIns.indexOf(PCZT_INS.TRANSPARENT_INPUT);
+    const firstOutput = bundleIns.indexOf(PCZT_INS.TRANSPARENT_OUTPUT);
+    const firstOrchard = bundleIns.indexOf(PCZT_INS.ORCHARD_ACTION);
+    expect(firstInput).toBeLessThan(firstOutput);
+    expect(firstOutput).toBeLessThan(firstOrchard);
+  });
+
+  it("finalizes the PCZT with P2_FINISHED on the last ORCHARD packet only", async () => {
+    await run(privateToPrivateTransaction());
+
+    const orchardPackets = calls.filter(
+      (c) => c.ins === PCZT_INS.ORCHARD_ACTION,
+    );
+    const finished = orchardPackets.filter((c) => c.p2 === PCZT_P2.FINISHED);
+    expect(finished).toHaveLength(1);
+    expect(orchardPackets[orchardPackets.length - 1]!.p2).toBe(
+      PCZT_P2.FINISHED,
+    );
+    // no bundle packet finalizes before the last Orchard packet.
+    orchardPackets
+      .slice(0, -1)
+      .forEach((c) => expect(c.p2).toBe(PCZT_P2.CONTINUE));
+  });
+
+  it("collects one spendAuthSig per Orchard action and no bindingSig", async () => {
+    const result = await run(privateToPrivateTransaction());
+
+    expect(isSuccessDmkResult(result)).toBe(true);
+    if (isSuccessDmkResult(result)) {
+      expect(result.data.orchard).toHaveLength(1);
+      expect(result.data.orchard[0]!.spendAuthSig).toEqual(
+        new Uint8Array(64).fill(0x00),
+      ); // action index 0
+      expect(result.data.transparentInputSigs).toHaveLength(0);
+    }
+    // SIGN_ORCHARD issued once, with P2 = action index 0.
+    const orchardSigns = calls.filter((c) => c.ins === PCZT_INS.SIGN_ORCHARD);
+    expect(orchardSigns).toHaveLength(1);
+    expect(orchardSigns[0]!.p2).toBe(0);
+    expect(calls.some((c) => c.ins === PCZT_INS.SIGN_TRANSPARENT)).toBe(false);
+  });
+
+  it("collects one secp256k1 signature per transparent input", async () => {
+    const result = await run(publicToPublicTransaction());
+
+    expect(isSuccessDmkResult(result)).toBe(true);
+    if (isSuccessDmkResult(result)) {
+      expect(result.data.transparentInputSigs).toHaveLength(1);
+      expect(result.data.transparentInputSigs[0]).toEqual(
+        Uint8Array.of(0x30, 0x00, 0x01),
+      ); // input index 0
+      expect(result.data.orchard).toHaveLength(0);
+    }
+    const transparentSigns = calls.filter(
+      (c) => c.ins === PCZT_INS.SIGN_TRANSPARENT,
+    );
+    expect(transparentSigns).toHaveLength(1);
+    expect(transparentSigns[0]!.p2).toBe(0);
+  });
+
+  it.each([
+    ["public -> public", publicToPublicTransaction, 0, 1],
+    ["private -> private", privateToPrivateTransaction, 1, 0],
+    ["public -> private", publicToPrivateTransaction, 1, 1],
+    ["private -> public", privateToPublicTransaction, 1, 0],
+  ] as const)(
+    "supports the %s transfer flow",
+    async (_label, build, orchardCount, transparentCount) => {
+      const result = await run(build());
+      expect(isSuccessDmkResult(result)).toBe(true);
+      if (isSuccessDmkResult(result)) {
+        expect(result.data.orchard).toHaveLength(orchardCount);
+        expect(result.data.transparentInputSigs).toHaveLength(transparentCount);
+      }
+    },
+  );
+
+  it("aborts and surfaces the error when a bundle command fails", async () => {
+    vi.mocked(apiMock.sendCommand).mockImplementation((command: unknown) => {
+      const cmd = command as CapturedCommand;
+      const raw: Uint8Array = cmd.getApdu().getRawApdu();
+      calls.push({ name: cmd.name, ins: raw[1]!, p1: raw[2]!, p2: raw[3]! });
+      return Promise.resolve(
+        CommandResultFactory({
+          error: new InvalidStatusWordError("header rejected"),
+        }),
+      );
+    });
+
+    const result = await run(privateToPrivateTransaction());
+
+    expect(isSuccessDmkResult(result)).toBe(false);
+    // failed on the very first command (HEADER); nothing else streamed.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.ins).toBe(PCZT_INS.HEADER);
+  });
+
+  it("surfaces a device rejection during Orchard signing", async () => {
+    vi.mocked(apiMock.sendCommand).mockImplementation((command: unknown) => {
+      const cmd = command as CapturedCommand;
+      if (cmd.name === "SignPcztOrchard") {
+        return Promise.resolve(
+          CommandResultFactory({
+            error: new InvalidStatusWordError("action rejected"),
+          }),
+        );
+      }
+      return Promise.resolve(CommandResultFactory({ data: undefined }));
+    });
+
+    const result = await run(privateToPrivateTransaction());
+    expect(isSuccessDmkResult(result)).toBe(false);
+  });
+});

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.test.ts
@@ -116,9 +116,7 @@ describe("SignPcztTransactionTask", () => {
       expect(result.data.transparentInputSigs).toHaveLength(0);
     }
     // SIGN_ORCHARD issued once, with P2 = action index 0.
-    const orchardSigns = calls.filter(
-      (c) => c.ins === INS_PCZT_SIGN_ORCHARD,
-    );
+    const orchardSigns = calls.filter((c) => c.ins === INS_PCZT_SIGN_ORCHARD);
     expect(orchardSigns).toHaveLength(1);
     expect(orchardSigns[0]!.p2).toBe(0);
     expect(calls.some((c) => c.ins === INS_PCZT_SIGN_TRANSPARENT)).toBe(false);

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.ts
@@ -1,0 +1,156 @@
+import {
+  type CommandErrorResult,
+  type DmkResult,
+  DmkResultFactory,
+  type InternalApi,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import {
+  type OrchardActionSignature,
+  type SignPcztTransactionResult,
+} from "@api/model/PcztSignature";
+import {
+  type PcztOrchardBundle,
+  type PcztTransaction,
+} from "@api/model/PcztTransaction";
+import { PcztHeaderCommand } from "@internal/app-binder/command/PcztHeaderCommand";
+import { PcztOrchardActionCommand } from "@internal/app-binder/command/PcztOrchardActionCommand";
+import { PcztTransparentInputCommand } from "@internal/app-binder/command/PcztTransparentInputCommand";
+import { PcztTransparentOutputCommand } from "@internal/app-binder/command/PcztTransparentOutputCommand";
+import { SignPcztOrchardCommand } from "@internal/app-binder/command/SignPcztOrchardCommand";
+import { SignPcztTransparentCommand } from "@internal/app-binder/command/SignPcztTransparentCommand";
+import { PCZT_P2 } from "@internal/app-binder/command/utils/apduHeaderUtils";
+import {
+  pcztP1,
+  pcztP2,
+  serializeOrchardActions,
+  serializePcztHeader,
+  serializeTransparentInputs,
+  serializeTransparentOutputs,
+} from "@internal/app-binder/command/utils/pcztSerializer";
+import { type ZcashErrorCodes } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+export type SignPcztTransactionTaskArgs = {
+  transaction: PcztTransaction;
+};
+
+type SignPcztTransactionTaskError =
+  CommandErrorResult<ZcashErrorCodes>["error"];
+
+export type SignPcztTransactionTaskResult = DmkResult<
+  SignPcztTransactionResult,
+  SignPcztTransactionTaskError
+>;
+
+const EMPTY_ORCHARD_BUNDLE: PcztOrchardBundle = {
+  actions: [],
+  flags: 0,
+  valueBalance: 0n,
+  anchor: new Uint8Array(32),
+};
+
+/**
+ * Drives the device PCZT Orchard signing protocol end-to-end:
+ *
+ * 1. streams the PCZT bundle in the fixed order — `PCZT_HEADER`,
+ *    `PCZT_TRANSPARENT_INPUT`, `PCZT_TRANSPARENT_OUTPUT`, `PCZT_ORCHARD_ACTION`
+ *    (every section always sent; count `0` when empty), the last Orchard packet
+ *    carrying `PCZT_P2.FINISHED` to finalize the payload;
+ * 2. collects one `spendAuthSig[64]` per Orchard action (`PCZT_SIGN_ORCHARD`);
+ * 3. collects one secp256k1 signature per transparent input
+ *    (`PCZT_SIGN_TRANSPARENT`).
+ *
+ * It never sends `bsk` nor collects `bindingSig` — the binding signature is a
+ * host-side concern (zcash-utils). Supports all four transfer flows; they
+ * differ only in which bundle sections are non-empty.
+ */
+export class SignPcztTransactionTask {
+  constructor(
+    private readonly api: InternalApi,
+    private readonly args: SignPcztTransactionTaskArgs,
+  ) {}
+
+  async run(): Promise<SignPcztTransactionTaskResult> {
+    const { global, transparentInputs, transparentOutputs, orchardBundle } =
+      this.args.transaction;
+    const bundle = orchardBundle ?? EMPTY_ORCHARD_BUNDLE;
+
+    // 1. Stream the PCZT bundle, in order.
+    const headerResult = await this.api.sendCommand(
+      new PcztHeaderCommand({ data: serializePcztHeader(global) }),
+    );
+    if (!isSuccessCommandResult(headerResult)) {
+      return DmkResultFactory({ error: headerResult.error });
+    }
+
+    const inputPackets = serializeTransparentInputs(transparentInputs);
+    for (let i = 0; i < inputPackets.length; i += 1) {
+      const result = await this.api.sendCommand(
+        new PcztTransparentInputCommand({
+          data: inputPackets[i]!,
+          p1: pcztP1(i, inputPackets.length),
+          p2: PCZT_P2.CONTINUE,
+        }),
+      );
+      if (!isSuccessCommandResult(result)) {
+        return DmkResultFactory({ error: result.error });
+      }
+    }
+
+    const outputPackets = serializeTransparentOutputs(transparentOutputs);
+    for (let i = 0; i < outputPackets.length; i += 1) {
+      const result = await this.api.sendCommand(
+        new PcztTransparentOutputCommand({
+          data: outputPackets[i]!,
+          p1: pcztP1(i, outputPackets.length),
+          p2: PCZT_P2.CONTINUE,
+        }),
+      );
+      if (!isSuccessCommandResult(result)) {
+        return DmkResultFactory({ error: result.error });
+      }
+    }
+
+    const orchardPackets = serializeOrchardActions(bundle);
+    for (let i = 0; i < orchardPackets.length; i += 1) {
+      const result = await this.api.sendCommand(
+        new PcztOrchardActionCommand({
+          data: orchardPackets[i]!,
+          p1: pcztP1(i, orchardPackets.length),
+          // The last Orchard packet finalizes the whole PCZT payload.
+          p2: pcztP2(i, orchardPackets.length, true),
+        }),
+      );
+      if (!isSuccessCommandResult(result)) {
+        return DmkResultFactory({ error: result.error });
+      }
+    }
+
+    // 2. Collect one spendAuthSig per Orchard action.
+    const orchard: OrchardActionSignature[] = [];
+    for (let i = 0; i < bundle.actions.length; i += 1) {
+      const result = await this.api.sendCommand(
+        new SignPcztOrchardCommand({ actionIndex: i }),
+      );
+      if (!isSuccessCommandResult(result)) {
+        return DmkResultFactory({ error: result.error });
+      }
+      orchard.push(result.data);
+    }
+
+    // 3. Collect one signature per transparent input.
+    const transparentInputSigs: Uint8Array[] = [];
+    for (let i = 0; i < transparentInputs.length; i += 1) {
+      const result = await this.api.sendCommand(
+        new SignPcztTransparentCommand({ inputIndex: i }),
+      );
+      if (!isSuccessCommandResult(result)) {
+        return DmkResultFactory({ error: result.error });
+      }
+      transparentInputSigs.push(result.data.signature);
+    }
+
+    return DmkResultFactory({ data: { orchard, transparentInputSigs } });
+  }
+}

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.ts
@@ -118,7 +118,13 @@ export class SignPcztTransactionTask {
         new PcztOrchardActionCommand({
           data: orchardPackets[i]!,
           p1: pcztP1(i, orchardPackets.length),
-          // The last Orchard packet finalizes the whole PCZT payload.
+          // `finished: true` here is correct for every flow, including the
+          // transparent-only one where the Orchard section is a single count-0
+          // packet: `pcztP2` only sets `FINISHED` on the *last* Orchard packet,
+          // and `ORCHARD_ACTION` is always the final bundle command, so the
+          // marker lands exactly where the device expects it. The device
+          // accepts signing commands only after seeing `FINISHED`
+          // (`app-zcash` `src/handlers/pczt.rs::finish_pczt_if_requested`).
           p2: pcztP2(i, orchardPackets.length, true),
         }),
       );

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/__fixtures__/pcztFixtures.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/__fixtures__/pcztFixtures.ts
@@ -1,0 +1,132 @@
+import {
+  type PcztGlobal,
+  type PcztOrchardAction,
+  type PcztOrchardBundle,
+  type PcztTransaction,
+  type PcztTransparentInput,
+  type PcztTransparentOutput,
+} from "@api/model/PcztTransaction";
+
+/** Deterministic byte array of `length`, every byte set to `fill`. */
+export const bytes = (length: number, fill: number): Uint8Array =>
+  new Uint8Array(length).fill(fill);
+
+export const hexToBytes = (hex: string): Uint8Array =>
+  Uint8Array.from(Buffer.from(hex, "hex"));
+
+export const bytesToHex = (data: Uint8Array): string =>
+  Buffer.from(data).toString("hex");
+
+/** Real Orchard ciphertext sizes from app-zcash `develop` test client. */
+export const ORCHARD_ENC_CIPHERTEXT_SIZE = 580;
+export const ORCHARD_OUT_CIPHERTEXT_SIZE = 80;
+
+/** Mirrors `PcztGlobal` defaults in app-zcash `tests/application_client/pczt.py`. */
+export const SAMPLE_GLOBAL: PcztGlobal = {
+  txVersion: 5,
+  versionGroupId: 0x26a7270a,
+  consensusBranchId: 0xc2d6d0b4,
+  fallbackLockTime: 0,
+  expiryHeight: 0,
+  coinType: 133,
+  txModifiable: 0,
+};
+
+/**
+ * Expected `PCZT_HEADER` payload for {@link SAMPLE_GLOBAL}, computed by hand
+ * from `docs/PCZT_APDU.md`: "PCZT" + version(1) + global, all little-endian.
+ */
+export const SAMPLE_HEADER_HEX =
+  "50435a54" + // "PCZT"
+  "01000000" + // PCZT version 1
+  "05000000" + // tx_version 5
+  "0a27a726" + // version_group_id 0x26A7270A LE
+  "b4d0d6c2" + // consensus_branch_id 0xC2D6D0B4 LE
+  "0100000000" + // fallback_lock_time Option<u32>: present, 0
+  "00000000" + // expiry_height 0
+  "85000000" + // coin_type 133 LE
+  "00"; // tx_modifiable 0
+
+export const sampleTransparentInput = (): PcztTransparentInput => ({
+  prevoutTxid: bytes(32, 0x11),
+  prevoutIndex: 0,
+  sequence: 0xffffffff,
+  value: 1000n,
+  scriptPubKey: hexToBytes(
+    "76a914000000000000000000000000000000000000000088ac",
+  ),
+  sighashType: 0x01,
+  derivation: {
+    signingPath: "44'/133'/0'/0/0",
+    pubkey: bytes(33, 0x02),
+    seedFingerprint: bytes(32, 0x00),
+  },
+});
+
+export const sampleTransparentOutput = (): PcztTransparentOutput => ({
+  value: 900n,
+  scriptPubKey: hexToBytes(
+    "76a914111111111111111111111111111111111111111188ac",
+  ),
+  derivation: null,
+});
+
+export const sampleOrchardAction = (): PcztOrchardAction => ({
+  cvNet: bytes(32, 0x01),
+  nullifier: bytes(32, 0x02),
+  rk: bytes(32, 0x03),
+  spendRecipient: bytes(43, 0x04),
+  spendValue: 5n,
+  spendRho: bytes(32, 0x05),
+  spendRseed: bytes(32, 0x06),
+  alpha: bytes(32, 0x07),
+  signingPath: "44'/133'/0'",
+  seedFingerprint: bytes(32, 0x00),
+  cmx: bytes(32, 0x08),
+  ephemeralKey: bytes(32, 0x09),
+  encCiphertext: bytes(ORCHARD_ENC_CIPHERTEXT_SIZE, 0xaa),
+  outCiphertext: bytes(ORCHARD_OUT_CIPHERTEXT_SIZE, 0xbb),
+  recipient: bytes(43, 0x0a),
+  value: 5n,
+  rseed: bytes(32, 0x0b),
+  rcv: bytes(32, 0x0c),
+});
+
+export const sampleOrchardBundle = (): PcztOrchardBundle => ({
+  actions: [sampleOrchardAction()],
+  flags: 2,
+  valueBalance: 0n,
+  anchor: bytes(32, 0x0d),
+});
+
+/** Public → Public: transparent only, no Orchard bundle. */
+export const publicToPublicTransaction = (): PcztTransaction => ({
+  global: SAMPLE_GLOBAL,
+  transparentInputs: [sampleTransparentInput()],
+  transparentOutputs: [sampleTransparentOutput()],
+  orchardBundle: null,
+});
+
+/** Private → Private: Orchard only, empty transparent sections. */
+export const privateToPrivateTransaction = (): PcztTransaction => ({
+  global: SAMPLE_GLOBAL,
+  transparentInputs: [],
+  transparentOutputs: [],
+  orchardBundle: sampleOrchardBundle(),
+});
+
+/** Public → Private: transparent input spent into an Orchard output. */
+export const publicToPrivateTransaction = (): PcztTransaction => ({
+  global: SAMPLE_GLOBAL,
+  transparentInputs: [sampleTransparentInput()],
+  transparentOutputs: [],
+  orchardBundle: sampleOrchardBundle(),
+});
+
+/** Private → Public: Orchard spend into a transparent output. */
+export const privateToPublicTransaction = (): PcztTransaction => ({
+  global: SAMPLE_GLOBAL,
+  transparentInputs: [],
+  transparentOutputs: [sampleTransparentOutput()],
+  orchardBundle: sampleOrchardBundle(),
+});

--- a/packages/signer/signer-zcash/src/internal/use-cases/transaction/SignPcztTransactionUseCase.ts
+++ b/packages/signer/signer-zcash/src/internal/use-cases/transaction/SignPcztTransactionUseCase.ts
@@ -1,0 +1,26 @@
+import { inject, injectable } from "inversify";
+
+import { type SignPcztTransactionDAReturnType } from "@api/app-binder/SignPcztTransactionDeviceActionTypes";
+import { type PcztTransaction } from "@api/model/PcztTransaction";
+import { type TransactionOptions } from "@api/model/TransactionOptions";
+import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
+import { ZcashAppBinder } from "@internal/app-binder/ZcashAppBinder";
+
+@injectable()
+export class SignPcztTransactionUseCase {
+  private readonly _appBinder: ZcashAppBinder;
+
+  constructor(@inject(appBinderTypes.AppBinding) appBinder: ZcashAppBinder) {
+    this._appBinder = appBinder;
+  }
+
+  execute(
+    transaction: PcztTransaction,
+    options?: TransactionOptions,
+  ): SignPcztTransactionDAReturnType {
+    return this._appBinder.signPcztTransaction({
+      transaction,
+      skipOpenApp: options?.skipOpenApp,
+    });
+  }
+}

--- a/packages/signer/signer-zcash/src/internal/use-cases/transaction/di/transactionModule.ts
+++ b/packages/signer/signer-zcash/src/internal/use-cases/transaction/di/transactionModule.ts
@@ -2,10 +2,14 @@ import { ContainerModule } from "inversify";
 
 import { transactionTypes } from "@internal/use-cases/transaction/di/transactionTypes";
 import { GetTrustedInputUseCase } from "@internal/use-cases/transaction/GetTrustedInputUseCase";
+import { SignPcztTransactionUseCase } from "@internal/use-cases/transaction/SignPcztTransactionUseCase";
 import { SignTransactionUseCase } from "@internal/use-cases/transaction/SignTransactionUseCase";
 
 export const transactionModuleFactory = () =>
   new ContainerModule(({ bind }) => {
     bind(transactionTypes.GetTrustedInputUseCase).to(GetTrustedInputUseCase);
     bind(transactionTypes.SignTransactionUseCase).to(SignTransactionUseCase);
+    bind(transactionTypes.SignPcztTransactionUseCase).to(
+      SignPcztTransactionUseCase,
+    );
   });

--- a/packages/signer/signer-zcash/src/internal/use-cases/transaction/di/transactionTypes.ts
+++ b/packages/signer/signer-zcash/src/internal/use-cases/transaction/di/transactionTypes.ts
@@ -1,4 +1,5 @@
 export const transactionTypes = {
   GetTrustedInputUseCase: Symbol.for("GetTrustedInputUseCase"),
   SignTransactionUseCase: Symbol.for("SignTransactionUseCase"),
+  SignPcztTransactionUseCase: Symbol.for("SignPcztTransactionUseCase"),
 } as const;


### PR DESCRIPTION
### 📝 Description

Adds PCZT (Partially Created Zcash Transaction) Orchard shielded signing to the Zcash signer.

A new `signPcztTransaction` method streams the PCZT bundle to the device — header, transparent inputs/outputs, and Orchard actions — and returns the per-action Orchard `spendAuthSig`s together with the per-input transparent signatures. The legacy transparent `signTransaction` path is left unchanged.

The change introduces:
- New public API: `signPcztTransaction`, `PcztTransaction`/`PcztSignature` models, and the `SignPcztTransaction` device action types.
- App-binder commands for each PCZT section (header, transparent input/output, Orchard action) plus the transparent/Orchard signing commands and a PCZT serializer.
- A `SignPcztTransactionTask`, a `SignPcztTransactionUseCase`, and the DI wiring.
- Sample-app wiring in `SignerZcashView`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-31200](https://ledgerhq.atlassian.net/browse/LIVE-31200)
- **Feature**: PCZT Orchard shielded signing for the Zcash signer.

### ✅ Checklist

- [x] **Covered by automatic tests** — unit tests added for the new commands, serializer, task, app-binder, and signer.
- [x] **Changeset is provided** — `minor` bump for `@ledgerhq/device-signer-kit-zcash`.
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - New `signPcztTransaction` entry point on the Zcash signer (additive; legacy `signTransaction` unchanged).
  - QA focus: PCZT bundle streaming/chunking to the device and correctness of returned Orchard `spendAuthSig`s and transparent signatures.

[LIVE-31200]: https://ledgerhq.atlassian.net/browse/LIVE-31200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ