### PR TITLE
✨ (mock-server) [DSDK-1323]: Derive CLS responses by default

### DIFF
--- a/apps/device-mock-server/src/internal/os/service/osApdus.test.ts
+++ b/apps/device-mock-server/src/internal/os/service/osApdus.test.ts
@@ -1,6 +1,7 @@
 import { type Device } from "@ledgerhq/device-mockserver-client";
 
 import {
+  deriveCustomLockScreen,
   deriveGetAppAndVersion,
   deriveGetBatteryStatus,
   deriveGetDeviceName,
@@ -159,6 +160,45 @@ describe("deriveOsApduResponse", () => {
         "e0de000000",
       ),
     ).toBe("9000");
+  });
+
+  it("dispatches GetBackgroundImageSize (0xE0 0x64) as an empty device", () => {
+    expect(deriveOsApduResponse(device({}), "e064000000")).toBe("000000009000");
+  });
+});
+
+describe("deriveCustomLockScreen", () => {
+  it("reports no image for GetBackgroundImageSize (0xE0 0x64) with size 0", () => {
+    expect(deriveCustomLockScreen("e064000000")).toBe("000000009000");
+  });
+
+  it("reports no image (662e) for FetchBackgroundImageChunk (0xE0 0x65)", () => {
+    expect(deriveCustomLockScreen("e0650000050000000005")).toBe("662e");
+  });
+
+  it("reports no image (662e) for GetBackgroundImageHash (0xE0 0x66)", () => {
+    expect(deriveCustomLockScreen("e066000000")).toBe("662e");
+  });
+
+  it("reports nothing to delete (662e) for DeleteBackgroundImage (0xE0 0x63)", () => {
+    expect(deriveCustomLockScreen("e063000000")).toBe("662e");
+  });
+
+  it("succeeds for CreateBackgroundImage (0xE0 0x60)", () => {
+    expect(deriveCustomLockScreen("e06000000400001000")).toBe("9000");
+  });
+
+  it("succeeds for UploadBackgroundImageChunk (0xE0 0x61)", () => {
+    expect(deriveCustomLockScreen("e0610000050000000000")).toBe("9000");
+  });
+
+  it("succeeds for CommitBackgroundImage (0xE0 0x62)", () => {
+    expect(deriveCustomLockScreen("e062000000")).toBe("9000");
+  });
+
+  it("returns undefined for a non-CLS APDU", () => {
+    expect(deriveCustomLockScreen("e0010000")).toBeUndefined();
+    expect(deriveCustomLockScreen("e0f1000000")).toBeUndefined();
   });
 });
 

--- a/apps/device-mock-server/src/internal/os/service/osApdus.ts
+++ b/apps/device-mock-server/src/internal/os/service/osApdus.ts
@@ -28,7 +28,26 @@ export const LIST_APPS_CONTINUE_PREFIX = "e0df0000";
 export const GET_DEVICE_NAME_CLEANING_PREFIX = "e0500000";
 export const GET_DEVICE_NAME_PREFIX = "e0d20000";
 
+/**
+ * Custom Lock Screen commands (CLA 0xe0), matched on their cla+ins prefix. The
+ * mock models a device with no lock screen image loaded (an "empty" device), so
+ * read commands report empty and mutation commands succeed.
+ */
+export const CLS_CREATE_PREFIX = "e060"; // CreateBackgroundImage
+export const CLS_UPLOAD_PREFIX = "e061"; // UploadBackgroundImageChunk
+export const CLS_COMMIT_PREFIX = "e062"; // CommitBackgroundImage
+export const CLS_DELETE_PREFIX = "e063"; // DeleteBackgroundImage
+export const CLS_GET_SIZE_PREFIX = "e064"; // GetBackgroundImageSize
+export const CLS_FETCH_CHUNK_PREFIX = "e065"; // FetchBackgroundImageChunk
+export const CLS_GET_HASH_PREFIX = "e066"; // GetBackgroundImageHash
+
 const STATUS_OK = "9000";
+
+/** SW returned by CLS read/delete commands when no image is loaded (`662e`). */
+const CLS_NO_IMAGE_SW = "662e";
+
+/** GetBackgroundImageSize response for an empty device: size 0 + success SW. */
+const CLS_EMPTY_SIZE_RESPONSE = "00000000" + STATUS_OK;
 
 /** Upper-16-bit target-id mask per device model (lower bits are `0x0004`). */
 const TARGET_ID_MASK: Record<string, number> = {
@@ -254,6 +273,34 @@ export function deriveGetBatteryStatus(
 }
 
 /**
+ * Derived response for a Custom Lock Screen command (CLA 0xe0, INS 0x60..0x66),
+ * modelling a device with no lock screen image loaded, or `undefined` when the
+ * APDU is not one of them. Reads report the empty state (GetSize -> size 0,
+ * Fetch/GetHash -> `662e` no image), mutations succeed (Create/Upload/Commit ->
+ * `9000`) and Delete reports there is nothing to delete (`662e`).
+ */
+export function deriveCustomLockScreen(apdu: string): string | undefined {
+  if (apdu.startsWith(CLS_GET_SIZE_PREFIX)) {
+    return CLS_EMPTY_SIZE_RESPONSE;
+  }
+  if (
+    apdu.startsWith(CLS_FETCH_CHUNK_PREFIX) ||
+    apdu.startsWith(CLS_GET_HASH_PREFIX) ||
+    apdu.startsWith(CLS_DELETE_PREFIX)
+  ) {
+    return CLS_NO_IMAGE_SW;
+  }
+  if (
+    apdu.startsWith(CLS_CREATE_PREFIX) ||
+    apdu.startsWith(CLS_UPLOAD_PREFIX) ||
+    apdu.startsWith(CLS_COMMIT_PREFIX)
+  ) {
+    return STATUS_OK;
+  }
+  return undefined;
+}
+
+/**
  * Derived default response for an OS-handshake APDU (GetOsVersion /
  * GetAppAndVersion / GetBatteryStatus) synthesized from the device metadata, or
  * `undefined` when the APDU is not one of them (or the model is unsupported).
@@ -286,6 +333,10 @@ export function deriveOsApduResponse(
   }
   if (apdu.startsWith(GET_DEVICE_NAME_PREFIX)) {
     return deriveGetDeviceName(device);
+  }
+  const cls = deriveCustomLockScreen(apdu);
+  if (cls) {
+    return cls;
   }
   return undefined;
 }


### PR DESCRIPTION
### 📝 Description

Adds default (derived) responses for the Custom Lock Screen (CLS) command family in the device mock server, so the mock behaves like a device with **no lock screen image loaded** without requiring explicit mock configuration.

A new `deriveCustomLockScreen` helper handles the CLA `0xe0` CLS commands (INS `0x60`..`0x66`) and is wired into `deriveOsApduResponse`:

- **Reads** report the empty state:
  - `GetBackgroundImageSize` (`0xe0 0x64`) → size `0` + `9000`
  - `FetchBackgroundImageChunk` (`0xe0 0x65`) → `662e` (no image)
  - `GetBackgroundImageHash` (`0xe0 0x66`) → `662e` (no image)
- **Delete** reports nothing to delete:
  - `DeleteBackgroundImage` (`0xe0 0x63`) → `662e`
- **Mutations** succeed:
  - `CreateBackgroundImage` (`0xe0 0x60`) → `9000`
  - `UploadBackgroundImageChunk` (`0xe0 0x61`) → `9000`
  - `CommitBackgroundImage` (`0xe0 0x62`) → `9000`
- Non-CLS APDUs return `undefined` so the existing resolution flow is unaffected.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1323]
- **Feature**: Mock server derives CLS responses by default.

### ✅ Checklist

- [x] **Covered by automatic tests** <!-- new unit tests in osApdus.test.ts -->
- [ ] **Changeset is provided** <!-- Not needed — changes only affect apps/device-mock-server (internal tooling), not a published package -->
- [x] **Documentation is up-to-date**
- [ ] **Impact of the changes:**
  - Device mock server now returns default CLS responses modelling an empty (no image) device.

Made with [Cursor](https://cursor.com)

[DSDK-1323]: https://ledgerhq.atlassian.net/browse/DSDK-1323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ