### PR TITLE
✨ (signer-solana) [LBD-580]: Expose public SignMessage/GetAddress device-action factories

### DIFF
--- a/.changeset/solana-public-device-action-factories.md
+++ b/.changeset/solana-public-device-action-factories.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": minor
+---
+
+Expose public `SignMessageDeviceActionFactory` and `GetAddressDeviceActionFactory` (mirroring the Ethereum signer kit) so consumers can compose their own `OpenApp -> GetAddress -> Sign` flows without deep-importing from `/internal/`. Also expose the user-rejection error publicly via the `isSolanaAppError` type guard and the `SolanaAppCommandError` class. `SolanaAppBinder.signMessage` and `.getAddress` now delegate to these factories to guarantee a single source of truth.

--- a/packages/signer/signer-solana/src/api/app-binder/GetAddressDeviceActionFactory.test.ts
+++ b/packages/signer/signer-solana/src/api/app-binder/GetAddressDeviceActionFactory.test.ts
@@ -1,0 +1,83 @@
+import {
+  SendCommandInAppDeviceAction,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import { GetPubKeyCommand } from "@internal/app-binder/command/GetPubKeyCommand";
+import { APP_NAME } from "@internal/app-binder/constants";
+
+import { GetAddressDeviceActionFactory } from "./GetAddressDeviceActionFactory";
+
+vi.mock("@ledgerhq/device-management-kit", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@ledgerhq/device-management-kit")>();
+  return {
+    ...original,
+    SendCommandInAppDeviceAction: vi.fn(),
+  };
+});
+
+const mockLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  subscribers: [],
+};
+
+describe("GetAddressDeviceActionFactory", () => {
+  const defaultArgs = {
+    derivationPath: "44'/501'/0'/0'",
+    checkOnDevice: false,
+    skipOpenApp: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    {
+      desc: "checkOnDevice is false",
+      overrides: { checkOnDevice: false },
+      expectedInteraction: UserInteractionRequired.None,
+    },
+    {
+      desc: "checkOnDevice is true",
+      overrides: { checkOnDevice: true },
+      expectedInteraction: UserInteractionRequired.VerifyAddress,
+    },
+  ])(
+    "should use $expectedInteraction interaction when $desc",
+    ({ overrides, expectedInteraction }) => {
+      GetAddressDeviceActionFactory({ ...defaultArgs, ...overrides });
+
+      expect(SendCommandInAppDeviceAction).toHaveBeenCalledWith({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        input: expect.objectContaining({
+          appName: APP_NAME,
+          requiredUserInteraction: expectedInteraction,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          command: expect.any(GetPubKeyCommand),
+        }),
+        logger: undefined,
+      });
+    },
+  );
+
+  it("should forward skipOpenApp and logger to the device action", () => {
+    GetAddressDeviceActionFactory({
+      ...defaultArgs,
+      skipOpenApp: true,
+      logger: mockLogger,
+    });
+
+    expect(SendCommandInAppDeviceAction).toHaveBeenCalledWith({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      input: expect.objectContaining({
+        skipOpenApp: true,
+      }),
+      logger: mockLogger,
+    });
+  });
+});

--- a/packages/signer/signer-solana/src/api/app-binder/GetAddressDeviceActionFactory.ts
+++ b/packages/signer/signer-solana/src/api/app-binder/GetAddressDeviceActionFactory.ts
@@ -1,0 +1,44 @@
+import {
+  type LoggerPublisherService,
+  SendCommandInAppDeviceAction,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import { type PublicKey } from "@api/model/PublicKey";
+import {
+  GetPubKeyCommand,
+  type GetPubKeyCommandArgs,
+} from "@internal/app-binder/command/GetPubKeyCommand";
+import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+import { APP_NAME } from "@internal/app-binder/constants";
+
+export const GetAddressDeviceActionFactory = (args: {
+  derivationPath: string;
+  checkOnDevice: boolean;
+  skipOpenApp: boolean;
+  logger?: LoggerPublisherService;
+}): SendCommandInAppDeviceAction<
+  PublicKey,
+  GetPubKeyCommandArgs,
+  SolanaAppErrorCodes,
+  UserInteractionRequired.VerifyAddress | UserInteractionRequired.None
+> =>
+  new SendCommandInAppDeviceAction<
+    PublicKey,
+    GetPubKeyCommandArgs,
+    SolanaAppErrorCodes,
+    UserInteractionRequired.VerifyAddress | UserInteractionRequired.None
+  >({
+    input: {
+      command: new GetPubKeyCommand({
+        derivationPath: args.derivationPath,
+        checkOnDevice: args.checkOnDevice,
+      }),
+      appName: APP_NAME,
+      requiredUserInteraction: args.checkOnDevice
+        ? UserInteractionRequired.VerifyAddress
+        : UserInteractionRequired.None,
+      skipOpenApp: args.skipOpenApp,
+    },
+    logger: args.logger,
+  });

--- a/packages/signer/signer-solana/src/api/app-binder/SignMessageDeviceActionFactory.test.ts
+++ b/packages/signer/signer-solana/src/api/app-binder/SignMessageDeviceActionFactory.test.ts
@@ -1,0 +1,106 @@
+import {
+  CallTaskInAppDeviceAction,
+  type InternalApi,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import { SignMessageVersion } from "@api/model/MessageOptions";
+import { APP_NAME } from "@internal/app-binder/constants";
+import { SendSignMessageTask } from "@internal/app-binder/task/SendSignMessageTask";
+
+import { SignMessageDeviceActionFactory } from "./SignMessageDeviceActionFactory";
+
+vi.mock("@ledgerhq/device-management-kit", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@ledgerhq/device-management-kit")>();
+  return {
+    ...original,
+    CallTaskInAppDeviceAction: vi.fn(),
+  };
+});
+
+vi.mock("@internal/app-binder/task/SendSignMessageTask", () => ({
+  SendSignMessageTask: vi.fn().mockImplementation(() => ({
+    run: vi.fn().mockResolvedValue({ data: { signature: "sig" } }),
+  })),
+}));
+
+const mockLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  subscribers: [],
+};
+
+describe("SignMessageDeviceActionFactory", () => {
+  const defaultArgs = {
+    derivationPath: "44'/501'/0'/0'",
+    message: "Hello, world!" as string | Uint8Array,
+    skipOpenApp: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    { desc: "a string message", message: "Hello, world!" },
+    {
+      desc: "a Uint8Array message",
+      message: new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f]),
+    },
+  ])("should create a CallTaskInAppDeviceAction for $desc", ({ message }) => {
+    SignMessageDeviceActionFactory({ ...defaultArgs, message });
+
+    expect(CallTaskInAppDeviceAction).toHaveBeenCalledWith({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      input: expect.objectContaining({
+        appName: APP_NAME,
+        requiredUserInteraction: UserInteractionRequired.SignPersonalMessage,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        task: expect.any(Function),
+      }),
+      logger: undefined,
+    });
+  });
+
+  it("should forward skipOpenApp and logger to the device action", () => {
+    SignMessageDeviceActionFactory({
+      ...defaultArgs,
+      skipOpenApp: true,
+      logger: mockLogger,
+    });
+
+    expect(CallTaskInAppDeviceAction).toHaveBeenCalledWith({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      input: expect.objectContaining({
+        skipOpenApp: true,
+      }),
+      logger: mockLogger,
+    });
+  });
+
+  it("should build the task with the forwarded args", async () => {
+    const signers = [new Uint8Array(32)];
+    SignMessageDeviceActionFactory({
+      ...defaultArgs,
+      message: "signed",
+      version: SignMessageVersion.V1,
+      appDomain: "example.com",
+      signers,
+    });
+
+    const { task } = vi.mocked(CallTaskInAppDeviceAction).mock.calls[0]![0]
+      .input;
+    await task({} as InternalApi);
+
+    expect(SendSignMessageTask).toHaveBeenCalledWith(expect.anything(), {
+      derivationPath: defaultArgs.derivationPath,
+      sendingData: "signed",
+      version: SignMessageVersion.V1,
+      appDomain: "example.com",
+      signers,
+    });
+  });
+});

--- a/packages/signer/signer-solana/src/api/app-binder/SignMessageDeviceActionFactory.ts
+++ b/packages/signer/signer-solana/src/api/app-binder/SignMessageDeviceActionFactory.ts
@@ -1,0 +1,47 @@
+import {
+  CallTaskInAppDeviceAction,
+  type LoggerPublisherService,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import {
+  type SignMessageDAOutput,
+  type SignMessageTaskError,
+} from "@api/app-binder/SignMessageDeviceActionTypes";
+import { type SignMessageVersion } from "@api/model/MessageOptions";
+import { APP_NAME } from "@internal/app-binder/constants";
+import { SendSignMessageTask } from "@internal/app-binder/task/SendSignMessageTask";
+
+export const SignMessageDeviceActionFactory = (args: {
+  derivationPath: string;
+  message: string | Uint8Array;
+  skipOpenApp: boolean;
+  version?: SignMessageVersion;
+  appDomain?: string;
+  signers?: Uint8Array[];
+  logger?: LoggerPublisherService;
+}): CallTaskInAppDeviceAction<
+  SignMessageDAOutput,
+  SignMessageTaskError,
+  UserInteractionRequired.SignPersonalMessage
+> =>
+  new CallTaskInAppDeviceAction<
+    SignMessageDAOutput,
+    SignMessageTaskError,
+    UserInteractionRequired.SignPersonalMessage
+  >({
+    input: {
+      task: async (internalApi) =>
+        new SendSignMessageTask(internalApi, {
+          derivationPath: args.derivationPath,
+          sendingData: args.message,
+          version: args.version,
+          appDomain: args.appDomain,
+          signers: args.signers,
+        }).run(),
+      appName: APP_NAME,
+      requiredUserInteraction: UserInteractionRequired.SignPersonalMessage,
+      skipOpenApp: args.skipOpenApp,
+    },
+    logger: args.logger,
+  });

--- a/packages/signer/signer-solana/src/api/app-binder/SignMessageDeviceActionTypes.ts
+++ b/packages/signer/signer-solana/src/api/app-binder/SignMessageDeviceActionTypes.ts
@@ -1,4 +1,5 @@
 import {
+  type CommandErrorResult,
   type ExecuteDeviceActionReturnType,
   type OpenAppDAError,
   type OpenAppDARequiredInteraction,
@@ -11,6 +12,9 @@ import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/Sol
 export type SignMessageDAOutput = {
   signature: string;
 };
+
+export type SignMessageTaskError =
+  CommandErrorResult<SolanaAppErrorCodes>["error"];
 
 export type SignMessageDAError =
   | OpenAppDAError

--- a/packages/signer/signer-solana/src/api/index.ts
+++ b/packages/signer/signer-solana/src/api/index.ts
@@ -1,3 +1,4 @@
+export { GetAddressDeviceActionFactory } from "@api/app-binder/GetAddressDeviceActionFactory";
 export type {
   GetAddressDAError,
   GetAddressDAIntermediateValue,
@@ -9,10 +10,12 @@ export type {
   GetAppConfigurationDAIntermediateValue,
   GetAppConfigurationDAOutput,
 } from "@api/app-binder/GetAppConfigurationDeviceActionTypes";
+export { SignMessageDeviceActionFactory } from "@api/app-binder/SignMessageDeviceActionFactory";
 export type {
   SignMessageDAError,
   SignMessageDAIntermediateValue,
   SignMessageDAOutput,
+  SignMessageTaskError,
 } from "@api/app-binder/SignMessageDeviceActionTypes";
 export type {
   SignTransactionDAError,
@@ -23,6 +26,10 @@ export type {
 export type { MessageOptions } from "@api/model/MessageOptions";
 export { SignMessageVersion } from "@api/model/MessageOptions";
 export type { Signature } from "@api/model/Signature";
+export {
+  isSolanaAppError,
+  SolanaAppCommandError,
+} from "@api/model/SolanaAppErrors";
 export type { SolanaTransactionOptionalConfig } from "@api/model/SolanaTransactionOptionalConfig";
 export type { Transaction } from "@api/model/Transaction";
 export type {

--- a/packages/signer/signer-solana/src/api/model/SolanaAppErrors.test.ts
+++ b/packages/signer/signer-solana/src/api/model/SolanaAppErrors.test.ts
@@ -12,8 +12,31 @@ describe("isSolanaAppError", () => {
     expect(isSolanaAppError(error)).toBe(true);
   });
 
+  it("should return true for a structurally-equivalent error from another class instance (dual-package safe)", () => {
+    // Simulates an error minted by a different copy/format (ESM vs CJS) of the
+    // kit: same structural contract, different class identity. A structural
+    // guard must still recognize it, whereas `instanceof` would not.
+    const foreignError = {
+      _tag: "SolanaAppCommandError",
+      errorCode: "6985",
+      message: "Canceled by user",
+    };
+
+    expect(isSolanaAppError(foreignError)).toBe(true);
+  });
+
   it("should return false for a plain error", () => {
     expect(isSolanaAppError(new Error("boom"))).toBe(false);
+  });
+
+  it("should return false for an object with a different _tag", () => {
+    expect(
+      isSolanaAppError({ _tag: "SomeOtherError", errorCode: "6985" }),
+    ).toBe(false);
+  });
+
+  it("should return false when errorCode is missing", () => {
+    expect(isSolanaAppError({ _tag: "SolanaAppCommandError" })).toBe(false);
   });
 
   it("should return false for non-error values", () => {

--- a/packages/signer/signer-solana/src/api/model/SolanaAppErrors.test.ts
+++ b/packages/signer/signer-solana/src/api/model/SolanaAppErrors.test.ts
@@ -1,0 +1,24 @@
+import { SolanaAppCommandError } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+
+import { isSolanaAppError } from "./SolanaAppErrors";
+
+describe("isSolanaAppError", () => {
+  it("should return true for a SolanaAppCommandError", () => {
+    const error = new SolanaAppCommandError({
+      message: "Canceled by user",
+      errorCode: "6985",
+    });
+
+    expect(isSolanaAppError(error)).toBe(true);
+  });
+
+  it("should return false for a plain error", () => {
+    expect(isSolanaAppError(new Error("boom"))).toBe(false);
+  });
+
+  it("should return false for non-error values", () => {
+    expect(isSolanaAppError(undefined)).toBe(false);
+    expect(isSolanaAppError(null)).toBe(false);
+    expect(isSolanaAppError("6985")).toBe(false);
+  });
+});

--- a/packages/signer/signer-solana/src/api/model/SolanaAppErrors.ts
+++ b/packages/signer/signer-solana/src/api/model/SolanaAppErrors.ts
@@ -1,0 +1,11 @@
+import { SolanaAppCommandError } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+
+export { SolanaAppCommandError };
+
+/**
+ * Type guard to detect a Solana app command error (e.g. user rejection `6985`)
+ * without importing from the internal API.
+ */
+export const isSolanaAppError = (
+  error: unknown,
+): error is SolanaAppCommandError => error instanceof SolanaAppCommandError;

--- a/packages/signer/signer-solana/src/api/model/SolanaAppErrors.ts
+++ b/packages/signer/signer-solana/src/api/model/SolanaAppErrors.ts
@@ -1,11 +1,25 @@
-import { SolanaAppCommandError } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+import {
+  SOLANA_APP_COMMAND_ERROR_TAG,
+  SolanaAppCommandError,
+} from "@internal/app-binder/command/utils/SolanaApplicationErrors";
 
 export { SolanaAppCommandError };
 
 /**
  * Type guard to detect a Solana app command error (e.g. user rejection `6985`)
  * without importing from the internal API.
+ *
+ * The check is intentionally structural (based on the `_tag` contract) rather
+ * than `instanceof`: the kit is published in both ESM and CJS, so a consumer
+ * graph can end up with more than one copy/format of the class. An `instanceof`
+ * guard would return `false` for an error minted by a different copy of the
+ * class even though it is semantically the same error. Testing `_tag` mirrors
+ * what the kit already does internally and is immune to that duplication.
  */
 export const isSolanaAppError = (
   error: unknown,
-): error is SolanaAppCommandError => error instanceof SolanaAppCommandError;
+): error is SolanaAppCommandError =>
+  typeof error === "object" &&
+  error !== null &&
+  (error as { _tag?: unknown })._tag === SOLANA_APP_COMMAND_ERROR_TAG &&
+  typeof (error as { errorCode?: unknown }).errorCode === "string";

--- a/packages/signer/signer-solana/src/internal/app-binder/SolanaAppBinder.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/SolanaAppBinder.test.ts
@@ -164,7 +164,10 @@ describe("SolanaAppBinder", () => {
             sessionId: "sessionId",
             deviceAction: expect.objectContaining({
               input: {
-                command: new GetPubKeyCommand(params),
+                command: new GetPubKeyCommand({
+                  derivationPath: params.derivationPath,
+                  checkOnDevice,
+                }),
                 appName: APP_NAME,
                 requiredUserInteraction: UserInteractionRequired.VerifyAddress,
                 skipOpenApp: false,
@@ -199,7 +202,10 @@ describe("SolanaAppBinder", () => {
             sessionId: "sessionId",
             deviceAction: expect.objectContaining({
               input: {
-                command: new GetPubKeyCommand(params),
+                command: new GetPubKeyCommand({
+                  derivationPath: params.derivationPath,
+                  checkOnDevice,
+                }),
                 appName: APP_NAME,
                 requiredUserInteraction: UserInteractionRequired.None,
                 skipOpenApp: false,

--- a/packages/signer/signer-solana/src/internal/app-binder/SolanaAppBinder.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/SolanaAppBinder.ts
@@ -1,6 +1,5 @@
 import { type ContextModule } from "@ledgerhq/context-module";
 import {
-  CallTaskInAppDeviceAction,
   DeviceManagementKit,
   type DeviceSessionId,
   LoggerPublisherService,
@@ -9,18 +8,18 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 
+import { GetAddressDeviceActionFactory } from "@api/app-binder/GetAddressDeviceActionFactory";
 import { GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
 import { GetAppConfigurationDAReturnType } from "@api/app-binder/GetAppConfigurationDeviceActionTypes";
+import { SignMessageDeviceActionFactory } from "@api/app-binder/SignMessageDeviceActionFactory";
 import { SignMessageDAReturnType } from "@api/app-binder/SignMessageDeviceActionTypes";
 import { SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { type SignMessageVersion } from "@api/model/MessageOptions";
 import { SolanaTransactionOptionalConfig } from "@api/model/SolanaTransactionOptionalConfig";
 import { Transaction } from "@api/model/Transaction";
-import { SendSignMessageTask } from "@internal/app-binder/task/SendSignMessageTask";
 import { externalTypes } from "@internal/externalTypes";
 
 import { GetAppConfigurationCommand } from "./command/GetAppConfigurationCommand";
-import { GetPubKeyCommand } from "./command/GetPubKeyCommand";
 import { SignTransactionDeviceAction } from "./device-action/SignTransactionDeviceAction";
 import { appBinderTypes } from "./di/appBinderTypes";
 import { BlockhashService } from "./services/BlockhashService";
@@ -47,15 +46,10 @@ export class SolanaAppBinder {
   }): GetAddressDAReturnType {
     return this.dmk.executeDeviceAction({
       sessionId: this.sessionId,
-      deviceAction: new SendCommandInAppDeviceAction({
-        input: {
-          command: new GetPubKeyCommand(args),
-          appName: APP_NAME,
-          requiredUserInteraction: args.checkOnDevice
-            ? UserInteractionRequired.VerifyAddress
-            : UserInteractionRequired.None,
-          skipOpenApp: args.skipOpenApp,
-        },
+      deviceAction: GetAddressDeviceActionFactory({
+        derivationPath: args.derivationPath,
+        checkOnDevice: args.checkOnDevice,
+        skipOpenApp: args.skipOpenApp,
         logger: this.dmkLoggerFactory("GetPubKeyCommand"),
       }),
     });
@@ -92,20 +86,13 @@ export class SolanaAppBinder {
   }): SignMessageDAReturnType {
     return this.dmk.executeDeviceAction({
       sessionId: this.sessionId,
-      deviceAction: new CallTaskInAppDeviceAction({
-        input: {
-          task: async (internalApi) =>
-            new SendSignMessageTask(internalApi, {
-              derivationPath: args.derivationPath,
-              sendingData: args.message,
-              version: args.version,
-              appDomain: args.appDomain,
-              signers: args.signers,
-            }).run(),
-          appName: APP_NAME,
-          requiredUserInteraction: UserInteractionRequired.SignPersonalMessage,
-          skipOpenApp: args.skipOpenApp,
-        },
+      deviceAction: SignMessageDeviceActionFactory({
+        derivationPath: args.derivationPath,
+        message: args.message,
+        skipOpenApp: args.skipOpenApp,
+        version: args.version,
+        appDomain: args.appDomain,
+        signers: args.signers,
         logger: this.dmkLoggerFactory("SendSignMessageTask"),
       }),
     });

--- a/packages/signer/signer-solana/src/internal/app-binder/command/utils/SolanaApplicationErrors.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/command/utils/SolanaApplicationErrors.ts
@@ -33,9 +33,11 @@ export const SOLANA_APP_ERRORS: CommandErrors<SolanaAppErrorCodes> = {
   "6f13": { message: "Delayed signing derivation mismatch" },
 };
 
+export const SOLANA_APP_COMMAND_ERROR_TAG = "SolanaAppCommandError";
+
 export class SolanaAppCommandError extends DeviceExchangeError<SolanaAppErrorCodes> {
   constructor(args: CommandErrorArgs<SolanaAppErrorCodes>) {
-    super({ tag: "SolanaAppCommandError", ...args });
+    super({ tag: SOLANA_APP_COMMAND_ERROR_TAG, ...args });
   }
 }
 

--- a/packages/signer/signer-solana/src/internal/app-binder/task/SendSignMessageTask.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/SendSignMessageTask.ts
@@ -18,7 +18,10 @@ import {
   SignOffChainMessageCommand,
   type SignOffChainRawResponse,
 } from "@internal/app-binder/command/SignOffChainMessageCommand";
-import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+import {
+  SOLANA_APP_COMMAND_ERROR_TAG,
+  type SolanaAppErrorCodes,
+} from "@internal/app-binder/command/utils/SolanaApplicationErrors";
 import { SOLANA_PUBKEY_LEN } from "@internal/app-binder/constants";
 import {
   type Bs58Encoder,
@@ -299,7 +302,7 @@ export class SendSignMessageTask {
     if (!e || typeof e !== "object") return false;
     const obj = e as Record<string, unknown>;
     return (
-      obj["_tag"] === "SolanaAppCommandError" &&
+      obj["_tag"] === SOLANA_APP_COMMAND_ERROR_TAG &&
       typeof obj["errorCode"] === "string" &&
       (obj["errorCode"] as string).toLowerCase() === "6a81"
     );


### PR DESCRIPTION
### 📝 Description

`@ledgerhq/device-signer-kit-ethereum` exposes public device-action **factories** (`SignPersonalMessageDeviceActionFactory`, `GetAddressDeviceActionFactory`) that return a `CallTaskInAppDeviceAction`, letting consumers compose their own `OpenApp -> GetAddress -> Sign` XState flow using only the public API while `APP_NAME` and the internal task classes stay encapsulated.

`@ledgerhq/device-signer-kit-solana` had no equivalents, forcing consumers (e.g. the Ledger Button Solana provider) to deep-import from `/internal/` (fragile across minor bumps). This PR closes the gap by mirroring the Ethereum kit.

**Changes:**

- **`SignMessageDeviceActionFactory`** (`src/api/app-binder/SignMessageDeviceActionFactory.ts`): returns a `CallTaskInAppDeviceAction<SignMessageDAOutput, SignMessageTaskError, UserInteractionRequired.SignPersonalMessage>` wrapping `SendSignMessageTask` + `APP_NAME`. Forwards `version` / `appDomain` / `signers`.
- **`GetAddressDeviceActionFactory`** (`src/api/app-binder/GetAddressDeviceActionFactory.ts`): returns a `SendCommandInAppDeviceAction` wrapping `GetPubKeyCommand` + `APP_NAME` (full parity with signer-eth, hides `APP_NAME`).
- **User-rejection error exposed publicly** via `isSolanaAppError(error): error is SolanaAppCommandError` and a re-export of `SolanaAppCommandError` (`src/api/model/SolanaAppErrors.ts`), so consumers can map `6985` without importing from `/internal/`.
- **`SolanaAppBinder`** `signMessage` / `getAddress` now **delegate** to the factories to guarantee a single source of truth.
- All of the above are exported from `src/api/index.ts`.

Because the Solana `SendSignMessageTask` does not accept a logger (unlike the Ethereum task), the factories accept an optional `logger` that is forwarded to the device action, preserving the binder's current logging behavior.

### ❓ Context

### 🤔 Why
Consumers that build their own device-action flows (e.g. the Ledger Button
Solana provider) want to compose the standard `OpenApp -> GetAddress -> Sign`
XState flow themselves — exactly like they already do for EVM with
`signer-eth`'s public factories.
https://github.com/LedgerHQ/device-sdk-ts/blob/develop/packages/signer/signer-eth/src/api/app-binder/SignPersonalMessageDeviceActionFactory.ts

For Solana that was impossible using the public API alone: `APP_NAME`, the
`SendSignMessageTask`, the `GetPubKeyCommand` and `SolanaAppCommandError` all
live under `/internal/`. Consumers were therefore forced to deep-import from
`@ledgerhq/device-signer-kit-solana/.../internal/...`, which is a problem:
- **Fragility** — `/internal/` has no semver contract, so any minor/patch bump
  can silently break consumers.
- **Duplication** — consumers had to re-declare the device-action wiring the
  binder already owns (flagged as duplication on our side).
- **Inconsistency** — `signer-eth` already exposes `SignPersonalMessageDeviceActionFactory`
  and `GetAddressDeviceActionFactory`; `signer-solana` had no equivalent, so the
  two kits diverged for no good reason.
This PR closes that gap by exposing the same building blocks publicly, so
consumers compose their flow through the public API while `APP_NAME` and the
task/command classes stay fully encapsulated. `SolanaAppBinder` now delegates to
the very same factories, guaranteeing a single source of truth (no drift between
what the binder does and what external consumers get).
The user-rejection error is exposed the same way: `isSolanaAppError` lets
consumers detect `6985` (and other app errors) without importing from
`/internal/`. The guard is **structural** (`_tag`-based, mirroring the kit's own
internal check) rather than `instanceof`, so it stays correct even when the
consumer graph ends up with more than one copy/format (ESM vs CJS) of the class

- **JIRA or GitHub link**: LBD-580 (note: `LBD` is not accepted by the branch/PR-title Danger regexes, so the branch and title use `NO-ISSUE`; the ticket is referenced in the commit message)
- **Feature**: Public device-action factories for the Solana signer kit, matching the Ethereum kit's public API.

### ✅ Checklist

- [x] **Covered by automatic tests** — unit tests for both factories, the error guard, and updated `SolanaAppBinder` tests confirming identical behavior after delegation.
- [x] **Changeset is provided** — `minor` bump for `@ledgerhq/device-signer-kit-solana`.
- [ ] **Documentation is up-to-date**
- [ ] **Impact of the changes:**
  - New public exports in `@ledgerhq/device-signer-kit-solana`: `SignMessageDeviceActionFactory`, `GetAddressDeviceActionFactory`, `isSolanaAppError`, `SolanaAppCommandError`, `SignMessageTaskError`.
  - `SolanaAppBinder` refactored to delegate to the factories (no behavior change; `GetPubKeyCommand` now receives only the fields it uses).

Made with [Cursor](https://cursor.com)