### PR TITLE
✨ (os-update) [DSDK-1273]: Adds init restore app storage command

### DIFF
--- a/.changeset/sixty-nights-cheer.md
+++ b/.changeset/sixty-nights-cheer.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": minor
+---
+
+Add `InitRestoreAppStorageCommand` implementing the `INS_APP_STORAGE_RESTORE_INIT` APDU, used to initiate the restore of a previously backed up application storage.

--- a/apps/sample/src/components/CommandsView/index.tsx
+++ b/apps/sample/src/components/CommandsView/index.tsx
@@ -19,6 +19,9 @@ import {
   type GetBatteryStatusResponse,
   GetOsVersionCommand,
   type GetOsVersionResponse,
+  InitRestoreAppStorageCommand,
+  type InitRestoreAppStorageCommandArgs,
+  type InitRestoreAppStorageCommandErrorCodes,
   type ListAppsArgs,
   ListAppsCommand,
   type ListAppsErrorCodes,
@@ -160,6 +163,26 @@ export const CommandsView: React.FC<{ sessionId: string }> = ({
         void,
         BackupStorageCommandResponse,
         BackupStorageCommandErrorCodes
+      >,
+      {
+        title: "Init restore app storage",
+        description:
+          "Initialize the restore of a previously backed up app storage",
+        sendCommand: ({ appName, backupLength }) => {
+          const command = new InitRestoreAppStorageCommand({
+            appName,
+            backupLength,
+          });
+          return dmk.sendCommand({
+            sessionId: selectedSessionId,
+            command,
+          });
+        },
+        initialValues: { appName: "", backupLength: 0 },
+      } satisfies CommandProps<
+        InitRestoreAppStorageCommandArgs,
+        void,
+        InitRestoreAppStorageCommandErrorCodes
       >,
       {
         title: "List language packs",

--- a/packages/device-management-kit/src/api/command/os/InitRestoreAppStorageCommand.test.ts
+++ b/packages/device-management-kit/src/api/command/os/InitRestoreAppStorageCommand.test.ts
@@ -1,0 +1,125 @@
+import { isSuccessCommandResult } from "@api/command/model/CommandResult";
+import { InitRestoreAppStorageCommand } from "@api/command/os/InitRestoreAppStorageCommand";
+import { ApduResponse } from "@api/device-session/ApduResponse";
+
+describe("InitRestoreAppStorageCommand", () => {
+  describe("Name", () => {
+    it("name should be 'InitRestoreAppStorage'", () => {
+      // ARRANGE
+      const command = new InitRestoreAppStorageCommand({
+        appName: "MyApp",
+        backupLength: 10,
+      });
+
+      // ACT
+      const name = command.name;
+
+      // ASSERT
+      expect(name).toBe("InitRestoreAppStorage");
+    });
+  });
+
+  describe("Command", () => {
+    it("should return the correct APDU for initializing an app storage restore", () => {
+      // ARRANGE
+      const expectedApdu = Uint8Array.from([
+        0xe0, 0x6c, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x0a, 0x4d, 0x79, 0x41,
+        0x70, 0x70,
+      ]);
+
+      // ACT
+      const apdu = new InitRestoreAppStorageCommand({
+        appName: "MyApp",
+        backupLength: 10,
+      }).getApdu();
+
+      // ASSERT
+      expect(apdu.getRawApdu()).toEqual(expectedApdu);
+    });
+  });
+
+  describe("Success response", () => {
+    it("should return a success result", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x90, 0x00]),
+        data: new Uint8Array([]),
+      });
+
+      // ACT
+      const result = new InitRestoreAppStorageCommand({
+        appName: "MyApp",
+        backupLength: 10,
+      }).parseResponse(response);
+
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      expect(result).toEqual({
+        data: undefined,
+        status: "SUCCESS",
+      });
+    });
+  });
+
+  describe("Error response", () => {
+    it.each([
+      {
+        description: "application is not found",
+        statusCode: [0x51, 0x23],
+        expectedMessage: "Application not found.",
+      },
+      {
+        description: "device is in recovery mode",
+        statusCode: [0x66, 0x2f],
+        expectedMessage: "Invalid device state, recovery mode.",
+      },
+      {
+        description: "user rejected the consent",
+        statusCode: [0x55, 0x01],
+        expectedMessage: "Invalid consent, user rejected.",
+      },
+      {
+        description: "pin is not set",
+        statusCode: [0x55, 0x02],
+        expectedMessage: "Invalid consent, pin is not set.",
+      },
+      {
+        description: "application name length is invalid",
+        statusCode: [0x67, 0x0a],
+        expectedMessage: "Invalid application name length, two chars minimum.",
+      },
+      {
+        description: "backup length value is invalid",
+        statusCode: [0x67, 0x33],
+        expectedMessage: "Invalid backup length value.",
+      },
+      {
+        description:
+          "error code is not specific to InitRestoreAppStorageCommand (global error)",
+        statusCode: [0x55, 0x15],
+        expectedMessage: "Device is locked.",
+      },
+    ])(
+      "should return error when $description",
+      ({ statusCode, expectedMessage }) => {
+        // ARRANGE
+        const response = new ApduResponse({
+          statusCode: Uint8Array.from(statusCode),
+          data: new Uint8Array([]),
+        });
+
+        // ACT
+        const result = new InitRestoreAppStorageCommand({
+          appName: "MyApp",
+          backupLength: 10,
+        }).parseResponse(response);
+
+        // ASSERT
+        expect(isSuccessCommandResult(result)).toBe(false);
+        expect((result as unknown as { error: Error }).error.message).toBe(
+          expectedMessage,
+        );
+      },
+    );
+  });
+});

--- a/packages/device-management-kit/src/api/command/os/InitRestoreAppStorageCommand.ts
+++ b/packages/device-management-kit/src/api/command/os/InitRestoreAppStorageCommand.ts
@@ -1,0 +1,102 @@
+import { type Apdu } from "@api/apdu/model/Apdu";
+import { ApduBuilder } from "@api/apdu/utils/ApduBuilder";
+import { ApduParser } from "@api/apdu/utils/ApduParser";
+import { type Command } from "@api/command/Command";
+import {
+  type CommandResult,
+  CommandResultFactory,
+} from "@api/command/model/CommandResult";
+import {
+  type CommandErrors,
+  isCommandErrorCode,
+} from "@api/command/utils/CommandErrors";
+import { CommandUtils } from "@api/command/utils/CommandUtils";
+import { GlobalCommandErrorHandler } from "@api/command/utils/GlobalCommandError";
+import { type ApduResponse } from "@api/device-session/ApduResponse";
+import { type CommandErrorArgs, DeviceExchangeError } from "@api/Error";
+
+export type InitRestoreAppStorageCommandArgs = {
+  appName: string;
+  backupLength: number;
+};
+
+export type InitRestoreAppStorageCommandErrorCodes =
+  | "5123"
+  | "662f"
+  | "5501"
+  | "5502"
+  | "670a"
+  | "6733";
+
+export const INIT_RESTORE_APP_STORAGE_ERRORS: CommandErrors<InitRestoreAppStorageCommandErrorCodes> =
+  {
+    "5123": { message: "Application not found." },
+    "662f": { message: "Invalid device state, recovery mode." },
+    "5501": { message: "Invalid consent, user rejected." },
+    "5502": { message: "Invalid consent, pin is not set." },
+    "670a": { message: "Invalid application name length, two chars minimum." },
+    "6733": { message: "Invalid backup length value." },
+  };
+
+export class InitRestoreAppStorageCommandError extends DeviceExchangeError<InitRestoreAppStorageCommandErrorCodes> {
+  constructor(args: CommandErrorArgs<InitRestoreAppStorageCommandErrorCodes>) {
+    super({ tag: "InitRestoreAppStorageCommandError", ...args });
+  }
+}
+
+export type InitRestoreAppStorageCommandResult = CommandResult<
+  void,
+  InitRestoreAppStorageCommandErrorCodes
+>;
+
+export class InitRestoreAppStorageCommand
+  implements
+    Command<
+      void,
+      InitRestoreAppStorageCommandArgs,
+      InitRestoreAppStorageCommandErrorCodes
+    >
+{
+  readonly name = "InitRestoreAppStorage";
+
+  private readonly header = {
+    cla: 0xe0,
+    ins: 0x6c,
+    p1: 0x00,
+    p2: 0x00,
+  };
+
+  constructor(private readonly args: InitRestoreAppStorageCommandArgs) {}
+
+  getApdu(): Apdu {
+    const { appName, backupLength } = this.args;
+    return new ApduBuilder(this.header)
+      .add32BitUIntToData(backupLength)
+      .addAsciiStringToData(appName)
+      .build();
+  }
+
+  parseResponse(
+    apduResponse: ApduResponse,
+  ): InitRestoreAppStorageCommandResult {
+    const parser = new ApduParser(apduResponse);
+    if (!CommandUtils.isSuccessResponse(apduResponse)) {
+      const errorCode = parser.encodeToHexaString(apduResponse.statusCode);
+      if (isCommandErrorCode(errorCode, INIT_RESTORE_APP_STORAGE_ERRORS)) {
+        return CommandResultFactory({
+          error: new InitRestoreAppStorageCommandError({
+            ...INIT_RESTORE_APP_STORAGE_ERRORS[errorCode],
+            errorCode,
+          }),
+        });
+      }
+      return CommandResultFactory({
+        error: GlobalCommandErrorHandler.handle(apduResponse),
+      });
+    }
+
+    return CommandResultFactory({
+      data: undefined,
+    });
+  }
+}

--- a/packages/device-management-kit/src/api/index.ts
+++ b/packages/device-management-kit/src/api/index.ts
@@ -59,6 +59,13 @@ export {
   type GetOsVersionResponse,
 } from "@api/command/os/GetOsVersionCommand";
 export {
+  InitRestoreAppStorageCommand,
+  type InitRestoreAppStorageCommandArgs,
+  InitRestoreAppStorageCommandError,
+  type InitRestoreAppStorageCommandErrorCodes,
+  type InitRestoreAppStorageCommandResult,
+} from "@api/command/os/InitRestoreAppStorageCommand";
+export {
   type ListAppsArgs,
   ListAppsCommand,
   type ListAppsErrorCodes,


### PR DESCRIPTION
### 📝 Description

This PR adds a new `InitRestoreAppStorageCommand` to the Device Management Kit, implementing the `INS_APP_STORAGE_RESTORE_INIT` APDU. This command will be used to initiate the restore of a previously backed-up application storage on the device (as described [here](https://ledgerhq.atlassian.net/wiki/spaces/TA/pages/4166320301/ARCH+Applications+NVRAM+management+and+backup)).

The command has also been added in the sample app for manual testing.

### ❓ Context
- **JIRA or GitHub link**: [DSDK-1273](https://ledgerhq.atlassian.net/browse/DSDK-1273?atlOrigin=eyJpIjoiNThhZGJjOTI3NDgzNGU1Y2FmMTY0MjhjMDZkMGZmNjYiLCJwIjoiaiJ9)
- **Feature**:
### ✅ Checklist
- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [ ] ~~**Documentation is up-to-date**~~
- [x] **Impact of the changes:**
  - Adds a new `InitRestoreAppStorageCommand` to `@ledgerhq/device-management-kit` (minor version bump)
  - No changes to existing commands or behavior; purely additive
  - Adds a manual test entry in the sample app's Commands view
---
### 🧐 Checklist for the PR Reviewers
- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.




[DSDK-1273]: https://ledgerhq.atlassian.net/browse/DSDK-1273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ