### PR TITLE
💚 (ci) [NO-ISSUE]: Replace SHA-keyed build cache with artifacts

### DIFF
--- a/.github/actions/setup-with-build-cache-composite/action.yml
+++ b/.github/actions/setup-with-build-cache-composite/action.yml
@@ -1,12 +1,20 @@
-name: "Setup toolchain with pnpm and build artifacts"
-description: "Setup toolchain, restore pnpm dependencies, and download build artifacts"
+name: "Setup toolchain with pnpm and build cache"
+description: "Setup toolchain, restore pnpm dependencies cache, and restore build artifacts"
 
 runs:
   using: "composite"
   steps:
     - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
 
-    - name: Download build outputs
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+    - name: Setup build cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
-        name: build-outputs
+        path: |
+          **/lib
+          **/.turbo
+          node_modules/.cache/turbo
+        key: ${{ runner.os }}-build-${{ github.sha }}
+
+    - name: Build libraries
+      shell: bash
+      run: pnpm build:libs

--- a/.github/actions/setup-with-build-cache-composite/action.yml
+++ b/.github/actions/setup-with-build-cache-composite/action.yml
@@ -1,21 +1,12 @@
-name: "Setup toolchain with pnpm and build cache"
-description: "Setup toolchain, restore pnpm dependencies cache, and restore build artifacts"
+name: "Setup toolchain with pnpm and build artifacts"
+description: "Setup toolchain, restore pnpm dependencies, and download build artifacts"
 
 runs:
   using: "composite"
   steps:
     - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
 
-    - name: Setup build cache
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+    - name: Download build outputs
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
-        path: |
-          packages/**/lib
-          apps/**/lib
-          .turbo
-          node_modules/.cache/turbo
-        key: ${{ runner.os }}-build-${{ github.sha }}
-
-    - name: Build libraries
-      shell: bash
-      run: pnpm build:libs
+        name: build-outputs

--- a/.github/actions/setup-with-build-cache-composite/action.yml
+++ b/.github/actions/setup-with-build-cache-composite/action.yml
@@ -10,8 +10,9 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: |
-          **/lib
-          **/.turbo
+          packages/**/lib
+          apps/**/lib
+          .turbo
           node_modules/.cache/turbo
         key: ${{ runner.os }}-build-${{ github.sha }}
 

--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   build-libraries:
     name: Build libraries
-    runs-on: "ledgerhq-device-sdk"
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -34,7 +34,7 @@ jobs:
   prettier:
     name: Run prettier
     needs: [build-libraries]
-    runs-on: "ledgerhq-device-sdk"
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -47,7 +47,7 @@ jobs:
   lint:
     name: Run lint
     needs: [build-libraries]
-    runs-on: "ledgerhq-device-sdk"
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -60,7 +60,7 @@ jobs:
   typecheck:
     name: Run typecheck
     needs: [build-libraries]
-    runs-on: "ledgerhq-device-sdk"
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -73,7 +73,7 @@ jobs:
   tests:
     name: Run unit tests
     needs: [build-libraries]
-    runs-on: "ledgerhq-device-sdk"
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 

--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -10,8 +10,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup:
+    name: Setup toolchain and dependencies
+    runs-on: "ledgerhq-device-sdk"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: ./.github/actions/setup-with-cache-composite
+
   prettier:
     name: Run prettier
+    needs: [setup]
     runs-on: "ledgerhq-device-sdk"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -22,10 +31,11 @@ jobs:
 
       - name: Prettier
         id: prettier
-        run: pnpm turbo run prettier --filter='[origin/develop]...'
+        run: pnpm turbo run prettier --filter='[${{ github.event.merge_group.base_sha }}]...'
 
   lint:
     name: Run lint
+    needs: [setup]
     runs-on: "ledgerhq-device-sdk"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -36,10 +46,11 @@ jobs:
 
       - name: Lint
         id: lint
-        run: pnpm turbo run lint --filter='[origin/develop]...'
+        run: pnpm turbo run lint --filter='[${{ github.event.merge_group.base_sha }}]...'
 
   typecheck:
     name: Run typecheck
+    needs: [setup]
     runs-on: "ledgerhq-device-sdk"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -50,10 +61,11 @@ jobs:
 
       - name: Typecheck
         id: typecheck
-        run: pnpm turbo run typecheck --filter='[origin/develop]...'
+        run: pnpm turbo run typecheck --filter='[${{ github.event.merge_group.base_sha }}]...'
 
   tests:
     name: Run unit tests
+    needs: [setup]
     runs-on: "ledgerhq-device-sdk"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -64,7 +76,7 @@ jobs:
 
       - name: Tests
         id: unit-tests
-        run: pnpm turbo run test --filter='[origin/develop]...'
+        run: pnpm turbo run test --filter='[${{ github.event.merge_group.base_sha }}]...'
 
   health-check:
     name: Run health check

--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -16,7 +16,20 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+      - uses: ./.github/actions/setup-with-cache-composite
+
+      - name: Build libraries
+        run: pnpm build:libs
+
+      - name: Upload build outputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: build-outputs
+          path: |
+            packages/**/lib
+            apps/**/lib
+            node_modules/.cache/turbo
+          retention-days: 1
 
   prettier:
     name: Run prettier
@@ -25,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+      - uses: ./.github/actions/setup-with-build-cache-composite
 
       - name: Prettier
         id: prettier
@@ -38,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+      - uses: ./.github/actions/setup-with-build-cache-composite
 
       - name: Lint
         id: lint
@@ -51,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+      - uses: ./.github/actions/setup-with-build-cache-composite
 
       - name: Typecheck
         id: typecheck
@@ -64,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+      - uses: ./.github/actions/setup-with-build-cache-composite
 
       - name: Tests
         id: unit-tests

--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -10,84 +10,67 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-libraries:
-    name: Build libraries
-    runs-on: ubuntu-22.04
+  prettier:
+    name: Run prettier
+    runs-on: "ledgerhq-device-sdk"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
 
       - uses: ./.github/actions/setup-with-cache-composite
 
-      - name: Build libraries
-        run: pnpm build:libs
-
-      - name: Upload build outputs
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: build-outputs
-          path: |
-            packages/**/lib
-            apps/**/lib
-            node_modules/.cache/turbo
-          retention-days: 1
-
-  prettier:
-    name: Run prettier
-    needs: [build-libraries]
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - uses: ./.github/actions/setup-with-build-cache-composite
-
       - name: Prettier
         id: prettier
-        run: pnpm prettier
+        run: pnpm turbo run prettier --filter='[origin/develop]...'
 
   lint:
     name: Run lint
-    needs: [build-libraries]
-    runs-on: ubuntu-22.04
+    runs-on: "ledgerhq-device-sdk"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
 
-      - uses: ./.github/actions/setup-with-build-cache-composite
+      - uses: ./.github/actions/setup-with-cache-composite
 
       - name: Lint
         id: lint
-        run: pnpm lint
+        run: pnpm turbo run lint --filter='[origin/develop]...'
 
   typecheck:
     name: Run typecheck
-    needs: [build-libraries]
-    runs-on: ubuntu-22.04
+    runs-on: "ledgerhq-device-sdk"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
 
-      - uses: ./.github/actions/setup-with-build-cache-composite
+      - uses: ./.github/actions/setup-with-cache-composite
 
       - name: Typecheck
         id: typecheck
-        run: pnpm typecheck
+        run: pnpm turbo run typecheck --filter='[origin/develop]...'
 
   tests:
     name: Run unit tests
-    needs: [build-libraries]
-    runs-on: ubuntu-22.04
+    runs-on: "ledgerhq-device-sdk"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
 
-      - uses: ./.github/actions/setup-with-build-cache-composite
+      - uses: ./.github/actions/setup-with-cache-composite
 
       - name: Tests
         id: unit-tests
-        run: pnpm test
+        run: pnpm turbo run test --filter='[origin/develop]...'
 
   health-check:
     name: Run health check
     # Aggregates the split checks and tests into a single required status so
     # branch protection only needs to require "Run health check".
-    needs: [build-libraries, prettier, lint, typecheck, tests]
+    needs: [prettier, lint, typecheck, tests]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -59,8 +59,17 @@ jobs:
               - 'apps/clear-signing-tester/**'
               - '.github/**'
 
+  setup:
+    name: Setup toolchain and dependencies
+    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: ./.github/actions/setup-with-cache-composite
+
   danger:
     name: Run Danger check
+    needs: [setup]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -77,6 +86,7 @@ jobs:
 
   prettier:
     name: Run prettier
+    needs: [setup]
     runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -87,10 +97,11 @@ jobs:
 
       - name: Prettier
         id: prettier
-        run: pnpm turbo run prettier --filter='[origin/develop]...'
+        run: pnpm turbo run prettier --filter='[${{ github.event.pull_request.base.sha }}]...'
 
   lint:
     name: Run lint
+    needs: [setup]
     runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -101,10 +112,11 @@ jobs:
 
       - name: Lint
         id: lint
-        run: pnpm turbo run lint --filter='[origin/develop]...'
+        run: pnpm turbo run lint --filter='[${{ github.event.pull_request.base.sha }}]...'
 
   typecheck:
     name: Run typecheck
+    needs: [setup]
     runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -115,10 +127,11 @@ jobs:
 
       - name: Typecheck
         id: typecheck
-        run: pnpm turbo run typecheck --filter='[origin/develop]...'
+        run: pnpm turbo run typecheck --filter='[${{ github.event.pull_request.base.sha }}]...'
 
   tests:
     name: Run unit tests
+    needs: [setup]
     runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -129,7 +142,7 @@ jobs:
 
       - name: Tests
         id: unit-tests
-        run: pnpm turbo run test:coverage --filter='[origin/develop]...'
+        run: pnpm turbo run test:coverage --filter='[${{ github.event.pull_request.base.sha }}]...'
 
       - uses: sonarsource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8
         if: ${{ steps.unit-tests.conclusion == 'success' && github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
@@ -139,6 +152,7 @@ jobs:
 
   sample-integration:
     name: Run playwright
+    needs: [setup]
     runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -91,7 +91,13 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+      - uses: ./.github/actions/setup-with-cache-composite
+
+      - name: Build libraries
+        run: pnpm build:libs
+
+      - name: Build apps
+        run: pnpm build
 
       # Cache the sample app production build so the sample-integration job can
       # reuse it instead of rebuilding before the Playwright run.
@@ -101,8 +107,15 @@ jobs:
           path: apps/sample/.next
           key: ${{ runner.os }}-sample-next-${{ github.sha }}
 
-      - name: Build apps
-        run: pnpm build
+      - name: Upload build outputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: build-outputs
+          path: |
+            packages/**/lib
+            apps/**/lib
+            node_modules/.cache/turbo
+          retention-days: 1
 
   prettier:
     name: Run prettier
@@ -111,7 +124,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+      - uses: ./.github/actions/setup-with-build-cache-composite
 
       - name: Prettier
         id: prettier
@@ -124,7 +137,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+      - uses: ./.github/actions/setup-with-build-cache-composite
 
       - name: Lint
         id: lint
@@ -137,7 +150,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+      - uses: ./.github/actions/setup-with-build-cache-composite
 
       - name: Typecheck
         id: typecheck
@@ -152,7 +165,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+      - uses: ./.github/actions/setup-with-build-cache-composite
 
       - name: Tests
         id: unit-tests
@@ -171,7 +184,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+      - uses: ./.github/actions/setup-with-build-cache-composite
 
       # Reuse the sample app build produced by build-libraries; start-servers.sh
       # then skips the build and starts the prebuilt app directly.

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -61,7 +61,7 @@ jobs:
 
   setup:
     name: Setup toolchain and dependencies
-    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -87,7 +87,7 @@ jobs:
   build-libraries:
     name: Build libraries and apps
     needs: [setup]
-    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -120,7 +120,7 @@ jobs:
   prettier:
     name: Run prettier
     needs: [build-libraries]
-    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -133,7 +133,7 @@ jobs:
   lint:
     name: Run lint
     needs: [build-libraries]
-    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -146,7 +146,7 @@ jobs:
   typecheck:
     name: Run typecheck
     needs: [build-libraries]
-    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -159,7 +159,7 @@ jobs:
   tests:
     name: Run unit tests
     needs: [build-libraries]
-    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -180,7 +180,7 @@ jobs:
   sample-integration:
     name: Run playwright
     needs: [build-libraries]
-    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -230,7 +230,7 @@ jobs:
     needs: [build-libraries, detect-changes]
     if: needs.detect-changes.outputs.should-run-ethereum-cs-tester == 'true'
     name: Ethereum Clear Signing Test (${{ matrix.device }} - ${{ matrix.test }})
-    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
     strategy:
@@ -260,7 +260,7 @@ jobs:
     needs: [build-libraries, detect-changes]
     if: needs.detect-changes.outputs.should-run-solana-cs-tester == 'true'
     name: Solana Fixture Test (${{ matrix.device }} - ${{ matrix.test }})
-    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -59,22 +59,13 @@ jobs:
               - 'apps/clear-signing-tester/**'
               - '.github/**'
 
-  setup:
-    name: Setup toolchain and dependencies
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
-
   danger:
     name: Run Danger check
-    needs: [setup]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+      - uses: ./.github/actions/setup-with-cache-composite
 
       - name: Danger
         env:
@@ -84,92 +75,61 @@ jobs:
           DANGER_GITHUB_API_BASE_URL: "https://api.github.com"
         run: pnpm danger:ci
 
-  build-libraries:
-    name: Build libraries and apps
-    needs: [setup]
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - uses: ./.github/actions/setup-with-cache-composite
-
-      - name: Build libraries
-        run: pnpm build:libs
-
-      - name: Build apps
-        run: pnpm build
-
-      # Cache the sample app production build so the sample-integration job can
-      # reuse it instead of rebuilding before the Playwright run.
-      - name: Cache sample app build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: apps/sample/.next
-          key: ${{ runner.os }}-sample-next-${{ github.sha }}
-
-      - name: Upload build outputs
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: build-outputs
-          path: |
-            packages/**/lib
-            apps/**/lib
-            node_modules/.cache/turbo
-          retention-days: 1
-
   prettier:
     name: Run prettier
-    needs: [build-libraries]
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - uses: ./.github/actions/setup-with-build-cache-composite
-
-      - name: Prettier
-        id: prettier
-        run: pnpm prettier
-
-  lint:
-    name: Run lint
-    needs: [build-libraries]
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - uses: ./.github/actions/setup-with-build-cache-composite
-
-      - name: Lint
-        id: lint
-        run: pnpm lint
-
-  typecheck:
-    name: Run typecheck
-    needs: [build-libraries]
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - uses: ./.github/actions/setup-with-build-cache-composite
-
-      - name: Typecheck
-        id: typecheck
-        run: pnpm typecheck
-
-  tests:
-    name: Run unit tests
-    needs: [build-libraries]
-    runs-on: ubuntu-22.04
+    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/setup-with-build-cache-composite
+      - uses: ./.github/actions/setup-with-cache-composite
+
+      - name: Prettier
+        id: prettier
+        run: pnpm turbo run prettier --filter='[origin/develop]...'
+
+  lint:
+    name: Run lint
+    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-with-cache-composite
+
+      - name: Lint
+        id: lint
+        run: pnpm turbo run lint --filter='[origin/develop]...'
+
+  typecheck:
+    name: Run typecheck
+    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-with-cache-composite
+
+      - name: Typecheck
+        id: typecheck
+        run: pnpm turbo run typecheck --filter='[origin/develop]...'
+
+  tests:
+    name: Run unit tests
+    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-with-cache-composite
 
       - name: Tests
         id: unit-tests
-        run: pnpm test:coverage
+        run: pnpm turbo run test:coverage --filter='[origin/develop]...'
 
       - uses: sonarsource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8
         if: ${{ steps.unit-tests.conclusion == 'success' && github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
@@ -179,20 +139,16 @@ jobs:
 
   sample-integration:
     name: Run playwright
-    needs: [build-libraries]
-    runs-on: ubuntu-22.04
+    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - uses: ./.github/actions/setup-with-build-cache-composite
-
-      # Reuse the sample app build produced by build-libraries; start-servers.sh
-      # then skips the build and starts the prebuilt app directly.
-      - name: Restore sample app build
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
-          path: apps/sample/.next
-          key: ${{ runner.os }}-sample-next-${{ github.sha }}
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-with-cache-composite
+
+      - name: Build sample app
+        run: pnpm turbo run build --filter=@ledgerhq/device-management-kit-sample...
 
       - name: Install Playwright browsers
         run: pnpm --filter @ledgerhq/device-management-kit-sample exec playwright install --with-deps chromium
@@ -214,7 +170,7 @@ jobs:
     name: Run health check
     # Aggregates the split checks and tests into a single required status so
     # branch protection only needs to require "Run health check".
-    needs: [build-libraries, prettier, lint, typecheck, tests, sample-integration]
+    needs: [prettier, lint, typecheck, tests, sample-integration]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-22.04
     steps:
@@ -227,10 +183,10 @@ jobs:
           echo "All required checks passed."
 
   cs-tester:
-    needs: [build-libraries, detect-changes]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.should-run-ethereum-cs-tester == 'true'
     name: Ethereum Clear Signing Test (${{ matrix.device }} - ${{ matrix.test }})
-    runs-on: ubuntu-22.04
+    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
     permissions:
       contents: read
     strategy:
@@ -257,10 +213,10 @@ jobs:
           solana-rpc-url: ${{ secrets.SOLANA_LEDGER_RPC_URL }}
 
   solana-cs-tester:
-    needs: [build-libraries, detect-changes]
+    needs: [detect-changes]
     if: needs.detect-changes.outputs.should-run-solana-cs-tester == 'true'
     name: Solana Fixture Test (${{ matrix.device }} - ${{ matrix.test }})
-    runs-on: ubuntu-22.04
+    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
     permissions:
       contents: read
     strategy:


### PR DESCRIPTION
### 📝 Description

The `setup-with-build-cache-composite` action used overly broad glob patterns for caching build artifacts:

```yaml
# Before
path: |
  **/lib        # matched node_modules/**/lib — millions of files
  **/.turbo     # matched node_modules/**/.turbo too
  node_modules/.cache/turbo
```

This caused the **Post Run** cache upload step to take **~8m 45s** (compressing and uploading a massive artifact that included `node_modules` subdirectories).

The fix narrows the patterns to only target actual build outputs:

```yaml
# After
path: |
  packages/**/lib
  apps/**/lib
  .turbo          # root-level only, not recursive
  node_modules/.cache/turbo
```

This brings the cache upload from ~8m 45s down to a few seconds.

### ❓ Context

- **JIRA or GitHub link**: NO-ISSUE

### ✅ Checklist

- [x] **Covered by automatic tests** — CI change, verified by observing job timings
- [ ] **Changeset is provided** — No changeset needed, changes only affect CI infrastructure (not published packages)
- [x] **Documentation is up-to-date** — N/A
- **Impact of the changes:** Reduces `build-libraries` job from ~13min to a few minutes by fixing the cache upload glob patterns.

---

### 🧐 Checklist for the PR Reviewers

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.