### PR TITLE
♻️ (os-update) [NO-ISSUE]: App storage commands cleanup

### DIFF
--- a/.changeset/smart-ties-drive.md
+++ b/.changeset/smart-ties-drive.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/dmk-ledger-wallet": patch
+---
+
+Update usage of `BackupStorageCommand` following its rename to `BackupAppStorageCommand` in `@ledgerhq/device-management-kit`.

--- a/.changeset/wicked-vans-turn.md
+++ b/.changeset/wicked-vans-turn.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Rename `BackupStorageCommand` to `BackupAppStorageCommand`, rename `InitRestoreAppStorageCommand`'s `backupLength` field to `appStorageDataLength`, and type `BackupAppStorageCommand`'s `data` response as `HexaString`.

--- a/apps/sample/src/components/CommandsView/index.tsx
+++ b/apps/sample/src/components/CommandsView/index.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from "react";
 import {
-  BackupStorageCommand,
-  type BackupStorageCommandErrorCodes,
-  type BackupStorageCommandResponse,
+  BackupAppStorageCommand,
+  type BackupAppStorageCommandErrorCodes,
+  type BackupAppStorageCommandResponse,
   BatteryStatusType,
   CloseAppCommand,
   DeleteLanguagePackCommand,
@@ -152,7 +152,7 @@ export const CommandsView: React.FC<{ sessionId: string }> = ({
         title: "Backup app storage",
         description: "Backup the app storage of the device",
         sendCommand: () => {
-          const command = new BackupStorageCommand();
+          const command = new BackupAppStorageCommand();
           return dmk.sendCommand({
             sessionId: selectedSessionId,
             command,
@@ -161,24 +161,24 @@ export const CommandsView: React.FC<{ sessionId: string }> = ({
         initialValues: undefined,
       } satisfies CommandProps<
         void,
-        BackupStorageCommandResponse,
-        BackupStorageCommandErrorCodes
+        BackupAppStorageCommandResponse,
+        BackupAppStorageCommandErrorCodes
       >,
       {
         title: "Init restore app storage",
         description:
           "Initialize the restore of a previously backed up app storage",
-        sendCommand: ({ appName, backupLength }) => {
+        sendCommand: ({ appName, appStorageDataLength }) => {
           const command = new InitRestoreAppStorageCommand({
             appName,
-            backupLength,
+            appStorageDataLength,
           });
           return dmk.sendCommand({
             sessionId: selectedSessionId,
             command,
           });
         },
-        initialValues: { appName: "", backupLength: 0 },
+        initialValues: { appName: "", appStorageDataLength: 0 },
       } satisfies CommandProps<
         InitRestoreAppStorageCommandArgs,
         void,

--- a/packages/device-management-kit/src/api/command/os/BackupAppStorageCommand.test.ts
+++ b/packages/device-management-kit/src/api/command/os/BackupAppStorageCommand.test.ts
@@ -1,18 +1,18 @@
 import { isSuccessCommandResult } from "@api/command/model/CommandResult";
-import { BackupStorageCommand } from "@api/command/os/BackupStorageCommand";
+import { BackupAppStorageCommand } from "@api/command/os/BackupAppStorageCommand";
 import { ApduResponse } from "@api/device-session/ApduResponse";
 
-describe("BackupStorageCommand", () => {
+describe("BackupAppStorageCommand", () => {
   describe("Name", () => {
-    it("name should be 'BackupStorage'", () => {
+    it("name should be 'BackupAppStorage'", () => {
       // ARRANGE
-      const command = new BackupStorageCommand();
+      const command = new BackupAppStorageCommand();
 
       // ACT
       const name = command.name;
 
       // ASSERT
-      expect(name).toBe("BackupStorage");
+      expect(name).toBe("BackupAppStorage");
     });
   });
 
@@ -22,7 +22,7 @@ describe("BackupStorageCommand", () => {
       const expectedApdu = Uint8Array.from([0xe0, 0x6b, 0x00, 0x00, 0x00]);
 
       // ACT
-      const apdu = new BackupStorageCommand().getApdu();
+      const apdu = new BackupAppStorageCommand().getApdu();
 
       // ASSERT
       expect(apdu.getRawApdu()).toEqual(expectedApdu);
@@ -39,7 +39,7 @@ describe("BackupStorageCommand", () => {
       });
 
       // ACT
-      const result = new BackupStorageCommand().parseResponse(response);
+      const result = new BackupAppStorageCommand().parseResponse(response);
 
       // ASSERT
       expect(isSuccessCommandResult(result)).toBe(true);
@@ -106,7 +106,7 @@ describe("BackupStorageCommand", () => {
         });
 
         // ACT
-        const result = new BackupStorageCommand().parseResponse(response);
+        const result = new BackupAppStorageCommand().parseResponse(response);
 
         // ASSERT
         expect(isSuccessCommandResult(result)).toBe(false);

--- a/packages/device-management-kit/src/api/command/os/BackupAppStorageCommand.ts
+++ b/packages/device-management-kit/src/api/command/os/BackupAppStorageCommand.ts
@@ -16,12 +16,12 @@ import { GlobalCommandErrorHandler } from "@api/command/utils/GlobalCommandError
 import { type ApduResponse } from "@api/device-session/ApduResponse";
 import { type CommandErrorArgs, DeviceExchangeError } from "@api/Error";
 
-export type BackupStorageCommandResponse = {
+export type BackupAppStorageCommandResponse = {
   chunkData: Uint8Array;
   chunkSize: number;
 };
 
-export type BackupStorageCommandErrorCodes =
+export type BackupAppStorageCommandErrorCodes =
   | "5123"
   | "5419"
   | "541a"
@@ -30,7 +30,7 @@ export type BackupStorageCommandErrorCodes =
   | "622f"
   | "6642";
 
-export const BACKUP_STORAGE_ERRORS: CommandErrors<BackupStorageCommandErrorCodes> =
+export const BACKUP_APP_STORAGE_ERRORS: CommandErrors<BackupAppStorageCommandErrorCodes> =
   {
     "5123": { message: "Invalid context. Get info must be called." },
     "5419": { message: "Failed to generate AES key." },
@@ -41,22 +41,26 @@ export const BACKUP_STORAGE_ERRORS: CommandErrors<BackupStorageCommandErrorCodes
     "6642": { message: "Invalid backup state, backup already performed." },
   };
 
-export class BackupStorageCommandError extends DeviceExchangeError<BackupStorageCommandErrorCodes> {
-  constructor(args: CommandErrorArgs<BackupStorageCommandErrorCodes>) {
-    super({ tag: "BackupStorageCommandError", ...args });
+export class BackupAppStorageCommandError extends DeviceExchangeError<BackupAppStorageCommandErrorCodes> {
+  constructor(args: CommandErrorArgs<BackupAppStorageCommandErrorCodes>) {
+    super({ tag: "BackupAppStorageCommandError", ...args });
   }
 }
 
-export type BackupStorageCommandResult = CommandResult<
-  BackupStorageCommandResponse,
-  BackupStorageCommandErrorCodes
+export type BackupAppStorageCommandResult = CommandResult<
+  BackupAppStorageCommandResponse,
+  BackupAppStorageCommandErrorCodes
 >;
 
-export class BackupStorageCommand
+export class BackupAppStorageCommand
   implements
-    Command<BackupStorageCommandResponse, void, BackupStorageCommandErrorCodes>
+    Command<
+      BackupAppStorageCommandResponse,
+      void,
+      BackupAppStorageCommandErrorCodes
+    >
 {
-  readonly name = "BackupStorage";
+  readonly name = "BackupAppStorage";
 
   private readonly header = {
     cla: 0xe0,
@@ -69,15 +73,15 @@ export class BackupStorageCommand
     return new ApduBuilder(this.header).build();
   }
 
-  parseResponse(apduResponse: ApduResponse): BackupStorageCommandResult {
+  parseResponse(apduResponse: ApduResponse): BackupAppStorageCommandResult {
     const parser = new ApduParser(apduResponse);
 
     if (!CommandUtils.isSuccessResponse(apduResponse)) {
       const errorCode = parser.encodeToHexaString(apduResponse.statusCode);
-      if (isCommandErrorCode(errorCode, BACKUP_STORAGE_ERRORS)) {
+      if (isCommandErrorCode(errorCode, BACKUP_APP_STORAGE_ERRORS)) {
         return CommandResultFactory({
-          error: new BackupStorageCommandError({
-            ...BACKUP_STORAGE_ERRORS[errorCode],
+          error: new BackupAppStorageCommandError({
+            ...BACKUP_APP_STORAGE_ERRORS[errorCode],
             errorCode,
           }),
         });

--- a/packages/device-management-kit/src/api/command/os/InitRestoreAppStorageCommand.test.ts
+++ b/packages/device-management-kit/src/api/command/os/InitRestoreAppStorageCommand.test.ts
@@ -8,7 +8,7 @@ describe("InitRestoreAppStorageCommand", () => {
       // ARRANGE
       const command = new InitRestoreAppStorageCommand({
         appName: "MyApp",
-        backupLength: 10,
+        appStorageDataLength: 10,
       });
 
       // ACT
@@ -30,7 +30,7 @@ describe("InitRestoreAppStorageCommand", () => {
       // ACT
       const apdu = new InitRestoreAppStorageCommand({
         appName: "MyApp",
-        backupLength: 10,
+        appStorageDataLength: 10,
       }).getApdu();
 
       // ASSERT
@@ -49,7 +49,7 @@ describe("InitRestoreAppStorageCommand", () => {
       // ACT
       const result = new InitRestoreAppStorageCommand({
         appName: "MyApp",
-        backupLength: 10,
+        appStorageDataLength: 10,
       }).parseResponse(response);
 
       // ASSERT
@@ -111,7 +111,7 @@ describe("InitRestoreAppStorageCommand", () => {
         // ACT
         const result = new InitRestoreAppStorageCommand({
           appName: "MyApp",
-          backupLength: 10,
+          appStorageDataLength: 10,
         }).parseResponse(response);
 
         // ASSERT

--- a/packages/device-management-kit/src/api/command/os/InitRestoreAppStorageCommand.ts
+++ b/packages/device-management-kit/src/api/command/os/InitRestoreAppStorageCommand.ts
@@ -17,7 +17,7 @@ import { type CommandErrorArgs, DeviceExchangeError } from "@api/Error";
 
 export type InitRestoreAppStorageCommandArgs = {
   appName: string;
-  backupLength: number;
+  appStorageDataLength: number;
 };
 
 export type InitRestoreAppStorageCommandErrorCodes =
@@ -69,9 +69,9 @@ export class InitRestoreAppStorageCommand
   constructor(private readonly args: InitRestoreAppStorageCommandArgs) {}
 
   getApdu(): Apdu {
-    const { appName, backupLength } = this.args;
+    const { appName, appStorageDataLength } = this.args;
     return new ApduBuilder(this.header)
-      .add32BitUIntToData(backupLength)
+      .add32BitUIntToData(appStorageDataLength)
       .addAsciiStringToData(appName)
       .build();
   }

--- a/packages/device-management-kit/src/api/device-action/task/BackupAppStorageTask.test.ts
+++ b/packages/device-management-kit/src/api/device-action/task/BackupAppStorageTask.test.ts
@@ -1,4 +1,4 @@
-import { BackupStorageCommandError } from "@api/command/os/BackupStorageCommand";
+import { BackupAppStorageCommandError } from "@api/command/os/BackupAppStorageCommand";
 import { GetAppStorageInfoCommandError } from "@api/command/os/GetAppStorageInfoCommand";
 import { type InternalApi } from "@api/device-action/DeviceAction";
 import {
@@ -128,7 +128,7 @@ describe("BackupAppStorageTask", () => {
         )
         .mockResolvedValueOnce(
           CommandResultFactory({
-            error: new BackupStorageCommandError({
+            error: new BackupAppStorageCommandError({
               message: "Failed to backup app storage data.",
               errorCode: "541c",
             }),
@@ -141,10 +141,10 @@ describe("BackupAppStorageTask", () => {
       // ASSERT
       expect(isSuccessDmkResult(result)).toBe(false);
       expect(
-        (result as { error: BackupStorageCommandError }).error,
-      ).toBeInstanceOf(BackupStorageCommandError);
+        (result as { error: BackupAppStorageCommandError }).error,
+      ).toBeInstanceOf(BackupAppStorageCommandError);
       expect(
-        (result as { error: BackupStorageCommandError }).error.message,
+        (result as { error: BackupAppStorageCommandError }).error.message,
       ).toBe("Failed to backup app storage data.");
     });
   });

--- a/packages/device-management-kit/src/api/device-action/task/BackupAppStorageTask.ts
+++ b/packages/device-management-kit/src/api/device-action/task/BackupAppStorageTask.ts
@@ -3,9 +3,9 @@ import {
   isSuccessCommandResult,
 } from "@api/command/model/CommandResult";
 import {
-  BackupStorageCommand,
-  type BackupStorageCommandErrorCodes,
-} from "@api/command/os/BackupStorageCommand";
+  BackupAppStorageCommand,
+  type BackupAppStorageCommandErrorCodes,
+} from "@api/command/os/BackupAppStorageCommand";
 import {
   GetAppStorageInfoCommand,
   type GetAppStorageInfoCommandErrorCodes,
@@ -25,11 +25,11 @@ export type BackupAppStorageTaskResponse = {
 
 export type BackupAppStorageTaskErrorCodes =
   | GetAppStorageInfoCommandErrorCodes
-  | BackupStorageCommandErrorCodes;
+  | BackupAppStorageCommandErrorCodes;
 
 export type BackupAppStorageTaskError =
   | CommandErrorResult<GetAppStorageInfoCommandErrorCodes>["error"]
-  | CommandErrorResult<BackupStorageCommandErrorCodes>["error"];
+  | CommandErrorResult<BackupAppStorageCommandErrorCodes>["error"];
 
 export class BackupAppStorageTask {
   constructor(
@@ -70,7 +70,7 @@ export class BackupAppStorageTask {
 
     while (offset < storageSize) {
       const backupStorage = await this.api.sendCommand(
-        new BackupStorageCommand(),
+        new BackupAppStorageCommand(),
       );
       if (!isSuccessCommandResult(backupStorage)) {
         this.logger.debug("[run] Failed to backup app storage", {

--- a/packages/device-management-kit/src/api/index.ts
+++ b/packages/device-management-kit/src/api/index.ts
@@ -17,11 +17,11 @@ export {
   isSuccessCommandResult,
 } from "@api/command/model/CommandResult";
 export {
-  BackupStorageCommand,
-  type BackupStorageCommandErrorCodes,
-  type BackupStorageCommandResponse,
-  type BackupStorageCommandResult,
-} from "@api/command/os/BackupStorageCommand";
+  BackupAppStorageCommand,
+  type BackupAppStorageCommandErrorCodes,
+  type BackupAppStorageCommandResponse,
+  type BackupAppStorageCommandResult,
+} from "@api/command/os/BackupAppStorageCommand";
 export { CloseAppCommand } from "@api/command/os/CloseAppCommand";
 export {
   DeleteLanguagePackCommand,

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Backup/CreateBackupDeviceAction.test.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Backup/CreateBackupDeviceAction.test.ts
@@ -158,7 +158,7 @@ describe("BackupDeviceAction", () => {
     vi
       .mocked(backupAppsStorage)
       .mockReturnValue(() =>
-        Promise.resolve(Right([{ appName: "TestApp", data: "appData" }])),
+        Promise.resolve(Right([{ appName: "TestApp", data: "0xappData" }])),
       );
 
   const setupDownloadCls = () =>
@@ -216,7 +216,7 @@ describe("BackupDeviceAction", () => {
           pendingState(CreateBackupSteps.DownloadCustomLockScreen),
           completedState({
             languageId: 1,
-            installedApps: [{ appName: "TestApp", data: "appData" }],
+            installedApps: [{ appName: "TestApp", data: "0xappData" }],
             clsHexImage: "0x0102",
           }),
         ];
@@ -282,7 +282,7 @@ describe("BackupDeviceAction", () => {
           pendingState(CreateBackupSteps.BackupAppsStorage),
           completedState({
             languageId: 1,
-            installedApps: [{ appName: "TestApp", data: "appData" }],
+            installedApps: [{ appName: "TestApp", data: "0xappData" }],
             clsHexImage: undefined,
           }),
         ];
@@ -320,7 +320,7 @@ describe("BackupDeviceAction", () => {
           pendingState(CreateBackupSteps.BackupAppsStorage),
           completedState({
             languageId: 1,
-            installedApps: [{ appName: "TestApp", data: "appData" }],
+            installedApps: [{ appName: "TestApp", data: "0xappData" }],
             clsHexImage: undefined,
           }),
         ];

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Backup/types.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Backup/types.ts
@@ -3,6 +3,7 @@ import {
   type GoToDashboardDAError,
   type GoToDashboardDAIntermediateValue,
   type GoToDashboardDARequiredInteraction,
+  type HexaString,
   type InstalledApp,
   type ListInstalledAppsDAError,
   type ListInstalledAppsDAIntermediateValue,
@@ -78,7 +79,7 @@ export enum CreateBackupSteps {
 
 export type BackupApp = {
   appName: string;
-  data: string | undefined;
+  data: HexaString | undefined;
 };
 
 export type Backup = {


### PR DESCRIPTION
### 📝 Description

This PR cleans up the naming and typing of the app storage commands used by the OS update backup/restore flow.

- Renamed `BackupStorageCommand` to `BackupAppStorageCommand` for consistency with `InitRestoreAppStorageCommand` and `BackupAppStorageTask`.
- Renamed `InitRestoreAppStorageCommand`'s `backupLength` argument to `appStorageDataLength` to better reflect what it represents.
- Typed `BackupApp.data` as `HexaString` instead of `string` for stronger typing.

This is purely a naming/typing refactor with no behavioral change. These commands are not yet used in production, so there is no breaking change.

### ❓ Context

- **JIRA**: [NO-ISSUE]

### ✅ Checklist

- [x] **Covered by automatic tests** <!-- existing tests updated for the renames -->
- [x] **Changeset is provided**
- [ ] ~~**Documentation is up-to-date**~~
- [x] **Impact of the changes:**
  - `BackupStorageCommand` renamed to `BackupAppStorageCommand` (and its test file)
  - `InitRestoreAppStorageCommand`'s `backupLength` field renamed to `appStorageDataLength`
  - `BackupApp.data` now typed as `HexaString`
  - Updated all internal usages (`BackupAppStorageTask`, `CreateBackupDeviceAction`, sample app `CommandsView`, `api/index.ts` exports)