### PR TITLE
✨ (signer-trx) [DSDK-1304]: Implement Get App Configuration device ac…

### DIFF
--- a/.changeset/tron-get-app-configuration.md
+++ b/.changeset/tron-get-app-configuration.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-tron": minor
+---
+
+Complete the Tron Get App Configuration device action: read the app version and its `allowData`, `allowContract`, `truncateAddress` and `signByHash` flags from the device, plus a sample-app playground panel and unit/e2e coverage

--- a/apps/sample/playwright/cases/signers/tron/get-app-configuration.spec.ts
+++ b/apps/sample/playwright/cases/signers/tron/get-app-configuration.spec.ts
@@ -1,0 +1,58 @@
+/* eslint-disable no-restricted-imports */
+import { type DeviceConfig } from "@ledgerhq/device-mockserver-client";
+
+import { expect, test } from "../../../fixtures";
+
+const STAX_WITH_TRX: DeviceConfig = {
+  name: "Ledger Stax",
+  device_type: "stax",
+  connectivity_type: "USB",
+  firmware_version: "1.9.1",
+  apps: [
+    { name: "BOLOS", version: "1.9.1" },
+    { name: "Tron", version: "0.7.4" },
+  ],
+  masks: [0x33200000],
+};
+
+interface AppConfigurationOutput {
+  version: string;
+  versionN: number;
+  allowData: boolean;
+  allowContract: boolean;
+  truncateAddress: boolean;
+  signByHash: boolean;
+}
+
+// A semantic version string, e.g. "0.5.0". The exact value depends on the
+// emulated Tron app, so we assert on the shape rather than a fixed version.
+const VERSION_RE = /^\d+\.\d+\.\d+$/;
+
+test.describe("signer tron: get app configuration", () => {
+  test("returns the Tron app configuration", async ({ device, trxSigner }) => {
+    // Opening the Tron app provisions a real Speculos instance, which can take
+    // a while to become ready.
+    test.setTimeout(120_000);
+
+    await test.step("Given the device with the Tron app is connected", async () => {
+      await device.addAndConnect(STAX_WITH_TRX);
+    });
+
+    await test.step("When Get app configuration is executed", async () => {
+      await trxSigner.open();
+      await trxSigner.getAppConfiguration();
+    });
+
+    await test.step("Then the app configuration is returned", async () => {
+      const result = await trxSigner.lastResult<AppConfigurationOutput>();
+
+      expect(result.status).toBe("completed");
+      expect(result.output!.version).toMatch(VERSION_RE);
+      expect(typeof result.output!.versionN).toBe("number");
+      expect(typeof result.output!.allowData).toBe("boolean");
+      expect(typeof result.output!.allowContract).toBe("boolean");
+      expect(typeof result.output!.truncateAddress).toBe("boolean");
+      expect(typeof result.output!.signByHash).toBe("boolean");
+    });
+  });
+});

--- a/apps/sample/playwright/utils/drivers/TrxSignerDriver.ts
+++ b/apps/sample/playwright/utils/drivers/TrxSignerDriver.ts
@@ -43,6 +43,12 @@ export class TrxSignerDriver {
     await this.page.getByTestId("CTA_send-device-action").click();
   }
 
+  /** Open the Get app configuration action and Execute it (no inputs). */
+  async getAppConfiguration(): Promise<void> {
+    await this.page.getByTestId("CTA_command-Get app configuration").click();
+    await this.page.getByTestId("CTA_send-device-action").click();
+  }
+
   /**
    * Wait for the last emitted device-action state to be terminal and return it
    * parsed.

--- a/apps/sample/src/components/SignerTrxView/index.tsx
+++ b/apps/sample/src/components/SignerTrxView/index.tsx
@@ -4,6 +4,9 @@ import {
   type GetAddressDAError,
   type GetAddressDAIntermediateValue,
   type GetAddressDAOutput,
+  type GetAppConfigurationDAError,
+  type GetAppConfigurationDAIntermediateValue,
+  type GetAppConfigurationDAOutput,
   SignerTrxBuilder,
 } from "@ledgerhq/device-signer-kit-tron";
 
@@ -55,6 +58,21 @@ export const SignerTrxView: React.FC<{ sessionId: string }> = ({
         },
         GetAddressDAError,
         GetAddressDAIntermediateValue
+      >,
+      {
+        title: "Get app configuration",
+        description:
+          "Perform all the actions necessary to get the Tron app configuration from the device",
+        executeDeviceAction: () => {
+          return signer.getAppConfiguration();
+        },
+        initialValues: {},
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        GetAppConfigurationDAOutput,
+        Record<string, never>,
+        GetAppConfigurationDAError,
+        GetAppConfigurationDAIntermediateValue
       >,
     ],
     [deviceModelId, signer],

--- a/packages/signer/signer-trx/README.md
+++ b/packages/signer/signer-trx/README.md
@@ -80,6 +80,43 @@ observable.subscribe((state) => {
 });
 ```
 
+### Get app configuration
+
+Reads the Tron app configuration from the device (version and the flags the app
+was built with). No user interaction is required.
+
+```typescript
+signer.getAppConfiguration(): GetAppConfigurationDAReturnType;
+```
+
+The returned device action resolves to:
+
+```typescript
+{
+  version: string; // semantic version, e.g. "0.5.0"
+  versionN: number; // numeric version (major * 10000 + minor * 100 + patch)
+  allowData: boolean; // "sign data" setting enabled on the device
+  allowContract: boolean; // "sign custom contracts" setting enabled
+  truncateAddress: boolean; // addresses are truncated on the device screen
+  signByHash: boolean; // "sign by hash" setting enabled
+}
+```
+
+```typescript
+const { observable, cancel } = signer.getAppConfiguration();
+
+observable.subscribe((state) => {
+  switch (state.status) {
+    case "completed":
+      console.log(state.output.version, state.output.allowContract);
+      break;
+    case "error":
+      console.error(state.error);
+      break;
+  }
+});
+```
+
 ## Development
 
 ```bash

--- a/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.test.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.test.ts
@@ -14,7 +14,13 @@ import {
   type GetAddressDAIntermediateValue,
   type GetAddressDAOutput,
 } from "@api/app-binder/GetAddressDeviceActionTypes";
+import {
+  type GetAppConfigurationDAError,
+  type GetAppConfigurationDAIntermediateValue,
+  type GetAppConfigurationDAOutput,
+} from "@api/app-binder/GetAppConfigurationDeviceActionTypes";
 import { GetAddressCommand } from "@internal/app-binder/command/GetAddressCommand";
+import { GetAppConfigurationCommand } from "@internal/app-binder/command/GetAppConfigurationCommand";
 import { APP_NAME } from "@internal/app-binder/constants";
 
 import { TronAppBinder } from "./TronAppBinder";
@@ -168,6 +174,90 @@ describe("TronAppBinder", () => {
           }),
         );
       });
+    });
+  });
+
+  describe("getAppConfiguration", () => {
+    it("should return the app configuration", () =>
+      new Promise<void>((resolve, reject) => {
+        // GIVEN
+        const output: GetAppConfigurationDAOutput = {
+          version: "0.5.0",
+          versionN: 500,
+          allowData: true,
+          allowContract: true,
+          truncateAddress: true,
+          signByHash: true,
+        };
+
+        vi.spyOn(mockedDmk, "executeDeviceAction").mockReturnValue({
+          observable: from([
+            {
+              status: DeviceActionStatus.Completed,
+              output,
+            } as DeviceActionState<
+              GetAppConfigurationDAOutput,
+              GetAppConfigurationDAError,
+              GetAppConfigurationDAIntermediateValue
+            >,
+          ]),
+          cancel: vi.fn(),
+        });
+
+        // WHEN
+        const binder = new TronAppBinder(
+          mockedDmk,
+          "sessionId",
+          loggerFactoryMock,
+        );
+        const { observable } = binder.getAppConfiguration();
+
+        // THEN
+        const states: DeviceActionState<
+          GetAppConfigurationDAOutput,
+          GetAppConfigurationDAError,
+          GetAppConfigurationDAIntermediateValue
+        >[] = [];
+        observable.subscribe({
+          next: (state) => states.push(state),
+          error: reject,
+          complete: () => {
+            try {
+              expect(states).toEqual([
+                { status: DeviceActionStatus.Completed, output },
+              ]);
+              resolve();
+            } catch (err) {
+              reject(err as Error);
+            }
+          },
+        });
+      }));
+
+    it("should call executeDeviceAction with the correct params", () => {
+      // WHEN
+      const binder = new TronAppBinder(
+        mockedDmk,
+        "sessionId",
+        loggerFactoryMock,
+      );
+      binder.getAppConfiguration();
+
+      // THEN
+      expect(mockedDmk.executeDeviceAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: "sessionId",
+          deviceAction: new SendCommandInAppDeviceAction({
+            input: {
+              command: new GetAppConfigurationCommand(),
+              appName: APP_NAME,
+              requiredUserInteraction: UserInteractionRequired.None,
+              skipOpenApp: false,
+            },
+            logger: loggerMock,
+          }),
+        }),
+      );
     });
   });
 });

--- a/packages/signer/signer-trx/src/internal/use-cases/app-configuration/GetAppConfigurationUseCase.test.ts
+++ b/packages/signer/signer-trx/src/internal/use-cases/app-configuration/GetAppConfigurationUseCase.test.ts
@@ -1,0 +1,26 @@
+import { type TronAppBinder } from "@internal/app-binder/TronAppBinder";
+
+import { GetAppConfigurationUseCase } from "./GetAppConfigurationUseCase";
+
+describe("GetAppConfigurationUseCase", () => {
+  const returnedValue = { observable: {}, cancel: vi.fn() };
+  const getAppConfigurationMock = vi.fn().mockReturnValue(returnedValue);
+  const appBinderMock = {
+    getAppConfiguration: getAppConfigurationMock,
+  } as unknown as TronAppBinder;
+  let useCase: GetAppConfigurationUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new GetAppConfigurationUseCase(appBinderMock);
+  });
+
+  it("should call getAppConfiguration on the app binder", () => {
+    // WHEN
+    const result = useCase.execute();
+
+    // THEN
+    expect(result).toEqual(returnedValue);
+    expect(getAppConfigurationMock).toHaveBeenCalledWith();
+  });
+});


### PR DESCRIPTION
### 📝 Description

This PR completes the **Get App Configuration** device action for the Tron signer kit (`@ledgerhq/device-signer-kit-tron`).

`signer.getAppConfiguration()` reads the Tron app's configuration from the device - its version and the flags the app was built with. It's a read-only action that requires no user interaction on the device.

```typescript
const { observable, cancel } = signer.getAppConfiguration();

observable.subscribe((state) => {
  switch (state.status) {
    case "completed":
      // state.output => { version, versionN, allowData, allowContract, truncateAddress, signByHash }
      console.log(state.output.version, state.output.allowContract);
      break;
    case "error":
      console.error(state.error);
      break;
  }
});
```

The device action resolves to:

{
  version: string;        // semantic version, e.g. "0.5.0"
  versionN: number;       // numeric version (major * 10000 + minor * 100 + patch)
  allowData: boolean;     // "sign data" setting enabled on the device
  allowContract: boolean; // "sign custom contracts" setting enabled
  truncateAddress: boolean; // addresses are truncated on the device screen
  signByHash: boolean;    // "sign by hash" setting enabled
}

The command parses the configuration flags out of the first APDU response byte and applies the same backwards-compatibility overrides as @ledgerhq/hw-app-trx for older app versions (0.0.x / 0.1.x).

Alongside the device action, this PR adds:
- A Get app configuration panel in the sample app (Tron signer view) to exercise the flow manually.
- Playwright e2e coverage against a Speculos-backed Stax running the Tron app.
- Unit tests for GetAppConfigurationUseCase and a getAppConfiguration block in TronAppBinder.
- README documentation for getAppConfiguration.

▎ Stacked PR - this targets feat/dsdk-1264-trx-get-address-device-action (Get Address, #1602), which in turn targets feat/dsdk-1263-… (#1601). Please review/merge bottom-up. The diff shown here is the Get App Configuration work only.

❓ Context

- JIRA or GitHub link: [DSDK-1304]
- Feature: Get App Configuration device action for the Tron signer kit - read the app version and its allowData, allowContract, truncateAddress and signByHash flags from the device.

✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] Covered by automatic tests 
- [x] Changeset is provided 
- [x] Documentation is up-to-date 
- [ ] Impact of the changes: QA should focus on:
  - getAppConfiguration on the Tron signer across supported devices (Nano S+/X, Stax, Flex).
  - Verifying the returned version and flags match the app installed on the device.
  - The new Get app configuration panel in the sample app's Tron signer view.

---
🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] The code aligns with the requirements described in the linked JIRA or GitHub issue.
- [ ] The PR description clearly documents the changes made and explains any technical trade-offs or design decisions.
- [ ] There are no undocumented trade-offs, technical debt, or maintainability issues.
- [ ] The PR has been tested thoroughly, and any potential edge cases have been considered and handled.
- [ ] Any new dependencies have been justified and documented.

[DSDK-1304]: https://ledgerhq.atlassian.net/browse/DSDK-1304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ