### PR TITLE
✨ (signer-trx) [DSDK-1264]: Add Get Address device action e2e

### DIFF
--- a/.changeset/tron-get-address.md
+++ b/.changeset/tron-get-address.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-tron": minor
+---
+
+Complete the Tron Get Address device action: derive the address and public key for a derivation path, with optional on-device verification (`checkOnDevice`) and `skipOpenApp`, plus a sample-app playground panel and unit/e2e coverage

--- a/apps/sample/package.json
+++ b/apps/sample/package.json
@@ -33,6 +33,7 @@
     "@ledgerhq/device-signer-kit-hyperliquid": "workspace:^",
     "@ledgerhq/device-signer-kit-polkadot": "workspace:^",
     "@ledgerhq/device-signer-kit-solana": "workspace:^",
+    "@ledgerhq/device-signer-kit-tron": "workspace:^",
     "@ledgerhq/device-signer-kit-zcash": "workspace:^",
     "@ledgerhq/device-transport-kit-mockserver": "workspace:^",
     "@ledgerhq/device-transport-kit-speculos": "workspace:^",

--- a/apps/sample/playwright/cases/signers/tron/get-address.spec.ts
+++ b/apps/sample/playwright/cases/signers/tron/get-address.spec.ts
@@ -1,0 +1,89 @@
+/* eslint-disable no-restricted-imports */
+import { type DeviceConfig } from "@ledgerhq/device-mockserver-client";
+
+import { expect, test } from "../../../fixtures";
+
+const STAX_WITH_TRX: DeviceConfig = {
+  name: "Ledger Stax",
+  device_type: "stax",
+  connectivity_type: "USB",
+  firmware_version: "1.9.1",
+  apps: [
+    { name: "BOLOS", version: "1.9.1" },
+    { name: "Tron", version: "0.7.4" },
+  ],
+  masks: [0x33200000],
+};
+
+interface GetAddressOutput {
+  address: string;
+  publicKey: string;
+  chainCode?: string;
+}
+
+// A mainnet Tron address is a Base58Check string starting with "T" and 34
+// characters long. The exact value is deterministic (fixed Speculos seed +
+// path 44'/195'/0'/0/0), but we assert on the format to stay robust to the
+// emulator's seed configuration.
+const TRON_ADDRESS_RE = /^T[1-9A-HJ-NP-Za-km-z]{33}$/;
+
+test.describe("signer tron: get address", () => {
+  test("returns an address with default inputs (no options selected)", async ({
+    device,
+    trxSigner,
+  }) => {
+    // Opening the Tron app provisions a real Speculos instance, which can take
+    // a while to become ready.
+    test.setTimeout(120_000);
+
+    await test.step("Given the device with the Tron app is connected", async () => {
+      await device.addAndConnect(STAX_WITH_TRX);
+    });
+
+    await test.step("When Get address is executed with default inputs", async () => {
+      await trxSigner.open();
+      await trxSigner.getAddress();
+    });
+
+    await test.step("Then a valid Tron address is returned", async () => {
+      const result = await trxSigner.lastResult<GetAddressOutput>();
+
+      expect(result.status).toBe("completed");
+      expect(result.output!.address).toMatch(TRON_ADDRESS_RE);
+      expect(result.output!.publicKey).toMatch(/^[0-9a-fA-F]+$/);
+    });
+  });
+
+  test("validates the address on the device screen", async ({
+    device,
+    trxSigner,
+    speculos,
+  }) => {
+    // Opening the Tron app provisions a real Speculos instance and the address
+    // must be approved on screen, so this flow is slow.
+    test.setTimeout(120_000);
+
+    let dev!: Awaited<ReturnType<typeof device.addAndConnect>>;
+    await test.step("Given the device with the Tron app is connected", async () => {
+      dev = await device.addAndConnect(STAX_WITH_TRX);
+    });
+
+    await test.step("When Get address is executed with on-device verification", async () => {
+      await trxSigner.open();
+      await trxSigner.getAddress({ checkOnDevice: true });
+    });
+
+    await test.step("And the address is approved on the Speculos screen", async () => {
+      const emulator = speculos(dev);
+      await emulator.waitReady();
+      await emulator.approve();
+    });
+
+    await test.step("Then a valid Tron address is returned", async () => {
+      const result = await trxSigner.lastResult<GetAddressOutput>();
+
+      expect(result.status).toBe("completed");
+      expect(result.output!.address).toMatch(TRON_ADDRESS_RE);
+    });
+  });
+});

--- a/apps/sample/playwright/fixtures.ts
+++ b/apps/sample/playwright/fixtures.ts
@@ -12,6 +12,7 @@ import { MockDeviceDriver } from "./utils/drivers/MockDeviceDriver";
 import { SettingsDriver } from "./utils/drivers/SettingsDriver";
 import { SidebarDriver } from "./utils/drivers/SidebarDriver";
 import { SpeculosDriver } from "./utils/drivers/SpeculosDriver";
+import { TrxSignerDriver } from "./utils/drivers/TrxSignerDriver";
 import { setupMockServerSession } from "./utils/setup";
 
 type Fixtures = {
@@ -29,6 +30,7 @@ type Fixtures = {
   sidebar: SidebarDriver;
   ethSigner: EthSignerDriver;
   btcSigner: BtcSignerDriver;
+  trxSigner: TrxSignerDriver;
   /** Build a Speculos driver for a connected device (its app must be opened). */
   speculos: (device: Device) => SpeculosDriver;
 };
@@ -68,6 +70,9 @@ export const test = base.extend<Fixtures>({
   },
   btcSigner: async ({ page }, use) => {
     await use(new BtcSignerDriver(page));
+  },
+  trxSigner: async ({ page }, use) => {
+    await use(new TrxSignerDriver(page));
   },
   speculos: async ({ mockClient }, use, testInfo) => {
     const drivers: SpeculosDriver[] = [];

--- a/apps/sample/playwright/utils/drivers/TrxSignerDriver.ts
+++ b/apps/sample/playwright/utils/drivers/TrxSignerDriver.ts
@@ -1,0 +1,58 @@
+import { type Page } from "@playwright/test";
+
+import { ResponsesDriver } from "./ResponsesDriver";
+
+export interface DeviceActionResult<Output> {
+  status: string; // "completed" | "error" | "pending" | ...
+  output?: Output;
+  error?: unknown;
+}
+
+/**
+ * Drives the Tron signer view: navigating to it, executing device actions and
+ * reading back the emitted device-action states.
+ */
+export class TrxSignerDriver {
+  private readonly responses: ResponsesDriver;
+
+  constructor(private readonly page: Page) {
+    this.responses = new ResponsesDriver(page);
+  }
+
+  /** Navigate Signer Kits -> Tron. */
+  async open(): Promise<void> {
+    await this.page.getByTestId("CTA_route-to-/signers").click();
+    await this.page.waitForURL("http://localhost:3000/signers");
+    await this.page.getByTestId("CTA_command-Tron").click();
+    await this.page.waitForURL("http://localhost:3000/signers/tron");
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  /**
+   * Open the Get address action and Execute it. When `checkOnDevice` is set, the
+   * address is verified on the device screen (the action stays pending until the
+   * user approves on Speculos).
+   */
+  async getAddress({
+    checkOnDevice = false,
+  }: { checkOnDevice?: boolean } = {}): Promise<void> {
+    await this.page.getByTestId("CTA_command-Get address").click();
+    if (checkOnDevice) {
+      await this.page.getByTestId("input-switch_checkOnDevice").click();
+    }
+    await this.page.getByTestId("CTA_send-device-action").click();
+  }
+
+  /**
+   * Wait for the last emitted device-action state to be terminal and return it
+   * parsed.
+   */
+  async lastResult<Output>({
+    timeout = 90_000,
+  }: { timeout?: number } = {}): Promise<DeviceActionResult<Output>> {
+    return this.responses.lastJson<DeviceActionResult<Output>>(
+      /"status": "(completed|error)"/,
+      { timeout },
+    );
+  }
+}

--- a/apps/sample/src/app/signers/tron/page.tsx
+++ b/apps/sample/src/app/signers/tron/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+import React from "react";
+
+import { SessionIdWrapper } from "@/components/SessionIdWrapper";
+import { SignerTrxView } from "@/components/SignerTrxView";
+
+const Signer: React.FC = () => {
+  return <SessionIdWrapper ChildComponent={SignerTrxView} />;
+};
+
+export default Signer;

--- a/apps/sample/src/components/SignerTrxView/index.tsx
+++ b/apps/sample/src/components/SignerTrxView/index.tsx
@@ -1,0 +1,66 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useMemo } from "react";
+import {
+  type GetAddressDAError,
+  type GetAddressDAIntermediateValue,
+  type GetAddressDAOutput,
+  SignerTrxBuilder,
+} from "@ledgerhq/device-signer-kit-tron";
+
+import { DeviceActionsList } from "@/components/DeviceActionsView/DeviceActionsList";
+import { type DeviceActionProps } from "@/components/DeviceActionsView/DeviceActionTester";
+import { useDmk } from "@/providers/DeviceManagementKitProvider";
+
+const DEFAULT_DERIVATION_PATH = "44'/195'/0'/0/0";
+
+export const SignerTrxView: React.FC<{ sessionId: string }> = ({
+  sessionId,
+}) => {
+  const dmk = useDmk();
+  const signer = useMemo(
+    () => new SignerTrxBuilder({ dmk, sessionId }).build(),
+    [dmk, sessionId],
+  );
+
+  const deviceModelId = dmk.getConnectedDevice({ sessionId }).modelId;
+
+  const deviceActions = useMemo<DeviceActionProps<any, any, any, any>[]>(
+    () => [
+      {
+        title: "Get address",
+        description:
+          "Perform all the actions necessary to get a Tron address from the device",
+        executeDeviceAction: ({
+          derivationPath,
+          checkOnDevice,
+          skipOpenApp,
+        }) => {
+          return signer.getAddress(derivationPath, {
+            checkOnDevice,
+            skipOpenApp,
+          });
+        },
+        initialValues: {
+          derivationPath: DEFAULT_DERIVATION_PATH,
+          checkOnDevice: false,
+          skipOpenApp: false,
+        },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        GetAddressDAOutput,
+        {
+          derivationPath: string;
+          checkOnDevice?: boolean;
+          skipOpenApp?: boolean;
+        },
+        GetAddressDAError,
+        GetAddressDAIntermediateValue
+      >,
+    ],
+    [deviceModelId, signer],
+  );
+
+  return (
+    <DeviceActionsList title="Tron Signer" deviceActions={deviceActions} />
+  );
+};

--- a/apps/sample/src/components/SignerView/index.tsx
+++ b/apps/sample/src/components/SignerView/index.tsx
@@ -51,6 +51,11 @@ const SUPPORTED_SIGNERS = [
     description: "Access Polkadot signer functionality",
     icon: <CryptoIcon ledgerId="polkadot" ticker="POLKADOT" size={size} />,
   },
+  {
+    title: "Tron",
+    description: "Access Tron signer functionality",
+    icon: <CryptoIcon ledgerId="tron" ticker="TRX" size={size} />,
+  },
 ];
 
 export const SignerView = () => {

--- a/packages/signer/signer-trx/README.md
+++ b/packages/signer/signer-trx/README.md
@@ -36,6 +36,50 @@ const { observable: messageObservable } = signer.signPersonalMessage(
 const { observable: configObservable } = signer.getAppConfiguration();
 ```
 
+### Get address
+
+Derives the Tron address and public key for a BIP32 derivation path (Tron uses
+coin type `195`).
+
+```typescript
+signer.getAddress(
+  derivationPath: string,
+  options?: {
+    // Display the address on the device for user verification (default: false).
+    checkOnDevice?: boolean;
+    // Skip the "open app" step if the Tron app is already open (default: false).
+    skipOpenApp?: boolean;
+  },
+): GetAddressDAReturnType;
+```
+
+The returned device action resolves to:
+
+```typescript
+{
+  address: string; // Base58Check Tron address, e.g. "TWdnWBzFdBP1b8sqZ5RcFDbkV3sBmnxsYu"
+  publicKey: string; // hex-encoded public key
+  chainCode?: string; // hex-encoded chain code (only when requested)
+}
+```
+
+```typescript
+const { observable, cancel } = signer.getAddress("44'/195'/0'/0/0", {
+  checkOnDevice: true,
+});
+
+observable.subscribe((state) => {
+  switch (state.status) {
+    case "completed":
+      console.log(state.output.address, state.output.publicKey);
+      break;
+    case "error":
+      console.error(state.error);
+      break;
+  }
+});
+```
+
 ## Development
 
 ```bash

--- a/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.test.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.test.ts
@@ -1,0 +1,173 @@
+import {
+  type DeviceActionState,
+  DeviceActionStatus,
+  type DeviceManagementKit,
+  type DeviceSessionId,
+  type LoggerPublisherService,
+  SendCommandInAppDeviceAction,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+import { from } from "rxjs";
+
+import {
+  type GetAddressDAError,
+  type GetAddressDAIntermediateValue,
+  type GetAddressDAOutput,
+} from "@api/app-binder/GetAddressDeviceActionTypes";
+import { GetAddressCommand } from "@internal/app-binder/command/GetAddressCommand";
+import { APP_NAME } from "@internal/app-binder/constants";
+
+import { TronAppBinder } from "./TronAppBinder";
+
+describe("TronAppBinder", () => {
+  const mockedDmk: DeviceManagementKit = {
+    sendCommand: vi.fn(),
+    executeDeviceAction: vi.fn(),
+  } as unknown as DeviceManagementKit;
+
+  const loggerMock = {
+    debug: vi.fn(),
+  } as unknown as LoggerPublisherService;
+  const loggerFactoryMock = vi.fn().mockReturnValue(loggerMock);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should be defined", () => {
+    const binder = new TronAppBinder(
+      {} as DeviceManagementKit,
+      {} as DeviceSessionId,
+      loggerFactoryMock,
+    );
+    expect(binder).toBeDefined();
+  });
+
+  describe("getAddress", () => {
+    it("should return the address", () =>
+      new Promise<void>((resolve, reject) => {
+        // GIVEN
+        const output: GetAddressDAOutput = {
+          publicKey: "0401020304",
+          address: "TWdnWBzFdBP1b8sqZ5RcFDbkV3sBmnxsYu",
+        };
+
+        vi.spyOn(mockedDmk, "executeDeviceAction").mockReturnValue({
+          observable: from([
+            {
+              status: DeviceActionStatus.Completed,
+              output,
+            } as DeviceActionState<
+              GetAddressDAOutput,
+              GetAddressDAError,
+              GetAddressDAIntermediateValue
+            >,
+          ]),
+          cancel: vi.fn(),
+        });
+
+        // WHEN
+        const binder = new TronAppBinder(
+          mockedDmk,
+          "sessionId",
+          loggerFactoryMock,
+        );
+        const { observable } = binder.getAddress({
+          derivationPath: "44'/195'/0'/0/0",
+          checkOnDevice: false,
+          skipOpenApp: false,
+        });
+
+        // THEN
+        const states: DeviceActionState<
+          GetAddressDAOutput,
+          GetAddressDAError,
+          GetAddressDAIntermediateValue
+        >[] = [];
+        observable.subscribe({
+          next: (state) => states.push(state),
+          error: reject,
+          complete: () => {
+            try {
+              expect(states).toEqual([
+                { status: DeviceActionStatus.Completed, output },
+              ]);
+              resolve();
+            } catch (err) {
+              reject(err as Error);
+            }
+          },
+        });
+      }));
+
+    describe("calls executeDeviceAction with the correct params", () => {
+      const derivationPath = "44'/195'/0'/0/0";
+
+      it("requires no user interaction when checkOnDevice is false", () => {
+        // WHEN
+        const binder = new TronAppBinder(
+          mockedDmk,
+          "sessionId",
+          loggerFactoryMock,
+        );
+        binder.getAddress({
+          derivationPath,
+          checkOnDevice: false,
+          skipOpenApp: false,
+        });
+
+        // THEN
+        expect(mockedDmk.executeDeviceAction).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sessionId: "sessionId",
+            deviceAction: new SendCommandInAppDeviceAction({
+              input: {
+                command: new GetAddressCommand({
+                  derivationPath,
+                  checkOnDevice: false,
+                }),
+                appName: APP_NAME,
+                requiredUserInteraction: UserInteractionRequired.None,
+                skipOpenApp: false,
+              },
+              logger: loggerMock,
+            }),
+          }),
+        );
+      });
+
+      it("requires VerifyAddress interaction when checkOnDevice is true", () => {
+        // WHEN
+        const binder = new TronAppBinder(
+          mockedDmk,
+          "sessionId",
+          loggerFactoryMock,
+        );
+        binder.getAddress({
+          derivationPath,
+          checkOnDevice: true,
+          skipOpenApp: true,
+        });
+
+        // THEN
+        expect(mockedDmk.executeDeviceAction).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sessionId: "sessionId",
+            deviceAction: new SendCommandInAppDeviceAction({
+              input: {
+                command: new GetAddressCommand({
+                  derivationPath,
+                  checkOnDevice: true,
+                }),
+                appName: APP_NAME,
+                requiredUserInteraction: UserInteractionRequired.VerifyAddress,
+                skipOpenApp: true,
+              },
+              logger: loggerMock,
+            }),
+          }),
+        );
+      });
+    });
+  });
+});

--- a/packages/signer/signer-trx/src/internal/use-cases/address/GetAddressUseCase.test.ts
+++ b/packages/signer/signer-trx/src/internal/use-cases/address/GetAddressUseCase.test.ts
@@ -1,0 +1,51 @@
+import { type TronAppBinder } from "@internal/app-binder/TronAppBinder";
+
+import { GetAddressUseCase } from "./GetAddressUseCase";
+
+describe("GetAddressUseCase", () => {
+  const derivationPath = "44'/195'/0'/0/0";
+  const returnedValue = { address: "some-address" };
+  const getAddressMock = vi.fn().mockReturnValue(returnedValue);
+  const appBinderMock = {
+    getAddress: getAddressMock,
+  } as unknown as TronAppBinder;
+  let useCase: GetAddressUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new GetAddressUseCase(appBinderMock);
+  });
+
+  it("should forward the provided options to the app binder", () => {
+    // GIVEN
+    const checkOnDevice = true;
+    const skipOpenApp = true;
+
+    // WHEN
+    const result = useCase.execute(derivationPath, {
+      checkOnDevice,
+      skipOpenApp,
+    });
+
+    // THEN
+    expect(result).toEqual(returnedValue);
+    expect(getAddressMock).toHaveBeenCalledWith({
+      derivationPath,
+      checkOnDevice,
+      skipOpenApp,
+    });
+  });
+
+  it("should default checkOnDevice and skipOpenApp to false", () => {
+    // WHEN
+    const result = useCase.execute(derivationPath);
+
+    // THEN
+    expect(result).toEqual(returnedValue);
+    expect(getAddressMock).toHaveBeenCalledWith({
+      derivationPath,
+      checkOnDevice: false,
+      skipOpenApp: false,
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -968,6 +968,9 @@ importers:
       '@ledgerhq/device-signer-kit-solana':
         specifier: workspace:^
         version: link:../../packages/signer/signer-solana
+      '@ledgerhq/device-signer-kit-tron':
+        specifier: workspace:^
+        version: link:../../packages/signer/signer-trx
       '@ledgerhq/device-signer-kit-zcash':
         specifier: workspace:^
         version: link:../../packages/signer/signer-zcash


### PR DESCRIPTION
How### 📝 Description

This PR completes the **Get Address** device action for the Tron signer kit (`@ledgerhq/device-signer-kit-tron`).

`signer.getAddress(...)` now derives the Tron address and public key for a given BIP32 derivation path (Tron coin type `195`), with optional on-device address verification (`checkOnDevice`) and the ability to bypass the open-app step when the Tron app is already running (`skipOpenApp`).

```typescript
const { observable, cancel } = signer.getAddress("44'/195'/0'/0/0", {
  checkOnDevice: true, // display the address on the device for user confirmation
  skipOpenApp: false,  // skip the "open app" step if the Tron app is already open
});

observable.subscribe((state) => {
  switch (state.status) {
    case "completed":
      // state.output => { address, publicKey, chainCode? }
      console.log(state.output.address, state.output.publicKey);
      break;
    case "error":
      console.error(state.error);
      break;
  }
});
```

The device action resolves to:

{
  address: string;    // Base58Check Tron address, e.g. "TWdnWBzFdBP1b8sqZ5RcFDbkV3sBmnxsYu"
  publicKey: string;  // hex-encoded public key
  chainCode?: string; // hex-encoded chain code
}

Alongside the feature, this PR adds:
- A Get address playground panel in the sample app (Tron signer view) to exercise the flow manually.
- Playwright e2e coverage against a Speculos-backed Stax running the Tron app: one flow with default inputs, and one with checkOnDevice where the address is approved on the device screen.
- Unit tests for TronAppBinder and GetAddressUseCase.
- README documentation for getAddress.

❓ Context

- JIRA or GitHub link: [DSDK-1264]
- Feature: Get Address device action for the Tron signer kit - derive a Tron address/public key from a derivation path, with optional on-device verification.

✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] Covered by automatic tests
- [x] Changeset is provided
- [x] Documentation is up-to-date - signer-trx README updated with the getAddress API, options, and return shape.
- [ ] Impact of the changes: QA should focus on:
  - getAddress on the Tron signer with default options, checkOnDevice: true, and skipOpenApp: true.
  - On-device address verification (approve/reject) on Stax/other supported devices.
  - The new Get address panel in the sample app's Tron signer view.

---
🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] The code aligns with the requirements described in the linked JIRA or GitHub issue.
- [ ] The PR description clearly documents the changes made and explains any technical trade-offs or design decisions.
- [ ] There are no undocumented trade-offs, technical debt, or maintainability issues.
- [ ] The PR has been tested thoroughly, and any potential edge cases have been considered and handled.
- [ ] Any new dependencies have been justified and documented.


[DSDK-1264]: https://ledgerhq.atlassian.net/browse/DSDK-1264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ