### PR TITLE
♻️ (os-update) [NO-ISSUE]: Moves os update commands to dmk ledger wallet

### DIFF
--- a/.changeset/dull-bags-drive.md
+++ b/.changeset/dull-bags-drive.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Remove OS update backup/restore commands and tasks (`BackupAppStorageCommand`, `GetAppStorageInfoCommand`, `CommitRestoreAppStorageCommand`, `InitRestoreAppStorageCommand`, `RequestMasterConsentCommand`, `RestoreAppStorageCommand`, `BackupAppStorageTask`, `RestoreAppStorageTask`) from the public API. This code was unused and has moved to `@ledgerhq/dmk-ledger-wallet`.

--- a/.changeset/smooth-trains-poke.md
+++ b/.changeset/smooth-trains-poke.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/dmk-ledger-wallet": minor
+---
+
+Add OS update backup/restore commands and tasks (`BackupAppStorageCommand`, `GetAppStorageInfoCommand`, `CommitRestoreAppStorageCommand`, `InitRestoreAppStorageCommand`, `RequestMasterConsentCommand`, `RestoreAppStorageCommand`, `BackupAppStorageTask`, `RestoreAppStorageTask`), moved here from `@ledgerhq/device-management-kit`.

--- a/apps/sample/src/components/CommandsView/index.tsx
+++ b/apps/sample/src/components/CommandsView/index.tsx
@@ -1,8 +1,5 @@
 import React, { useMemo } from "react";
 import {
-  BackupAppStorageCommand,
-  type BackupAppStorageCommandErrorCodes,
-  type BackupAppStorageCommandResponse,
   BatteryStatusType,
   CloseAppCommand,
   DeleteLanguagePackCommand,
@@ -10,18 +7,11 @@ import {
   type DeleteLanguagePackErrorCodes,
   GetAppAndVersionCommand,
   type GetAppAndVersionResponse,
-  GetAppStorageInfoCommand,
-  type GetAppStorageInfoCommandArgs,
-  type GetAppStorageInfoCommandErrorCodes,
-  type GetAppStorageInfoCommandResponse,
   type GetBatteryStatusArgs,
   GetBatteryStatusCommand,
   type GetBatteryStatusResponse,
   GetOsVersionCommand,
   type GetOsVersionResponse,
-  InitRestoreAppStorageCommand,
-  type InitRestoreAppStorageCommandArgs,
-  type InitRestoreAppStorageCommandErrorCodes,
   type ListAppsArgs,
   ListAppsCommand,
   type ListAppsErrorCodes,
@@ -33,10 +23,22 @@ import {
   type OpenAppArgs,
   OpenAppCommand,
   type OpenAppErrorCodes,
+} from "@ledgerhq/device-management-kit";
+import {
+  BackupAppStorageCommand,
+  type BackupAppStorageCommandErrorCodes,
+  type BackupAppStorageCommandResponse,
+  GetAppStorageInfoCommand,
+  type GetAppStorageInfoCommandArgs,
+  type GetAppStorageInfoCommandErrorCodes,
+  type GetAppStorageInfoCommandResponse,
+  InitRestoreAppStorageCommand,
+  type InitRestoreAppStorageCommandArgs,
+  type InitRestoreAppStorageCommandErrorCodes,
   RequestMasterConsentCommand,
   type RequestMasterConsentCommandArgs,
   type RequestMasterConsentCommandErrorCodes,
-} from "@ledgerhq/device-management-kit";
+} from "@ledgerhq/dmk-ledger-wallet";
 import { Grid } from "@ledgerhq/react-ui";
 
 import { getValueSelectorFromEnum } from "@/components/Form";

--- a/packages/device-management-kit/src/api/index.ts
+++ b/packages/device-management-kit/src/api/index.ts
@@ -16,19 +16,7 @@ export {
   CommandResultStatus,
   isSuccessCommandResult,
 } from "@api/command/model/CommandResult";
-export {
-  BackupAppStorageCommand,
-  type BackupAppStorageCommandErrorCodes,
-  type BackupAppStorageCommandResponse,
-  type BackupAppStorageCommandResult,
-} from "@api/command/os/BackupAppStorageCommand";
 export { CloseAppCommand } from "@api/command/os/CloseAppCommand";
-export {
-  CommitRestoreAppStorageCommand,
-  CommitRestoreAppStorageCommandError,
-  type CommitRestoreAppStorageCommandErrorCodes,
-  type CommitRestoreAppStorageCommandResult,
-} from "@api/command/os/CommitRestoreAppStorageCommand";
 export {
   DeleteLanguagePackCommand,
   type DeleteLanguagePackCommandArgs,
@@ -40,13 +28,6 @@ export {
   GetAppAndVersionCommand,
   type GetAppAndVersionResponse,
 } from "@api/command/os/GetAppAndVersionCommand";
-export {
-  GetAppStorageInfoCommand,
-  type GetAppStorageInfoCommandArgs,
-  type GetAppStorageInfoCommandErrorCodes,
-  type GetAppStorageInfoCommandResponse,
-  type GetAppStorageInfoCommandResult,
-} from "@api/command/os/GetAppStorageInfoCommand";
 export {
   GetBackgroundImageSizeCommand,
   GetBackgroundImageSizeCommandError,
@@ -64,13 +45,6 @@ export {
   GetOsVersionCommand,
   type GetOsVersionResponse,
 } from "@api/command/os/GetOsVersionCommand";
-export {
-  InitRestoreAppStorageCommand,
-  type InitRestoreAppStorageCommandArgs,
-  InitRestoreAppStorageCommandError,
-  type InitRestoreAppStorageCommandErrorCodes,
-  type InitRestoreAppStorageCommandResult,
-} from "@api/command/os/InitRestoreAppStorageCommand";
 export {
   type ListAppsArgs,
   ListAppsCommand,
@@ -94,19 +68,6 @@ export {
   type OpenAppArgs,
   OpenAppCommand,
 } from "@api/command/os/OpenAppCommand";
-export {
-  RequestMasterConsentCommand,
-  type RequestMasterConsentCommandArgs,
-  type RequestMasterConsentCommandErrorCodes,
-  type RequestMasterConsentCommandResult,
-} from "@api/command/os/RequestMasterConsentCommand";
-export {
-  RestoreAppStorageCommand,
-  type RestoreAppStorageCommandArgs,
-  RestoreAppStorageCommandError,
-  type RestoreAppStorageCommandErrorCodes,
-  type RestoreAppStorageCommandResult,
-} from "@api/command/os/RestoreAppStorageCommand";
 export { isCommandErrorCode } from "@api/command/utils/CommandErrors";
 export { CommandUtils } from "@api/command/utils/CommandUtils";
 export {
@@ -165,16 +126,10 @@ export type {
   WaitForAppAndVersionDAState,
 } from "@api/device-action/os/WaitForAppAndVersion/types";
 export { WaitForAppAndVersionDeviceAction } from "@api/device-action/os/WaitForAppAndVersion/WaitForAppAndVersionDeviceAction";
-export { BackupAppStorageTask } from "@api/device-action/task/BackupAppStorageTask";
 export {
   GetApplicationsMetadataTaskError,
   InvalidGetFirmwareMetadataResponseError,
 } from "@api/device-action/task/Errors";
-export {
-  RestoreAppStorageTask,
-  type RestoreAppStorageTaskArgs,
-  type RestoreAppStorageTaskError,
-} from "@api/device-action/task/RestoreAppStorageTask";
 export {
   type DeviceActionStateMachine,
   XStateDeviceAction,

--- a/packages/ledger-wallet/src/api/command/OsUpdate/Backup/BackupAppStorageCommand.test.ts
+++ b/packages/ledger-wallet/src/api/command/OsUpdate/Backup/BackupAppStorageCommand.test.ts
@@ -1,6 +1,9 @@
-import { isSuccessCommandResult } from "@api/command/model/CommandResult";
-import { BackupAppStorageCommand } from "@api/command/os/BackupAppStorageCommand";
-import { ApduResponse } from "@api/device-session/ApduResponse";
+import {
+  ApduResponse,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { BackupAppStorageCommand } from "./BackupAppStorageCommand";
 
 describe("BackupAppStorageCommand", () => {
   describe("Name", () => {

--- a/packages/ledger-wallet/src/api/command/OsUpdate/Backup/BackupAppStorageCommand.ts
+++ b/packages/ledger-wallet/src/api/command/OsUpdate/Backup/BackupAppStorageCommand.ts
@@ -1,20 +1,19 @@
-import { type Apdu } from "@api/apdu/model/Apdu";
-import { ApduBuilder } from "@api/apdu/utils/ApduBuilder";
-import { ApduParser } from "@api/apdu/utils/ApduParser";
-import { type Command } from "@api/command/Command";
-import { InvalidStatusWordError } from "@api/command/Errors";
 import {
+  type Apdu,
+  ApduBuilder,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandErrorArgs,
+  type CommandErrors,
   type CommandResult,
   CommandResultFactory,
-} from "@api/command/model/CommandResult";
-import {
-  type CommandErrors,
+  CommandUtils,
+  DeviceExchangeError,
+  GlobalCommandErrorHandler,
+  InvalidStatusWordError,
   isCommandErrorCode,
-} from "@api/command/utils/CommandErrors";
-import { CommandUtils } from "@api/command/utils/CommandUtils";
-import { GlobalCommandErrorHandler } from "@api/command/utils/GlobalCommandError";
-import { type ApduResponse } from "@api/device-session/ApduResponse";
-import { type CommandErrorArgs, DeviceExchangeError } from "@api/Error";
+} from "@ledgerhq/device-management-kit";
 
 export type BackupAppStorageCommandResponse = {
   chunkData: Uint8Array;

--- a/packages/ledger-wallet/src/api/command/OsUpdate/Backup/GetAppStorageInfoCommand.test.ts
+++ b/packages/ledger-wallet/src/api/command/OsUpdate/Backup/GetAppStorageInfoCommand.test.ts
@@ -1,7 +1,10 @@
-import { InvalidStatusWordError } from "@api/command/Errors";
-import { isSuccessCommandResult } from "@api/command/model/CommandResult";
-import { GetAppStorageInfoCommand } from "@api/command/os/GetAppStorageInfoCommand";
-import { ApduResponse } from "@api/device-session/ApduResponse";
+import {
+  ApduResponse,
+  InvalidStatusWordError,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { GetAppStorageInfoCommand } from "./GetAppStorageInfoCommand";
 
 describe("GetAppStorageInfoCommand", () => {
   describe("Name", () => {

--- a/packages/ledger-wallet/src/api/command/OsUpdate/Backup/GetAppStorageInfoCommand.ts
+++ b/packages/ledger-wallet/src/api/command/OsUpdate/Backup/GetAppStorageInfoCommand.ts
@@ -1,18 +1,19 @@
-import { type Apdu } from "@api/apdu/model/Apdu";
-import { ApduBuilder } from "@api/apdu/utils/ApduBuilder";
-import { ApduParser } from "@api/apdu/utils/ApduParser";
-import { type Command } from "@api/command/Command";
-import { InvalidStatusWordError } from "@api/command/Errors";
 import {
+  type Apdu,
+  ApduBuilder,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandErrorArgs,
+  type CommandErrors,
   type CommandResult,
   CommandResultFactory,
-} from "@api/command/model/CommandResult";
-import { isCommandErrorCode } from "@api/command/utils/CommandErrors";
-import { type CommandErrors } from "@api/command/utils/CommandErrors";
-import { CommandUtils } from "@api/command/utils/CommandUtils";
-import { GlobalCommandErrorHandler } from "@api/command/utils/GlobalCommandError";
-import { type ApduResponse } from "@api/device-session/ApduResponse";
-import { type CommandErrorArgs, DeviceExchangeError } from "@api/Error";
+  CommandUtils,
+  DeviceExchangeError,
+  GlobalCommandErrorHandler,
+  InvalidStatusWordError,
+  isCommandErrorCode,
+} from "@ledgerhq/device-management-kit";
 
 export type GetAppStorageInfoCommandArgs = {
   appName: string;

--- a/packages/ledger-wallet/src/api/command/OsUpdate/Restore/CommitRestoreAppStorageCommand.test.ts
+++ b/packages/ledger-wallet/src/api/command/OsUpdate/Restore/CommitRestoreAppStorageCommand.test.ts
@@ -1,6 +1,9 @@
-import { isSuccessCommandResult } from "@api/command/model/CommandResult";
-import { CommitRestoreAppStorageCommand } from "@api/command/os/CommitRestoreAppStorageCommand";
-import { ApduResponse } from "@api/device-session/ApduResponse";
+import {
+  ApduResponse,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { CommitRestoreAppStorageCommand } from "./CommitRestoreAppStorageCommand";
 
 describe("CommitRestoreAppStorageCommand", () => {
   describe("Name", () => {

--- a/packages/ledger-wallet/src/api/command/OsUpdate/Restore/CommitRestoreAppStorageCommand.ts
+++ b/packages/ledger-wallet/src/api/command/OsUpdate/Restore/CommitRestoreAppStorageCommand.ts
@@ -1,19 +1,18 @@
-import { type Apdu } from "@api/apdu/model/Apdu";
-import { ApduBuilder } from "@api/apdu/utils/ApduBuilder";
-import { ApduParser } from "@api/apdu/utils/ApduParser";
-import { type Command } from "@api/command/Command";
 import {
+  type Apdu,
+  ApduBuilder,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandErrorArgs,
+  type CommandErrors,
   type CommandResult,
   CommandResultFactory,
-} from "@api/command/model/CommandResult";
-import {
-  type CommandErrors,
+  CommandUtils,
+  DeviceExchangeError,
+  GlobalCommandErrorHandler,
   isCommandErrorCode,
-} from "@api/command/utils/CommandErrors";
-import { CommandUtils } from "@api/command/utils/CommandUtils";
-import { GlobalCommandErrorHandler } from "@api/command/utils/GlobalCommandError";
-import { type ApduResponse } from "@api/device-session/ApduResponse";
-import { type CommandErrorArgs, DeviceExchangeError } from "@api/Error";
+} from "@ledgerhq/device-management-kit";
 
 export type CommitRestoreAppStorageCommandErrorCodes =
   | "5123"

--- a/packages/ledger-wallet/src/api/command/OsUpdate/Restore/InitRestoreAppStorageCommand.test.ts
+++ b/packages/ledger-wallet/src/api/command/OsUpdate/Restore/InitRestoreAppStorageCommand.test.ts
@@ -1,6 +1,9 @@
-import { isSuccessCommandResult } from "@api/command/model/CommandResult";
-import { InitRestoreAppStorageCommand } from "@api/command/os/InitRestoreAppStorageCommand";
-import { ApduResponse } from "@api/device-session/ApduResponse";
+import {
+  ApduResponse,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { InitRestoreAppStorageCommand } from "./InitRestoreAppStorageCommand";
 
 describe("InitRestoreAppStorageCommand", () => {
   describe("Name", () => {

--- a/packages/ledger-wallet/src/api/command/OsUpdate/Restore/InitRestoreAppStorageCommand.ts
+++ b/packages/ledger-wallet/src/api/command/OsUpdate/Restore/InitRestoreAppStorageCommand.ts
@@ -1,19 +1,18 @@
-import { type Apdu } from "@api/apdu/model/Apdu";
-import { ApduBuilder } from "@api/apdu/utils/ApduBuilder";
-import { ApduParser } from "@api/apdu/utils/ApduParser";
-import { type Command } from "@api/command/Command";
 import {
+  type Apdu,
+  ApduBuilder,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandErrorArgs,
+  type CommandErrors,
   type CommandResult,
   CommandResultFactory,
-} from "@api/command/model/CommandResult";
-import {
-  type CommandErrors,
+  CommandUtils,
+  DeviceExchangeError,
+  GlobalCommandErrorHandler,
   isCommandErrorCode,
-} from "@api/command/utils/CommandErrors";
-import { CommandUtils } from "@api/command/utils/CommandUtils";
-import { GlobalCommandErrorHandler } from "@api/command/utils/GlobalCommandError";
-import { type ApduResponse } from "@api/device-session/ApduResponse";
-import { type CommandErrorArgs, DeviceExchangeError } from "@api/Error";
+} from "@ledgerhq/device-management-kit";
 
 export type InitRestoreAppStorageCommandArgs = {
   appName: string;

--- a/packages/ledger-wallet/src/api/command/OsUpdate/Restore/RequestMasterConsentCommand.test.ts
+++ b/packages/ledger-wallet/src/api/command/OsUpdate/Restore/RequestMasterConsentCommand.test.ts
@@ -1,9 +1,9 @@
 import {
+  ApduResponse,
   CommandResultFactory,
+  InvalidArgumentError,
   isSuccessCommandResult,
-} from "@api/command/model/CommandResult";
-import { ApduResponse } from "@api/device-session/ApduResponse";
-import { InvalidArgumentError } from "@api/Error";
+} from "@ledgerhq/device-management-kit";
 
 import {
   RequestMasterConsentCommand,

--- a/packages/ledger-wallet/src/api/command/OsUpdate/Restore/RequestMasterConsentCommand.ts
+++ b/packages/ledger-wallet/src/api/command/OsUpdate/Restore/RequestMasterConsentCommand.ts
@@ -1,21 +1,20 @@
-import { type Apdu } from "@api/apdu/model/Apdu";
-import { ApduBuilder, type ApduBuilderArgs } from "@api/apdu/utils/ApduBuilder";
-import { ApduParser } from "@api/apdu/utils/ApduParser";
-import { CommandResultFactory } from "@api/command/model/CommandResult";
-import { isCommandErrorCode } from "@api/command/utils/CommandErrors";
-import { CommandUtils } from "@api/command/utils/CommandUtils";
-import { GlobalCommandErrorHandler } from "@api/command/utils/GlobalCommandError";
-import { type ApduResponse } from "@api/device-session/ApduResponse";
 import {
-  type CommandErrorArgs,
-  DeviceExchangeError,
-  InvalidArgumentError,
-} from "@api/Error";
-import {
+  type Apdu,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  ApduParser,
+  type ApduResponse,
   type Command,
+  type CommandErrorArgs,
   type CommandErrors,
   type CommandResult,
-} from "@api/types";
+  CommandResultFactory,
+  CommandUtils,
+  DeviceExchangeError,
+  GlobalCommandErrorHandler,
+  InvalidArgumentError,
+  isCommandErrorCode,
+} from "@ledgerhq/device-management-kit";
 
 export type RequestMasterConsentCommandArgs = {
   languagePackConsentEnabled: boolean;

--- a/packages/ledger-wallet/src/api/command/OsUpdate/Restore/RestoreAppStorageCommand.test.ts
+++ b/packages/ledger-wallet/src/api/command/OsUpdate/Restore/RestoreAppStorageCommand.test.ts
@@ -1,6 +1,9 @@
-import { isSuccessCommandResult } from "@api/command/model/CommandResult";
-import { RestoreAppStorageCommand } from "@api/command/os/RestoreAppStorageCommand";
-import { ApduResponse } from "@api/device-session/ApduResponse";
+import {
+  ApduResponse,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { RestoreAppStorageCommand } from "./RestoreAppStorageCommand";
 
 describe("RestoreAppStorageCommand", () => {
   describe("Name", () => {

--- a/packages/ledger-wallet/src/api/command/OsUpdate/Restore/RestoreAppStorageCommand.ts
+++ b/packages/ledger-wallet/src/api/command/OsUpdate/Restore/RestoreAppStorageCommand.ts
@@ -1,19 +1,18 @@
-import { type Apdu } from "@api/apdu/model/Apdu";
-import { ApduBuilder } from "@api/apdu/utils/ApduBuilder";
-import { ApduParser } from "@api/apdu/utils/ApduParser";
-import { type Command } from "@api/command/Command";
 import {
+  type Apdu,
+  ApduBuilder,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandErrorArgs,
+  type CommandErrors,
   type CommandResult,
   CommandResultFactory,
-} from "@api/command/model/CommandResult";
-import {
-  type CommandErrors,
+  CommandUtils,
+  DeviceExchangeError,
+  GlobalCommandErrorHandler,
   isCommandErrorCode,
-} from "@api/command/utils/CommandErrors";
-import { CommandUtils } from "@api/command/utils/CommandUtils";
-import { GlobalCommandErrorHandler } from "@api/command/utils/GlobalCommandError";
-import { type ApduResponse } from "@api/device-session/ApduResponse";
-import { type CommandErrorArgs, DeviceExchangeError } from "@api/Error";
+} from "@ledgerhq/device-management-kit";
 
 export type RestoreAppStorageCommandArgs = {
   chunkData: Uint8Array;

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Backup/Substeps/BackupAppsStorage.test.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Backup/Substeps/BackupAppsStorage.test.ts
@@ -1,5 +1,4 @@
 import {
-  BackupAppStorageTask,
   CommandResultFactory,
   GLOBAL_ERRORS,
   GlobalCommandError,
@@ -8,15 +7,9 @@ import {
 import { makeDeviceActionInternalApiMock } from "@api/device-action/__test-utils__/makeInternalApi";
 import { BackupAppsStorageError } from "@api/device-action/OsUpdate/Backup/CreateBackupDeviceActionErrors";
 import { backupAppsStorage } from "@api/device-action/OsUpdate/Backup/Substeps/BackupAppsStorage";
+import { BackupAppStorageTask } from "@api/task/OsUpdate/Backup/BackupAppStorageTask";
 
-vi.mock("@ledgerhq/device-management-kit", async (importOriginal) => {
-  const original =
-    await importOriginal<typeof import("@ledgerhq/device-management-kit")>();
-  return {
-    ...original,
-    BackupAppStorageTask: vi.fn(),
-  };
-});
+vi.mock("@api/task/OsUpdate/Backup/BackupAppStorageTask");
 
 describe("BackupAppStorage", () => {
   const apiMock = makeDeviceActionInternalApiMock();

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Backup/Substeps/BackupAppsStorage.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Backup/Substeps/BackupAppsStorage.ts
@@ -1,5 +1,4 @@
 import {
-  BackupAppStorageTask,
   type InstalledApp,
   type InternalApi,
   isSuccessCommandResult,
@@ -9,6 +8,7 @@ import { type Either, Left, Right } from "purify-ts";
 
 import { BackupAppsStorageError } from "@api/device-action/OsUpdate/Backup/CreateBackupDeviceActionErrors";
 import { type BackupApp } from "@api/device-action/OsUpdate/Backup/types";
+import { BackupAppStorageTask } from "@api/task/OsUpdate/Backup/BackupAppStorageTask";
 
 const EMPTY_STORAGE = "0x";
 

--- a/packages/ledger-wallet/src/api/task/OsUpdate/Backup/BackupAppStorageTask.test.ts
+++ b/packages/ledger-wallet/src/api/task/OsUpdate/Backup/BackupAppStorageTask.test.ts
@@ -1,16 +1,18 @@
-import { BackupAppStorageCommandError } from "@api/command/os/BackupAppStorageCommand";
-import { GetAppStorageInfoCommandError } from "@api/command/os/GetAppStorageInfoCommand";
-import { type InternalApi } from "@api/device-action/DeviceAction";
-import {
-  BackupAppStorageTask,
-  type BackupAppStorageTaskResponse,
-} from "@api/device-action/task/BackupAppStorageTask";
 import {
   CommandResultFactory,
   DmkResultFactory,
+  type InternalApi,
   isSuccessDmkResult,
-} from "@api/index";
-import { type LoggerPublisherService } from "@api/logger-publisher/service/LoggerPublisherService";
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+
+import { BackupAppStorageCommandError } from "@api/command/OsUpdate/Backup/BackupAppStorageCommand";
+import { GetAppStorageInfoCommandError } from "@api/command/OsUpdate/Backup/GetAppStorageInfoCommand";
+
+import {
+  BackupAppStorageTask,
+  type BackupAppStorageTaskResponse,
+} from "./BackupAppStorageTask";
 
 describe("BackupAppStorageTask", () => {
   let api: InternalApi;

--- a/packages/ledger-wallet/src/api/task/OsUpdate/Backup/BackupAppStorageTask.ts
+++ b/packages/ledger-wallet/src/api/task/OsUpdate/Backup/BackupAppStorageTask.ts
@@ -1,19 +1,22 @@
 import {
+  bufferToHexaString,
   type CommandErrorResult,
+  type DmkResult,
+  DmkResultFactory,
+  type HexaString,
+  type InternalApi,
   isSuccessCommandResult,
-} from "@api/command/model/CommandResult";
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+
 import {
   BackupAppStorageCommand,
   type BackupAppStorageCommandErrorCodes,
-} from "@api/command/os/BackupAppStorageCommand";
+} from "@api/command/OsUpdate/Backup/BackupAppStorageCommand";
 import {
   GetAppStorageInfoCommand,
   type GetAppStorageInfoCommandErrorCodes,
-} from "@api/command/os/GetAppStorageInfoCommand";
-import { type InternalApi } from "@api/device-action/DeviceAction";
-import { type LoggerPublisherService } from "@api/logger-publisher/service/LoggerPublisherService";
-import { type DmkResult, DmkResultFactory } from "@api/model/DmkResult";
-import { bufferToHexaString, type HexaString } from "@api/utils/HexaString";
+} from "@api/command/OsUpdate/Backup/GetAppStorageInfoCommand";
 
 export type BackupAppStorageTaskArgs = {
   appName: string;

--- a/packages/ledger-wallet/src/api/task/OsUpdate/Restore/RestoreAppStorageTask.test.ts
+++ b/packages/ledger-wallet/src/api/task/OsUpdate/Restore/RestoreAppStorageTask.test.ts
@@ -1,13 +1,15 @@
-import { APDU_MAX_PAYLOAD } from "@api/apdu/utils/ApduBuilder";
-import { RestoreAppStorageCommandError } from "@api/command/os/RestoreAppStorageCommand";
-import { type InternalApi } from "@api/device-action/DeviceAction";
-import { RestoreAppStorageTask } from "@api/device-action/task/RestoreAppStorageTask";
+import { APDU_MAX_PAYLOAD } from "@ledgerhq/device-management-kit";
 import {
   CommandResultFactory,
   DmkResultFactory,
+  type InternalApi,
   isSuccessDmkResult,
-} from "@api/index";
-import { type LoggerPublisherService } from "@api/logger-publisher/service/LoggerPublisherService";
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+
+import { RestoreAppStorageCommandError } from "@api/command/OsUpdate/Restore/RestoreAppStorageCommand";
+
+import { RestoreAppStorageTask } from "./RestoreAppStorageTask";
 
 describe("RestoreAppStorageTask", () => {
   let api: InternalApi;

--- a/packages/ledger-wallet/src/api/task/OsUpdate/Restore/RestoreAppStorageTask.ts
+++ b/packages/ledger-wallet/src/api/task/OsUpdate/Restore/RestoreAppStorageTask.ts
@@ -1,15 +1,17 @@
-import { APDU_MAX_PAYLOAD } from "@api/apdu/utils/ApduBuilder";
 import {
+  APDU_MAX_PAYLOAD,
   type CommandErrorResult,
+  type DmkResult,
+  DmkResultFactory,
+  type InternalApi,
   isSuccessCommandResult,
-} from "@api/command/model/CommandResult";
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+
 import {
   RestoreAppStorageCommand,
   type RestoreAppStorageCommandErrorCodes,
-} from "@api/command/os/RestoreAppStorageCommand";
-import { type InternalApi } from "@api/device-action/DeviceAction";
-import { type LoggerPublisherService } from "@api/logger-publisher/service/LoggerPublisherService";
-import { type DmkResult, DmkResultFactory } from "@api/model/DmkResult";
+} from "@api/command/OsUpdate/Restore/RestoreAppStorageCommand";
 
 export type RestoreAppStorageTaskArgs = {
   appStorageData: Uint8Array;

--- a/packages/ledger-wallet/src/index.ts
+++ b/packages/ledger-wallet/src/index.ts
@@ -52,6 +52,45 @@ export {
 } from "./api/device-action/customLockScreenDeviceActionErrors";
 
 // Device Actions
+export {
+  BackupAppStorageCommand,
+  type BackupAppStorageCommandErrorCodes,
+  type BackupAppStorageCommandResponse,
+  type BackupAppStorageCommandResult,
+} from "./api/command/OsUpdate/Backup/BackupAppStorageCommand";
+export {
+  GetAppStorageInfoCommand,
+  type GetAppStorageInfoCommandArgs,
+  type GetAppStorageInfoCommandErrorCodes,
+  type GetAppStorageInfoCommandResponse,
+  type GetAppStorageInfoCommandResult,
+} from "./api/command/OsUpdate/Backup/GetAppStorageInfoCommand";
+export {
+  CommitRestoreAppStorageCommand,
+  CommitRestoreAppStorageCommandError,
+  type CommitRestoreAppStorageCommandErrorCodes,
+  type CommitRestoreAppStorageCommandResult,
+} from "./api/command/OsUpdate/Restore/CommitRestoreAppStorageCommand";
+export {
+  InitRestoreAppStorageCommand,
+  type InitRestoreAppStorageCommandArgs,
+  InitRestoreAppStorageCommandError,
+  type InitRestoreAppStorageCommandErrorCodes,
+  type InitRestoreAppStorageCommandResult,
+} from "./api/command/OsUpdate/Restore/InitRestoreAppStorageCommand";
+export {
+  RequestMasterConsentCommand,
+  type RequestMasterConsentCommandArgs,
+  type RequestMasterConsentCommandErrorCodes,
+  type RequestMasterConsentCommandResult,
+} from "./api/command/OsUpdate/Restore/RequestMasterConsentCommand";
+export {
+  RestoreAppStorageCommand,
+  type RestoreAppStorageCommandArgs,
+  RestoreAppStorageCommandError,
+  type RestoreAppStorageCommandErrorCodes,
+  type RestoreAppStorageCommandResult,
+} from "./api/command/OsUpdate/Restore/RestoreAppStorageCommand";
 export { DownloadCustomLockScreenDeviceAction } from "./api/device-action/DownloadCustomLockScreen/DownloadCustomLockScreenDeviceAction";
 export type {
   DownloadCustomLockScreenDAError,
@@ -98,3 +137,9 @@ export type {
   UploadCustomLockScreenDAState,
 } from "./api/device-action/UploadCustomLockScreen/types";
 export { UploadCustomLockScreenDeviceAction } from "./api/device-action/UploadCustomLockScreen/UploadCustomLockScreenDeviceAction";
+export { BackupAppStorageTask } from "./api/task/OsUpdate/Backup/BackupAppStorageTask";
+export {
+  RestoreAppStorageTask,
+  type RestoreAppStorageTaskArgs,
+  type RestoreAppStorageTaskError,
+} from "./api/task/OsUpdate/Restore/RestoreAppStorageTask";


### PR DESCRIPTION
### 📝 Description

This PR moves the OS update backup/restore commands and tasks from `@ledgerhq/device-management-kit` to `@ledgerhq/dmk-ledger-wallet`, since this logic is specific to the Ledger Wallet OS update flow and is not used anywhere outside of it.

Moved:
- Commands: `BackupAppStorageCommand`, `GetAppStorageInfoCommand`, `CommitRestoreAppStorageCommand`, `InitRestoreAppStorageCommand`, `RestoreAppStorageCommand`, `RequestMasterConsentCommand`
- Tasks: `BackupAppStorageTask`, `RestoreAppStorageTask`

These are now exported from `@ledgerhq/dmk-ledger-wallet` instead of `@ledgerhq/device-management-kit`, and internal imports (e.g. the `BackupAppsStorage` substep, sample app's `CommandsView`) have been updated accordingly. No behavioral changes were made to the commands/tasks themselves.

### ❓ Context

- **JIRA or GitHub link**: NO-ISSUE

### ✅ Checklist

- [x] **Covered by automatic tests** <!-- existing unit tests were moved and updated alongside the source files -->
- [x] **Changeset is provided** <!-- patch for @ledgerhq/device-management-kit (removal, unused/unreleased), minor for @ledgerhq/dmk-ledger-wallet (new exports) -->
- [ ] ~~**Documentation is up-to-date**~~
- [x] **Impact of the changes:**
  - `@ledgerhq/device-management-kit` no longer exports `BackupAppStorageCommand`, `GetAppStorageInfoCommand`, `CommitRestoreAppStorageCommand`, `InitRestoreAppStorageCommand`, `RestoreAppStorageCommand`, `BackupAppStorageTask`, `RestoreAppStorageTask`, `RequestMasterConsentCommand`.
  - `@ledgerhq/dmk-ledger-wallet` now exports these instead.
  - Sample app's `CommandsView` and `BackupAppsStorage` substep updated to import from the new location.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.