### PR TITLE
✨ (os-update) [DSDK-1319]: Adds restore apps storage device action

### DIFF
--- a/.changeset/clever-cases-press.md
+++ b/.changeset/clever-cases-press.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/dmk-ledger-wallet": minor
+---
+
+Add `RestoreAppsStorageDeviceAction`, restoring per-app storage backups (produced by `CreateBackupDeviceAction`) onto a device, one app at a time, gracefully skipping apps whose restore consent is rejected by the user. 

--- a/.changeset/strong-crews-decide.md
+++ b/.changeset/strong-crews-decide.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": minor
+---
+
+Add `UserInteractionRequired.GrantMasterConsent`, signaling that the user must grant the master consent on the device when restoring data on it after an OS update.

--- a/apps/sample/src/components/DeviceActionsView/AllDeviceActions.tsx
+++ b/apps/sample/src/components/DeviceActionsView/AllDeviceActions.tsx
@@ -76,6 +76,10 @@ import {
   type CreateBackupDAIntermediateValue,
   type CreateBackupDAOutput,
   CreateBackupDeviceAction,
+  type RestoreAppsStorageDAError,
+  type RestoreAppsStorageDAIntermediateValue,
+  type RestoreAppsStorageDAOutput,
+  RestoreAppsStorageDeviceAction,
 } from "@ledgerhq/dmk-ledger-wallet";
 
 import { useDmk } from "@/providers/DeviceManagementKitProvider";
@@ -486,6 +490,59 @@ export const AllDeviceActions: React.FC<{ sessionId: string }> = ({
         CreateBackupDAInput,
         CreateBackupDAError,
         CreateBackupDAIntermediateValue
+      >,
+      {
+        title: `${SECURE_CHANNEL_ICON} Restore Apps Storage`,
+        description:
+          "Restore per-app storage backups (as produced by Create Backup) onto the device",
+        executeDeviceAction: (
+          { backupAppsJson, isMasterConsentGranted, unlockTimeout },
+          inspect,
+        ) => {
+          const backupApps = JSON.parse(backupAppsJson) as Array<{
+            appName: string;
+            data: `0x${string}` | undefined;
+          }>;
+          const deviceAction = new RestoreAppsStorageDeviceAction({
+            input: {
+              backupApps,
+              isMasterConsentGranted,
+              unlockTimeout,
+            },
+            inspect,
+          });
+          return dmk.executeDeviceAction({
+            sessionId,
+            deviceAction,
+          });
+        },
+        initialValues: {
+          backupAppsJson: JSON.stringify([
+            { appName: "Ethereum", data: "0x00" },
+          ]),
+          isMasterConsentGranted: false,
+          unlockTimeout: UNLOCK_TIMEOUT,
+        },
+        labelSelector: {
+          backupAppsJson: "Backup apps (JSON array of {appName, data})",
+        },
+        validateValues: ({ backupAppsJson }) => {
+          try {
+            return Array.isArray(JSON.parse(backupAppsJson));
+          } catch {
+            return false;
+          }
+        },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        RestoreAppsStorageDAOutput,
+        {
+          backupAppsJson: string;
+          isMasterConsentGranted: boolean;
+          unlockTimeout: number;
+        },
+        RestoreAppsStorageDAError,
+        RestoreAppsStorageDAIntermediateValue
       >,
     ],
     [deviceModelId, dmk, sessionId],

--- a/packages/device-management-kit/src/api/device-action/model/UserInteractionRequired.ts
+++ b/packages/device-management-kit/src/api/device-action/model/UserInteractionRequired.ts
@@ -19,4 +19,5 @@ export enum UserInteractionRequired {
   ConfirmLoadImage = "confirm-load-image",
   ConfirmCommitImage = "confirm-commit-image",
   ConfirmRemoveImage = "confirm-remove-image",
+  GrantConsent = "grant-consent",
 }

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceAction.test.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceAction.test.ts
@@ -1,0 +1,493 @@
+import {
+  DeviceActionStatus,
+  UnknownDAError,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+import { type Either, Left, Right } from "purify-ts";
+import { assign, createMachine } from "xstate";
+
+import { makeDeviceActionInternalApiMock } from "@api/device-action/__test-utils__/makeInternalApi";
+import { testDeviceActionStates } from "@api/device-action/__test-utils__/testDeviceActionStates";
+import { type BackupApp } from "@api/device-action/OsUpdate/Backup/types";
+import { RestoreAppsStorageDeviceAction } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceAction";
+import {
+  CommitRestoreAppStorageError,
+  InitRestoreAppStorageError,
+  RestoreAppStorageError,
+} from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceActionErrors";
+import { commitRestoreAppStorage } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/CommitRestoreAppStorage";
+import { goToDashboard } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/GoToDashboard";
+import { initRestoreAppStorage } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/InitRestoreAppStorage";
+import { restoreAppStorage } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/RestoreAppStorage";
+import { waitForAppAndVersion } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/WaitForAppAndVersion";
+import {
+  InitRestoreAppStorageConsentResult,
+  type RestoreAppsStorageDAError,
+  type RestoreAppsStorageDAOutput,
+  type RestoreAppsStorageDARequiredInteraction,
+  type RestoreAppsStorageDAState,
+  RestoreAppsStorageSteps,
+} from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/types";
+
+vi.mock(
+  "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/WaitForAppAndVersion",
+);
+vi.mock(
+  "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/GoToDashboard",
+);
+vi.mock(
+  "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/InitRestoreAppStorage",
+);
+vi.mock(
+  "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/RestoreAppStorage",
+);
+vi.mock(
+  "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/CommitRestoreAppStorage",
+);
+
+// ─── State builders ───────────────────────────────────────────────────────────
+
+const pendingState = (
+  step: RestoreAppsStorageSteps,
+  requiredUserInteraction: RestoreAppsStorageDARequiredInteraction = UserInteractionRequired.None,
+): RestoreAppsStorageDAState => ({
+  status: DeviceActionStatus.Pending,
+  intermediateValue: {
+    requiredUserInteraction,
+    step,
+  },
+});
+
+const completedState = (
+  output: RestoreAppsStorageDAOutput,
+): RestoreAppsStorageDAState => ({
+  status: DeviceActionStatus.Completed,
+  output,
+});
+
+const errorState = (
+  error: RestoreAppsStorageDAError,
+): RestoreAppsStorageDAState => ({
+  status: DeviceActionStatus.Error,
+  error,
+});
+
+// ─── Mock actor factory ───────────────────────────────────────────────────────
+//
+// Creates a minimal XState machine that immediately completes (after 0 ms) with
+// the given Either output. The machine exposes the `intermediateValue` shape
+// required by the parent's `onSnapshot` handler.
+
+const createMockActorMachineFromOutput = (
+  output: () => Either<unknown, unknown>,
+) =>
+  createMachine({
+    initial: "ready",
+    states: {
+      ready: {
+        after: { 0: "done" },
+        entry: assign({
+          intermediateValue: () => ({
+            requiredUserInteraction: UserInteractionRequired.None,
+          }),
+        }),
+      },
+      done: { type: "final" },
+    },
+    output,
+  });
+
+const createMockActorMachine = (output: Either<unknown, unknown>) =>
+  createMockActorMachineFromOutput(() => output);
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("RestoreAppsStorageDeviceAction", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  // ─── Setup helpers ──────────────────────────────────────────────────────────
+
+  const setupWaitForAppAndVersion = (appName = "BOLOS") =>
+    vi
+      .mocked(waitForAppAndVersion)
+      .mockReturnValue(
+        createMockActorMachine(
+          Right({ name: appName, version: "1.0.0" }),
+        ) as unknown as ReturnType<typeof waitForAppAndVersion>,
+      );
+
+  const setupWaitForAppAndVersionSequence = (appNames: string[]) => {
+    const remainingAppNames = [...appNames];
+    vi.mocked(waitForAppAndVersion).mockReturnValue(
+      createMockActorMachineFromOutput(() =>
+        Right({
+          name: remainingAppNames.shift() ?? "BOLOS",
+          version: "1.0.0",
+        }),
+      ) as unknown as ReturnType<typeof waitForAppAndVersion>,
+    );
+  };
+
+  const setupGoToDashboard = (
+    output: Either<unknown, unknown> = Right(undefined),
+  ) =>
+    vi
+      .mocked(goToDashboard)
+      .mockReturnValue(
+        createMockActorMachine(output) as unknown as ReturnType<
+          typeof goToDashboard
+        >,
+      );
+
+  const setupInitRestoreAppStorage = (
+    results: Either<
+      InitRestoreAppStorageError,
+      InitRestoreAppStorageConsentResult
+    >[] = [Right(InitRestoreAppStorageConsentResult.GRANTED)],
+  ) => {
+    const queue = [...results];
+    vi.mocked(initRestoreAppStorage).mockReturnValue(() =>
+      Promise.resolve(
+        queue.shift() ?? Right(InitRestoreAppStorageConsentResult.GRANTED),
+      ),
+    );
+  };
+
+  const setupRestoreAppStorage = (
+    result: Either<RestoreAppStorageError, void> = Right(undefined),
+  ) =>
+    vi.mocked(restoreAppStorage).mockReturnValue(() => Promise.resolve(result));
+
+  const setupCommitRestoreAppStorage = (
+    result: Either<CommitRestoreAppStorageError, void> = Right(undefined),
+  ) =>
+    vi
+      .mocked(commitRestoreAppStorage)
+      .mockReturnValue(() => Promise.resolve(result));
+
+  const makeDeviceAction = (
+    backupApp: BackupApp[] = [],
+    isMasterConsentGranted = false,
+  ) =>
+    new RestoreAppsStorageDeviceAction({
+      input: {
+        backupApps: backupApp,
+        unlockTimeout: 30_000,
+        isMasterConsentGranted,
+      },
+    });
+
+  // ─── Success ────────────────────────────────────────────────────────────────
+
+  describe("Success", () => {
+    it("should restore storage for every app that has one, skipping apps without storage", () =>
+      new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersion();
+        setupGoToDashboard();
+        setupInitRestoreAppStorage([
+          Right(InitRestoreAppStorageConsentResult.GRANTED),
+          Right(InitRestoreAppStorageConsentResult.GRANTED),
+        ]);
+        setupRestoreAppStorage();
+        setupCommitRestoreAppStorage();
+
+        const backupApp: BackupApp[] = [
+          { appName: "AppWithStorage1", data: "0xaa" },
+          { appName: "AppNoStorage", data: undefined },
+          { appName: "AppWithStorage2", data: "0xbb" },
+        ];
+
+        const expectedStates: RestoreAppsStorageDAState[] = [
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(
+            RestoreAppsStorageSteps.InitRestoreAppStorage,
+            UserInteractionRequired.GrantConsent,
+          ),
+          pendingState(RestoreAppsStorageSteps.RestoreAppStorage),
+          pendingState(RestoreAppsStorageSteps.CommitRestoreAppStorage),
+          pendingState(
+            RestoreAppsStorageSteps.InitRestoreAppStorage,
+            UserInteractionRequired.GrantConsent,
+          ),
+          pendingState(RestoreAppsStorageSteps.RestoreAppStorage),
+          pendingState(RestoreAppsStorageSteps.CommitRestoreAppStorage),
+          completedState([
+            { appName: "AppWithStorage1", restoredAppStorage: true },
+            { appName: "AppWithStorage2", restoredAppStorage: true },
+          ]),
+        ];
+
+        testDeviceActionStates(
+          makeDeviceAction(backupApp),
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          { onDone: resolve, onError: reject },
+        );
+      }));
+
+    it("should not require grant consent user interaction when isMasterConsentGranted is true", () =>
+      new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersion();
+        setupGoToDashboard();
+        setupInitRestoreAppStorage([
+          Right(InitRestoreAppStorageConsentResult.GRANTED),
+        ]);
+        setupRestoreAppStorage();
+        setupCommitRestoreAppStorage();
+
+        const backupApp: BackupApp[] = [
+          { appName: "AppWithStorage1", data: "0xaa" },
+        ];
+
+        const expectedStates: RestoreAppsStorageDAState[] = [
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(RestoreAppsStorageSteps.InitRestoreAppStorage),
+          pendingState(RestoreAppsStorageSteps.RestoreAppStorage),
+          pendingState(RestoreAppsStorageSteps.CommitRestoreAppStorage),
+          completedState([
+            { appName: "AppWithStorage1", restoredAppStorage: true },
+          ]),
+        ];
+
+        testDeviceActionStates(
+          makeDeviceAction(backupApp, true),
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          { onDone: resolve, onError: reject },
+        );
+      }));
+
+    it("should complete with an empty result when no app has storage to restore", () =>
+      new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersion();
+        setupGoToDashboard();
+
+        const expectedStates: RestoreAppsStorageDAState[] = [
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          completedState([]),
+        ];
+
+        testDeviceActionStates(
+          makeDeviceAction([]),
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          { onDone: resolve, onError: reject },
+        );
+      }));
+
+    it("should go to dashboard and wait for app and version again when an app is open", () =>
+      new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersionSequence(["Bitcoin", "BOLOS"]);
+        setupGoToDashboard();
+
+        const expectedStates: RestoreAppsStorageDAState[] = [
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(RestoreAppsStorageSteps.GoToDashboard),
+          pendingState(RestoreAppsStorageSteps.GoToDashboard),
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          completedState([]),
+        ];
+
+        testDeviceActionStates(
+          makeDeviceAction([]),
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          { onDone: resolve, onError: reject },
+        );
+      }));
+
+    it("should record restoredAppStorage: false and move on when consent is rejected", () =>
+      new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersion();
+        setupGoToDashboard();
+        setupInitRestoreAppStorage([
+          Right(InitRestoreAppStorageConsentResult.REJECTED),
+        ]);
+        setupRestoreAppStorage(); // registered in actors but never invoked (consent rejected)
+        setupCommitRestoreAppStorage(); // registered in actors but never invoked (consent rejected)
+
+        const backupApp: BackupApp[] = [
+          { appName: "AppWithStorage1", data: "0xaa" },
+        ];
+
+        const expectedStates: RestoreAppsStorageDAState[] = [
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(
+            RestoreAppsStorageSteps.InitRestoreAppStorage,
+            UserInteractionRequired.GrantConsent,
+          ),
+          completedState([
+            { appName: "AppWithStorage1", restoredAppStorage: false },
+          ]),
+        ];
+
+        testDeviceActionStates(
+          makeDeviceAction(backupApp),
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          { onDone: resolve, onError: reject },
+        );
+      }));
+  });
+
+  // ─── Error ──────────────────────────────────────────────────────────────────
+
+  describe("Error", () => {
+    it("should go to Error when waitForAppAndVersion returns Left", () =>
+      new Promise<void>((resolve, reject) => {
+        const error = new UnknownDAError("waitForAppAndVersion failed");
+        vi.mocked(waitForAppAndVersion).mockReturnValue(
+          createMockActorMachine(Left(error)) as unknown as ReturnType<
+            typeof waitForAppAndVersion
+          >,
+        );
+
+        const expectedStates: RestoreAppsStorageDAState[] = [
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          errorState(error),
+        ];
+
+        testDeviceActionStates(
+          makeDeviceAction([]),
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          { onDone: resolve, onError: reject },
+        );
+      }));
+
+    it("should go to Error when goToDashboard returns Left", () =>
+      new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersion("Bitcoin");
+        const error = new UnknownDAError("goToDashboard failed");
+        setupGoToDashboard(Left(error));
+
+        const expectedStates: RestoreAppsStorageDAState[] = [
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(RestoreAppsStorageSteps.GoToDashboard),
+          pendingState(RestoreAppsStorageSteps.GoToDashboard),
+          errorState(error),
+        ];
+
+        testDeviceActionStates(
+          makeDeviceAction([]),
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          { onDone: resolve, onError: reject },
+        );
+      }));
+
+    it("should go to Error when initRestoreAppStorage fails with a fatal error", () =>
+      new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersion();
+        setupGoToDashboard();
+        const error = new InitRestoreAppStorageError(
+          new Error("command failed"),
+        );
+        setupInitRestoreAppStorage([Left(error)]);
+        setupRestoreAppStorage(); // registered in actors but never invoked
+        setupCommitRestoreAppStorage(); // registered in actors but never invoked
+
+        const backupApp: BackupApp[] = [
+          { appName: "AppWithStorage1", data: "0xaa" },
+        ];
+
+        const expectedStates: RestoreAppsStorageDAState[] = [
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(
+            RestoreAppsStorageSteps.InitRestoreAppStorage,
+            UserInteractionRequired.GrantConsent,
+          ),
+          errorState(error),
+        ];
+
+        testDeviceActionStates(
+          makeDeviceAction(backupApp),
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          { onDone: resolve, onError: reject },
+        );
+      }));
+
+    it("should go to Error when restoreAppStorage returns Left", () =>
+      new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersion();
+        setupGoToDashboard();
+        setupInitRestoreAppStorage([
+          Right(InitRestoreAppStorageConsentResult.GRANTED),
+        ]);
+        const error = new RestoreAppStorageError(new Error("chunk failed"));
+        setupRestoreAppStorage(Left(error));
+        setupCommitRestoreAppStorage(); // registered in actors but never invoked
+
+        const backupApp: BackupApp[] = [
+          { appName: "AppWithStorage1", data: "0xaa" },
+        ];
+
+        const expectedStates: RestoreAppsStorageDAState[] = [
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(
+            RestoreAppsStorageSteps.InitRestoreAppStorage,
+            UserInteractionRequired.GrantConsent,
+          ),
+          pendingState(RestoreAppsStorageSteps.RestoreAppStorage),
+          errorState(error),
+        ];
+
+        testDeviceActionStates(
+          makeDeviceAction(backupApp),
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          { onDone: resolve, onError: reject },
+        );
+      }));
+
+    it("should go to Error when commitRestoreAppStorage returns Left", () =>
+      new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersion();
+        setupGoToDashboard();
+        setupInitRestoreAppStorage([
+          Right(InitRestoreAppStorageConsentResult.GRANTED),
+        ]);
+        setupRestoreAppStorage();
+        const error = new CommitRestoreAppStorageError(
+          new Error("commit failed"),
+        );
+        setupCommitRestoreAppStorage(Left(error));
+
+        const backupApp: BackupApp[] = [
+          { appName: "AppWithStorage1", data: "0xaa" },
+        ];
+
+        const expectedStates: RestoreAppsStorageDAState[] = [
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(RestoreAppsStorageSteps.WaitForAppAndVersion),
+          pendingState(
+            RestoreAppsStorageSteps.InitRestoreAppStorage,
+            UserInteractionRequired.GrantConsent,
+          ),
+          pendingState(RestoreAppsStorageSteps.RestoreAppStorage),
+          pendingState(RestoreAppsStorageSteps.CommitRestoreAppStorage),
+          errorState(error),
+        ];
+
+        testDeviceActionStates(
+          makeDeviceAction(backupApp),
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          { onDone: resolve, onError: reject },
+        );
+      }));
+  });
+});

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceAction.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceAction.ts
@@ -1,0 +1,472 @@
+import {
+  type DeviceActionStateMachine,
+  hexaStringToBuffer,
+  type InternalApi,
+  isDashboardName,
+  type StateMachineTypes,
+  UserInteractionRequired,
+  XStateDeviceAction,
+} from "@ledgerhq/device-management-kit";
+import { Left, Right } from "purify-ts";
+import { assign, fromPromise, setup } from "xstate";
+
+import { type BackupApp } from "@api/device-action/OsUpdate/Backup/types";
+import { type InitRestoreAppStorageError } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceActionErrors";
+import { commitRestoreAppStorage } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/CommitRestoreAppStorage";
+import { goToDashboard } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/GoToDashboard";
+import { initRestoreAppStorage } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/InitRestoreAppStorage";
+import { restoreAppStorage } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/RestoreAppStorage";
+import { waitForAppAndVersion } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/WaitForAppAndVersion";
+import {
+  type BackupAppWithStorage,
+  InitRestoreAppStorageConsentResult,
+  type RestoreAppsStorageDAError,
+  type RestoreAppsStorageDAInput,
+  type RestoreAppsStorageDAIntermediateValue,
+  type RestoreAppsStorageDAInternalState,
+  type RestoreAppsStorageDAOutput,
+  RestoreAppsStorageSteps,
+} from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/types";
+
+const hasStorageData = (app: BackupApp): app is BackupAppWithStorage =>
+  app.data !== undefined;
+
+export class RestoreAppsStorageDeviceAction extends XStateDeviceAction<
+  RestoreAppsStorageDAOutput,
+  RestoreAppsStorageDAInput,
+  RestoreAppsStorageDAError,
+  RestoreAppsStorageDAIntermediateValue,
+  RestoreAppsStorageDAInternalState
+> {
+  protected override makeStateMachine(
+    internalAPI: InternalApi,
+  ): DeviceActionStateMachine<
+    RestoreAppsStorageDAOutput,
+    RestoreAppsStorageDAInput,
+    RestoreAppsStorageDAError,
+    RestoreAppsStorageDAIntermediateValue,
+    RestoreAppsStorageDAInternalState
+  > {
+    type types = StateMachineTypes<
+      RestoreAppsStorageDAOutput,
+      RestoreAppsStorageDAInput,
+      RestoreAppsStorageDAError,
+      RestoreAppsStorageDAIntermediateValue,
+      RestoreAppsStorageDAInternalState
+    >;
+
+    return setup({
+      types: {
+        input: {} as types["input"],
+        output: {} as types["output"],
+        context: {} as types["context"],
+      } as types,
+      actors: {
+        waitForAppAndVersion: waitForAppAndVersion(
+          internalAPI,
+          this.input.unlockTimeout,
+        ),
+        goToDashboard: goToDashboard(internalAPI, this.input.unlockTimeout),
+        initRestoreAppStorage: fromPromise(initRestoreAppStorage(internalAPI)),
+        restoreAppStorage: fromPromise(
+          restoreAppStorage(internalAPI, this.getLoggerFactory(internalAPI)),
+        ),
+        commitRestoreAppStorage: fromPromise(
+          commitRestoreAppStorage(internalAPI),
+        ),
+      },
+      guards: {
+        isDeviceOnDashboard: ({ context }) =>
+          isDashboardName(context._internalState.currentApp),
+        hasError: ({ context }) => context._internalState.error !== null,
+        hasMoreAppsWithStorage: ({ context }) =>
+          context._internalState.appsWithStorage.length > 0 &&
+          context._internalState.currentAppStorageIndex <
+            context._internalState.appsWithStorage.length,
+      },
+      actions: {
+        assignErrorFromEvent: assign({
+          _internalState: (_) => ({
+            ..._.context._internalState,
+            error: _.event["error"], // NOTE: should never happen
+          }),
+        }),
+      },
+    }).createMachine({
+      id: "RestoreAppsStorageDeviceAction",
+      initial: "WaitForAppAndVersion",
+      context: ({ input }) => ({
+        input: {
+          backupApps: input.backupApps,
+          unlockTimeout: input.unlockTimeout,
+          isMasterConsentGranted: input.isMasterConsentGranted,
+        },
+        intermediateValue: {
+          requiredUserInteraction: UserInteractionRequired.None,
+          step: RestoreAppsStorageSteps.Idle,
+        },
+        _internalState: {
+          error: null,
+          currentApp: null,
+          appsWithStorage: [],
+          currentAppStorageIndex: 0,
+          currentAppStorageName: null,
+          currentAppStorageDataBytes: null,
+          currentAppStorageDataLength: null,
+          restoreAppsStorageResult: [],
+        },
+      }),
+      states: {
+        WaitForAppAndVersion: {
+          entry: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              step: RestoreAppsStorageSteps.WaitForAppAndVersion,
+            }),
+          }),
+          invoke: {
+            src: "waitForAppAndVersion",
+            input: ({ context }) => ({
+              unlockTimeout: context.input.unlockTimeout,
+            }),
+            onSnapshot: {
+              actions: assign({
+                intermediateValue: (_) => ({
+                  ..._.event.snapshot.context.intermediateValue,
+                  step: _.context.intermediateValue.step,
+                }),
+              }),
+            },
+            onDone: {
+              actions: assign({
+                _internalState: (_) => {
+                  return _.event.output.caseOf<RestoreAppsStorageDAInternalState>(
+                    {
+                      Left: (error) => ({
+                        ..._.context._internalState,
+                        error,
+                      }),
+                      Right: (output) => ({
+                        ..._.context._internalState,
+                        currentApp: output.name,
+                      }),
+                    },
+                  );
+                },
+              }),
+              target: "CheckIfDeviceIsOnDashboard",
+            },
+            onError: {
+              actions: "assignErrorFromEvent",
+              target: "Error",
+            },
+          },
+        },
+        CheckIfDeviceIsOnDashboard: {
+          always: [
+            {
+              guard: "hasError",
+              target: "Error",
+            },
+            {
+              guard: "isDeviceOnDashboard",
+              target: "FilterAppsWithStorage",
+            },
+            {
+              target: "GoToDashboard",
+            },
+          ],
+        },
+        GoToDashboard: {
+          entry: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              step: RestoreAppsStorageSteps.GoToDashboard,
+            }),
+          }),
+          invoke: {
+            src: "goToDashboard",
+            input: ({ context }) => ({
+              unlockTimeout: context.input.unlockTimeout,
+            }),
+            onSnapshot: {
+              actions: assign({
+                intermediateValue: (_) => ({
+                  ..._.event.snapshot.context.intermediateValue,
+                  step: _.context.intermediateValue.step,
+                }),
+              }),
+            },
+            onDone: {
+              actions: assign({
+                _internalState: (_) => {
+                  return _.event.output.caseOf<RestoreAppsStorageDAInternalState>(
+                    {
+                      Left: (error) => ({
+                        ..._.context._internalState,
+                        error,
+                      }),
+                      Right: () => _.context._internalState,
+                    },
+                  );
+                },
+              }),
+              target: "CheckGoToDashboard",
+            },
+            onError: {
+              actions: "assignErrorFromEvent",
+              target: "Error",
+            },
+          },
+        },
+        CheckGoToDashboard: {
+          always: [
+            {
+              guard: "hasError",
+              target: "Error",
+            },
+            {
+              target: "WaitForAppAndVersion",
+            },
+          ],
+        },
+        FilterAppsWithStorage: {
+          entry: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              step: RestoreAppsStorageSteps.FilterAppsWithStorage,
+            }),
+            _internalState: (_) => ({
+              ..._.context._internalState,
+              appsWithStorage:
+                _.context.input.backupApps.filter(hasStorageData),
+            }),
+          }),
+          always: {
+            target: "CheckIfThereIsAppWithStorage",
+          },
+        },
+        CheckIfThereIsAppWithStorage: {
+          always: [
+            {
+              guard: "hasMoreAppsWithStorage",
+              target: "ExtractAppData",
+            },
+            {
+              target: "Success",
+            },
+          ],
+        },
+        ExtractAppData: {
+          entry: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              step: RestoreAppsStorageSteps.ExtractAppData,
+            }),
+            _internalState: (_) => {
+              const currentAppWithStorage =
+                _.context._internalState.appsWithStorage[
+                  _.context._internalState.currentAppStorageIndex
+                ]!;
+              const currentAppStorageDataBytes =
+                hexaStringToBuffer(currentAppWithStorage.data) ??
+                new Uint8Array(0);
+              return {
+                ..._.context._internalState,
+                currentAppStorageName: currentAppWithStorage.appName,
+                currentAppStorageDataBytes,
+                currentAppStorageDataLength: currentAppStorageDataBytes.length,
+              };
+            },
+          }),
+          always: {
+            target: "InitRestoreAppStorage",
+          },
+        },
+        InitRestoreAppStorage: {
+          entry: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              step: RestoreAppsStorageSteps.InitRestoreAppStorage,
+              requiredUserInteraction: _.context.input.isMasterConsentGranted
+                ? UserInteractionRequired.None
+                : UserInteractionRequired.GrantConsent,
+            }),
+          }),
+          exit: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              requiredUserInteraction: UserInteractionRequired.None,
+            }),
+          }),
+          invoke: {
+            src: "initRestoreAppStorage",
+            input: ({ context }) => ({
+              appName: context._internalState.currentAppStorageName!,
+              appStorageDataLength:
+                context._internalState.currentAppStorageDataLength!,
+            }),
+            onDone: [
+              {
+                guard: ({ event }) => event.output.isLeft(),
+                actions: assign({
+                  _internalState: ({ event, context }) => ({
+                    ...context._internalState,
+                    error: event.output.extract() as InitRestoreAppStorageError,
+                  }),
+                }),
+                target: "Error",
+              },
+              {
+                guard: ({ event }) =>
+                  event.output.extract() ===
+                  InitRestoreAppStorageConsentResult.REJECTED,
+                actions: assign({
+                  _internalState: ({ context }) => ({
+                    ...context._internalState,
+                    restoreAppsStorageResult: [
+                      ...context._internalState.restoreAppsStorageResult,
+                      {
+                        appName: context._internalState.currentAppStorageName!,
+                        restoredAppStorage: false,
+                      },
+                    ],
+                    currentAppStorageIndex:
+                      context._internalState.currentAppStorageIndex + 1,
+                    currentAppStorageName: null,
+                    currentAppStorageDataBytes: null,
+                    currentAppStorageDataLength: null,
+                  }),
+                }),
+                target: "CheckIfThereIsAppWithStorage",
+              },
+              {
+                target: "RestoreAppStorage",
+              },
+            ],
+            onError: {
+              actions: "assignErrorFromEvent",
+              target: "Error",
+            },
+          },
+        },
+        RestoreAppStorage: {
+          entry: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              step: RestoreAppsStorageSteps.RestoreAppStorage,
+            }),
+          }),
+          invoke: {
+            src: "restoreAppStorage",
+            input: ({ context }) => ({
+              appStorageData:
+                context._internalState.currentAppStorageDataBytes ??
+                new Uint8Array(0),
+            }),
+            onDone: {
+              actions: assign({
+                _internalState: (_) => {
+                  return _.event.output.caseOf<RestoreAppsStorageDAInternalState>(
+                    {
+                      Left: (error) => ({
+                        ..._.context._internalState,
+                        error,
+                      }),
+                      Right: () => _.context._internalState,
+                    },
+                  );
+                },
+              }),
+              target: "CheckRestoreAppStorage",
+            },
+            onError: {
+              actions: "assignErrorFromEvent",
+              target: "Error",
+            },
+          },
+        },
+        CheckRestoreAppStorage: {
+          always: [
+            {
+              guard: "hasError",
+              target: "Error",
+            },
+            {
+              target: "CommitRestoreAppStorage",
+            },
+          ],
+        },
+        CommitRestoreAppStorage: {
+          entry: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              step: RestoreAppsStorageSteps.CommitRestoreAppStorage,
+            }),
+          }),
+          invoke: {
+            src: "commitRestoreAppStorage",
+            onDone: {
+              actions: assign({
+                _internalState: (_) => {
+                  return _.event.output.caseOf<RestoreAppsStorageDAInternalState>(
+                    {
+                      Left: (error) => ({
+                        ..._.context._internalState,
+                        error,
+                      }),
+                      Right: () => ({
+                        ..._.context._internalState,
+                        restoreAppsStorageResult: [
+                          ..._.context._internalState.restoreAppsStorageResult,
+                          {
+                            appName:
+                              _.context._internalState.currentAppStorageName!,
+                            restoredAppStorage: true,
+                          },
+                        ],
+                        currentAppStorageIndex:
+                          _.context._internalState.currentAppStorageIndex + 1,
+                        currentAppStorageName: null,
+                        currentAppStorageDataBytes: null,
+                        currentAppStorageDataLength: null,
+                      }),
+                    },
+                  );
+                },
+              }),
+              target: "CheckCommitRestoreAppStorage",
+            },
+            onError: {
+              actions: "assignErrorFromEvent",
+              target: "Error",
+            },
+          },
+        },
+        CheckCommitRestoreAppStorage: {
+          always: [
+            {
+              guard: "hasError",
+              target: "Error",
+            },
+            {
+              target: "CheckIfThereIsAppWithStorage",
+            },
+          ],
+        },
+        Success: {
+          type: "final",
+        },
+        Error: {
+          type: "final",
+        },
+      },
+      output: ({ context }) => {
+        if (context._internalState.error !== null) {
+          return Left(context._internalState.error);
+        }
+        return Right(context._internalState.restoreAppsStorageResult);
+      },
+    });
+  }
+}

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceActionErrors.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceActionErrors.ts
@@ -1,0 +1,33 @@
+import { type DmkError } from "@ledgerhq/device-management-kit";
+
+export class InitRestoreAppStorageError implements DmkError {
+  readonly _tag = "InitRestoreAppStorageError";
+  readonly originalError?: unknown;
+
+  constructor(originalError?: unknown) {
+    this.originalError = originalError;
+  }
+}
+
+export class RestoreAppStorageError implements DmkError {
+  readonly _tag = "RestoreAppStorageError";
+  readonly originalError?: unknown;
+
+  constructor(originalError?: unknown) {
+    this.originalError = originalError;
+  }
+}
+
+export class CommitRestoreAppStorageError implements DmkError {
+  readonly _tag = "CommitRestoreAppStorageError";
+  readonly originalError?: unknown;
+
+  constructor(originalError?: unknown) {
+    this.originalError = originalError;
+  }
+}
+
+export type RestoreAppsStorageDeviceActionErrors =
+  | InitRestoreAppStorageError
+  | RestoreAppStorageError
+  | CommitRestoreAppStorageError;

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/CommitRestoreAppStorage.test.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/CommitRestoreAppStorage.test.ts
@@ -1,0 +1,48 @@
+import {
+  CommandResultFactory,
+  GLOBAL_ERRORS,
+  GlobalCommandError,
+} from "@ledgerhq/device-management-kit";
+
+import { makeDeviceActionInternalApiMock } from "@api/device-action/__test-utils__/makeInternalApi";
+import { CommitRestoreAppStorageError } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceActionErrors";
+import { commitRestoreAppStorage } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/CommitRestoreAppStorage";
+
+describe("CommitRestoreAppStorage", () => {
+  const apiMock = makeDeviceActionInternalApiMock();
+  const { sendCommand: sendCommandMock } = apiMock;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("Success", () => {
+    it("Should commit the restored app storage", async () => {
+      sendCommandMock.mockResolvedValueOnce(
+        CommandResultFactory({ data: undefined }),
+      );
+
+      const result = await commitRestoreAppStorage(apiMock)();
+
+      expect(result.isRight()).toBe(true);
+    });
+  });
+
+  describe("Error", () => {
+    it("Should return CommitRestoreAppStorageError", async () => {
+      const error = new GlobalCommandError({
+        errorCode: "6e00",
+        ...GLOBAL_ERRORS["6e00"],
+      });
+      sendCommandMock.mockResolvedValueOnce(CommandResultFactory({ error }));
+
+      const result = await commitRestoreAppStorage(apiMock)();
+
+      expect(result.isLeft()).toBe(true);
+      result.mapLeft((e) => {
+        expect(e).toBeInstanceOf(CommitRestoreAppStorageError);
+        expect(e.originalError).toBe(error.originalError);
+      });
+    });
+  });
+});

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/CommitRestoreAppStorage.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/CommitRestoreAppStorage.ts
@@ -1,0 +1,29 @@
+import {
+  type InternalApi,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { type Either, Left, Right } from "purify-ts/Either";
+
+import { CommitRestoreAppStorageCommand } from "@api/command/OsUpdate/Restore/CommitRestoreAppStorageCommand";
+import { CommitRestoreAppStorageError } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceActionErrors";
+
+type CommitRestoreAppStorageHandlerResponse = Promise<
+  Either<CommitRestoreAppStorageError, void>
+>;
+
+type CommitRestoreAppStorageHandler =
+  () => CommitRestoreAppStorageHandlerResponse;
+
+export const commitRestoreAppStorage =
+  (internalApi: InternalApi): CommitRestoreAppStorageHandler =>
+  async (): CommitRestoreAppStorageHandlerResponse => {
+    const result = await internalApi.sendCommand(
+      new CommitRestoreAppStorageCommand(),
+    );
+
+    if (!isSuccessCommandResult(result)) {
+      return Left(new CommitRestoreAppStorageError(result.error.originalError));
+    }
+
+    return Right(undefined);
+  };

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/GoToDashboard.test.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/GoToDashboard.test.ts
@@ -1,0 +1,52 @@
+import { GoToDashboardDeviceAction } from "@ledgerhq/device-management-kit";
+
+import { makeDeviceActionInternalApiMock } from "@api/device-action/__test-utils__/makeInternalApi";
+import { goToDashboard } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/GoToDashboard";
+
+vi.mock("@ledgerhq/device-management-kit", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@ledgerhq/device-management-kit")>();
+  return {
+    ...original,
+    GoToDashboardDeviceAction: vi.fn(),
+  };
+});
+
+describe("GoToDashboard", () => {
+  const apiMock = makeDeviceActionInternalApiMock();
+  const MockDA = vi.mocked(GoToDashboardDeviceAction);
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("Success", () => {
+    it("Should return the go to dashboard device action state machine", () => {
+      const fakeStateMachine = Symbol("stateMachine");
+      const makeStateMachineMock = vi.fn().mockReturnValue(fakeStateMachine);
+      MockDA.mockImplementation(
+        () => ({ makeStateMachine: makeStateMachineMock }) as never,
+      );
+
+      const result = goToDashboard(apiMock, 5000);
+
+      expect(MockDA).toHaveBeenCalledWith({ input: { unlockTimeout: 5000 } });
+      expect(makeStateMachineMock).toHaveBeenCalledWith(apiMock);
+      expect(result).toBe(fakeStateMachine);
+    });
+  });
+
+  describe("Error", () => {
+    it("Should return the error from the device action", () => {
+      const error = new Error("Device action failed");
+      const makeStateMachineMock = vi.fn().mockImplementation(() => {
+        throw error;
+      });
+      MockDA.mockImplementation(
+        () => ({ makeStateMachine: makeStateMachineMock }) as never,
+      );
+
+      expect(() => goToDashboard(apiMock, 5000)).toThrow(error);
+    });
+  });
+});

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/GoToDashboard.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/GoToDashboard.ts
@@ -1,0 +1,16 @@
+import {
+  GoToDashboardDeviceAction,
+  type InternalApi,
+} from "@ledgerhq/device-management-kit";
+
+type GoToDashboardResult = ReturnType<
+  GoToDashboardDeviceAction["makeStateMachine"]
+>;
+
+export const goToDashboard = (
+  internalApi: InternalApi,
+  unlockTimeout: number,
+): GoToDashboardResult =>
+  new GoToDashboardDeviceAction({
+    input: { unlockTimeout },
+  }).makeStateMachine(internalApi);

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/InitRestoreAppStorage.test.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/InitRestoreAppStorage.test.ts
@@ -1,0 +1,75 @@
+import {
+  CommandResultFactory,
+  GLOBAL_ERRORS,
+  GlobalCommandError,
+} from "@ledgerhq/device-management-kit";
+
+import { InitRestoreAppStorageCommandError } from "@api/command/OsUpdate/Restore/InitRestoreAppStorageCommand";
+import { makeDeviceActionInternalApiMock } from "@api/device-action/__test-utils__/makeInternalApi";
+import { InitRestoreAppStorageError } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceActionErrors";
+import { initRestoreAppStorage } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/InitRestoreAppStorage";
+import { InitRestoreAppStorageConsentResult } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/types";
+
+describe("InitRestoreAppStorage", () => {
+  const apiMock = makeDeviceActionInternalApiMock();
+  const { sendCommand: sendCommandMock } = apiMock;
+  const input = { appName: "MyApp", appStorageDataLength: 42 };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("Success", () => {
+    it("Should return consent granted when the command succeeds", async () => {
+      sendCommandMock.mockResolvedValueOnce(
+        CommandResultFactory({ data: undefined }),
+      );
+
+      const result = await initRestoreAppStorage(apiMock)({ input });
+
+      expect(result.isRight()).toBe(true);
+      expect(result.extract()).toBe(InitRestoreAppStorageConsentResult.GRANTED);
+    });
+  });
+
+  describe("Consent rejected", () => {
+    it.each(["5501", "5502"] as const)(
+      "Should return consent rejected when the command fails with %s",
+      async (errorCode) => {
+        sendCommandMock.mockResolvedValueOnce(
+          CommandResultFactory({
+            error: new InitRestoreAppStorageCommandError({
+              errorCode,
+              message: "Invalid consent",
+            }),
+          }),
+        );
+
+        const result = await initRestoreAppStorage(apiMock)({ input });
+
+        expect(result.isRight()).toBe(true);
+        expect(result.extract()).toBe(
+          InitRestoreAppStorageConsentResult.REJECTED,
+        );
+      },
+    );
+  });
+
+  describe("Error", () => {
+    it("Should return InitRestoreAppStorageError for other error codes", async () => {
+      const error = new GlobalCommandError({
+        errorCode: "6e00",
+        ...GLOBAL_ERRORS["6e00"],
+      });
+      sendCommandMock.mockResolvedValueOnce(CommandResultFactory({ error }));
+
+      const result = await initRestoreAppStorage(apiMock)({ input });
+
+      expect(result.isLeft()).toBe(true);
+      result.mapLeft((e) => {
+        expect(e).toBeInstanceOf(InitRestoreAppStorageError);
+        expect(e.originalError).toBe(error.originalError);
+      });
+    });
+  });
+});

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/InitRestoreAppStorage.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/InitRestoreAppStorage.ts
@@ -1,0 +1,50 @@
+import {
+  type InternalApi,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { type Either, Left, Right } from "purify-ts/Either";
+
+import {
+  InitRestoreAppStorageCommand,
+  InitRestoreAppStorageCommandError,
+} from "@api/command/OsUpdate/Restore/InitRestoreAppStorageCommand";
+import { InitRestoreAppStorageError } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceActionErrors";
+import { InitRestoreAppStorageConsentResult } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/types";
+
+// "5501" = rejected by user, "5502" = pin is not set
+const INVALID_CONSENT_ERROR_CODES: string[] = ["5501", "5502"];
+
+type InitRestoreAppStorageHandlerArgs = {
+  input: { appName: string; appStorageDataLength: number };
+};
+
+type InitRestoreAppStorageHandlerResponse = Promise<
+  Either<InitRestoreAppStorageError, InitRestoreAppStorageConsentResult>
+>;
+
+type InitRestoreAppStorageHandler = (
+  args: InitRestoreAppStorageHandlerArgs,
+) => InitRestoreAppStorageHandlerResponse;
+
+export const initRestoreAppStorage =
+  (internalApi: InternalApi): InitRestoreAppStorageHandler =>
+  async ({
+    input,
+  }: InitRestoreAppStorageHandlerArgs): InitRestoreAppStorageHandlerResponse => {
+    const { appName, appStorageDataLength } = input;
+    const result = await internalApi.sendCommand(
+      new InitRestoreAppStorageCommand({ appName, appStorageDataLength }),
+    );
+
+    if (!isSuccessCommandResult(result)) {
+      if (
+        result.error instanceof InitRestoreAppStorageCommandError &&
+        INVALID_CONSENT_ERROR_CODES.includes(result.error.errorCode)
+      ) {
+        return Right(InitRestoreAppStorageConsentResult.REJECTED);
+      }
+      return Left(new InitRestoreAppStorageError(result.error.originalError));
+    }
+
+    return Right(InitRestoreAppStorageConsentResult.GRANTED);
+  };

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/RestoreAppStorage.test.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/RestoreAppStorage.test.ts
@@ -1,0 +1,68 @@
+import {
+  CommandResultFactory,
+  GLOBAL_ERRORS,
+  GlobalCommandError,
+} from "@ledgerhq/device-management-kit";
+
+import { makeDeviceActionInternalApiMock } from "@api/device-action/__test-utils__/makeInternalApi";
+import { RestoreAppStorageError } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceActionErrors";
+import { restoreAppStorage } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/RestoreAppStorage";
+import { RestoreAppStorageTask } from "@api/task/OsUpdate/Restore/RestoreAppStorageTask";
+
+vi.mock("@api/task/OsUpdate/Restore/RestoreAppStorageTask");
+
+describe("RestoreAppStorage", () => {
+  const apiMock = makeDeviceActionInternalApiMock();
+  const MockTask = vi.mocked(RestoreAppStorageTask);
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("Success", () => {
+    it("Should restore the app storage data", async () => {
+      const appStorageData = Uint8Array.from([0x01, 0x02]);
+      const runMock = vi
+        .fn()
+        .mockResolvedValueOnce(CommandResultFactory({ data: undefined }));
+      MockTask.mockImplementation(() => ({ run: runMock }) as never);
+
+      const result = await restoreAppStorage(
+        apiMock,
+        apiMock.loggerFactory!,
+      )({ input: { appStorageData } });
+
+      expect(result.isRight()).toBe(true);
+      expect(MockTask).toHaveBeenCalledWith(
+        { appStorageData },
+        apiMock,
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("Error", () => {
+    it("Should return RestoreAppStorageError", async () => {
+      const appStorageData = Uint8Array.from([0x01, 0x02]);
+      const error = new GlobalCommandError({
+        errorCode: "6e00",
+        ...GLOBAL_ERRORS["6e00"],
+      });
+      const runMock = vi
+        .fn()
+        .mockResolvedValueOnce(CommandResultFactory({ error }));
+      MockTask.mockImplementation(() => ({ run: runMock }) as never);
+
+      const result = await restoreAppStorage(
+        apiMock,
+        apiMock.loggerFactory!,
+      )({ input: { appStorageData } });
+
+      expect(result.isLeft()).toBe(true);
+      result.mapLeft((e) => {
+        expect(e).toBeInstanceOf(RestoreAppStorageError);
+        expect(e.originalError).toBe(error.originalError);
+      });
+    });
+  });
+});

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/RestoreAppStorage.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/RestoreAppStorage.ts
@@ -1,0 +1,43 @@
+import {
+  type InternalApi,
+  isSuccessCommandResult,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+import { type Either, Left, Right } from "purify-ts/Either";
+
+import { RestoreAppStorageError } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceActionErrors";
+import { RestoreAppStorageTask } from "@api/task/OsUpdate/Restore/RestoreAppStorageTask";
+
+type RestoreAppStorageHandlerArgs = {
+  input: { appStorageData: Uint8Array };
+};
+
+type RestoreAppStorageHandlerResponse = Promise<
+  Either<RestoreAppStorageError, void>
+>;
+
+type RestoreAppStorageHandler = (
+  args: RestoreAppStorageHandlerArgs,
+) => RestoreAppStorageHandlerResponse;
+
+export const restoreAppStorage =
+  (
+    internalApi: InternalApi,
+    loggerFactory: (tag: string) => LoggerPublisherService,
+  ): RestoreAppStorageHandler =>
+  async ({
+    input,
+  }: RestoreAppStorageHandlerArgs): RestoreAppStorageHandlerResponse => {
+    const logger = loggerFactory("RestoreAppStorageTask");
+    const result = await new RestoreAppStorageTask(
+      { appStorageData: input.appStorageData },
+      internalApi,
+      logger,
+    ).run();
+
+    if (!isSuccessCommandResult(result)) {
+      return Left(new RestoreAppStorageError(result.error.originalError));
+    }
+
+    return Right(undefined);
+  };

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/WaitForAppAndVersion.test.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/WaitForAppAndVersion.test.ts
@@ -1,0 +1,52 @@
+import { WaitForAppAndVersionDeviceAction } from "@ledgerhq/device-management-kit";
+
+import { makeDeviceActionInternalApiMock } from "@api/device-action/__test-utils__/makeInternalApi";
+import { waitForAppAndVersion } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/WaitForAppAndVersion";
+
+vi.mock("@ledgerhq/device-management-kit", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@ledgerhq/device-management-kit")>();
+  return {
+    ...original,
+    WaitForAppAndVersionDeviceAction: vi.fn(),
+  };
+});
+
+describe("WaitForAppAndVersion", () => {
+  const apiMock = makeDeviceActionInternalApiMock();
+  const MockDA = vi.mocked(WaitForAppAndVersionDeviceAction);
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("Success", () => {
+    it("Should return the wait for app and version device action state machine", () => {
+      const fakeStateMachine = Symbol("stateMachine");
+      const makeStateMachineMock = vi.fn().mockReturnValue(fakeStateMachine);
+      MockDA.mockImplementation(
+        () => ({ makeStateMachine: makeStateMachineMock }) as never,
+      );
+
+      const result = waitForAppAndVersion(apiMock, 5000);
+
+      expect(MockDA).toHaveBeenCalledWith({ input: { unlockTimeout: 5000 } });
+      expect(makeStateMachineMock).toHaveBeenCalledWith(apiMock);
+      expect(result).toBe(fakeStateMachine);
+    });
+  });
+
+  describe("Error", () => {
+    it("Should return the error from the device action", () => {
+      const error = new Error("Device action failed");
+      const makeStateMachineMock = vi.fn().mockImplementation(() => {
+        throw error;
+      });
+      MockDA.mockImplementation(
+        () => ({ makeStateMachine: makeStateMachineMock }) as never,
+      );
+
+      expect(() => waitForAppAndVersion(apiMock, 5000)).toThrow(error);
+    });
+  });
+});

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/WaitForAppAndVersion.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/Substeps/WaitForAppAndVersion.ts
@@ -1,0 +1,16 @@
+import {
+  type InternalApi,
+  WaitForAppAndVersionDeviceAction,
+} from "@ledgerhq/device-management-kit";
+
+type WaitForAppAndVersionResult = ReturnType<
+  WaitForAppAndVersionDeviceAction["makeStateMachine"]
+>;
+
+export const waitForAppAndVersion = (
+  internalApi: InternalApi,
+  unlockTimeout: number,
+): WaitForAppAndVersionResult =>
+  new WaitForAppAndVersionDeviceAction({
+    input: { unlockTimeout },
+  }).makeStateMachine(internalApi);

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/types.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Restore/RestoreAppsStorage/types.ts
@@ -1,0 +1,79 @@
+import {
+  type DeviceActionState,
+  type GoToDashboardDAError,
+  type GoToDashboardDARequiredInteraction,
+  type HexaString,
+  type UserInteractionRequired,
+  type WaitForAppAndVersionDAError,
+  type WaitForAppAndVersionDARequiredInteraction,
+} from "@ledgerhq/device-management-kit";
+
+import { type BackupApp } from "@api/device-action/OsUpdate/Backup/types";
+import { type RestoreAppsStorageDeviceActionErrors } from "@api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceActionErrors";
+
+export type RestoreAppsStorageDAInput = {
+  backupApps: BackupApp[];
+  isMasterConsentGranted: boolean;
+  unlockTimeout: number;
+};
+
+export type RestoreAppStorageResult = {
+  appName: string;
+  restoredAppStorage: boolean;
+};
+
+export type RestoreAppsStorageDAOutput = RestoreAppStorageResult[];
+
+export type RestoreAppsStorageDAError =
+  | WaitForAppAndVersionDAError
+  | GoToDashboardDAError
+  | RestoreAppsStorageDeviceActionErrors;
+
+export type RestoreAppsStorageDARequiredInteraction =
+  | WaitForAppAndVersionDARequiredInteraction
+  | GoToDashboardDARequiredInteraction
+  | UserInteractionRequired.None
+  | UserInteractionRequired.GrantConsent;
+
+export type RestoreAppsStorageDAIntermediateValue = {
+  requiredUserInteraction: RestoreAppsStorageDARequiredInteraction;
+  step: RestoreAppsStorageSteps;
+};
+
+// A BackupApp whose storage `data` is known to be defined, i.e. it was
+// actually backed up and therefore has app storage to restore.
+export type BackupAppWithStorage = BackupApp & { data: HexaString };
+
+export type RestoreAppsStorageDAInternalState = {
+  error: RestoreAppsStorageDAError | null;
+  currentApp: string | null;
+  appsWithStorage: BackupAppWithStorage[];
+  currentAppStorageIndex: number;
+  currentAppStorageName: string | null;
+  currentAppStorageDataBytes: Uint8Array | null;
+  currentAppStorageDataLength: number | null;
+  restoreAppsStorageResult: RestoreAppStorageResult[];
+};
+
+export type RestoreAppsStorageDAState = DeviceActionState<
+  RestoreAppsStorageDAOutput,
+  RestoreAppsStorageDAError,
+  RestoreAppsStorageDAIntermediateValue
+>;
+
+export enum RestoreAppsStorageSteps {
+  Idle = "idle",
+  WaitForAppAndVersion = "waitForAppAndVersion",
+  GoToDashboard = "goToDashboard",
+  FilterAppsWithStorage = "filterAppsWithStorage",
+  ExtractAppData = "extractAppData",
+  InitRestoreAppStorage = "initRestoreAppStorage",
+  RestoreAppStorage = "restoreAppStorage",
+  CommitRestoreAppStorage = "commitRestoreAppStorage",
+}
+
+// Outcome of the consent prompt triggered by InitRestoreAppStorageCommand.
+export enum InitRestoreAppStorageConsentResult {
+  GRANTED = "consentGranted",
+  REJECTED = "consentRejected",
+}

--- a/packages/ledger-wallet/src/index.ts
+++ b/packages/ledger-wallet/src/index.ts
@@ -119,6 +119,17 @@ export type {
   CreateBackupDAState,
   CreateBackupSteps,
 } from "./api/device-action/OsUpdate/Backup/types";
+export { RestoreAppsStorageDeviceAction } from "./api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceAction";
+export type {
+  RestoreAppsStorageDAError,
+  RestoreAppsStorageDAInput,
+  RestoreAppsStorageDAIntermediateValue,
+  RestoreAppsStorageDAOutput,
+  RestoreAppsStorageDARequiredInteraction,
+  RestoreAppsStorageDAState,
+  RestoreAppsStorageSteps,
+  RestoreAppStorageResult,
+} from "./api/device-action/OsUpdate/Restore/RestoreAppsStorage/types";
 export { RemoveCustomLockScreenDeviceAction } from "./api/device-action/RemoveCustomLockScreen/RemoveCustomLockScreenDeviceAction";
 export type {
   RemoveCustomLockScreenDAError,


### PR DESCRIPTION
### 📝 Description

Adds `RestoreAppsStorageDeviceAction` to `@ledgerhq/dmk-ledger-wallet`: it restores per-app storage backups (produced by `CreateBackupDeviceAction`) onto a device, one app at a time.

For each app whose backup contains storage data, the device action:
1. Waits for the dashboard app and initializes the restore on-device (`InitRestoreAppStorageCommand`).
2. If the user rejects the restore consent for that app, it's skipped (not treated as a fatal error) and the flow moves on to the next app.
3. Otherwise, sends the storage data in chunks (`RestoreAppStorageTask`) and commits the restore (`CommitRestoreAppStorageCommand`).

The result is a `RestoreAppStorageResult[]` reporting, per app, whether its storage was successfully restored.

This also adds a new input, `isMasterConsentGranted: boolean`, and a new `UserInteractionRequired.GrantConsent` value (added to `@ledgerhq/device-management-kit`) so that consumers can be told to prompt the user to grant the device's consent before the restoring an app storage, via `requiredUserInteraction`.

#### Result: 

https://github.com/user-attachments/assets/b1c53d7f-9c49-4091-b478-36c8d8710c5f

### ❓ Context

- **JIRA link**: [DSDK-1319](https://ledgerhq.atlassian.net/browse/DSDK-1319?atlOrigin=eyJpIjoiOGE3NTliNTFkZjExNGY4MDhhMzJhOGZlZTU4MGY1MGIiLCJwIjoiaiJ9)

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [ ] ~~**Documentation is up-to-date**~~
- [x] **Impact of the changes:**
  - New `RestoreAppsStorageDeviceAction`, `RestoreAppsStorageDAInput/Output/Error/IntermediateValue/State` and related substeps/types exported from `@ledgerhq/dmk-ledger-wallet`.
  - New `UserInteractionRequired.GrantConsent` value exported from `@ledgerhq/device-management-kit`.
  - No changes to existing device actions or public APIs.

[DSDK-1319]: https://ledgerhq.atlassian.net/browse/DSDK-1319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ