### PR TITLE
✨ (os-update) [DSDK-1317]: Adds RestoreAppStorageCommand and RestoreAppStorageTask

### DIFF
--- a/.changeset/dark-worms-doubt.md
+++ b/.changeset/dark-worms-doubt.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": minor
+---
+
+Add `RestoreAppStorageCommand` implementing the `INS_APP_STORAGE_RESTORE` APDU, and a `RestoreAppStorageTask` to restore a previously backed up application storage in chunks that fit within a single APDU.

--- a/packages/device-management-kit/src/api/command/os/RestoreAppStorageCommand.test.ts
+++ b/packages/device-management-kit/src/api/command/os/RestoreAppStorageCommand.test.ts
@@ -1,0 +1,125 @@
+import { isSuccessCommandResult } from "@api/command/model/CommandResult";
+import { RestoreAppStorageCommand } from "@api/command/os/RestoreAppStorageCommand";
+import { ApduResponse } from "@api/device-session/ApduResponse";
+
+describe("RestoreAppStorageCommand", () => {
+  describe("Name", () => {
+    it("name should be 'RestoreAppStorage'", () => {
+      // ARRANGE
+      const command = new RestoreAppStorageCommand({
+        chunkData: Uint8Array.from([0x01, 0x02, 0x03]),
+      });
+
+      // ACT
+      const name = command.name;
+
+      // ASSERT
+      expect(name).toBe("RestoreAppStorage");
+    });
+  });
+
+  describe("Command", () => {
+    it("should return the correct APDU for restoring an app storage chunk", () => {
+      // ARRANGE
+      const expectedApdu = Uint8Array.from([
+        0xe0, 0x6d, 0x00, 0x00, 0x03, 0x01, 0x02, 0x03,
+      ]);
+
+      // ACT
+      const apdu = new RestoreAppStorageCommand({
+        chunkData: Uint8Array.from([0x01, 0x02, 0x03]),
+      }).getApdu();
+
+      // ASSERT
+      expect(apdu.getRawApdu()).toEqual(expectedApdu);
+    });
+  });
+
+  describe("Success response", () => {
+    it("should return a success result", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x90, 0x00]),
+        data: new Uint8Array([]),
+      });
+
+      // ACT
+      const result = new RestoreAppStorageCommand({
+        chunkData: Uint8Array.from([0x01, 0x02, 0x03]),
+      }).parseResponse(response);
+
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      expect(result).toEqual({
+        data: undefined,
+        status: "SUCCESS",
+      });
+    });
+  });
+
+  describe("Error response", () => {
+    it.each([
+      {
+        description: "restore init has not been called",
+        statusCode: [0x51, 0x23],
+        expectedMessage: "Invalid context, Restore Init must be called first.",
+      },
+      {
+        description: "AES key generation failed",
+        statusCode: [0x54, 0x19],
+        expectedMessage: "Failed to generate AES key.",
+      },
+      {
+        description: "decryption failed",
+        statusCode: [0x54, 0x1a],
+        expectedMessage: "Failed to decrypt the app storage backup.",
+      },
+      {
+        description: "device is in recovery mode",
+        statusCode: [0x66, 0x2f],
+        expectedMessage: "Invalid device state, recovery mode.",
+      },
+      {
+        description: "restore has already been performed",
+        statusCode: [0x66, 0x43],
+        expectedMessage: "Invalid restore state, restore already performed.",
+      },
+      {
+        description: "chunk length is invalid",
+        statusCode: [0x67, 0x34],
+        expectedMessage: "Invalid chunk length.",
+      },
+      {
+        description: "app storage header is invalid",
+        statusCode: [0x68, 0x4a],
+        expectedMessage: "Invalid backup, app storage header is not valid.",
+      },
+      {
+        description:
+          "error code is not specific to RestoreAppStorageCommand (global error)",
+        statusCode: [0x55, 0x15],
+        expectedMessage: "Device is locked.",
+      },
+    ])(
+      "should return error when $description",
+      ({ statusCode, expectedMessage }) => {
+        // ARRANGE
+        const response = new ApduResponse({
+          statusCode: Uint8Array.from(statusCode),
+          data: new Uint8Array([]),
+        });
+
+        // ACT
+        const result = new RestoreAppStorageCommand({
+          chunkData: Uint8Array.from([0x01, 0x02, 0x03]),
+        }).parseResponse(response);
+
+        // ASSERT
+        expect(isSuccessCommandResult(result)).toBe(false);
+        expect((result as unknown as { error: Error }).error.message).toBe(
+          expectedMessage,
+        );
+      },
+    );
+  });
+});

--- a/packages/device-management-kit/src/api/command/os/RestoreAppStorageCommand.ts
+++ b/packages/device-management-kit/src/api/command/os/RestoreAppStorageCommand.ts
@@ -1,0 +1,98 @@
+import { type Apdu } from "@api/apdu/model/Apdu";
+import { ApduBuilder } from "@api/apdu/utils/ApduBuilder";
+import { ApduParser } from "@api/apdu/utils/ApduParser";
+import { type Command } from "@api/command/Command";
+import {
+  type CommandResult,
+  CommandResultFactory,
+} from "@api/command/model/CommandResult";
+import {
+  type CommandErrors,
+  isCommandErrorCode,
+} from "@api/command/utils/CommandErrors";
+import { CommandUtils } from "@api/command/utils/CommandUtils";
+import { GlobalCommandErrorHandler } from "@api/command/utils/GlobalCommandError";
+import { type ApduResponse } from "@api/device-session/ApduResponse";
+import { type CommandErrorArgs, DeviceExchangeError } from "@api/Error";
+
+export type RestoreAppStorageCommandArgs = {
+  chunkData: Uint8Array;
+};
+
+export type RestoreAppStorageCommandErrorCodes =
+  | "5123"
+  | "5419"
+  | "541a"
+  | "662f"
+  | "6643"
+  | "6734"
+  | "684a";
+
+export const RESTORE_APP_STORAGE_ERRORS: CommandErrors<RestoreAppStorageCommandErrorCodes> =
+  {
+    "5123": { message: "Invalid context, Restore Init must be called first." },
+    "5419": { message: "Failed to generate AES key." },
+    "541a": { message: "Failed to decrypt the app storage backup." },
+    "662f": { message: "Invalid device state, recovery mode." },
+    "6643": { message: "Invalid restore state, restore already performed." },
+    "6734": { message: "Invalid chunk length." },
+    "684a": { message: "Invalid backup, app storage header is not valid." },
+  };
+
+export class RestoreAppStorageCommandError extends DeviceExchangeError<RestoreAppStorageCommandErrorCodes> {
+  constructor(args: CommandErrorArgs<RestoreAppStorageCommandErrorCodes>) {
+    super({ tag: "RestoreAppStorageCommandError", ...args });
+  }
+}
+
+export type RestoreAppStorageCommandResult = CommandResult<
+  void,
+  RestoreAppStorageCommandErrorCodes
+>;
+
+export class RestoreAppStorageCommand
+  implements
+    Command<
+      void,
+      RestoreAppStorageCommandArgs,
+      RestoreAppStorageCommandErrorCodes
+    >
+{
+  readonly name = "RestoreAppStorage";
+
+  private readonly header = {
+    cla: 0xe0,
+    ins: 0x6d,
+    p1: 0x00,
+    p2: 0x00,
+  };
+
+  constructor(private readonly args: RestoreAppStorageCommandArgs) {}
+
+  getApdu(): Apdu {
+    const { chunkData } = this.args;
+    return new ApduBuilder(this.header).addBufferToData(chunkData).build();
+  }
+
+  parseResponse(apduResponse: ApduResponse): RestoreAppStorageCommandResult {
+    const parser = new ApduParser(apduResponse);
+    if (!CommandUtils.isSuccessResponse(apduResponse)) {
+      const errorCode = parser.encodeToHexaString(apduResponse.statusCode);
+      if (isCommandErrorCode(errorCode, RESTORE_APP_STORAGE_ERRORS)) {
+        return CommandResultFactory({
+          error: new RestoreAppStorageCommandError({
+            ...RESTORE_APP_STORAGE_ERRORS[errorCode],
+            errorCode,
+          }),
+        });
+      }
+      return CommandResultFactory({
+        error: GlobalCommandErrorHandler.handle(apduResponse),
+      });
+    }
+
+    return CommandResultFactory({
+      data: undefined,
+    });
+  }
+}

--- a/packages/device-management-kit/src/api/device-action/task/RestoreAppStorageTask.test.ts
+++ b/packages/device-management-kit/src/api/device-action/task/RestoreAppStorageTask.test.ts
@@ -1,0 +1,149 @@
+import { APDU_MAX_PAYLOAD } from "@api/apdu/utils/ApduBuilder";
+import { RestoreAppStorageCommandError } from "@api/command/os/RestoreAppStorageCommand";
+import { type InternalApi } from "@api/device-action/DeviceAction";
+import { RestoreAppStorageTask } from "@api/device-action/task/RestoreAppStorageTask";
+import {
+  CommandResultFactory,
+  DmkResultFactory,
+  isSuccessDmkResult,
+} from "@api/index";
+import { type LoggerPublisherService } from "@api/logger-publisher/service/LoggerPublisherService";
+
+describe("RestoreAppStorageTask", () => {
+  let api: InternalApi;
+  let logger: LoggerPublisherService;
+  const sendCommand = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api = {
+      sendCommand,
+    } as unknown as InternalApi;
+    logger = {
+      debug: vi.fn(),
+    } as unknown as LoggerPublisherService;
+  });
+
+  describe("Success", () => {
+    it("should send a single chunk when the data fits in one APDU", async () => {
+      // ARRANGE
+      const appStorageData = Uint8Array.from([0x01, 0x02, 0x03]);
+      const task = new RestoreAppStorageTask({ appStorageData }, api, logger);
+
+      sendCommand.mockResolvedValueOnce(
+        CommandResultFactory({ data: undefined }),
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(isSuccessDmkResult(result)).toBe(true);
+      expect(sendCommand).toHaveBeenCalledTimes(1);
+      expect(sendCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          args: { chunkData: appStorageData },
+        }),
+      );
+    });
+
+    it("should split the data into several chunks when it does not fit in a single APDU", async () => {
+      // ARRANGE
+      const appStorageData = new Uint8Array(APDU_MAX_PAYLOAD + 45).map(
+        (_, i) => i % 256,
+      );
+      const task = new RestoreAppStorageTask({ appStorageData }, api, logger);
+
+      sendCommand
+        .mockResolvedValueOnce(CommandResultFactory({ data: undefined }))
+        .mockResolvedValueOnce(CommandResultFactory({ data: undefined }));
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(isSuccessDmkResult(result)).toBe(true);
+      expect(sendCommand).toHaveBeenCalledTimes(2);
+      expect(sendCommand).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          args: { chunkData: appStorageData.slice(0, APDU_MAX_PAYLOAD) },
+        }),
+      );
+      expect(sendCommand).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          args: { chunkData: appStorageData.slice(APDU_MAX_PAYLOAD) },
+        }),
+      );
+    });
+
+    it("should not send any command when the data is empty", async () => {
+      // ARRANGE
+      const task = new RestoreAppStorageTask(
+        { appStorageData: new Uint8Array(0) },
+        api,
+        logger,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(isSuccessDmkResult(result)).toBe(true);
+      expect(sendCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Error", () => {
+    it("should return error when restoring a chunk fails", async () => {
+      // ARRANGE
+      const appStorageData = Uint8Array.from([0x01, 0x02, 0x03]);
+      const task = new RestoreAppStorageTask({ appStorageData }, api, logger);
+
+      sendCommand.mockResolvedValueOnce(
+        CommandResultFactory({
+          error: new RestoreAppStorageCommandError({
+            message: "Failed to decrypt the app storage backup.",
+            errorCode: "541a",
+          }),
+        }),
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(result).toStrictEqual(
+        DmkResultFactory({
+          error: new RestoreAppStorageCommandError({
+            message: "Failed to decrypt the app storage backup.",
+            errorCode: "541a",
+          }),
+        }),
+      );
+    });
+
+    it("should stop sending chunks as soon as one fails", async () => {
+      // ARRANGE
+      const appStorageData = new Uint8Array(APDU_MAX_PAYLOAD + 10);
+      const task = new RestoreAppStorageTask({ appStorageData }, api, logger);
+
+      sendCommand.mockResolvedValueOnce(
+        CommandResultFactory({
+          error: new RestoreAppStorageCommandError({
+            message: "Invalid chunk length.",
+            errorCode: "6734",
+          }),
+        }),
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(isSuccessDmkResult(result)).toBe(false);
+      expect(sendCommand).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/device-management-kit/src/api/device-action/task/RestoreAppStorageTask.ts
+++ b/packages/device-management-kit/src/api/device-action/task/RestoreAppStorageTask.ts
@@ -1,0 +1,67 @@
+import { APDU_MAX_PAYLOAD } from "@api/apdu/utils/ApduBuilder";
+import {
+  type CommandErrorResult,
+  isSuccessCommandResult,
+} from "@api/command/model/CommandResult";
+import {
+  RestoreAppStorageCommand,
+  type RestoreAppStorageCommandErrorCodes,
+} from "@api/command/os/RestoreAppStorageCommand";
+import { type InternalApi } from "@api/device-action/DeviceAction";
+import { type LoggerPublisherService } from "@api/logger-publisher/service/LoggerPublisherService";
+import { type DmkResult, DmkResultFactory } from "@api/model/DmkResult";
+
+export type RestoreAppStorageTaskArgs = {
+  appStorageData: Uint8Array;
+};
+
+export type RestoreAppStorageTaskError =
+  CommandErrorResult<RestoreAppStorageCommandErrorCodes>["error"];
+
+export class RestoreAppStorageTask {
+  constructor(
+    private readonly args: RestoreAppStorageTaskArgs,
+    private readonly api: InternalApi,
+    private readonly logger: LoggerPublisherService,
+  ) {}
+
+  public async run(): Promise<DmkResult<void, RestoreAppStorageTaskError>> {
+    const { appStorageData } = this.args;
+
+    this.logger.debug("[run] Starting RestoreAppStorageTask", {
+      data: {
+        appStorageDataLength: appStorageData.length,
+      },
+    });
+
+    let offset = 0;
+
+    while (offset < appStorageData.length) {
+      const chunkData = appStorageData.subarray(
+        offset,
+        offset + APDU_MAX_PAYLOAD,
+      );
+
+      const restoreAppStorage = await this.api.sendCommand(
+        new RestoreAppStorageCommand({ chunkData }),
+      );
+
+      if (!isSuccessCommandResult(restoreAppStorage)) {
+        this.logger.debug("[run] Failed to restore app storage chunk", {
+          data: { error: restoreAppStorage.error },
+        });
+        return DmkResultFactory({
+          error: restoreAppStorage.error,
+        });
+      }
+
+      offset += chunkData.length;
+    }
+
+    this.logger.debug("[run] App storage data restored successfully");
+
+    return DmkResultFactory({
+      data: undefined,
+    });
+  }
+}

--- a/packages/device-management-kit/src/api/index.ts
+++ b/packages/device-management-kit/src/api/index.ts
@@ -88,6 +88,13 @@ export {
   type OpenAppArgs,
   OpenAppCommand,
 } from "@api/command/os/OpenAppCommand";
+export {
+  RestoreAppStorageCommand,
+  type RestoreAppStorageCommandArgs,
+  RestoreAppStorageCommandError,
+  type RestoreAppStorageCommandErrorCodes,
+  type RestoreAppStorageCommandResult,
+} from "@api/command/os/RestoreAppStorageCommand";
 export { isCommandErrorCode } from "@api/command/utils/CommandErrors";
 export { CommandUtils } from "@api/command/utils/CommandUtils";
 export {
@@ -151,6 +158,11 @@ export {
   GetApplicationsMetadataTaskError,
   InvalidGetFirmwareMetadataResponseError,
 } from "@api/device-action/task/Errors";
+export {
+  RestoreAppStorageTask,
+  type RestoreAppStorageTaskArgs,
+  type RestoreAppStorageTaskError,
+} from "@api/device-action/task/RestoreAppStorageTask";
 export {
   type DeviceActionStateMachine,
   XStateDeviceAction,


### PR DESCRIPTION
### 📝 Description

This PR implements the `INS_APP_STORAGE_RESTORE` APDU, the command that follows `INS_APP_STORAGE_RESTORE_INIT` (implemented separately in [DSDK-1273](https://ledgerhq.atlassian.net/browse/DSDK-1273)) in the application NVRAM restore flow described in [\[ARCH\] Applications' NVRAM management and backup](https://ledgerhq.atlassian.net/wiki/spaces/TA/pages/4166320301/ARCH+Applications+NVRAM+management+and+backup#2.1.2.2-INS_APP_STORAGE_RESTORE-APDU-syntax).

It adds:

- **`RestoreAppStorageCommand`**: sends a single chunk of a previously backed-up application storage to the device in one APDU exchange.
- **`RestoreAppStorageTask`**: since the backup to restore may not fit in a single APDU, this task splits the full backup buffer into `APDU_MAX_PAYLOAD`-sized chunks and calls `RestoreAppStorageCommand` repeatedly until everything is sent, stopping on the first error.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1317](https://ledgerhq.atlassian.net/browse/DSDK-1317?atlOrigin=eyJpIjoiYWM2YWFjNzA1MmNhNDM5MTk3MTNkMGUyOGY0N2I2YzciLCJwIjoiaiJ9) 

### ✅ Checklist

- [x] **Covered by automatic tests** — 11 unit tests for `RestoreAppStorageCommand` (APDU building, success, and every spec error code) and 5 for `RestoreAppStorageTask` (single-chunk, multi-chunk splitting, empty buffer, and error propagation).
- [x] **Changeset is provided**
- [ ] ~~**Documentation is up-to-date**~~
- [x] **Impact of the changes:**
  - New `RestoreAppStorageCommand` and `RestoreAppStorageTask` exported from `@ledgerhq/device-management-kit`'s public API.
  - New "Restore app storage" entry in the sample app's Commands view.
  - No changes to existing commands/tasks; purely additive.

---

### 🧐 Checklist for the PR Reviewers

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.

[DSDK-1273]: https://ledgerhq.atlassian.net/browse/DSDK-1273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSDK-1317]: https://ledgerhq.atlassian.net/browse/DSDK-1317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ