### PR TITLE
🎨 (signer-solana) [DSDK-1310]: Align with new OCMS v1 specs (drop length)

### DIFF
--- a/.changeset/ocms-v1-drop-length.md
+++ b/.changeset/ocms-v1-drop-length.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": patch
+---
+
+Align OCMS (offchain message signing) V1 with the finalized sRFC 38 spec.

--- a/packages/signer/signer-solana/src/internal/app-binder/services/OffchainMessageBuilder.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/services/OffchainMessageBuilder.test.ts
@@ -3,6 +3,7 @@ import { OffchainMessageBuildError } from "@internal/app-binder/services/Errors"
 import {
   MessageFormat,
   OffchainMessageBuilder,
+  OFFCHAINMSG_MAX_LEN,
 } from "@internal/app-binder/services/OffchainMessageBuilder";
 
 const PUBKEY = new Uint8Array(32).fill(0x11);
@@ -64,10 +65,11 @@ describe("OffchainMessageBuilder", () => {
       expect(v0[49]).toBe(MessageFormat.Utf8);
     });
 
-    it("detects long UTF-8 format (format=2)", () => {
-      const longUtf8 = new TextEncoder().encode("x".repeat(15313));
-      const v0 = new OffchainMessageBuilder().buildV0(longUtf8, PUBKEY);
-      expect(v0[49]).toBe(MessageFormat.Utf8LongV0);
+    it("throws when the message exceeds the device payload ceiling", () => {
+      const tooLong = new Uint8Array(OFFCHAINMSG_MAX_LEN + 1).fill(0x41);
+      expect(() =>
+        new OffchainMessageBuilder().buildV0(tooLong, PUBKEY),
+      ).toThrow(OffchainMessageBuildError);
     });
   });
 
@@ -112,7 +114,7 @@ describe("OffchainMessageBuilder", () => {
   // ──────────────────────────────────────────────────────────────────────────
 
   describe("buildV1", () => {
-    it("writes signing domain, version 1, signerCount, pubkey, LE length, body", () => {
+    it("writes signing domain, version 1, signerCount, pubkey, body (no length prefix)", () => {
       const body = new Uint8Array([0xab, 0xcd]);
       const v1 = new OffchainMessageBuilder().buildV1(body, [PUBKEY]);
 
@@ -121,18 +123,15 @@ describe("OffchainMessageBuilder", () => {
       expect(v1[16]).toBe(1);
       expect(v1[17]).toBe(1);
       expect(v1.slice(18, 50)).toEqual(PUBKEY);
-      expect(v1[50]).toBe(body.length & 0xff);
-      expect(v1[51]).toBe((body.length >> 8) & 0xff);
-      expect(v1.slice(52)).toEqual(body);
-      expect(v1.length).toBe(16 + 1 + 1 + 32 + 2 + body.length);
+      expect(v1.slice(50)).toEqual(body);
+      expect(v1.length).toBe(16 + 1 + 1 + 32 + body.length);
     });
 
-    it("accepts message at exactly 65535 bytes (uint16 max)", () => {
+    it("accepts a large message with no length-prefix overflow", () => {
       const big = new Uint8Array(65535).fill(0xbb);
       const v1 = new OffchainMessageBuilder().buildV1(big, [PUBKEY]);
-      expect(v1.length).toBe(16 + 1 + 1 + 32 + 2 + big.length);
-      expect(v1[50]).toBe(0xff);
-      expect(v1[51]).toBe(0xff);
+      expect(v1.length).toBe(16 + 1 + 1 + 32 + big.length);
+      expect(v1.slice(50)).toEqual(big);
     });
 
     it("does not include appDomain even when provided", () => {
@@ -141,7 +140,7 @@ describe("OffchainMessageBuilder", () => {
         PUBKEY,
       ]);
 
-      expect(v1.length).toBe(16 + 1 + 1 + 32 + 2 + body.length);
+      expect(v1.length).toBe(16 + 1 + 1 + 32 + body.length);
     });
 
     it("includes multiple signers sorted and deduplicated", () => {
@@ -155,6 +154,34 @@ describe("OffchainMessageBuilder", () => {
         keyADup,
         keyA,
       ]);
+
+      expect(v1[17]).toBe(2);
+      expect(v1.slice(18, 50)).toEqual(keyA);
+      expect(v1.slice(50, 82)).toEqual(keyB);
+      expect(v1.slice(82)).toEqual(body);
+      expect(v1.length).toBe(16 + 1 + 1 + 32 * 2 + body.length);
+    });
+
+    it("writes the LE length prefix when includeLengthPrefix is true", () => {
+      const body = new Uint8Array([0xab, 0xcd]);
+      const v1 = new OffchainMessageBuilder().buildV1(body, [PUBKEY], true);
+
+      expect(v1[0]).toBe(0xff);
+      expect(v1[16]).toBe(1);
+      expect(v1[17]).toBe(1);
+      expect(v1.slice(18, 50)).toEqual(PUBKEY);
+      expect(v1[50]).toBe(body.length & 0xff);
+      expect(v1[51]).toBe((body.length >> 8) & 0xff);
+      expect(v1.slice(52)).toEqual(body);
+      expect(v1.length).toBe(16 + 1 + 1 + 32 + 2 + body.length);
+    });
+
+    it("keeps signers before the length prefix with multiple signers", () => {
+      const body = new Uint8Array([0xfe]);
+      const keyA = new Uint8Array(32).fill(0x01);
+      const keyB = new Uint8Array(32).fill(0x02);
+
+      const v1 = new OffchainMessageBuilder().buildV1(body, [keyB, keyA], true);
 
       expect(v1[17]).toBe(2);
       expect(v1.slice(18, 50)).toEqual(keyA);
@@ -272,13 +299,6 @@ describe("OffchainMessageBuilder", () => {
       expect(builder.findMessageFormat(msg, false)).toBe(MessageFormat.Utf8);
     });
 
-    it("returns Utf8LongV0 for long UTF-8", () => {
-      const msg = new TextEncoder().encode("x".repeat(15313));
-      expect(builder.findMessageFormat(msg, false)).toBe(
-        MessageFormat.Utf8LongV0,
-      );
-    });
-
     it("legacy forbids newline in ASCII (falls back to UTF-8)", () => {
       const msg = new TextEncoder().encode("hello\nworld");
       expect(builder.findMessageFormat(msg, true)).toBe(MessageFormat.Utf8);
@@ -292,7 +312,7 @@ describe("OffchainMessageBuilder", () => {
     });
 
     it("throws on oversized message", () => {
-      const big = new Uint8Array(65516).fill(0x41);
+      const big = new Uint8Array(OFFCHAINMSG_MAX_LEN + 1).fill(0x41);
       expect(() => builder.findMessageFormat(big, false)).toThrow(
         OffchainMessageBuildError,
       );

--- a/packages/signer/signer-solana/src/internal/app-binder/services/OffchainMessageBuilder.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/services/OffchainMessageBuilder.ts
@@ -10,17 +10,17 @@ const DEVICE_LEGACY_PAYLOAD_CEILING = 1280;
 const RESERVED_HEADER_BYTES = 40;
 const RESERVED_TRANSPORT_BYTES = 8;
 
-const OFFCHAINMSG_MAX_LEN =
+// The device buffers the whole off-chain message (header + body) into a single
+// payload; this matches app-solana's MAX_OFFCHAIN_MESSAGE_LENGTH
+// (= PACKET_DATA_SIZE = (15 * 1024) - 40 - 8 = 15312) and is the real ceiling
+// for every off-chain message version, regardless of wire layout.
+export const OFFCHAINMSG_MAX_LEN =
   DEVICE_V0_PAYLOAD_CEILING - RESERVED_HEADER_BYTES - RESERVED_TRANSPORT_BYTES;
 
 export const LEGACY_OFFCHAINMSG_MAX_LEN =
   DEVICE_LEGACY_PAYLOAD_CEILING -
   RESERVED_HEADER_BYTES -
   RESERVED_TRANSPORT_BYTES; // 1232
-
-export const OFFCHAINMSG_MAX_V0_LEN = 65515;
-
-export const OFFCHAINMSG_MAX_V1_LEN = 65535; // 2-byte LE uint16 max
 
 const ED25519_SIGNATURE_LEN = 64;
 const APP_DOMAIN_LEN = 32;
@@ -33,7 +33,6 @@ const LINE_FEED_ASCII = 0x0a;
 export enum MessageFormat {
   Ascii = 0,
   Utf8 = 1,
-  Utf8LongV0 = 2,
 }
 
 export class OffchainMessageBuilder {
@@ -44,7 +43,7 @@ export class OffchainMessageBuilder {
    *   signing domain  (16 B): 0xFF + "solana offchain"
    *   version         ( 1 B): 0x00
    *   application domain (32 B): UTF-8, padded/truncated to 32 bytes
-   *   format          ( 1 B): 0 = ASCII, 1 = UTF-8, 2 = UTF-8 long
+   *   format          ( 1 B): 0 = ASCII, 1 = UTF-8
    *   signer count    ( 1 B): 1
    *   signer          (32 B)
    *   message length  ( 2 B): little-endian uint16
@@ -95,15 +94,24 @@ export class OffchainMessageBuilder {
   }
 
   /**
-   * V1 wire format (per app-solana parser):
+   * V1 wire format (sRFC 38, per app-solana parser):
    *   signing domain  (16 B): 0xFF + "solana offchain"
    *   version         ( 1 B): 0x01
    *   signer count    ( 1 B)
    *   signers         (N * 32 B): lexicographically sorted, deduplicated
-   *   message length  ( 2 B): little-endian uint16
+   *   [message length ( 2 B): little-endian uint16] — only when includeLengthPrefix
    *   message body    (variable)
+   *
+   * The finalised sRFC 38 layout drops the length prefix: the message body is
+   * the trailing bytes. `includeLengthPrefix` reproduces the pre-spec-update
+   * layout for backward compatibility with older firmware, the task tries the
+   * no-prefix form first and falls back to the prefixed form on a 6a81 reject.
    */
-  buildV1(messageBody: Uint8Array, signers: Uint8Array[]): Uint8Array {
+  buildV1(
+    messageBody: Uint8Array,
+    signers: Uint8Array[],
+    includeLengthPrefix = false,
+  ): Uint8Array {
     const sorted = this.sortAndDedupeSigners(signers);
     const builder = new ByteArrayBuilder();
 
@@ -115,7 +123,9 @@ export class OffchainMessageBuilder {
       builder.addBufferToData(signer);
     }
 
-    this._writeLeU16(builder, messageBody.length);
+    if (includeLengthPrefix) {
+      this._writeLeU16(builder, messageBody.length);
+    }
     builder.addBufferToData(messageBody);
 
     return builder.build();
@@ -174,16 +184,13 @@ export class OffchainMessageBuilder {
       ? LEGACY_OFFCHAINMSG_MAX_LEN
       : OFFCHAINMSG_MAX_LEN;
 
-    if (message.length <= maxLedgerLen) {
-      if (this._isPrintableASCII(message, isLegacy)) return MessageFormat.Ascii;
-      if (this._isUTF8(message)) return MessageFormat.Utf8;
-    } else if (message.length <= OFFCHAINMSG_MAX_V0_LEN) {
-      if (this._isUTF8(message)) return MessageFormat.Utf8LongV0;
-    } else {
+    if (message.length > maxLedgerLen) {
       throw new OffchainMessageBuildError(
-        `Message too long: ${message.length} bytes (max is ${OFFCHAINMSG_MAX_V0_LEN})`,
+        `Message too long: ${message.length} bytes (max is ${maxLedgerLen})`,
       );
     }
+    if (this._isPrintableASCII(message, isLegacy)) return MessageFormat.Ascii;
+    if (this._isUTF8(message)) return MessageFormat.Utf8;
     throw new OffchainMessageBuildError(
       "Message is not valid printable ASCII or UTF-8",
     );

--- a/packages/signer/signer-solana/src/internal/app-binder/task/SendSignMessageTask.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/SendSignMessageTask.test.ts
@@ -10,7 +10,7 @@ import { makeDeviceActionInternalApiMock } from "@internal/app-binder/device-act
 import { DefaultBs58Encoder } from "@internal/app-binder/services/bs58Encoder";
 import {
   OffchainMessageBuilder,
-  OFFCHAINMSG_MAX_V0_LEN,
+  OFFCHAINMSG_MAX_LEN,
 } from "@internal/app-binder/services/OffchainMessageBuilder";
 import { SendSignMessageTask } from "@internal/app-binder/task/SendSignMessageTask";
 
@@ -114,9 +114,9 @@ describe("SendSignMessageTask", () => {
         ).rejects.toThrow();
       });
 
-      it("enforces V0 size limit (65515 bytes)", async () => {
+      it("enforces V0 size limit (device payload ceiling)", async () => {
         const res = await makeTask(apiMock, {
-          sendingData: new Uint8Array(OFFCHAINMSG_MAX_V0_LEN + 1).fill(0xaa),
+          sendingData: new Uint8Array(OFFCHAINMSG_MAX_LEN + 1).fill(0xaa),
           version: SignMessageVersion.V0,
         }).run();
 
@@ -124,7 +124,7 @@ describe("SendSignMessageTask", () => {
         expect((res as any).error).toBeInstanceOf(InvalidStatusWordError);
       });
 
-      it("accepts V0 message at exactly 65515 bytes (not rejected by guard)", async () => {
+      it("accepts V0 message at exactly the device limit (not rejected by guard)", async () => {
         apiMock.sendCommand.mockResolvedValueOnce(
           CommandResultFactory({
             error: new InvalidStatusWordError("pubkey error"),
@@ -132,7 +132,7 @@ describe("SendSignMessageTask", () => {
         );
 
         const res = await makeTask(apiMock, {
-          sendingData: new Uint8Array(OFFCHAINMSG_MAX_V0_LEN).fill(0x41),
+          sendingData: new Uint8Array(OFFCHAINMSG_MAX_LEN).fill(0x41),
           version: SignMessageVersion.V0,
         }).run();
 
@@ -140,16 +140,6 @@ describe("SendSignMessageTask", () => {
         expect((res as any).error).toEqual(
           new InvalidStatusWordError("Error getting public key from device"),
         );
-      });
-
-      it("rejects V0 message at 65516 bytes", async () => {
-        const res = await makeTask(apiMock, {
-          sendingData: new Uint8Array(OFFCHAINMSG_MAX_V0_LEN + 1).fill(0x41),
-          version: SignMessageVersion.V0,
-        }).run();
-
-        expect(apiMock.sendCommand).toHaveBeenCalledTimes(0);
-        expect((res as any).error).toBeInstanceOf(InvalidStatusWordError);
       });
 
       it("enforces Legacy size limit (1232 bytes)", async () => {
@@ -162,9 +152,9 @@ describe("SendSignMessageTask", () => {
         expect((res as any).error).toBeInstanceOf(InvalidStatusWordError);
       });
 
-      it("enforces V1 size limit (65535 bytes)", async () => {
+      it("enforces V1 size limit (device payload ceiling)", async () => {
         const res = await makeTask(apiMock, {
-          sendingData: new Uint8Array(65536).fill(0xbb),
+          sendingData: new Uint8Array(OFFCHAINMSG_MAX_LEN + 1).fill(0xbb),
           version: SignMessageVersion.V1,
         }).run();
 
@@ -172,7 +162,7 @@ describe("SendSignMessageTask", () => {
         expect((res as any).error).toBeInstanceOf(InvalidStatusWordError);
       });
 
-      it("accepts V1 message at exactly 65535 bytes", async () => {
+      it("accepts V1 message at exactly the device limit", async () => {
         apiMock.sendCommand.mockResolvedValueOnce(
           CommandResultFactory({
             error: new InvalidStatusWordError("pubkey error"),
@@ -180,7 +170,7 @@ describe("SendSignMessageTask", () => {
         );
 
         const res = await makeTask(apiMock, {
-          sendingData: new Uint8Array(65535).fill(0x41),
+          sendingData: new Uint8Array(OFFCHAINMSG_MAX_LEN).fill(0x41),
           version: SignMessageVersion.V1,
         }).run();
 
@@ -556,12 +546,39 @@ describe("SendSignMessageTask", () => {
         expect((res as any).error).toBeInstanceOf(InvalidStatusWordError);
       });
 
-      it("V1 -> V0 on 6a81", async () => {
+      it("V1 (no prefix) -> V1 (with prefix) on 6a81", async () => {
         const msg = new Uint8Array([0x61, 0x62]);
         const rawSig = new Uint8Array(64).fill(0x99);
 
         apiMock.sendCommand
           .mockResolvedValueOnce(CommandResultFactory({ data: PUBKEY_BASE58 }))
+          .mockResolvedValueOnce(
+            CommandResultFactory({ error: solanaHeaderErr() as any }),
+          )
+          .mockResolvedValueOnce(CommandResultFactory({ data: rawSig }));
+
+        const v1PrefixOCM = builder.buildV1(msg, [PUBKEY], true);
+        const res = await makeTask(apiMock, {
+          sendingData: msg,
+          version: SignMessageVersion.V1,
+        }).run();
+
+        expect(apiMock.sendCommand).toHaveBeenCalledTimes(3);
+        const envelope = DefaultBs58Encoder.decode(
+          (res as any).data.signature as string,
+        );
+        expect(envelope.slice(65)).toEqual(v1PrefixOCM);
+      });
+
+      it("V1 -> V0 after both V1 layouts 6a81", async () => {
+        const msg = new Uint8Array([0x61, 0x62]);
+        const rawSig = new Uint8Array(64).fill(0x99);
+
+        apiMock.sendCommand
+          .mockResolvedValueOnce(CommandResultFactory({ data: PUBKEY_BASE58 }))
+          .mockResolvedValueOnce(
+            CommandResultFactory({ error: solanaHeaderErr() as any }),
+          )
           .mockResolvedValueOnce(
             CommandResultFactory({ error: solanaHeaderErr() as any }),
           )
@@ -573,37 +590,22 @@ describe("SendSignMessageTask", () => {
           version: SignMessageVersion.V1,
         }).run();
 
-        expect(apiMock.sendCommand).toHaveBeenCalledTimes(3);
+        expect(apiMock.sendCommand).toHaveBeenCalledTimes(4);
         const envelope = DefaultBs58Encoder.decode(
           (res as any).data.signature as string,
         );
         expect(envelope.slice(65)).toEqual(v0OCM);
       });
 
-      it("V1 -> V0 size error when message exceeds V0 limit", async () => {
-        const msg = new Uint8Array(65520).fill(0x41);
-
-        apiMock.sendCommand
-          .mockResolvedValueOnce(CommandResultFactory({ data: PUBKEY_BASE58 }))
-          .mockResolvedValueOnce(
-            CommandResultFactory({ error: solanaHeaderErr() as any }),
-          );
-
-        const res = await makeTask(apiMock, {
-          sendingData: msg,
-          version: SignMessageVersion.V1,
-        }).run();
-
-        expect(apiMock.sendCommand).toHaveBeenCalledTimes(2);
-        expect((res as any).error).toBeInstanceOf(InvalidStatusWordError);
-      });
-
-      it("V1 -> V0 -> Legacy on double 6a81", async () => {
+      it("V1 -> V0 -> Legacy on triple 6a81", async () => {
         const msg = new Uint8Array([0x63]);
         const rawSig = new Uint8Array(64).fill(0xaa);
 
         apiMock.sendCommand
           .mockResolvedValueOnce(CommandResultFactory({ data: PUBKEY_BASE58 }))
+          .mockResolvedValueOnce(
+            CommandResultFactory({ error: solanaHeaderErr() as any }),
+          )
           .mockResolvedValueOnce(
             CommandResultFactory({ error: solanaHeaderErr() as any }),
           )
@@ -618,7 +620,7 @@ describe("SendSignMessageTask", () => {
           version: SignMessageVersion.V1,
         }).run();
 
-        expect(apiMock.sendCommand).toHaveBeenCalledTimes(4);
+        expect(apiMock.sendCommand).toHaveBeenCalledTimes(5);
         const envelope = DefaultBs58Encoder.decode(
           (res as any).data.signature as string,
         );

--- a/packages/signer/signer-solana/src/internal/app-binder/task/SendSignMessageTask.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/SendSignMessageTask.ts
@@ -5,6 +5,7 @@ import {
   InvalidArgumentError,
   InvalidStatusWordError,
   isSuccessCommandResult,
+  type LoggerPublisherService,
 } from "@ledgerhq/device-management-kit";
 import {
   type CommandFactory,
@@ -27,17 +28,19 @@ import {
 import {
   LEGACY_OFFCHAINMSG_MAX_LEN,
   OffchainMessageBuilder,
-  OFFCHAINMSG_MAX_V0_LEN,
-  OFFCHAINMSG_MAX_V1_LEN,
+  OFFCHAINMSG_MAX_LEN,
 } from "@internal/app-binder/services/OffchainMessageBuilder";
 
 export { MessageFormat } from "@internal/app-binder/services/OffchainMessageBuilder";
 
 const V1_MAX_SIGNERS = 255;
 
+// V0 and V1 share the device's single off-chain payload ceiling
+// (app-solana MAX_OFFCHAIN_MESSAGE_LENGTH). Legacy targets older, smaller-buffer
+// devices, so it keeps its own tighter limit.
 const MESSAGE_SIZE_LIMITS: Partial<Record<SignMessageVersion, number>> = {
-  [SignMessageVersion.V1]: OFFCHAINMSG_MAX_V1_LEN,
-  [SignMessageVersion.V0]: OFFCHAINMSG_MAX_V0_LEN,
+  [SignMessageVersion.V1]: OFFCHAINMSG_MAX_LEN,
+  [SignMessageVersion.V0]: OFFCHAINMSG_MAX_LEN,
   [SignMessageVersion.Legacy]: LEGACY_OFFCHAINMSG_MAX_LEN,
 };
 
@@ -55,6 +58,7 @@ export type SendSignMessageTaskRunFunctionReturn = Promise<
 
 export class SendSignMessageTask {
   private readonly _builder: OffchainMessageBuilder;
+  private readonly _logger?: LoggerPublisherService;
 
   constructor(
     private api: InternalApi,
@@ -62,6 +66,7 @@ export class SendSignMessageTask {
     private readonly bs58Encoder: Bs58Encoder = DefaultBs58Encoder,
   ) {
     this._builder = new OffchainMessageBuilder(args.appDomain);
+    this._logger = api.loggerFactory?.("SendSignMessageTask");
   }
 
   async run(): SendSignMessageTaskRunFunctionReturn {
@@ -222,15 +227,31 @@ export class SendSignMessageTask {
       });
     }
 
-    const v1OCM = this._builder.buildV1(sendingData, [
-      signerPubkey,
-      ...extraSigners,
-    ]);
-    const v1Result = await this._sendAndWrap(v1OCM, paths);
+    const signers = [signerPubkey, ...extraSigners];
 
-    return (
-      v1Result ?? this._runV0(sendingData, derivationPath, paths, signerPubkey)
+    // Preferred: finalised sRFC 38 layout (no length prefix). Older firmware
+    // rejects it with 6a81 (header.length != trailing bytes), so fall back to
+    // the pre-spec-update layout that still carries the 2-byte length prefix.
+    const v1OCM = this._builder.buildV1(sendingData, signers, false);
+    const v1Result = await this._sendAndWrap(v1OCM, paths);
+    if (v1Result) {
+      return v1Result;
+    }
+    this._logger?.warn(
+      "[_runV1] V1 (no length prefix) not supported by device firmware, falling back to V1 (with length prefix)",
+      { data: { signersCount: signers.length } },
     );
+
+    const v1LegacyOCM = this._builder.buildV1(sendingData, signers, true);
+    const v1LegacyResult = await this._sendAndWrap(v1LegacyOCM, paths);
+    if (v1LegacyResult) {
+      return v1LegacyResult;
+    }
+    this._logger?.warn(
+      "[_runV1] V1 (with length prefix) not supported by device firmware, falling back to V0",
+    );
+
+    return this._runV0(sendingData, derivationPath, paths, signerPubkey);
   }
 
   private async _runV0(
@@ -260,8 +281,14 @@ export class SendSignMessageTask {
 
     const v0OCM = this._builder.buildV0(sendingData, pubkey);
     const v0Result = await this._sendAndWrap(v0OCM, paths);
+    if (v0Result) {
+      return v0Result;
+    }
+    this._logger?.warn(
+      "[_runV0] V0 not supported by device firmware, falling back to Legacy",
+    );
 
-    return v0Result ?? this._runLegacy(sendingData, paths);
+    return this._runLegacy(sendingData, paths);
   }
 
   /**


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This aligns Solana off-chain message signing (OCMS) V1 with the finalised sRFC 38 spec, which drops the 2-byte little-endian message length prefix. In the new layout the message body is simply the trailing bytes after the signers, with no length field.

To stay compatible, the sign-message task now cascades through the possible layouts and advances on the device 6a81 (invalid off-chain header) reject, which is the same mechanism the existing V0 to Legacy fallback already uses. The order is:
  1. V1 without length prefix (finalised sRFC 38, preferred)
  2. V1 with length prefix (pre-spec-update firmware)
  3. V0
  4. Legacy


**Additional changes in this PR:**
  - Message length cap: V0 and V1 now use the real device limit that app-solana enforces (`MAX_OFFCHAIN_MESSAGE_LENGTH`, which is `PACKET_DATA_SIZE`, that is (15 times 1024) minus 40 minus 8, so 15312 bytes). Previously the caps were 65515 and 65535
  - Fallback logging: Each cascade transition now logs through the standard logger (warn on each fallback, error when every layout is exhausted), so the accepted layout can be traced from the exported logs.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [DSDK-1310](https://ledgerhq.atlassian.net/browse/DSDK-1310)

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
