### PR TITLE
🔧 (mockserver) [NO-ISSUE]: Change default port from 8080 to 9752

### DIFF
--- a/.changeset/mock-server-default-port-9752.md
+++ b/.changeset/mock-server-default-port-9752.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Change the default mock server base URL port from `8080` to the less commonly used `9752` to avoid conflicts with other local dev servers

--- a/apps/device-mock-server/README.md
+++ b/apps/device-mock-server/README.md
@@ -180,10 +180,10 @@ pnpm build
 pnpm start        # node lib/cjs/main.js
 ```
 
-By default it listens on port `8080`. Verify it is up:
+By default it listens on port `9752`. Verify it is up:
 
 ```bash
-curl http://127.0.0.1:8080/health
+curl http://127.0.0.1:9752/health
 # {"status":"ok","sessions":0}
 ```
 
@@ -193,7 +193,7 @@ The standalone server (`src/main.ts`) reads environment variables:
 
 | Variable                    | Default                             | Description                                                                                                         |
 | --------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `PORT`                      | `8080`                              | HTTP port.                                                                                                          |
+| `PORT`                      | `9752`                              | HTTP port.                                                                                                          |
 | `SPECULINHO_URL`            | `https://speculinho.ledgerlabs.net` | Speculinho operator base URL. Set to empty (`SPECULINHO_URL=`) to run as a **pure mock** with no Speculos proxying. |
 | `SPECULOS_SEED`             | built-in default seed               | BIP39 seed used for provisioned emulators.                                                                          |
 | `SPECULOS_VERSION`          | _unset_                             | Pin a Speculos version.                                                                                             |

--- a/apps/device-mock-server/openapi.yaml
+++ b/apps/device-mock-server/openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: Apache-2.0
 servers:
-  - url: http://127.0.0.1:8080
+  - url: http://127.0.0.1:9752
     description: Local dev server
 security:
   - bearerAuth: []

--- a/apps/device-mock-server/src/internal/server/openapi/definition.ts
+++ b/apps/device-mock-server/src/internal/server/openapi/definition.ts
@@ -19,7 +19,7 @@ export const openapiDefinition: OAS3Definition = {
       "and mock is scoped to a bearer-token session obtained from `POST /auth`.",
     license: { name: "Apache-2.0" },
   },
-  servers: [{ url: "http://127.0.0.1:8080", description: "Local dev server" }],
+  servers: [{ url: "http://127.0.0.1:9752", description: "Local dev server" }],
   security: [{ bearerAuth: [] }],
   tags: [
     { name: "Auth", description: "Session creation" },

--- a/apps/device-mock-server/src/main.ts
+++ b/apps/device-mock-server/src/main.ts
@@ -5,7 +5,7 @@ import { type MockServerConfig } from "@api/model/MockServerConfig";
 import { logger } from "@internal/logger/logger";
 import { DEFAULT_SPECULOS_SEED } from "@internal/speculos/model/SpeculosModels";
 
-const port = Number(process.env["PORT"] ?? 8080);
+const port = Number(process.env["PORT"] ?? 9752);
 
 /**
  * Speculinho is enabled by default against the labs operator; set

--- a/apps/sample/playwright/utils/setup.ts
+++ b/apps/sample/playwright/utils/setup.ts
@@ -1,7 +1,7 @@
 import { MockClient } from "@ledgerhq/device-mockserver-client";
 import { type Page } from "@playwright/test";
 
-const MOCK_SERVER_URL = "http://127.0.0.1:8080";
+const MOCK_SERVER_URL = "http://127.0.0.1:9752";
 const SETTINGS_STORAGE_KEY = "dmk-sample-settings";
 
 /**

--- a/apps/sample/src/state/settings/schema.ts
+++ b/apps/sample/src/state/settings/schema.ts
@@ -58,7 +58,7 @@ export type SettingsState = {
 export const initialState: SettingsState = {
   // Transport settings
   transportType: getInitialTransportType(),
-  mockServerUrl: "http://127.0.0.1:8080/",
+  mockServerUrl: "http://127.0.0.1:9752/",
   mockServerSessionToken: "",
   speculosUrl: DEFAULT_SPECULOS_URL,
   speculosVncUrl: DEFAULT_SPECULOS_VNC_URL,

--- a/packages/device-management-kit/src/internal/manager-api/model/Const.ts
+++ b/packages/device-management-kit/src/internal/manager-api/model/Const.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_MANAGER_API_BASE_URL =
   "https://manager.api.live.ledger.com/api";
-export const DEFAULT_MOCK_SERVER_BASE_URL = "http://localhost:8080";
+export const DEFAULT_MOCK_SERVER_BASE_URL = "http://localhost:9752";
 export const DEFAULT_PROVIDER = 1;
 export const DEFAULT_FIRMWARE_DISTRIBUTION_SALT = "0";


### PR DESCRIPTION
### 📝 Description

Changes the default device mock server port from `8080` to the less commonly used `9752`.

Port `8080` frequently conflicts with other local dev servers (proxies, other apps), which made the mock server awkward to run alongside typical development setups. `9752` sits in the registered range and is not assigned to common tooling, so it should be compatible with all apps out of the box. The port remains overridable via the `PORT` env var.

Updated across:
- **`@ledgerhq/device-management-kit`** — `DEFAULT_MOCK_SERVER_BASE_URL` → `http://localhost:9752` (published package; changeset included)
- **`@ledgerhq/device-mock-server`** — default `PORT` fallback, OpenAPI definition + generated `openapi.yaml`, and README (default port, curl example, `PORT` env table)
- **sample app** — default `mockServerUrl` and the Playwright `MOCK_SERVER_URL`

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Change the default mock server port to avoid conflicts with commonly-used ports.

### ✅ Checklist

- [x] **Covered by automatic tests** <!-- existing suites; only default constants/config changed -->
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date** <!-- device-mock-server README + OpenAPI updated -->
- [ ] **Impact of the changes:**
  - Default mock server URL/port changes from `8080` to `9752`; anyone relying on the old default must either set `PORT=8080` / point their client at `:8080`, or adopt the new default.
