### PR TITLE
✨ (os-update) [DSDK-1272]: Adds RequestMasterConsentCommand

### DIFF
--- a/.changeset/wet-hands-train.md
+++ b/.changeset/wet-hands-train.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": minor
+---
+
+Adds RequestMasterConsentCommand

--- a/apps/sample/src/components/CommandsView/index.tsx
+++ b/apps/sample/src/components/CommandsView/index.tsx
@@ -33,6 +33,9 @@ import {
   type OpenAppArgs,
   OpenAppCommand,
   type OpenAppErrorCodes,
+  RequestMasterConsentCommand,
+  type RequestMasterConsentCommandArgs,
+  type RequestMasterConsentCommandErrorCodes,
 } from "@ledgerhq/device-management-kit";
 import { Grid } from "@ledgerhq/react-ui";
 
@@ -163,6 +166,37 @@ export const CommandsView: React.FC<{ sessionId: string }> = ({
         void,
         BackupAppStorageCommandResponse,
         BackupAppStorageCommandErrorCodes
+      >,
+      {
+        title: "Request master consent",
+        description: "Request master consent for the device",
+        sendCommand: ({
+          languagePackConsentEnabled,
+          lockScreenPictureConsentEnabled,
+          appNumber,
+          appStorageNumber,
+        }) => {
+          const command = new RequestMasterConsentCommand({
+            languagePackConsentEnabled,
+            lockScreenPictureConsentEnabled,
+            appNumber,
+            appStorageNumber,
+          });
+          return dmk.sendCommand({
+            sessionId: selectedSessionId,
+            command,
+          });
+        },
+        initialValues: {
+          languagePackConsentEnabled: true,
+          lockScreenPictureConsentEnabled: true,
+          appNumber: 1,
+          appStorageNumber: 1,
+        },
+      } satisfies CommandProps<
+        RequestMasterConsentCommandArgs,
+        void,
+        RequestMasterConsentCommandErrorCodes
       >,
       {
         title: "Init restore app storage",

--- a/packages/device-management-kit/src/api/command/os/RequestMasterConsentCommand.test.ts
+++ b/packages/device-management-kit/src/api/command/os/RequestMasterConsentCommand.test.ts
@@ -1,0 +1,182 @@
+import {
+  CommandResultFactory,
+  isSuccessCommandResult,
+} from "@api/command/model/CommandResult";
+import { ApduResponse } from "@api/device-session/ApduResponse";
+import { InvalidArgumentError } from "@api/Error";
+
+import {
+  RequestMasterConsentCommand,
+  RequestMasterConsentCommandError,
+} from "./RequestMasterConsentCommand";
+
+describe("RequestMasterConsentCommand", () => {
+  describe("Name", () => {
+    it("name should be 'RequestMasterConsent'", () => {
+      // ACT
+      const command = new RequestMasterConsentCommand({
+        languagePackConsentEnabled: true,
+        lockScreenPictureConsentEnabled: true,
+        appNumber: 1,
+        appStorageNumber: 1,
+      });
+
+      // ASSERT
+      expect(command.name).toBe("RequestMasterConsent");
+    });
+  });
+
+  describe("Command", () => {
+    it("should return the correct APDU for requesting master consent", () => {
+      // ARRANGE
+      const command = new RequestMasterConsentCommand({
+        languagePackConsentEnabled: true,
+        lockScreenPictureConsentEnabled: true,
+        appNumber: 1,
+        appStorageNumber: 1,
+      });
+      const expectedApdu = Uint8Array.from([
+        0xe0, 0x6f, 0x00, 0x00, 0x04, 0x00, 0x00, 0x01, 0x01,
+      ]);
+
+      // ACT
+      const apdu = command.getApdu();
+
+      // ASSERT
+      expect(apdu.getRawApdu()).toEqual(expectedApdu);
+    });
+
+    it.each([
+      {
+        field: "appNumber",
+        args: { appNumber: -1, appStorageNumber: 1 },
+      },
+      {
+        field: "appNumber",
+        args: { appNumber: 256, appStorageNumber: 1 },
+      },
+      {
+        field: "appNumber",
+        args: { appNumber: 1.5, appStorageNumber: 1 },
+      },
+      {
+        field: "appStorageNumber",
+        args: { appNumber: 1, appStorageNumber: -1 },
+      },
+      {
+        field: "appStorageNumber",
+        args: { appNumber: 1, appStorageNumber: 256 },
+      },
+      {
+        field: "appStorageNumber",
+        args: { appNumber: 1, appStorageNumber: 1.5 },
+      },
+    ])(
+      "should throw when $field is not an 8-bit unsigned integer",
+      ({ field, args }) => {
+        const expectedErrorMessage = `${field} must be an integer between 0 and 255`;
+
+        // ACT
+        let caughtError: unknown;
+        try {
+          new RequestMasterConsentCommand({
+            languagePackConsentEnabled: true,
+            lockScreenPictureConsentEnabled: true,
+            ...args,
+          });
+        } catch (error) {
+          caughtError = error;
+        }
+
+        // ASSERT
+        expect(caughtError).toBeInstanceOf(InvalidArgumentError);
+        expect(
+          (caughtError as InvalidArgumentError).originalError.message,
+        ).toBe(expectedErrorMessage);
+      },
+    );
+  });
+
+  describe("Success response", () => {
+    it("should return the correct response", () => {
+      // ARRANGE
+      const command = new RequestMasterConsentCommand({
+        languagePackConsentEnabled: true,
+        lockScreenPictureConsentEnabled: true,
+        appNumber: 1,
+        appStorageNumber: 1,
+      });
+      const expectedResult = {
+        data: undefined,
+        status: "SUCCESS",
+      };
+
+      // ACT
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x90, 0x00]),
+          data: Uint8Array.from([]),
+        }),
+      );
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe("Error response", () => {
+    it("should return a RequestMasterConsentCommandError for status 0x5501", () => {
+      // ARRANGE
+      const command = new RequestMasterConsentCommand({
+        languagePackConsentEnabled: true,
+        lockScreenPictureConsentEnabled: true,
+        appNumber: 1,
+        appStorageNumber: 1,
+      });
+      const expectedResult = CommandResultFactory({
+        error: new RequestMasterConsentCommandError({
+          message: "Consent failed",
+          errorCode: "5501",
+        }),
+      });
+
+      // ACT
+      const commandResult = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x55, 0x01]),
+          data: Uint8Array.from([]),
+        }),
+      );
+
+      // ASSERT
+      expect(commandResult).toEqual(expectedResult);
+    });
+
+    it("should return a RequestMasterConsentCommandError for status 0x5502", () => {
+      // ARRANGE
+      const command = new RequestMasterConsentCommand({
+        languagePackConsentEnabled: true,
+        lockScreenPictureConsentEnabled: true,
+        appNumber: 1,
+        appStorageNumber: 1,
+      });
+      const expectedResult = CommandResultFactory({
+        error: new RequestMasterConsentCommandError({
+          message: "PIN not validated",
+          errorCode: "5502",
+        }),
+      });
+
+      // ACT
+      const commandResult = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x55, 0x02]),
+          data: Uint8Array.from([]),
+        }),
+      );
+
+      // ASSERT
+      expect(commandResult).toEqual(expectedResult);
+    });
+  });
+});

--- a/packages/device-management-kit/src/api/command/os/RequestMasterConsentCommand.ts
+++ b/packages/device-management-kit/src/api/command/os/RequestMasterConsentCommand.ts
@@ -1,0 +1,115 @@
+import { type Apdu } from "@api/apdu/model/Apdu";
+import { ApduBuilder, type ApduBuilderArgs } from "@api/apdu/utils/ApduBuilder";
+import { ApduParser } from "@api/apdu/utils/ApduParser";
+import { CommandResultFactory } from "@api/command/model/CommandResult";
+import { isCommandErrorCode } from "@api/command/utils/CommandErrors";
+import { CommandUtils } from "@api/command/utils/CommandUtils";
+import { GlobalCommandErrorHandler } from "@api/command/utils/GlobalCommandError";
+import { type ApduResponse } from "@api/device-session/ApduResponse";
+import {
+  type CommandErrorArgs,
+  DeviceExchangeError,
+  InvalidArgumentError,
+} from "@api/Error";
+import {
+  type Command,
+  type CommandErrors,
+  type CommandResult,
+} from "@api/types";
+
+export type RequestMasterConsentCommandArgs = {
+  languagePackConsentEnabled: boolean;
+  lockScreenPictureConsentEnabled: boolean;
+  appNumber: number;
+  appStorageNumber: number;
+};
+export type RequestMasterConsentCommandErrorCodes = "5501" | "5502";
+
+export type RequestMasterConsentCommandResult = CommandResult<
+  void,
+  RequestMasterConsentCommandErrorCodes
+>;
+export const REQUEST_MASTER_CONSENT_ERRORS: CommandErrors<RequestMasterConsentCommandErrorCodes> =
+  {
+    "5501": { message: "Consent failed" },
+    "5502": { message: "PIN not validated" },
+  };
+
+const assert8BitUInt = (name: string, value: number) => {
+  if (!Number.isInteger(value) || value < 0x00 || value > 0xff) {
+    throw new InvalidArgumentError(
+      `${name} must be an integer between 0 and 255`,
+    );
+  }
+};
+
+export class RequestMasterConsentCommandError extends DeviceExchangeError<RequestMasterConsentCommandErrorCodes> {
+  constructor(args: CommandErrorArgs<RequestMasterConsentCommandErrorCodes>) {
+    super({ tag: "RequestMasterConsentCommandError", ...args });
+  }
+}
+
+export class RequestMasterConsentCommand
+  implements
+    Command<
+      void,
+      RequestMasterConsentCommandArgs,
+      RequestMasterConsentCommandErrorCodes
+    >
+{
+  readonly name = "RequestMasterConsent";
+
+  readonly args: RequestMasterConsentCommandArgs;
+
+  private readonly header = {
+    cla: 0xe0,
+    ins: 0x6f,
+    p1: 0x00,
+    p2: 0x00,
+  };
+
+  constructor(args: RequestMasterConsentCommandArgs) {
+    assert8BitUInt("appNumber", args.appNumber);
+    assert8BitUInt("appStorageNumber", args.appStorageNumber);
+    this.args = args;
+  }
+
+  getApdu(): Apdu {
+    const apduArgs: ApduBuilderArgs = {
+      cla: this.header.cla,
+      ins: this.header.ins,
+      p1: this.header.p1,
+      p2: this.header.p2,
+    };
+    return new ApduBuilder(apduArgs)
+      .add8BitUIntToData(this.args.languagePackConsentEnabled ? 0x00 : 0x01)
+      .add8BitUIntToData(
+        this.args.lockScreenPictureConsentEnabled ? 0x00 : 0x01,
+      )
+      .add8BitUIntToData(this.args.appNumber)
+      .add8BitUIntToData(this.args.appStorageNumber)
+      .build();
+  }
+
+  parseResponse(apduResponse: ApduResponse): RequestMasterConsentCommandResult {
+    const parser = new ApduParser(apduResponse);
+    if (!CommandUtils.isSuccessResponse(apduResponse)) {
+      const errorCode = parser.encodeToHexaString(apduResponse.statusCode);
+      if (isCommandErrorCode(errorCode, REQUEST_MASTER_CONSENT_ERRORS)) {
+        return CommandResultFactory({
+          error: new RequestMasterConsentCommandError({
+            ...REQUEST_MASTER_CONSENT_ERRORS[errorCode],
+            errorCode,
+          }),
+        });
+      }
+      return CommandResultFactory({
+        error: GlobalCommandErrorHandler.handle(apduResponse),
+      });
+    }
+
+    return CommandResultFactory({
+      data: undefined,
+    });
+  }
+}

--- a/packages/device-management-kit/src/api/index.ts
+++ b/packages/device-management-kit/src/api/index.ts
@@ -95,6 +95,12 @@ export {
   OpenAppCommand,
 } from "@api/command/os/OpenAppCommand";
 export {
+  RequestMasterConsentCommand,
+  type RequestMasterConsentCommandArgs,
+  type RequestMasterConsentCommandErrorCodes,
+  type RequestMasterConsentCommandResult,
+} from "@api/command/os/RequestMasterConsentCommand";
+export {
   RestoreAppStorageCommand,
   type RestoreAppStorageCommandArgs,
   RestoreAppStorageCommandError,


### PR DESCRIPTION
### 📝 Description

Adds `RequestMasterConsentCommand` to `@ledgerhq/device-management-kit`, allowing callers to request master consent with language pack, lock screen picture, app, and app storage consent parameters as described in [Ledger OS APDU Commands](https://ledgerhq.atlassian.net/wiki/spaces/FW/pages/4455596105/Ledger+OS+-+APDU+commands#1.50.-Request-super-consent).

The command has been added to the sample app playground.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1272](https://ledgerhq.atlassian.net/browse/DSDK-1272?atlOrigin=eyJpIjoiNWYxMzU2MmY4ZjkwNDYwNmJjZDZhZGY1YjVhY2Y1ZTUiLCJwIjoiaiJ9)

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - Adds a new public DMK OS command.
  - Updates the sample app to exercise the command manually.
  - QA should focus on validating the generated APDU and device behavior for accepted/refused consent flows.

---

### 🧐 Checklist for the PR Reviewers

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.

[DSDK-1272]: https://ledgerhq.atlassian.net/browse/DSDK-1272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ