### PR TITLE
✨ (mock-server) [DSDK-1324]: Add OS update flow support to mock server

### DIFF
--- a/apps/device-mock-server/src/internal/apdu/service/ApduResolverService.test.ts
+++ b/apps/device-mock-server/src/internal/apdu/service/ApduResolverService.test.ts
@@ -1,8 +1,10 @@
-import { EitherAsync, Left, Right } from "purify-ts";
+import { EitherAsync, Left, Maybe, Right } from "purify-ts";
 import { vi } from "vitest";
 
 import { ApduResolverService } from "@internal/apdu/service/ApduResolverService";
 import { OsApduService } from "@internal/os/service/OsApduService";
+import { type FirmwareUpdateResolver } from "@internal/secure-channel/service/FirmwareUpdateResolver";
+import { INSTALL_COMMIT_APDU } from "@internal/secure-channel/service/secureChannelApdus";
 import { SecureChannelApduService } from "@internal/secure-channel/service/SecureChannelApduService";
 import { InMemorySessionRepository } from "@internal/session/data/InMemorySessionRepository";
 import { type SpeculosOperatorDataSource } from "@internal/speculos/data/SpeculosOperatorDataSource";
@@ -29,6 +31,11 @@ const makeOperator = (
   ...overrides,
 });
 
+const stubFirmwareResolver: FirmwareUpdateResolver = {
+  resolveNextVersion: vi.fn().mockResolvedValue(Maybe.empty()),
+  resolveCurrentMcuVersion: vi.fn().mockResolvedValue(Maybe.of("2.30")),
+} as unknown as FirmwareUpdateResolver;
+
 const setup = () => {
   const repo = new InMemorySessionRepository({});
   const { token } = repo.createSession();
@@ -38,7 +45,7 @@ const setup = () => {
     firmware_version: "1.3.0",
     apps: [{ name: "Bitcoin", version: "2.1.0" }],
   });
-  const os = new OsApduService();
+  const os = new OsApduService(stubFirmwareResolver);
   const secureChannel = new SecureChannelApduService();
   return { repo, record, device, os, secureChannel };
 };
@@ -173,5 +180,23 @@ describe("ApduResolverService", () => {
     const { repo, record, device, os, secureChannel } = setup();
     const resolver = new ApduResolverService(repo, os, secureChannel);
     expect(await resolver.resolve(record, device, OPEN_BITCOIN)).toBe("6d00");
+  });
+
+  it("commits a pending firmware operation when the final install block succeeds", async () => {
+    const { repo, record, device, os, secureChannel } = setup();
+    const resolver = new ApduResolverService(repo, os, secureChannel);
+    repo.setPendingFirmwareOperation(record, device.id, "1.9.1-osu");
+
+    // The final install block derives to success and triggers the commit.
+    expect(await resolver.resolve(record, device, INSTALL_COMMIT_APDU)).toBe(
+      "9000",
+    );
+    expect(
+      repo.findDevice(record, device.id).unsafeCoerce().firmware_version,
+    ).toBe("1.9.1-osu");
+    // The pending operation was cleared.
+    expect(
+      repo.commitPendingFirmwareOperation(record, device.id).isNothing(),
+    ).toBe(true);
   });
 });

--- a/apps/device-mock-server/src/internal/apdu/service/ApduResolverService.ts
+++ b/apps/device-mock-server/src/internal/apdu/service/ApduResolverService.ts
@@ -78,6 +78,16 @@ export class ApduResolverService {
               .join(", ")}`,
           ),
         );
+      // A firmware install advances the device version the same way: only once
+      // the final install block is acknowledged (OSU -> `<next>-osu`, final ->
+      // clean `<next>`). Only one of the two operations is ever armed.
+      this.repository
+        .commitPendingFirmwareOperation(record, device.id)
+        .ifJust((updated) =>
+          logger.info(
+            `Firmware operation committed on ${updated.id}; firmware_version: ${updated.firmware_version}`,
+          ),
+        );
     }
     return response;
   }
@@ -127,7 +137,7 @@ export class ApduResolverService {
     }
 
     // 3. Derived OS responses synthesized from the device metadata.
-    const osResponse = this.os.resolve(device, apdu);
+    const osResponse = await this.os.resolve(device, apdu);
     if (osResponse) {
       logger.info(`APDU [${device.id}] ${apdu} -> ${osResponse} (os)`);
       return osResponse;

--- a/apps/device-mock-server/src/internal/os/service/OsApduService.ts
+++ b/apps/device-mock-server/src/internal/os/service/OsApduService.ts
@@ -1,7 +1,13 @@
 import { type Device } from "@ledgerhq/device-mockserver-client";
-import { injectable } from "inversify";
+import { inject, injectable, optional } from "inversify";
 
-import { deriveOsApduResponse } from "@internal/os/service/osApdus";
+import {
+  deriveOsApduResponse,
+  GET_OS_VERSION_PREFIX,
+  resolveTargetId,
+} from "@internal/os/service/osApdus";
+import { secureChannelTypes } from "@internal/secure-channel/di/secureChannelTypes";
+import { type FirmwareUpdateResolver } from "@internal/secure-channel/service/FirmwareUpdateResolver";
 
 /**
  * Synthesizes the OS-handshake APDU responses (GetOsVersion / GetAppAndVersion /
@@ -10,8 +16,37 @@ import { deriveOsApduResponse } from "@internal/os/service/osApdus";
  */
 @injectable()
 export class OsApduService {
+  constructor(
+    @optional()
+    @inject(secureChannelTypes.FirmwareUpdateResolver)
+    private readonly firmwareResolver?: FirmwareUpdateResolver,
+  ) {}
+
   /** Derived OS-handshake response for an APDU, or `undefined`. */
-  resolve(device: Device, apdu: string): string | undefined {
+  async resolve(device: Device, apdu: string): Promise<string | undefined> {
+    if (apdu.startsWith(GET_OS_VERSION_PREFIX)) {
+      const mcuVersion = await this.resolveMcuVersion(device);
+      return deriveOsApduResponse(device, apdu, mcuVersion);
+    }
     return deriveOsApduResponse(device, apdu);
+  }
+
+  /**
+   * Resolve the device's current MCU version from the Manager API so GetOsVersion
+   * advertises an MCU that keeps `shouldFlashMCU` false. Returns `undefined` when
+   * no resolver is wired or the lookup yields nothing, so GetOsVersion is not
+   * synthesized and the APDU falls through.
+   */
+  private async resolveMcuVersion(device: Device): Promise<string | undefined> {
+    const targetId = resolveTargetId(device);
+    const currentVersion = device.firmware_version;
+    if (!this.firmwareResolver || targetId === undefined || !currentVersion) {
+      return undefined;
+    }
+    const resolved = await this.firmwareResolver.resolveCurrentMcuVersion({
+      targetId,
+      currentVersion,
+    });
+    return resolved.extract();
   }
 }

--- a/apps/device-mock-server/src/internal/os/service/osApdus.test.ts
+++ b/apps/device-mock-server/src/internal/os/service/osApdus.test.ts
@@ -21,9 +21,10 @@ const device = (overrides: Partial<Device>): Device => ({
 
 describe("deriveGetOsVersion", () => {
   it("reproduces the Nano X 2.2.3 reference response", () => {
-    // This is exactly the previously-hardcoded default mock.
-    expect(deriveGetOsVersion(device({ device_type: "nanoX" }))).toBe(
-      "3300000405322e322e3304e600000004322e333004312e31360100010001009000",
+    // The current MCU (2.40.2 -> `06322e34302e32`) is resolved by the caller and
+    // passed in; reporting it keeps the firmware update flow off an MCU flash.
+    expect(deriveGetOsVersion(device({ device_type: "nanoX" }), "2.40.2")).toBe(
+      "3300000405322e322e3304e600000006322e34302e3204312e31360100010001009000",
     );
   });
 
@@ -31,28 +32,36 @@ describe("deriveGetOsVersion", () => {
     expect(
       deriveGetOsVersion(
         device({ device_type: "stax", firmware_version: "1.3.0" }),
+        "5.32.3",
       ),
     ).toMatch(/^33200004/);
     expect(
       deriveGetOsVersion(
         device({ device_type: "nanoSP", firmware_version: "1.1.1" }),
+        "4.7.0",
       ),
     ).toMatch(/^33100004/);
   });
 
   it("omits hardware/recover fields per the model+version support matrix", () => {
     // Stax 1.3.0: recover requires >= 1.4.0, hw is Nano X only -> neither field.
-    // targetId + LV(1.3.0) + LV(seFlags) + LV(mcuSeph) + LV(mcuBoot) + LV(langId) + 9000
+    // targetId + LV(1.3.0) + LV(seFlags) + LV(mcuSeph=5.32.3) + LV(mcuBoot) + LV(langId) + 9000
     expect(
       deriveGetOsVersion(
         device({ device_type: "stax", firmware_version: "1.3.0" }),
+        "5.32.3",
       ),
-    ).toBe("3320000405312e332e3004e600000004322e333004312e31360100" + "9000");
+    ).toBe(
+      "3320000405312e332e3004e600000006352e33322e3304312e31360100" + "9000",
+    );
   });
 
   it("returns undefined for an unsupported model", () => {
     expect(
-      deriveGetOsVersion(device({ device_type: "blue", masks: undefined })),
+      deriveGetOsVersion(
+        device({ device_type: "blue", masks: undefined }),
+        "2.30",
+      ),
     ).toBeUndefined();
   });
 
@@ -60,6 +69,7 @@ describe("deriveGetOsVersion", () => {
     expect(
       deriveGetOsVersion(
         device({ device_type: "unknown", masks: [0x33000000] }),
+        "2.30",
       ),
     ).toMatch(/^33000004/);
   });
@@ -118,15 +128,23 @@ describe("deriveGetDeviceName", () => {
 describe("deriveOsApduResponse", () => {
   it("dispatches GetOsVersion (0xE0 0x01)", () => {
     expect(
-      deriveOsApduResponse(device({ device_type: "nanoX" }), "e0010000"),
+      deriveOsApduResponse(
+        device({ device_type: "nanoX" }),
+        "e0010000",
+        "2.40.2",
+      ),
     ).toBe(
-      "3300000405322e322e3304e600000004322e333004312e31360100010001009000",
+      "3300000405322e322e3304e600000006322e34302e3204312e31360100010001009000",
     );
   });
 
   it("dispatches GetAppAndVersion (0xB0 0x01)", () => {
     expect(
-      deriveOsApduResponse(device({ firmware_version: "2.2.3" }), "b0010000"),
+      deriveOsApduResponse(
+        device({ firmware_version: "2.2.3" }),
+        "b0010000",
+        "2.30",
+      ),
     ).toBe("0105424f4c4f5305322e322e339000");
   });
 
@@ -135,22 +153,25 @@ describe("deriveOsApduResponse", () => {
       deriveOsApduResponse(
         device({ device_type: "stax", firmware_version: "1.9.1" }),
         "e010000000",
+        "2.30",
       ),
     ).toBe("649000");
   });
 
   it("dispatches the GetDeviceName cleaning APDU (0xE0 0x50) as a bare success", () => {
-    expect(deriveOsApduResponse(device({}), "e0500000")).toBe("9000");
+    expect(deriveOsApduResponse(device({}), "e0500000", "2.30")).toBe("9000");
   });
 
   it("dispatches GetDeviceName (0xE0 0xD2)", () => {
-    expect(deriveOsApduResponse(device({ name: "Ledger" }), "e0d20000")).toBe(
-      "4c6564676572" + "9000",
-    );
+    expect(
+      deriveOsApduResponse(device({ name: "Ledger" }), "e0d20000", "2.30"),
+    ).toBe("4c6564676572" + "9000");
   });
 
   it("returns undefined for a non-OS APDU", () => {
-    expect(deriveOsApduResponse(device({}), "e0f1000000")).toBeUndefined();
+    expect(
+      deriveOsApduResponse(device({}), "e0f1000000", "2.30"),
+    ).toBeUndefined();
   });
 
   it("dispatches ListApps (0xE0 0xDE)", () => {
@@ -158,12 +179,15 @@ describe("deriveOsApduResponse", () => {
       deriveOsApduResponse(
         device({ apps: [{ name: "BOLOS", version: "1.5.0" }] }),
         "e0de000000",
+        "2.30",
       ),
     ).toBe("9000");
   });
 
   it("dispatches GetBackgroundImageSize (0xE0 0x64) as an empty device", () => {
-    expect(deriveOsApduResponse(device({}), "e064000000")).toBe("000000009000");
+    expect(deriveOsApduResponse(device({}), "e064000000", "2.30")).toBe(
+      "000000009000",
+    );
   });
 });
 

--- a/apps/device-mock-server/src/internal/os/service/osApdus.ts
+++ b/apps/device-mock-server/src/internal/os/service/osApdus.ts
@@ -157,20 +157,38 @@ const isRecoverSupported = (seVersion: string, model: string): boolean => {
 // --- derived responses ------------------------------------------------------
 
 /**
- * GetOsVersion response derived from the device model and firmware version,
- * matching the byte layout `GetOsVersionCommand` expects in non-bootloader
- * mode. Returns `undefined` for an unsupported model.
+ * Full target id (`<mask upper 16 bits>0004`) a device reports in GetOsVersion
+ * and that the Manager API keys firmware lookups on, or `undefined` for a model
+ * with no known mask and no explicit `masks` override.
  */
-export function deriveGetOsVersion(device: Device): string | undefined {
+export function resolveTargetId(device: Device): number | undefined {
   const model = normalizeModel(device.device_type);
   const mask = device.masks?.[0] ?? TARGET_ID_MASK[model];
   if (mask === undefined) return undefined;
+  return (mask & 0xffff0000) | 0x0004;
+}
+
+/**
+ * GetOsVersion response derived from the device model and firmware version,
+ * matching the byte layout `GetOsVersionCommand` expects in non-bootloader
+ * mode. `mcuVersion` is the current MCU (`mcuSephVersion`) to advertise,
+ * resolved dynamically by the caller. Returns `undefined` for an unsupported
+ * model.
+ */
+export function deriveGetOsVersion(
+  device: Device,
+  mcuVersion: string,
+): string | undefined {
+  const model = normalizeModel(device.device_type);
+  const mask = device.masks?.[0] ?? TARGET_ID_MASK[model];
+  if (mask === undefined) return undefined;
+  const targetId = (mask & 0xffff0000) | 0x0004;
   const seVersion = device.firmware_version ?? "0.0.0";
 
-  let hex = uint32Hex((mask & 0xffff0000) | 0x0004); // targetId
+  let hex = uint32Hex(targetId); // targetId
   hex += lvAscii(seVersion); // seVersion
   hex += lvHex("e6000000"); // seFlags (onboarded, pin-validated, ...)
-  hex += lvAscii("2.30"); // mcuSephVersion
+  hex += lvAscii(mcuVersion); // mcuSephVersion
   if (isBootloaderVersionSupported(seVersion, model)) {
     hex += lvAscii("1.16"); // mcuBootloaderVersion
   }
@@ -304,14 +322,16 @@ export function deriveCustomLockScreen(apdu: string): string | undefined {
  * Derived default response for an OS-handshake APDU (GetOsVersion /
  * GetAppAndVersion / GetBatteryStatus) synthesized from the device metadata, or
  * `undefined` when the APDU is not one of them (or the model is unsupported).
- * The three prefixes are mutually exclusive, so the first match wins.
+ * `mcuVersion` is only consumed by the GetOsVersion branch. The prefixes are
+ * mutually exclusive, so the first match wins.
  */
 export function deriveOsApduResponse(
   device: Device,
   apdu: string,
+  mcuVersion?: string,
 ): string | undefined {
   if (apdu.startsWith(GET_OS_VERSION_PREFIX)) {
-    return deriveGetOsVersion(device);
+    return mcuVersion ? deriveGetOsVersion(device, mcuVersion) : undefined;
   }
   if (apdu.startsWith(GET_APP_AND_VERSION_PREFIX)) {
     return deriveGetAppAndVersion(device);

--- a/apps/device-mock-server/src/internal/secure-channel/di/secureChannelModuleFactory.ts
+++ b/apps/device-mock-server/src/internal/secure-channel/di/secureChannelModuleFactory.ts
@@ -1,6 +1,7 @@
 import { ContainerModule } from "inversify";
 
 import { secureChannelTypes } from "@internal/secure-channel/di/secureChannelTypes";
+import { FirmwareUpdateResolver } from "@internal/secure-channel/service/FirmwareUpdateResolver";
 import { InstallAppResolver } from "@internal/secure-channel/service/InstallAppResolver";
 import { SecureChannelApduService } from "@internal/secure-channel/service/SecureChannelApduService";
 import { SecureChannelWebSocket } from "@internal/secure-channel/ws/SecureChannelWebSocket";
@@ -15,5 +16,8 @@ export const secureChannelModuleFactory = () =>
       .inSingletonScope();
     bind(secureChannelTypes.InstallAppResolver)
       .to(InstallAppResolver)
+      .inSingletonScope();
+    bind(secureChannelTypes.FirmwareUpdateResolver)
+      .to(FirmwareUpdateResolver)
       .inSingletonScope();
   });

--- a/apps/device-mock-server/src/internal/secure-channel/di/secureChannelTypes.ts
+++ b/apps/device-mock-server/src/internal/secure-channel/di/secureChannelTypes.ts
@@ -2,4 +2,5 @@ export const secureChannelTypes = {
   ApduService: Symbol.for("SecureChannelApduService"),
   WebSocket: Symbol.for("SecureChannelWebSocket"),
   InstallAppResolver: Symbol.for("InstallAppResolver"),
+  FirmwareUpdateResolver: Symbol.for("FirmwareUpdateResolver"),
 };

--- a/apps/device-mock-server/src/internal/secure-channel/service/FirmwareUpdateResolver.test.ts
+++ b/apps/device-mock-server/src/internal/secure-channel/service/FirmwareUpdateResolver.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { FirmwareUpdateResolver } from "./FirmwareUpdateResolver";
+
+const MANAGER_API_URL = "https://manager.test/api";
+
+const resolver = () =>
+  new FirmwareUpdateResolver({ managerApiUrl: MANAGER_API_URL });
+
+const json = (body: unknown): Promise<Response> =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve(body) } as Response);
+
+/** Route each Manager API endpoint to a canned response by path. */
+const mockFetch = (byPath: Record<string, unknown>) =>
+  vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+    const url = String(input);
+    const match = Object.keys(byPath).find((path) => url.includes(path));
+    if (!match) throw new Error(`unexpected fetch ${url}`);
+    return json(byPath[match]);
+  });
+
+describe("FirmwareUpdateResolver", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("resolves the clean next final version via the Manager API", async () => {
+    const fetchSpy = mockFetch({
+      "/get_device_version": { id: 42 },
+      "/get_firmware_version": { id: 100 },
+      "/get_latest_firmware": {
+        result: "ok",
+        se_firmware_osu_version: {
+          name: "1.9.0-to-1.9.1",
+          next_se_firmware_final_version: 101,
+        },
+      },
+      "/firmware_final_versions/101": { id: 101, name: "1.9.1" },
+    });
+
+    const resolved = await resolver().resolveNextVersion({
+      targetId: "857735172",
+      currentVersion: "1.9.0",
+    });
+
+    expect(resolved.extract()).toBe("1.9.1");
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it("returns empty when the Manager API reports no update", async () => {
+    mockFetch({
+      "/get_device_version": { id: 42 },
+      "/get_firmware_version": { id: 100 },
+      "/get_latest_firmware": { result: "null" },
+    });
+
+    const resolved = await resolver().resolveNextVersion({
+      targetId: "857735172",
+      currentVersion: "1.9.0",
+    });
+    expect(resolved.isNothing()).toBe(true);
+  });
+
+  it("returns empty when the target id is unknown", async () => {
+    mockFetch({ "/get_device_version": {} });
+    const resolved = await resolver().resolveNextVersion({
+      targetId: "0",
+      currentVersion: "1.9.0",
+    });
+    expect(resolved.isNothing()).toBe(true);
+  });
+
+  it("returns empty when a Manager API call fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+    const resolved = await resolver().resolveNextVersion({
+      targetId: "857735172",
+      currentVersion: "1.9.0",
+    });
+    expect(resolved.isNothing()).toBe(true);
+  });
+
+  describe("resolveCurrentMcuVersion", () => {
+    it("resolves the MCU name compatible with the next final firmware", async () => {
+      mockFetch({
+        "/get_device_version": { id: 42 },
+        "/get_firmware_version": { id: 100 },
+        "/get_latest_firmware": {
+          result: "ok",
+          se_firmware_osu_version: {
+            name: "1.9.0-to-1.9.1",
+            next_se_firmware_final_version: 101,
+          },
+        },
+        "/firmware_final_versions/101": {
+          id: 101,
+          name: "1.9.1",
+          mcu_versions: [55, 56],
+        },
+        "/mcu_versions": [
+          { id: 99, name: "9.9.9" },
+          { id: 55, name: "5.32.3" },
+        ],
+      });
+
+      const resolved = await resolver().resolveCurrentMcuVersion({
+        targetId: "857735172",
+        currentVersion: "1.9.0",
+      });
+      expect(resolved.extract()).toBe("5.32.3");
+    });
+
+    it("resolves the MCU name from the current firmware when already up to date", async () => {
+      mockFetch({
+        "/get_device_version": { id: 42 },
+        "/get_firmware_version": { id: 100 },
+        "/get_latest_firmware": { result: "null" },
+        "/firmware_final_versions/100": {
+          id: 100,
+          name: "1.9.0",
+          mcu_versions: [55],
+        },
+        "/mcu_versions": [{ id: 55, name: "5.32.3" }],
+      });
+
+      const resolved = await resolver().resolveCurrentMcuVersion({
+        targetId: "857735172",
+        currentVersion: "1.9.0",
+      });
+      expect(resolved.extract()).toBe("5.32.3");
+    });
+
+    it("memoizes the lookup per target id and current version", async () => {
+      const fetchSpy = mockFetch({
+        "/get_device_version": { id: 42 },
+        "/get_firmware_version": { id: 100 },
+        "/get_latest_firmware": {
+          result: "ok",
+          se_firmware_osu_version: {
+            name: "1.9.0-to-1.9.1",
+            next_se_firmware_final_version: 101,
+          },
+        },
+        "/firmware_final_versions/101": {
+          id: 101,
+          name: "1.9.1",
+          mcu_versions: [55],
+        },
+        "/mcu_versions": [{ id: 55, name: "5.32.3" }],
+      });
+
+      const instance = resolver();
+      await instance.resolveCurrentMcuVersion({
+        targetId: "857735172",
+        currentVersion: "1.9.0",
+      });
+      const callsAfterFirst = fetchSpy.mock.calls.length;
+      await instance.resolveCurrentMcuVersion({
+        targetId: "857735172",
+        currentVersion: "1.9.0",
+      });
+      expect(fetchSpy.mock.calls.length).toBe(callsAfterFirst);
+    });
+  });
+});

--- a/apps/device-mock-server/src/internal/secure-channel/service/FirmwareUpdateResolver.test.ts
+++ b/apps/device-mock-server/src/internal/secure-channel/service/FirmwareUpdateResolver.test.ts
@@ -77,6 +77,86 @@ describe("FirmwareUpdateResolver", () => {
     expect(resolved.isNothing()).toBe(true);
   });
 
+  it("does not cache transient failures and retries on the next call", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockImplementation((input) => {
+        const url = String(input);
+        if (url.includes("/get_device_version")) return json({ id: 42 });
+        if (url.includes("/get_firmware_version")) return json({ id: 100 });
+        if (url.includes("/get_latest_firmware")) {
+          return json({
+            result: "ok",
+            se_firmware_osu_version: {
+              name: "1.9.0-to-1.9.1",
+              next_se_firmware_final_version: 101,
+            },
+          });
+        }
+        if (url.includes("/firmware_final_versions/101")) {
+          return json({ id: 101, name: "1.9.1" });
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      });
+
+    const instance = resolver();
+    const first = await instance.resolveNextVersion({
+      targetId: "857735172",
+      currentVersion: "1.9.0",
+    });
+    expect(first.isNothing()).toBe(true);
+
+    const second = await instance.resolveNextVersion({
+      targetId: "857735172",
+      currentVersion: "1.9.0",
+    });
+    expect(second.extract()).toBe("1.9.1");
+    expect(fetchSpy.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("caches 5xx responses as transient and retries", async () => {
+    const serverError = Promise.resolve({
+      ok: false,
+      status: 503,
+    } as Response);
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockReturnValueOnce(serverError)
+      .mockImplementation((input) => {
+        const url = String(input);
+        if (url.includes("/get_device_version")) return json({ id: 42 });
+        if (url.includes("/get_firmware_version")) return json({ id: 100 });
+        if (url.includes("/get_latest_firmware")) {
+          return json({
+            result: "ok",
+            se_firmware_osu_version: {
+              name: "1.9.0-to-1.9.1",
+              next_se_firmware_final_version: 101,
+            },
+          });
+        }
+        if (url.includes("/firmware_final_versions/101")) {
+          return json({ id: 101, name: "1.9.1" });
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      });
+
+    const instance = resolver();
+    const first = await instance.resolveNextVersion({
+      targetId: "857735172",
+      currentVersion: "1.9.0",
+    });
+    expect(first.isNothing()).toBe(true);
+
+    const second = await instance.resolveNextVersion({
+      targetId: "857735172",
+      currentVersion: "1.9.0",
+    });
+    expect(second.extract()).toBe("1.9.1");
+    expect(fetchSpy.mock.calls.length).toBeGreaterThan(1);
+  });
+
   describe("resolveCurrentMcuVersion", () => {
     it("resolves the MCU name compatible with the next final firmware", async () => {
       mockFetch({

--- a/apps/device-mock-server/src/internal/secure-channel/service/FirmwareUpdateResolver.ts
+++ b/apps/device-mock-server/src/internal/secure-channel/service/FirmwareUpdateResolver.ts
@@ -1,0 +1,318 @@
+import { inject, injectable } from "inversify";
+import { Maybe } from "purify-ts";
+
+import { type MockServerConfig } from "@api/model/MockServerConfig";
+import { appTypes } from "@internal/di/types";
+import { logger } from "@internal/logger/logger";
+
+/** Production Manager API, used when no override is configured. */
+const DEFAULT_MANAGER_API_URL = "https://manager.api.live.ledger.com/api";
+
+/** Manager API version tag echoed on every request (value is not significant). */
+const LIVE_COMMON_VERSION = "36.2.0";
+
+/**
+ * Default provider (1 = Ledger). Mirrors `FORCE_PROVIDER`'s default in
+ * ledger-live; the mock does not model alternative firmware providers.
+ */
+const DEFAULT_PROVIDER = 1;
+
+/**
+ * Rollout salt the Manager API uses to gate staged firmware releases. In
+ * production it is derived from the user id; the mock sends a fixed value, so
+ * fully-rolled-out firmwares always resolve while a staged-rollout target may
+ * return no update (in which case the OSU install fails fast).
+ */
+const ROLLOUT_SALT = "00000000";
+
+interface DeviceVersionDto {
+  readonly id?: number;
+}
+
+interface FinalFirmwareDto {
+  readonly id?: number;
+  readonly name?: string;
+  /** Ids of the MCU versions this firmware is compatible with. */
+  readonly mcu_versions?: number[];
+}
+
+interface OsuFirmwareDto {
+  readonly name?: string;
+  readonly next_se_firmware_final_version?: number;
+}
+
+interface LatestFirmwareDto {
+  readonly result?: string;
+  readonly se_firmware_osu_version?: OsuFirmwareDto;
+}
+
+interface McuVersionDto {
+  readonly id?: number;
+  readonly name?: string;
+}
+
+/**
+ * Resolves firmware-update facts from the Manager API the way the real
+ * ScriptRunner backend does: the clean version a firmware install targets
+ * ({@link resolveNextVersion}) and the current MCU version to advertise so the
+ * update takes the no-MCU-flash path ({@link resolveCurrentMcuVersion}). Both
+ * replicate `getLatestFirmwareForDevice` (the non-OSU branch), mirroring
+ * {@link InstallAppResolver}'s lookup so firmware updates work without
+ * per-test seeding.
+ */
+@injectable()
+export class FirmwareUpdateResolver {
+  private readonly managerApiUrl: string;
+
+  /**
+   * Memoized final-firmware lookups keyed by `${targetId}:${currentVersion}:
+   * ${providerId}`. Shared by both public callers so the 4-call Manager API chain
+   * runs at most once per device/version pair per server lifetime.
+   */
+  private readonly finalFirmwareCache = new Map<
+    string,
+    Promise<Maybe<FinalFirmwareDto>>
+  >();
+
+  /**
+   * Memoized MCU-version lookups keyed by `${targetId}:${currentVersion}:
+   * ${providerId}`. GetOsVersion is replayed on every connect/poll, so caching
+   * the (deterministic) Manager API result keeps the handshake off the network
+   * after the first resolution. Negative results are cached too.
+   */
+  private readonly mcuVersionCache = new Map<string, Promise<Maybe<string>>>();
+
+  constructor(@inject(appTypes.Config) config: MockServerConfig) {
+    this.managerApiUrl = config.managerApiUrl ?? DEFAULT_MANAGER_API_URL;
+  }
+
+  /**
+   * Resolve the clean (non-OSU) version a device on `currentVersion` would
+   * update to, e.g. `1.10.1`. Desktop's update runs a single OSU install and
+   * then just polls `getDeviceInfo`; a real device auto-flashes the final image
+   * on reboot, so the mock commits straight to this clean target (no `-osu`
+   * intermediate, which would strand the device — nothing drops the suffix).
+   * Returns `Nothing` when the Manager API reports no update or a lookup fails.
+   */
+  async resolveNextVersion(params: {
+    targetId: string | number;
+    currentVersion: string;
+    providerId?: number;
+  }): Promise<Maybe<string>> {
+    return (await this.resolveFinalFirmware(params)).chain((final) =>
+      Maybe.fromNullable(final.name),
+    );
+  }
+
+  /**
+   * Resolve the MCU version name (e.g. `5.32.3`) to report as the device's
+   * *current* MCU in GetOsVersion, so Ledger Live's firmware-update flow takes
+   * the no-MCU-flash path. LLD computes
+   * `shouldFlashMCU = !finalFirmware.mcu_versions.includes(<id of the MCU named
+   * mcuSephVersion>)`; picking a name from the target firmware's `mcu_versions`
+   * (matched to the `/mcu_versions` catalog, which LLD also consults and would
+   * otherwise reject as an unknown MCU) guarantees `shouldFlashMCU` is false.
+   * Returns `Nothing` when there is no update or a lookup fails; callers can then
+   * choose whether to synthesize GetOsVersion or let the APDU fall through.
+   */
+  async resolveCurrentMcuVersion({
+    targetId,
+    currentVersion,
+    providerId = DEFAULT_PROVIDER,
+  }: {
+    targetId: string | number;
+    currentVersion: string;
+    providerId?: number;
+  }): Promise<Maybe<string>> {
+    const key = `${targetId}:${currentVersion}:${providerId}`;
+    const cached = this.mcuVersionCache.get(key);
+    if (cached) return cached;
+    const pending = this.computeCurrentMcuVersion({
+      targetId,
+      currentVersion,
+      providerId,
+    });
+    this.mcuVersionCache.set(key, pending);
+    return pending;
+  }
+
+  private async computeCurrentMcuVersion({
+    targetId,
+    currentVersion,
+    providerId,
+  }: {
+    targetId: string | number;
+    currentVersion: string;
+    providerId: number;
+  }): Promise<Maybe<string>> {
+    try {
+      const deviceVersion = await this.get<DeviceVersionDto>(
+        "get_device_version",
+        { provider: providerId, target_id: targetId },
+      );
+      if (deviceVersion?.id === undefined) {
+        logger.warn(`Manager API: unknown target_id ${targetId}`);
+        return Maybe.empty();
+      }
+
+      const currentFirmware = await this.get<FinalFirmwareDto>(
+        "get_firmware_version",
+        {
+          device_version: deviceVersion.id,
+          version_name: currentVersion,
+          provider: providerId,
+        },
+      );
+      if (currentFirmware?.id === undefined) {
+        logger.warn(`Manager API: unknown firmware ${currentVersion}`);
+        return Maybe.empty();
+      }
+
+      const latest = await this.get<LatestFirmwareDto>("get_latest_firmware", {
+        salt: ROLLOUT_SALT,
+        current_se_firmware_final_version: currentFirmware.id,
+        device_version: deviceVersion.id,
+        provider: providerId,
+      });
+      const osu = latest?.se_firmware_osu_version;
+      // When an update is available use the next firmware's MCU list so LLD's
+      // shouldFlashMCU check passes against the update target. When the device
+      // is already on the latest firmware, the current firmware's list is used
+      // — shouldFlashMCU is never evaluated in that case but we still need a
+      // valid MCU name so GetOsVersion succeeds.
+      const firmwareId =
+        latest?.result !== "null" &&
+        osu?.next_se_firmware_final_version !== undefined
+          ? osu.next_se_firmware_final_version
+          : currentFirmware.id;
+
+      const firmware = await this.get<FinalFirmwareDto>(
+        `firmware_final_versions/${firmwareId}`,
+      );
+      const mcuIds = firmware?.mcu_versions ?? [];
+      if (mcuIds.length === 0) return Maybe.empty();
+
+      const catalog = (await this.get<McuVersionDto[]>("mcu_versions")) ?? [];
+      const compatibleIds = new Set(mcuIds);
+      const match = catalog.find(
+        (mcu) =>
+          mcu.id !== undefined &&
+          compatibleIds.has(mcu.id) &&
+          Boolean(mcu.name),
+      );
+      return Maybe.fromNullable(match?.name);
+    } catch (error) {
+      logger.error(`Manager API MCU lookup failed: ${String(error)}`);
+      return Maybe.empty();
+    }
+  }
+
+  /**
+   * Replicate `getLatestFirmwareForDevice` (non-OSU branch) against the Manager
+   * API: `get_device_version` -> `get_firmware_version` -> `get_latest_firmware`
+   * -> `firmware_final_versions/{id}`, returning the target final firmware (with
+   * its `name` and `mcu_versions`). Memoized — multiple callers with the same
+   * key share a single in-flight request. Returns `Nothing` when there is no
+   * update or any lookup fails.
+   */
+  private resolveFinalFirmware(params: {
+    targetId: string | number;
+    currentVersion: string;
+    providerId?: number;
+  }): Promise<Maybe<FinalFirmwareDto>> {
+    const { targetId, currentVersion, providerId = DEFAULT_PROVIDER } = params;
+    const key = `${targetId}:${currentVersion}:${providerId}`;
+    const cached = this.finalFirmwareCache.get(key);
+    if (cached) return cached;
+    const pending = this.fetchFinalFirmware({
+      targetId,
+      currentVersion,
+      providerId,
+    });
+    this.finalFirmwareCache.set(key, pending);
+    return pending;
+  }
+
+  private async fetchFinalFirmware({
+    targetId,
+    currentVersion,
+    providerId,
+  }: {
+    targetId: string | number;
+    currentVersion: string;
+    providerId: number;
+  }): Promise<Maybe<FinalFirmwareDto>> {
+    try {
+      const deviceVersion = await this.get<DeviceVersionDto>(
+        "get_device_version",
+        { provider: providerId, target_id: targetId },
+      );
+      if (deviceVersion?.id === undefined) {
+        logger.warn(`Manager API: unknown target_id ${targetId}`);
+        return Maybe.empty();
+      }
+
+      const currentFirmware = await this.get<FinalFirmwareDto>(
+        "get_firmware_version",
+        {
+          device_version: deviceVersion.id,
+          version_name: currentVersion,
+          provider: providerId,
+        },
+      );
+      if (currentFirmware?.id === undefined) {
+        logger.warn(`Manager API: unknown firmware ${currentVersion}`);
+        return Maybe.empty();
+      }
+
+      const latest = await this.get<LatestFirmwareDto>("get_latest_firmware", {
+        salt: ROLLOUT_SALT,
+        current_se_firmware_final_version: currentFirmware.id,
+        device_version: deviceVersion.id,
+        provider: providerId,
+      });
+      const osu = latest?.se_firmware_osu_version;
+      if (
+        latest?.result === "null" ||
+        !osu?.name ||
+        osu.next_se_firmware_final_version === undefined
+      ) {
+        logger.warn(`Manager API: no firmware update for ${currentVersion}`);
+        return Maybe.empty();
+      }
+
+      const final = await this.get<FinalFirmwareDto>(
+        `firmware_final_versions/${osu.next_se_firmware_final_version}`,
+      );
+      if (!final?.name) {
+        logger.warn(
+          `Manager API: no final firmware ${osu.next_se_firmware_final_version}`,
+        );
+        return Maybe.empty();
+      }
+
+      return Maybe.of(final);
+    } catch (error) {
+      logger.error(`Manager API firmware lookup failed: ${String(error)}`);
+      return Maybe.empty();
+    }
+  }
+
+  private async get<T>(
+    path: string,
+    query: Record<string, string | number> = {},
+  ): Promise<T | undefined> {
+    const params = new URLSearchParams({
+      livecommonversion: LIVE_COMMON_VERSION,
+    });
+    for (const [key, value] of Object.entries(query)) {
+      params.set(key, String(value));
+    }
+    const response = await fetch(`${this.managerApiUrl}/${path}?${params}`);
+    if (!response.ok) {
+      logger.warn(`Manager API /${path} returned ${response.status}`);
+      return undefined;
+    }
+    return (await response.json()) as T;
+  }
+}

--- a/apps/device-mock-server/src/internal/secure-channel/service/FirmwareUpdateResolver.ts
+++ b/apps/device-mock-server/src/internal/secure-channel/service/FirmwareUpdateResolver.ts
@@ -78,7 +78,9 @@ export class FirmwareUpdateResolver {
    * Memoized MCU-version lookups keyed by `${targetId}:${currentVersion}:
    * ${providerId}`. GetOsVersion is replayed on every connect/poll, so caching
    * the (deterministic) Manager API result keeps the handshake off the network
-   * after the first resolution. Negative results are cached too.
+   * after the first resolution. Deterministic negatives (unknown target, no
+   * update) are cached too; transient failures (network error, 5xx) are evicted
+   * so the next poll retries instead of caching the error permanently.
    */
   private readonly mcuVersionCache = new Map<string, Promise<Maybe<string>>>();
 
@@ -131,7 +133,14 @@ export class FirmwareUpdateResolver {
       targetId,
       currentVersion,
       providerId,
-    });
+    })
+      // A transient failure must not poison the cache: evict the entry so the
+      // next poll retries, and surface it to callers as a (non-cached) empty.
+      .catch((error) => {
+        this.mcuVersionCache.delete(key);
+        logger.error(`Manager API MCU lookup failed: ${String(error)}`);
+        return Maybe.empty();
+      });
     this.mcuVersionCache.set(key, pending);
     return pending;
   }
@@ -145,66 +154,62 @@ export class FirmwareUpdateResolver {
     currentVersion: string;
     providerId: number;
   }): Promise<Maybe<string>> {
-    try {
-      const deviceVersion = await this.get<DeviceVersionDto>(
-        "get_device_version",
-        { provider: providerId, target_id: targetId },
-      );
-      if (deviceVersion?.id === undefined) {
-        logger.warn(`Manager API: unknown target_id ${targetId}`);
-        return Maybe.empty();
-      }
-
-      const currentFirmware = await this.get<FinalFirmwareDto>(
-        "get_firmware_version",
-        {
-          device_version: deviceVersion.id,
-          version_name: currentVersion,
-          provider: providerId,
-        },
-      );
-      if (currentFirmware?.id === undefined) {
-        logger.warn(`Manager API: unknown firmware ${currentVersion}`);
-        return Maybe.empty();
-      }
-
-      const latest = await this.get<LatestFirmwareDto>("get_latest_firmware", {
-        salt: ROLLOUT_SALT,
-        current_se_firmware_final_version: currentFirmware.id,
-        device_version: deviceVersion.id,
-        provider: providerId,
-      });
-      const osu = latest?.se_firmware_osu_version;
-      // When an update is available use the next firmware's MCU list so LLD's
-      // shouldFlashMCU check passes against the update target. When the device
-      // is already on the latest firmware, the current firmware's list is used
-      // — shouldFlashMCU is never evaluated in that case but we still need a
-      // valid MCU name so GetOsVersion succeeds.
-      const firmwareId =
-        latest?.result !== "null" &&
-        osu?.next_se_firmware_final_version !== undefined
-          ? osu.next_se_firmware_final_version
-          : currentFirmware.id;
-
-      const firmware = await this.get<FinalFirmwareDto>(
-        `firmware_final_versions/${firmwareId}`,
-      );
-      const mcuIds = firmware?.mcu_versions ?? [];
-      if (mcuIds.length === 0) return Maybe.empty();
-
-      const catalog = (await this.get<McuVersionDto[]>("mcu_versions")) ?? [];
-      const compatibleIds = new Set(mcuIds);
-      const match = catalog.find(
-        (mcu) =>
-          mcu.id !== undefined &&
-          compatibleIds.has(mcu.id) &&
-          Boolean(mcu.name),
-      );
-      return Maybe.fromNullable(match?.name);
-    } catch (error) {
-      logger.error(`Manager API MCU lookup failed: ${String(error)}`);
+    // Transient errors (network failure, 5xx) are left to propagate so the
+    // caching layer can evict them; only deterministic outcomes reach the
+    // `Maybe.empty()` returns below and are safe to cache.
+    const deviceVersion = await this.get<DeviceVersionDto>(
+      "get_device_version",
+      { provider: providerId, target_id: targetId },
+    );
+    if (deviceVersion?.id === undefined) {
+      logger.warn(`Manager API: unknown target_id ${targetId}`);
       return Maybe.empty();
     }
+
+    const currentFirmware = await this.get<FinalFirmwareDto>(
+      "get_firmware_version",
+      {
+        device_version: deviceVersion.id,
+        version_name: currentVersion,
+        provider: providerId,
+      },
+    );
+    if (currentFirmware?.id === undefined) {
+      logger.warn(`Manager API: unknown firmware ${currentVersion}`);
+      return Maybe.empty();
+    }
+
+    const latest = await this.get<LatestFirmwareDto>("get_latest_firmware", {
+      salt: ROLLOUT_SALT,
+      current_se_firmware_final_version: currentFirmware.id,
+      device_version: deviceVersion.id,
+      provider: providerId,
+    });
+    const osu = latest?.se_firmware_osu_version;
+    // When an update is available use the next firmware's MCU list so LLD's
+    // shouldFlashMCU check passes against the update target. When the device
+    // is already on the latest firmware, the current firmware's list is used
+    // — shouldFlashMCU is never evaluated in that case but we still need a
+    // valid MCU name so GetOsVersion succeeds.
+    const firmwareId =
+      latest?.result !== "null" &&
+      osu?.next_se_firmware_final_version !== undefined
+        ? osu.next_se_firmware_final_version
+        : currentFirmware.id;
+
+    const firmware = await this.get<FinalFirmwareDto>(
+      `firmware_final_versions/${firmwareId}`,
+    );
+    const mcuIds = firmware?.mcu_versions ?? [];
+    if (mcuIds.length === 0) return Maybe.empty();
+
+    const catalog = (await this.get<McuVersionDto[]>("mcu_versions")) ?? [];
+    const compatibleIds = new Set(mcuIds);
+    const match = catalog.find(
+      (mcu) =>
+        mcu.id !== undefined && compatibleIds.has(mcu.id) && Boolean(mcu.name),
+    );
+    return Maybe.fromNullable(match?.name);
   }
 
   /**
@@ -228,7 +233,14 @@ export class FirmwareUpdateResolver {
       targetId,
       currentVersion,
       providerId,
-    });
+    })
+      // A transient failure must not poison the cache: evict the entry so the
+      // next lookup retries, and surface it to callers as a (non-cached) empty.
+      .catch((error) => {
+        this.finalFirmwareCache.delete(key);
+        logger.error(`Manager API firmware lookup failed: ${String(error)}`);
+        return Maybe.empty();
+      });
     this.finalFirmwareCache.set(key, pending);
     return pending;
   }
@@ -242,60 +254,58 @@ export class FirmwareUpdateResolver {
     currentVersion: string;
     providerId: number;
   }): Promise<Maybe<FinalFirmwareDto>> {
-    try {
-      const deviceVersion = await this.get<DeviceVersionDto>(
-        "get_device_version",
-        { provider: providerId, target_id: targetId },
-      );
-      if (deviceVersion?.id === undefined) {
-        logger.warn(`Manager API: unknown target_id ${targetId}`);
-        return Maybe.empty();
-      }
-
-      const currentFirmware = await this.get<FinalFirmwareDto>(
-        "get_firmware_version",
-        {
-          device_version: deviceVersion.id,
-          version_name: currentVersion,
-          provider: providerId,
-        },
-      );
-      if (currentFirmware?.id === undefined) {
-        logger.warn(`Manager API: unknown firmware ${currentVersion}`);
-        return Maybe.empty();
-      }
-
-      const latest = await this.get<LatestFirmwareDto>("get_latest_firmware", {
-        salt: ROLLOUT_SALT,
-        current_se_firmware_final_version: currentFirmware.id,
-        device_version: deviceVersion.id,
-        provider: providerId,
-      });
-      const osu = latest?.se_firmware_osu_version;
-      if (
-        latest?.result === "null" ||
-        !osu?.name ||
-        osu.next_se_firmware_final_version === undefined
-      ) {
-        logger.warn(`Manager API: no firmware update for ${currentVersion}`);
-        return Maybe.empty();
-      }
-
-      const final = await this.get<FinalFirmwareDto>(
-        `firmware_final_versions/${osu.next_se_firmware_final_version}`,
-      );
-      if (!final?.name) {
-        logger.warn(
-          `Manager API: no final firmware ${osu.next_se_firmware_final_version}`,
-        );
-        return Maybe.empty();
-      }
-
-      return Maybe.of(final);
-    } catch (error) {
-      logger.error(`Manager API firmware lookup failed: ${String(error)}`);
+    // Transient errors (network failure, 5xx) are left to propagate so the
+    // caching layer can evict them; only deterministic outcomes reach the
+    // `Maybe.empty()` returns below and are safe to cache.
+    const deviceVersion = await this.get<DeviceVersionDto>(
+      "get_device_version",
+      { provider: providerId, target_id: targetId },
+    );
+    if (deviceVersion?.id === undefined) {
+      logger.warn(`Manager API: unknown target_id ${targetId}`);
       return Maybe.empty();
     }
+
+    const currentFirmware = await this.get<FinalFirmwareDto>(
+      "get_firmware_version",
+      {
+        device_version: deviceVersion.id,
+        version_name: currentVersion,
+        provider: providerId,
+      },
+    );
+    if (currentFirmware?.id === undefined) {
+      logger.warn(`Manager API: unknown firmware ${currentVersion}`);
+      return Maybe.empty();
+    }
+
+    const latest = await this.get<LatestFirmwareDto>("get_latest_firmware", {
+      salt: ROLLOUT_SALT,
+      current_se_firmware_final_version: currentFirmware.id,
+      device_version: deviceVersion.id,
+      provider: providerId,
+    });
+    const osu = latest?.se_firmware_osu_version;
+    if (
+      latest?.result === "null" ||
+      !osu?.name ||
+      osu.next_se_firmware_final_version === undefined
+    ) {
+      logger.warn(`Manager API: no firmware update for ${currentVersion}`);
+      return Maybe.empty();
+    }
+
+    const final = await this.get<FinalFirmwareDto>(
+      `firmware_final_versions/${osu.next_se_firmware_final_version}`,
+    );
+    if (!final?.name) {
+      logger.warn(
+        `Manager API: no final firmware ${osu.next_se_firmware_final_version}`,
+      );
+      return Maybe.empty();
+    }
+
+    return Maybe.of(final);
   }
 
   private async get<T>(
@@ -310,6 +320,12 @@ export class FirmwareUpdateResolver {
     }
     const response = await fetch(`${this.managerApiUrl}/${path}?${params}`);
     if (!response.ok) {
+      // 5xx responses are transient: throw so the caller can retry rather than
+      // cache the failure. 4xx (e.g. unknown target) is deterministic — return
+      // undefined and let the caller resolve to a cacheable Maybe.empty().
+      if (response.status >= 500) {
+        throw new Error(`Manager API /${path} returned ${response.status}`);
+      }
       logger.warn(`Manager API /${path} returned ${response.status}`);
       return undefined;
     }

--- a/apps/device-mock-server/src/internal/secure-channel/ws/SecureChannelWebSocket.test.ts
+++ b/apps/device-mock-server/src/internal/secure-channel/ws/SecureChannelWebSocket.test.ts
@@ -304,6 +304,57 @@ describe("secure channel WebSocket: install commits the app to the device contex
 });
 
 /**
+ * A firmware install hits the same `install` endpoint as an app install but
+ * carries `firmware`/`targetId` instead of an app `hash`. The single OSU install
+ * advances the device's `firmware_version` to the clean next version (resolved
+ * from the Manager API) once the final install block is acknowledged, mirroring
+ * a real device auto-flashing the final image on reboot.
+ */
+describe("secure channel WebSocket: firmware install advances the device version", () => {
+  const createDevice = async (firmware_version: string) => {
+    const token = (
+      (await (await api("/auth", { method: "POST" })).json()) as {
+        token: string;
+      }
+    ).token;
+    const device = (await (
+      await api(
+        "/devices",
+        {
+          method: "POST",
+          body: JSON.stringify({ device_type: "stax", firmware_version }),
+        },
+        token,
+      )
+    ).json()) as { id: string };
+    await api(`/devices/${device.id}/connect`, { method: "POST" }, token);
+    return { token, id: device.id };
+  };
+
+  const firmwareOf = async (token: string, id: string): Promise<string> =>
+    (
+      (await (await api(`/devices/${id}`, {}, token)).json()) as {
+        firmware_version: string;
+      }
+    ).firmware_version;
+
+  it("install fails fast when the next version cannot be resolved", async () => {
+    // The Manager API is pinned to a refused address (see beforeEach), so the
+    // version resolution returns Nothing and the install closes with an error
+    // without ever changing the device version.
+    const { token, id } = await createDevice("1.9.0");
+
+    const install = await drive(
+      token,
+      id,
+      "install?firmware=abcd&targetId=857735172",
+    );
+    expect(install.type).not.toBe("bulk");
+    expect(await firmwareOf(token, id)).toBe("1.9.0");
+  });
+});
+
+/**
  * Error paths shared by the device-action secure-channel flows. Both genuine
  * check and install run the same `e051`/`e052` handshake, so a device error on
  * either APDU makes the client report `error` and the server stop the session

--- a/apps/device-mock-server/src/internal/secure-channel/ws/SecureChannelWebSocket.ts
+++ b/apps/device-mock-server/src/internal/secure-channel/ws/SecureChannelWebSocket.ts
@@ -8,6 +8,7 @@ import { type WebSocket, WebSocketServer } from "ws";
 
 import { logger } from "@internal/logger/logger";
 import { secureChannelTypes } from "@internal/secure-channel/di/secureChannelTypes";
+import { type FirmwareUpdateResolver } from "@internal/secure-channel/service/FirmwareUpdateResolver";
 import { type InstallAppResolver } from "@internal/secure-channel/service/InstallAppResolver";
 import {
   buildSecureChannelScript,
@@ -47,6 +48,8 @@ export class SecureChannelWebSocket {
     private readonly repository: SessionRepository,
     @inject(secureChannelTypes.InstallAppResolver)
     private readonly installResolver: InstallAppResolver,
+    @inject(secureChannelTypes.FirmwareUpdateResolver)
+    private readonly firmwareResolver: FirmwareUpdateResolver,
   ) {}
 
   /** Attach the secure-channel WebSocket handler to an HTTP server. */
@@ -60,12 +63,7 @@ export class SecureChannelWebSocket {
         return;
       }
       wss.handleUpgrade(request, socket, head, (ws) => {
-        void this.handleConnection(
-          ws,
-          parsed.token,
-          parsed.endpoint,
-          parsed.hash,
-        );
+        void this.handleConnection(ws, parsed);
       });
     });
 
@@ -74,10 +72,9 @@ export class SecureChannelWebSocket {
 
   private async handleConnection(
     ws: WebSocket,
-    token: string,
-    endpoint: SecureChannelEndpoint,
-    hash?: string,
+    parsed: ParsedPath,
   ): Promise<void> {
+    const { token, endpoint, hash, firmware, targetId } = parsed;
     const record = this.repository.findByToken(token).extract();
     if (!record) {
       closeWithError(ws, "Invalid session token");
@@ -108,6 +105,14 @@ export class SecureChannelWebSocket {
         device.id,
         app.unsafeCoerce(),
       );
+    } else if (endpoint === "install" && firmware) {
+      // A firmware install hits the same `install` endpoint but carries
+      // `firmware`/`perso`/`firmwareKey` instead of an app `hash`. Arm the
+      // target `firmware_version`, applied once the final install block is
+      // acknowledged, so the device "reboots" onto the new firmware.
+      if (!(await this.armFirmwareOperation(ws, record, device, targetId))) {
+        return;
+      }
     }
 
     logger.info(`Secure channel [${endpoint}] opened for device ${device.id}`);
@@ -121,6 +126,41 @@ export class SecureChannelWebSocket {
     }
   }
 
+  /**
+   * Arm the clean target `firmware_version` the OSU install applies on commit,
+   * resolved from the Manager API like the real ScriptRunner backend. Returns
+   * `false` (after closing the socket) when the next version cannot be resolved,
+   * so the install fails fast instead of appearing to succeed while the device
+   * stays on its old version.
+   */
+  private async armFirmwareOperation(
+    ws: WebSocket,
+    record: SessionRecord,
+    device: Device,
+    targetId?: string,
+  ): Promise<boolean> {
+    const currentVersion = device.firmware_version ?? "";
+    const resolvedTargetId = targetId ?? device.masks?.[0]?.toString();
+    if (resolvedTargetId === undefined) {
+      closeWithError(ws, "Missing targetId for firmware update");
+      return false;
+    }
+    const next = await this.firmwareResolver.resolveNextVersion({
+      targetId: resolvedTargetId,
+      currentVersion,
+    });
+    if (next.isNothing()) {
+      closeWithError(ws, `No firmware update for ${currentVersion}`);
+      return false;
+    }
+    this.repository.setPendingFirmwareOperation(
+      record,
+      device.id,
+      next.unsafeCoerce(),
+    );
+    return true;
+  }
+
   /** Prefer the connected device; fall back to the first one in the session. */
   private pickDevice(record: SessionRecord): Device | undefined {
     const devices = this.repository.listDevices(record);
@@ -128,13 +168,24 @@ export class SecureChannelWebSocket {
   }
 }
 
+/** Parsed `/secure-channel/...` upgrade path. */
+interface ParsedPath {
+  token: string;
+  endpoint: SecureChannelEndpoint;
+  /** App install hash (`install` app flow). */
+  hash?: string;
+  /** Firmware binary id (`install` firmware flow). */
+  firmware?: string;
+  /** Device target id (`install` firmware flow). */
+  targetId?: string;
+}
+
 /**
- * Extract `{ token, endpoint, hash? }` from a `/secure-channel/...` upgrade
- * path. The install `hash` query param identifies which app is being installed.
+ * Extract the token, endpoint and install params from a `/secure-channel/...`
+ * upgrade path. The install `hash` query param identifies which app is being
+ * installed; a firmware install carries `firmware`/`targetId` instead.
  */
-function parsePath(
-  url: string,
-): { token: string; endpoint: SecureChannelEndpoint; hash?: string } | null {
+function parsePath(url: string): ParsedPath | null {
   const [pathname = "", query = ""] = url.split("?");
   if (!pathname.startsWith(PATH_PREFIX)) {
     return null;
@@ -151,8 +202,14 @@ function parsePath(
   if (!endpoint) {
     return null;
   }
-  const hash = new URLSearchParams(query).get("hash") ?? undefined;
-  return { token, endpoint, hash };
+  const params = new URLSearchParams(query);
+  return {
+    token,
+    endpoint,
+    hash: params.get("hash") ?? undefined,
+    firmware: params.get("firmware") ?? undefined,
+    targetId: params.get("targetId") ?? undefined,
+  };
 }
 
 /** Run the scripted message sequence, relaying `exchange` APDUs to the client. */

--- a/apps/device-mock-server/src/internal/session/data/InMemorySessionRepository.test.ts
+++ b/apps/device-mock-server/src/internal/session/data/InMemorySessionRepository.test.ts
@@ -222,4 +222,36 @@ describe("InMemorySessionRepository", () => {
       .unsafeCoerce();
     expect(uninstalled.apps).toEqual([{ name: "BOLOS", version: "1.5.0" }]);
   });
+
+  it("applies a pending firmware operation to the device version on commit", () => {
+    const { repo, record } = newSession();
+    const device = repo.addDevice(record, {
+      device_type: "stax",
+      firmware_version: "1.9.0",
+    });
+
+    // Nothing pending: no-op.
+    expect(
+      repo.commitPendingFirmwareOperation(record, device.id).isNothing(),
+    ).toBe(true);
+
+    // OSU install -> device reports the `-osu` version.
+    repo.setPendingFirmwareOperation(record, device.id, "1.9.1-osu");
+    expect(
+      repo.commitPendingFirmwareOperation(record, device.id).unsafeCoerce()
+        .firmware_version,
+    ).toBe("1.9.1-osu");
+
+    // Pending was cleared.
+    expect(
+      repo.commitPendingFirmwareOperation(record, device.id).isNothing(),
+    ).toBe(true);
+
+    // Final install -> device lands on the clean version.
+    repo.setPendingFirmwareOperation(record, device.id, "1.9.1");
+    expect(
+      repo.commitPendingFirmwareOperation(record, device.id).unsafeCoerce()
+        .firmware_version,
+    ).toBe("1.9.1");
+  });
 });

--- a/apps/device-mock-server/src/internal/session/data/InMemorySessionRepository.ts
+++ b/apps/device-mock-server/src/internal/session/data/InMemorySessionRepository.ts
@@ -53,6 +53,7 @@ export class InMemorySessionRepository implements SessionRepository {
       speculos: new Map(),
       catalog: new Map(),
       pendingAppOperations: new Map(),
+      pendingFirmwareOperations: new Map(),
     };
     this.sessions.set(record.token, record);
     return { token: record.token, expiresAt: this.expiresAt(record) };
@@ -204,6 +205,30 @@ export class InMemorySessionRepository implements SessionRepository {
     });
   }
 
+  setPendingFirmwareOperation(
+    record: SessionRecord,
+    deviceId: string,
+    targetVersion: string,
+  ): void {
+    record.pendingFirmwareOperations.set(deviceId, targetVersion);
+  }
+
+  commitPendingFirmwareOperation(
+    record: SessionRecord,
+    deviceId: string,
+  ): Maybe<Device> {
+    const targetVersion = record.pendingFirmwareOperations.get(deviceId);
+    if (targetVersion === undefined) {
+      return Maybe.empty();
+    }
+    record.pendingFirmwareOperations.delete(deviceId);
+    return this.findDevice(record, deviceId).map((device) => {
+      const updated: Device = { ...device, firmware_version: targetVersion };
+      record.devices.set(deviceId, updated);
+      return updated;
+    });
+  }
+
   // --- Speculos proxy -------------------------------------------------------
 
   findProxy(
@@ -312,6 +337,7 @@ export class InMemorySessionRepository implements SessionRepository {
     record.speculos.clear();
     record.catalog.clear();
     record.pendingAppOperations.clear();
+    record.pendingFirmwareOperations.clear();
     for (const device of snapshot.devices) {
       this.addDevice(record, device);
     }

--- a/apps/device-mock-server/src/internal/session/data/SessionRepository.ts
+++ b/apps/device-mock-server/src/internal/session/data/SessionRepository.ts
@@ -77,6 +77,26 @@ export interface SessionRepository {
     record: SessionRecord,
     deviceId: string,
   ): Maybe<Device>;
+  /**
+   * Arm the target `firmware_version` a secure-channel firmware install targets,
+   * to be applied to the device registry when the final install block is
+   * acknowledged. Used for both the OSU install (`<next>-osu`) and the final
+   * firmware install (clean `<next>`).
+   */
+  setPendingFirmwareOperation(
+    record: SessionRecord,
+    deviceId: string,
+    targetVersion: string,
+  ): void;
+  /**
+   * Apply a device's pending firmware operation and clear it: sets the device's
+   * `firmware_version` to the armed target. Idempotent and a no-op when nothing
+   * is pending.
+   */
+  commitPendingFirmwareOperation(
+    record: SessionRecord,
+    deviceId: string,
+  ): Maybe<Device>;
 
   // --- Speculos proxy -------------------------------------------------------
   findProxy(

--- a/apps/device-mock-server/src/internal/session/model/SessionModels.ts
+++ b/apps/device-mock-server/src/internal/session/model/SessionModels.ts
@@ -37,4 +37,11 @@ export interface SessionRecord {
    * commit when the final install block is acknowledged: deviceId -> app.
    */
   pendingAppOperations: Map<string, CatalogApp>;
+  /**
+   * Target `firmware_version` of an in-flight secure-channel firmware install
+   * (OSU or final), awaiting commit when the final install block is
+   * acknowledged: deviceId -> version. Set to `<next>-osu` for the OSU install
+   * and to the clean `<next>` for the final install.
+   */
+  pendingFirmwareOperations: Map<string, string>;
 }


### PR DESCRIPTION
### 📝 Description

Adds end-to-end OS update support to the device mock server. Previously, a firmware install on a mock device would appear to succeed (the secure-channel bulk transfer completed) but the device would stay on its original `firmware_version` — the mock had no concept of a pending firmware operation. The handshake also always advertised a hardcoded MCU version (`2.30`), which caused Ledger Live Desktop to attempt an MCU flash first, derailing the flow.

This PR wires three things together:

1. **`FirmwareUpdateResolver`** — queries the real Manager API (same call chain as `InstallAppResolver`) to resolve the clean target version and the MCU version compatible with the next firmware, so `shouldFlashMCU` stays false. Both lookups are memoized per `targetId:currentVersion:providerId`.
2. **`OsApduService`** — injects `FirmwareUpdateResolver` (optional) and advertises the live MCU in `GetOsVersion` responses. When the resolver is absent or the MCU lookup yields nothing, `GetOsVersion` is left **unsynthesized** (the handshake APDU falls through) rather than falling back to a hardcoded MCU.
3. **Pending firmware operations** — mirrors the existing app-operation arm/commit pattern: the secure-channel WebSocket arms a `pendingFirmwareOperation` when the install bulk starts, and `ApduResolverService` commits it (updating `firmware_version`) once the final install block is acknowledged.

---

### 🗺️ Architecture

```mermaid
graph LR
  subgraph apdu
    AR[ApduResolverService]
  end
  subgraph os
    OS[OsApduService]
  end
  subgraph secure-channel
    WS[SecureChannelWebSocket]
    FW[FirmwareUpdateResolver]
  end
  subgraph session
    Repo[InMemorySessionRepository]
  end

  AR -->|"await resolve(device, apdu)"| OS
  AR -->|"commitPendingFirmwareOperation()"| Repo
  OS -->|"resolveCurrentMcuVersion()"| FW
  WS -->|"resolveNextVersion()"| FW
  WS -->|"setPendingFirmwareOperation()"| Repo
  FW -->|"memoized 4–5 HTTP calls"| API[(Manager API)]
```

---

### 🔄 OS update sequence

```mermaid
sequenceDiagram
  actor LLD as Ledger Live Desktop
  participant WS as SecureChannelWebSocket
  participant AR as ApduResolverService
  participant OS as OsApduService
  participant FW as FirmwareUpdateResolver
  participant Repo as SessionRepository
  participant API as Manager API

  note over LLD,API: 1 · GetOsVersion — MCU resolved so shouldFlashMCU = false
  LLD->>AR: GetOsVersion APDU (e001...)
  AR->>OS: resolve(device, apdu)
  OS->>FW: resolveCurrentMcuVersion({targetId, "1.9.0"})
  FW->>API: get_device_version
  FW->>API: get_firmware_version
  FW->>API: get_latest_firmware
  FW->>API: firmware_final_versions/{id}
  FW->>API: mcu_versions
  FW-->>OS: Maybe("5.32.3")
  OS-->>AR: GetOsVersion hex (mcuSeph = "5.32.3")
  AR-->>LLD: 3300...9000

  note over LLD,API: 2 · Firmware install — pending operation armed
  LLD->>WS: WS /secure-channel/{token}/install?firmware=X&targetId=Y
  WS->>FW: resolveNextVersion({targetId, "1.9.0"})
  FW-->>WS: Maybe("1.9.1")
  WS->>Repo: setPendingFirmwareOperation(record, deviceId, "1.9.1")
  WS-->>LLD: bulk (firmware blocks streamed)

  note over LLD,API: 3 · Final block acknowledged — firmware committed
  LLD->>AR: INSTALL_COMMIT_APDU
  AR-->>LLD: 9000
  AR->>Repo: commitPendingFirmwareOperation(record, deviceId)
  Repo-->>AR: Maybe(device { firmware_version: "1.9.1" })
  note right of Repo: device.firmware_version = "1.9.1"
```

---

### 🔁 Pending-operation lifecycle

Mirrors the existing app-operation arm/commit pattern already in place for app installs/uninstalls.

```mermaid
stateDiagram-v2
  direction LR
  [*] --> Idle
  Idle --> Armed : WS install opened (firmware=…)\nresolveNextVersion() → "1.9.1"\nsetPendingFirmwareOperation()
  Armed --> Committed : Final APDU acknowledged (9000)\ncommitPendingFirmwareOperation()
  Committed --> Idle : device.firmware_version updated
  Armed --> Idle : WS closed before final block\n(pending silently dropped)
```

---

### ❓ Context

- **JIRA**: [DSDK-1324](https://ledgerhq.atlassian.net/browse/DSDK-1324)
- **Feature**: Mock server OS update support — enables E2E firmware-update tests without a real device.

### ✅ Checklist

- [x] **Covered by automatic tests** — `FirmwareUpdateResolver`, `OsApduService`, `InMemorySessionRepository`, and `ApduResolverService` all have new unit tests covering the happy path, empty/error returns, and memoization.
- [x] **Changeset is provided** — No changeset needed: `device-mock-server` is a private app (`"private": true`).
- [ ] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - `OsApduService.resolve()` is now `async` (only affects internal callers — `ApduResolverService` already awaits it).
  - `deriveGetOsVersion` gains a **required** `mcuVersion` parameter and `deriveOsApduResponse` gains an **optional** one (internal to the mock-server package).
  - `FirmwareUpdateResolver` makes live Manager API calls unless the device has no `firmware_version` or the resolver is not wired. When the MCU can't be resolved (offline, or the resolver returns `Nothing`), `GetOsVersion` is **not** synthesized — there is no hardcoded MCU fallback. Unit tests pass an explicit `mcuVersion`, so they keep exercising the derived response offline.

---

### 🧐 Checklist for the PR Reviewers

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.

[DSDK-1324]: https://ledgerhq.atlassian.net/browse/DSDK-1324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
