### PR TITLE
✨ (os-update) [DSDK-1318]: Adds CommitRestoreAppStorageCommand

### DIFF
--- a/.changeset/old-walls-watch.md
+++ b/.changeset/old-walls-watch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": minor
+---
+
+Add `CommitRestoreAppStorageCommand` implementing the `INS_APP_STORAGE_RESTORE_COMMIT` APDU, used to finalize a previously initiated and restored application storage.

--- a/packages/device-management-kit/src/api/command/os/CommitRestoreAppStorageCommand.test.ts
+++ b/packages/device-management-kit/src/api/command/os/CommitRestoreAppStorageCommand.test.ts
@@ -1,0 +1,109 @@
+import { isSuccessCommandResult } from "@api/command/model/CommandResult";
+import { CommitRestoreAppStorageCommand } from "@api/command/os/CommitRestoreAppStorageCommand";
+import { ApduResponse } from "@api/device-session/ApduResponse";
+
+describe("CommitRestoreAppStorageCommand", () => {
+  describe("Name", () => {
+    it("name should be 'CommitRestoreAppStorage'", () => {
+      // ARRANGE
+      const command = new CommitRestoreAppStorageCommand();
+
+      // ACT
+      const name = command.name;
+
+      // ASSERT
+      expect(name).toBe("CommitRestoreAppStorage");
+    });
+  });
+
+  describe("Command", () => {
+    it("should return the correct APDU for committing an app storage restore", () => {
+      // ARRANGE
+      const expectedApdu = Uint8Array.from([0xe0, 0x6e, 0x00, 0x00, 0x00]);
+
+      // ACT
+      const apdu = new CommitRestoreAppStorageCommand().getApdu();
+
+      // ASSERT
+      expect(apdu.getRawApdu()).toEqual(expectedApdu);
+    });
+  });
+
+  describe("Success response", () => {
+    it("should return a success result", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x90, 0x00]),
+        data: new Uint8Array([]),
+      });
+
+      // ACT
+      const result = new CommitRestoreAppStorageCommand().parseResponse(
+        response,
+      );
+
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      expect(result).toEqual({
+        data: undefined,
+        status: "SUCCESS",
+      });
+    });
+  });
+
+  describe("Error response", () => {
+    it.each([
+      {
+        description: "restore init has not been called",
+        statusCode: [0x51, 0x23],
+        expectedMessage: "Invalid context, restore init must be called first.",
+      },
+      {
+        description: "crypto operation failed",
+        statusCode: [0x54, 0x19],
+        expectedMessage: "Internal error, crypto operation failed.",
+      },
+      {
+        description: "backup authenticity verification failed",
+        statusCode: [0x54, 0x1b],
+        expectedMessage: "Failed to verify backup authenticity.",
+      },
+      {
+        description: "device is in recovery mode",
+        statusCode: [0x66, 0x2f],
+        expectedMessage: "Invalid device state, recovery mode.",
+      },
+      {
+        description: "restored app storage size is invalid",
+        statusCode: [0x67, 0x34],
+        expectedMessage: "Invalid size of the restored app storage.",
+      },
+      {
+        description:
+          "error code is not specific to CommitRestoreAppStorageCommand (global error)",
+        statusCode: [0x55, 0x15],
+        expectedMessage: "Device is locked.",
+      },
+    ])(
+      "should return error when $description",
+      ({ statusCode, expectedMessage }) => {
+        // ARRANGE
+        const response = new ApduResponse({
+          statusCode: Uint8Array.from(statusCode),
+          data: new Uint8Array([]),
+        });
+
+        // ACT
+        const result = new CommitRestoreAppStorageCommand().parseResponse(
+          response,
+        );
+
+        // ASSERT
+        expect(isSuccessCommandResult(result)).toBe(false);
+        expect((result as unknown as { error: Error }).error.message).toBe(
+          expectedMessage,
+        );
+      },
+    );
+  });
+});

--- a/packages/device-management-kit/src/api/command/os/CommitRestoreAppStorageCommand.ts
+++ b/packages/device-management-kit/src/api/command/os/CommitRestoreAppStorageCommand.ts
@@ -1,0 +1,86 @@
+import { type Apdu } from "@api/apdu/model/Apdu";
+import { ApduBuilder } from "@api/apdu/utils/ApduBuilder";
+import { ApduParser } from "@api/apdu/utils/ApduParser";
+import { type Command } from "@api/command/Command";
+import {
+  type CommandResult,
+  CommandResultFactory,
+} from "@api/command/model/CommandResult";
+import {
+  type CommandErrors,
+  isCommandErrorCode,
+} from "@api/command/utils/CommandErrors";
+import { CommandUtils } from "@api/command/utils/CommandUtils";
+import { GlobalCommandErrorHandler } from "@api/command/utils/GlobalCommandError";
+import { type ApduResponse } from "@api/device-session/ApduResponse";
+import { type CommandErrorArgs, DeviceExchangeError } from "@api/Error";
+
+export type CommitRestoreAppStorageCommandErrorCodes =
+  | "5123"
+  | "5419"
+  | "541b"
+  | "662f"
+  | "6734";
+
+export const COMMIT_RESTORE_APP_STORAGE_ERRORS: CommandErrors<CommitRestoreAppStorageCommandErrorCodes> =
+  {
+    "5123": { message: "Invalid context, restore init must be called first." },
+    "5419": { message: "Internal error, crypto operation failed." },
+    "541b": { message: "Failed to verify backup authenticity." },
+    "662f": { message: "Invalid device state, recovery mode." },
+    "6734": { message: "Invalid size of the restored app storage." },
+  };
+
+export class CommitRestoreAppStorageCommandError extends DeviceExchangeError<CommitRestoreAppStorageCommandErrorCodes> {
+  constructor(
+    args: CommandErrorArgs<CommitRestoreAppStorageCommandErrorCodes>,
+  ) {
+    super({ tag: "CommitRestoreAppStorageCommandError", ...args });
+  }
+}
+
+export type CommitRestoreAppStorageCommandResult = CommandResult<
+  void,
+  CommitRestoreAppStorageCommandErrorCodes
+>;
+
+export class CommitRestoreAppStorageCommand
+  implements Command<void, void, CommitRestoreAppStorageCommandErrorCodes>
+{
+  readonly name = "CommitRestoreAppStorage";
+
+  private readonly header = {
+    cla: 0xe0,
+    ins: 0x6e,
+    p1: 0x00,
+    p2: 0x00,
+  };
+
+  getApdu(): Apdu {
+    return new ApduBuilder(this.header).build();
+  }
+
+  parseResponse(
+    apduResponse: ApduResponse,
+  ): CommitRestoreAppStorageCommandResult {
+    const parser = new ApduParser(apduResponse);
+    if (!CommandUtils.isSuccessResponse(apduResponse)) {
+      const errorCode = parser.encodeToHexaString(apduResponse.statusCode);
+      if (isCommandErrorCode(errorCode, COMMIT_RESTORE_APP_STORAGE_ERRORS)) {
+        return CommandResultFactory({
+          error: new CommitRestoreAppStorageCommandError({
+            ...COMMIT_RESTORE_APP_STORAGE_ERRORS[errorCode],
+            errorCode,
+          }),
+        });
+      }
+      return CommandResultFactory({
+        error: GlobalCommandErrorHandler.handle(apduResponse),
+      });
+    }
+
+    return CommandResultFactory({
+      data: undefined,
+    });
+  }
+}

--- a/packages/device-management-kit/src/api/index.ts
+++ b/packages/device-management-kit/src/api/index.ts
@@ -24,6 +24,12 @@ export {
 } from "@api/command/os/BackupStorageCommand";
 export { CloseAppCommand } from "@api/command/os/CloseAppCommand";
 export {
+  CommitRestoreAppStorageCommand,
+  CommitRestoreAppStorageCommandError,
+  type CommitRestoreAppStorageCommandErrorCodes,
+  type CommitRestoreAppStorageCommandResult,
+} from "@api/command/os/CommitRestoreAppStorageCommand";
+export {
   DeleteLanguagePackCommand,
   type DeleteLanguagePackCommandArgs,
   DeleteLanguagePackCommandError,


### PR DESCRIPTION
### 📝 Description

This PR implements the `INS_APP_STORAGE_RESTORE_COMMIT` APDU, the command that follows `INS_APP_STORAGE_RESTORE` (implemented separately in [DSDK-1317](https://ledgerhq.atlassian.net/browse/DSDK-1317)) in the application NVRAM restore flow described in [[ARCH] Applications' NVRAM management and backup](https://ledgerhq.atlassian.net/wiki/spaces/TA/pages/4166320301/ARCH+Applications+NVRAM+management+and+backup#2.1.2.3-INS_APP_STORAGE_RESTORE_COMMIT-APDU-syntax).


### ❓ Context

- **JIRA or GitHub link**: [DSDK-1318](https://ledgerhq.atlassian.net/browse/DSDK-1318?atlOrigin=eyJpIjoiMjcwNjQ2NWZmNjJmNDExNDhkNzNhNmU1ZWFlYzJjZGQiLCJwIjoiaiJ9)

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [ ] ~~**Documentation is up-to-date**~~
- [x] **Impact of the changes:**
  - Adds a new public command `CommitRestoreAppStorageCommand` (non-breaking)
  - Adds a "Commit restore app storage" entry to the sample app's `CommandsView`

---

### 🧐 Checklist for the PR Reviewers

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.

[DSDK-1318]: https://ledgerhq.atlassian.net/browse/DSDK-1318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DSDK-1317]: https://ledgerhq.atlassian.net/browse/DSDK-1317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ