### PR TITLE
🔧 (sonar) [NO-ISSUE]: Fix SonarQube source encoding and coverage reporting

### DIFF
--- a/apps/sample/playwright/cases/device/mock-overrides-speculos.spec.ts
+++ b/apps/sample/playwright/cases/device/mock-overrides-speculos.spec.ts
@@ -3,7 +3,7 @@ import { type DeviceConfig } from "@ledgerhq/device-mockserver-client";
 
 import { expect, test } from "../../fixtures";
 
-// Stax with the Ethereum app installed — the known-good combo provisioned via
+// Stax with the Ethereum app installed - the known-good combo provisioned via
 // Speculinho in open-app.spec.ts.
 const STAX_ETH: DeviceConfig = {
   name: "Ledger Stax",

--- a/apps/sample/playwright/cases/signers/ethereum/sign-typed-data.spec.ts
+++ b/apps/sample/playwright/cases/signers/ethereum/sign-typed-data.spec.ts
@@ -74,7 +74,7 @@ test.describe("signer ethereum: sign typed message", () => {
     const emulator = speculos(dev);
     await test.step("And blind signing is enabled on the device", async () => {
       // Open the app first (via Get address) so its settings are reachable, then
-      // enable blind signing — the EIP-712 message has no clear-signing context.
+      // enable blind signing - the EIP-712 message has no clear-signing context.
       await ethSigner.open();
       await ethSigner.getAddress();
       await ethSigner.lastResult();

--- a/apps/sample/playwright/utils/drivers/SpeculosDriver.ts
+++ b/apps/sample/playwright/utils/drivers/SpeculosDriver.ts
@@ -190,7 +190,7 @@ export class SpeculosDriver {
 
   /**
    * Log the on-screen text to the test output by polling the current screen
-   * (one-shot requests — no long-lived connection that would keep the worker
+   * (one-shot requests - no long-lived connection that would keep the worker
    * alive). Stopped by {@link dispose}.
    */
   private startScreenLog(): void {
@@ -237,9 +237,9 @@ export class SpeculosDriver {
   /**
    * Approve a signing review (transaction or typed message) on touch devices,
    * mirroring the clear-signing-tester flow: wait for the review to start, page
-   * through to the last screen — handling the "continue to blind signing" /
+   * through to the last screen - handling the "continue to blind signing" /
    * "blind signing ahead" screens, and rejecting if blind signing is blocked
-   * ("Go to settings") — then hold to sign on the last page.
+   * ("Go to settings") - then hold to sign on the last page.
    */
   async approveSigning(): Promise<void> {
     if (!this.isTouch()) {
@@ -277,7 +277,7 @@ export class SpeculosDriver {
       } else if (includesAny(screen, BLIND_WARNING_MARKERS)) {
         await touch.acceptBlindSigning();
       } else if (screen === "" || includesAny(screen, HOME_MARKERS)) {
-        // Transient idle screen while the host builds clear-signing contexts —
+        // Transient idle screen while the host builds clear-signing contexts -
         // wait for the review to (re)appear rather than tapping blindly.
       } else {
         await touch.navigateNext();
@@ -296,7 +296,7 @@ export class SpeculosDriver {
 
   /**
    * Enable blind signing in the app settings (touch devices). Call from the app
-   * home screen — e.g. after a first action has opened the app — so the
+   * home screen - e.g. after a first action has opened the app - so the
    * transaction review can proceed without clear-signing context.
    */
   async enableBlindSigning(): Promise<void> {
@@ -334,7 +334,7 @@ export class SpeculosDriver {
 
   private ready(): DeviceControllerClient {
     if (!this.controller) {
-      throw new Error("SpeculosDriver not ready — call waitReady() first");
+      throw new Error("SpeculosDriver not ready - call waitReady() first");
     }
     return this.controller;
   }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,79 @@ sonar.projectKey=LedgerHQ_device-sdk-ts
 sonar.organization=ledger
 sonar.sourceEncoding=UTF-8
 sonar.typescript.tsconfigPaths=tsconfig.json
-sonar.javascript.lcov.reportPaths=**/coverage/lcov.info
 sonar.newCode.referenceBranch=develop
-sonar.exclusions=**/node_modules/**,**/coverage/**,**/.next,**/pocs/**,**/.turbo/**,**/lib/**,**/danger/**,**/scripts/**,**/_templates/**,**/packages/tools/**,**/apps/**,**/agent-files/**,**/packages/devtools/**,**/packages/config/**
-sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,**/*.stub.ts,**/*.stub.tsx,**/*.mock.ts,**/*.mock.tsx,**/__tests__/**,**/__mocks__/**,**/packages/devtools/**,**/packages/config/**,**/*.kt
+
+sonar.sources=\
+  packages/device-management-kit,\
+  packages/ledger-wallet,\
+  packages/mockserver-client,\
+  packages/speculos-device-controller,\
+  packages/ui,\
+  packages/signer/context-module,\
+  packages/signer/signer-aleo,\
+  packages/signer/signer-btc,\
+  packages/signer/signer-concordium,\
+  packages/signer/signer-cosmos,\
+  packages/signer/signer-eth,\
+  packages/signer/signer-hyperliquid,\
+  packages/signer/signer-polkadot,\
+  packages/signer/signer-solana,\
+  packages/signer/signer-utils,\
+  packages/signer/signer-zcash,\
+  packages/transport/mockserver,\
+  packages/transport/node-hid,\
+  packages/transport/rn-ble,\
+  packages/transport/rn-hid,\
+  packages/transport/speculos,\
+  packages/transport/web-ble,\
+  packages/transport/web-hid,\
+  packages/trusted-apps/ledger-keyring-protocol
+
+sonar.javascript.lcov.reportPaths=\
+  packages/device-management-kit/coverage/lcov.info,\
+  packages/ledger-wallet/coverage/lcov.info,\
+  packages/mockserver-client/coverage/lcov.info,\
+  packages/speculos-device-controller/coverage/lcov.info,\
+  packages/signer/context-module/coverage/lcov.info,\
+  packages/signer/signer-aleo/coverage/lcov.info,\
+  packages/signer/signer-btc/coverage/lcov.info,\
+  packages/signer/signer-concordium/coverage/lcov.info,\
+  packages/signer/signer-cosmos/coverage/lcov.info,\
+  packages/signer/signer-eth/coverage/lcov.info,\
+  packages/signer/signer-hyperliquid/coverage/lcov.info,\
+  packages/signer/signer-polkadot/coverage/lcov.info,\
+  packages/signer/signer-solana/coverage/lcov.info,\
+  packages/signer/signer-utils/coverage/lcov.info,\
+  packages/signer/signer-zcash/coverage/lcov.info,\
+  packages/transport/mockserver/coverage/lcov.info,\
+  packages/transport/node-hid/coverage/lcov.info,\
+  packages/transport/rn-ble/coverage/lcov.info,\
+  packages/transport/rn-hid/coverage/lcov.info,\
+  packages/transport/speculos/coverage/lcov.info,\
+  packages/transport/web-ble/coverage/lcov.info,\
+  packages/transport/web-hid/coverage/lcov.info,\
+  packages/trusted-apps/ledger-keyring-protocol/coverage/lcov.info
+
+sonar.exclusions=\
+  **/node_modules/**,\
+  **/coverage/**,\
+  **/lib/**,\
+  **/.next,\
+  **/.turbo/**,\
+  **/pocs/**,\
+  **/_templates/**,\
+  **/*.jar,\
+  **/*.class
+
+sonar.coverage.exclusions=\
+  **/*.test.ts,\
+  **/*.test.tsx,\
+  **/*.spec.ts,\
+  **/*.spec.tsx,\
+  **/*.stub.ts,\
+  **/*.stub.tsx,\
+  **/*.mock.ts,\
+  **/*.mock.tsx,\
+  **/__tests__/**,\
+  **/__mocks__/**,\
+  **/*.kt

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.projectKey=LedgerHQ_device-sdk-ts
 sonar.organization=ledger
+sonar.sourceEncoding=UTF-8
 sonar.typescript.tsconfigPaths=tsconfig.json
 sonar.javascript.lcov.reportPaths=**/coverage/lcov.info
 sonar.newCode.referenceBranch=develop


### PR DESCRIPTION
### 📝 Description

SonarQube analysis on \`develop\` reported two problems:

1. **File-encoding warning** — *"There are problems with file encoding in the source code."*
   Every tracked file is valid UTF-8, but \`sonar-project.properties\` never declared \`sonar.sourceEncoding\`, so the scanner fell back to the CI runner's platform default charset. ~96 source files legitimately contain non-ASCII UTF-8 characters (accents, emoji in comments/strings), which then failed to decode under a non-UTF-8 default.
   - Added \`sonar.sourceEncoding=UTF-8\` so the scanner decodes all sources correctly.
   - Removed the remaining non-ASCII characters from the \`apps/sample\` Playwright suite that were not strictly necessary.

2. **Coverage not reported** — the glob \`**/coverage/lcov.info\` was not being resolved by the SonarQube scanner.
   - Replaced the glob with an explicit per-package list for \`sonar.javascript.lcov.reportPaths\`.
   - Replaced the broad exclusion-based source discovery with an explicit \`sonar.sources\` list, scoping analysis to published packages only.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Fix SonarQube file-encoding warning and coverage reporting

### ✅ Checklist

- [x] **Covered by automatic tests** <!-- N/A - CI/scanner configuration only -->
- [ ] **Changeset is provided** <!-- No changeset needed - only affects CI/scanner config, no published package -->
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - Adds \`sonar.sourceEncoding=UTF-8\` to \`sonar-project.properties\`
  - Replaces coverage glob with explicit per-package \`lcov.info\` paths
  - Adds explicit \`sonar.sources\` list scoped to published packages
  - Removes non-ASCII characters from \`apps/sample\` Playwright files
  - No runtime/source code impact; affects SonarQube analysis only

🤖 Generated with [Claude Code](https://claude.com/claude-code)