### PR TITLE
👷 (danger) [LBD-662]: Accept LBD- Jira ticket prefix in CI checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Branch names **MUST** follow this format and are validated by CI.
 
 **Ticket** (required for branches on the main repository, not forks):
 
-- `DSDK-<number>` or `LIVE-<number>` — Jira ticket reference
+- `DSDK-<number>`, `LIVE-<number>` or `LBD-<number>` — Jira ticket reference
 - `no-issue` — When no ticket exists (**default for automated/AI contributions**)
 - `issue-<number>` — GitHub issue reference
 

--- a/danger/helpers.ts
+++ b/danger/helpers.ts
@@ -54,7 +54,7 @@ const Branch = (danger: DangerDSLType, isFork: boolean = false) => ({
   regex: isFork
     ? new RegExp(`^(${BRANCH_PREFIX.join("|")})\/.+`, "i")
     : new RegExp(
-        `^(release|chore\/backmerge(-.+){0,}|(${BRANCH_PREFIX.join("|")})\/((dsdk|live)-[0-9]+|no-issue|NOISSUE|issue-[0-9]+)-.+)`,
+        `^(release|chore\/backmerge(-.+){0,}|(${BRANCH_PREFIX.join("|")})\/((dsdk|live|lbd)-[0-9]+|no-issue|NOISSUE|issue-[0-9]+)-.+)`,
         "i",
       ),
 
@@ -92,7 +92,7 @@ Please fix the PR branch name to match the convention, see [CONTRIBUTING.md](htt
 - Rules:
   - Must start with a type (${BRANCH_PREFIX.join(", ")})
   - Followed by a SLASH ("/")
-  - Followed by a JIRA issue number (DSDK-1234) (LIVE-1234) or "no-issue" or "issue-1234" if fixing a Github issue
+  - Followed by a JIRA issue number (DSDK-1234) (LIVE-1234) (LBD-1234) or "no-issue" or "issue-1234" if fixing a Github issue
   - Followed by a DASH ("-")
   - Followed by a description
 
@@ -148,7 +148,7 @@ Special case for commit messages coming from a pull request merge:
 const Title = (_danger: DangerDSLType, fork: boolean = false) => ({
   regex: fork
     ? /^.+ \(([a-z]+\-?){1,}\): [A-Z].*/
-    : /^.+ \(([a-z]+\-?){1,}\) \[(DSDK-[0-9]+|LIVE-[0-9]+|NO-ISSUE|ISSUE-[0-9]+)\]: [A-Z].*/,
+    : /^.+ \(([a-z]+\-?){1,}\) \[(DSDK-[0-9]+|LIVE-[0-9]+|LBD-[0-9]+|NO-ISSUE|ISSUE-[0-9]+)\]: [A-Z].*/,
 
   failMessage(wrongTitle: string): string {
     if (fork) {


### PR DESCRIPTION
### 📝 Description

Adds the `LBD-` (Ledger Button Delivery) Jira ticket prefix to the Danger CI validation rules so the Button team can contribute to this repo without failing branch-name and PR-title checks.

Changes in `danger/helpers.ts`:
- **Branch name regex**: `(dsdk|live)-<number>` → `(dsdk|live|lbd)-<number>`
- **PR title regex**: added `LBD-[0-9]+` alongside `DSDK-`/`LIVE-`
- **Branch fail message**: documents the `LBD-1234` example

The commit-message regex already accepts any `[A-Z]+-<number>` pattern, so no change was needed there.

Also updated `CONTRIBUTING.md` to document `LBD-<number>` as a valid Jira ticket reference.

Branches like `feat/lbd-662-my-feature` and PR titles like `✨ (scope) [LBD-1234]: My feature` now pass Danger CI.

### ❓ Context

- **JIRA or GitHub link**: [LBD-662](https://ledgerhq.atlassian.net/browse/LBD-662)

### ✅ Checklist

- [ ] **Covered by automatic tests** — N/A, change to Danger regexes only; validated locally with `pnpm danger:local`.
- [ ] **Changeset is provided** — No changeset needed, changes only affect internal tooling (`danger/`) and documentation (`CONTRIBUTING.md`).
- [x] **Documentation is up-to-date** — `CONTRIBUTING.md` updated.
- [ ] **Impact of the changes:**
  - Adds `LBD-` as an accepted Jira ticket prefix for branch names and PR titles in CI.

Made with [Cursor](https://cursor.com)

[LBD-662]: https://ledgerhq.atlassian.net/browse/LBD-662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ