### PR TITLE
🐛 (clear-signing-tester) [NO-ISSUE]: Install userland undici to avoid Node 24 crash

### DIFF
--- a/apps/clear-signing-tester/package.json
+++ b/apps/clear-signing-tester/package.json
@@ -50,7 +50,8 @@
     "ethers": "catalog:",
     "inversify": "catalog:",
     "rxjs": "catalog:",
-    "semver": "catalog:"
+    "semver": "catalog:",
+    "undici": "^8.5.0"
   },
   "devDependencies": {
     "@ledgerhq/vitest-config-dmk": "workspace:^",

--- a/apps/clear-signing-tester/package.json
+++ b/apps/clear-signing-tester/package.json
@@ -65,6 +65,6 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   }
 }

--- a/apps/clear-signing-tester/src/cli/EthereumTransactionTesterCli.ts
+++ b/apps/clear-signing-tester/src/cli/EthereumTransactionTesterCli.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import "@root/src/setup/installUndici";
+
 import { type LoggerPublisherService } from "@ledgerhq/device-management-kit";
 import { Command } from "commander";
 import { type Container } from "inversify";

--- a/apps/clear-signing-tester/src/cli/SolanaTransactionTesterCli.ts
+++ b/apps/clear-signing-tester/src/cli/SolanaTransactionTesterCli.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import "@root/src/setup/installUndici";
+
 import { type LoggerPublisherService } from "@ledgerhq/device-management-kit";
 import { Command } from "commander";
 import { type Container } from "inversify";

--- a/apps/clear-signing-tester/src/setup/installUndici.ts
+++ b/apps/clear-signing-tester/src/setup/installUndici.ts
@@ -1,0 +1,18 @@
+import { install } from "undici";
+
+/**
+ * Replace Node's built-in `fetch` stack with the userland undici implementation.
+ *
+ * Node 24 bundles undici 7.x, whose HTTP/1 parser throws an *uncatchable*
+ * `AssertionError` from the socket `'end'` handler when the parser is paused
+ * under response-body backpressure and the peer closes the connection
+ * (see https://github.com/nodejs/undici/issues/5360). This crashes the whole
+ * CLI process mid-run instead of surfacing a catchable error.
+ *
+ * The fix ships in undici >= 8.4.1, so we install the patched userland version
+ * over the global `fetch`/`Headers`/`Request`/`Response`. Importing this module
+ * for its side effect (as early as possible) ensures every HTTP call — the
+ * Solana RPC adapter, the context module, the metadata service, etc. — routes
+ * through the patched client.
+ */
+install();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,6 +497,9 @@ importers:
       semver:
         specifier: 'catalog:'
         version: 7.7.2
+      undici:
+        specifier: ^8.5.0
+        version: 8.6.0
     devDependencies:
       '@ledgerhq/eslint-config-dsdk':
         specifier: workspace:^
@@ -12735,6 +12738,10 @@ packages:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
+  undici@8.6.0:
+    resolution: {integrity: sha512-l2FlC6I510GawyEd1qgcE/okihKrzy+BRTEBlu6T0fdbM9m5yxtIH5Oa3ysRsH0zC4EhmWUEaSDsy2QngBeRlw==}
+    engines: {node: '>=22.19.0'}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -18044,14 +18051,6 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.2.0
       tinyrainbow: 2.0.0
-
-  '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@24.13.2)(jiti@2.7.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 7.1.6(@types/node@24.13.2)(jiti@2.7.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0)
 
   '@vitest/mocker@3.2.4(vite@7.1.6(@types/node@24.13.2)(jiti@2.7.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.7.0))':
     dependencies:
@@ -25983,6 +25982,8 @@ snapshots:
 
   undici@6.27.0: {}
 
+  undici@8.6.0: {}
+
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -26356,7 +26357,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@24.13.2)(jiti@2.7.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))
+      '@vitest/mocker': 3.2.4(vite@7.1.6(@types/node@24.13.2)(jiti@2.7.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.7.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4


### PR DESCRIPTION
### 📝 Description

Install userland undici to avoid a Node 24 crash in the clear-signing-tester.

Node 24 bundles undici 7.x, whose HTTP/1 parser throws an uncatchable `AssertionError` on socket end under response-body backpressure ([nodejs/undici#5360](https://github.com/nodejs/undici/issues/5360)), crashing the cs-tester mid-run. This installs the patched userland undici (8.x, fix from [nodejs/undici#5389](https://github.com/nodejs/undici/pull/5389)) over the global `fetch` stack at the CLI entrypoints, so every HTTP call (Solana RPC, context module, metadata service) routes through the fixed client.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Bugfix — the Solana nightly cs-tester was crashing with `AssertionError [ERR_ASSERTION]: false == true at Parser.finish` after the toolchain bump from Node 20 → 24 (#1582).

### ✅ Checklist

- [ ] **Covered by automatic tests** — behavior verified by re-running the Solana nightly workflow; the crash no longer occurs. Not unit-testable (depends on Node's bundled HTTP client + live sockets).
- [ ] **Changeset is provided** — _Not needed: changes only affect the `apps/clear-signing-tester` app (not a published package)._
- [ ] **Documentation is up-to-date**
- [ ] **Impact of the changes:**
  - Adds `undici@^8.5.0` to `apps/clear-signing-tester`.
  - Adds `src/setup/installUndici.ts` and imports it first in both the Solana and Ethereum CLI entrypoints to replace the global fetch stack with the patched undici.

Made with [Cursor](https://cursor.com)