### PR TITLE
✨ (signer-zcash) [LIVE-34318]: add NU6.3 consensus branch id

### DIFF
--- a/.changeset/zcash-nu63-branch-id.md
+++ b/.changeset/zcash-nu63-branch-id.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-zcash": patch
+---
+
+Add the NU6.3 consensus branch id (0x37a5165b, mainnet activation height 3,428,143) to the Zcash transparent height→branch-id dispatch so transactions signed after NU6.3 activation are accepted by the network.

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/utils/legacyTransactionUtils.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/utils/legacyTransactionUtils.test.ts
@@ -28,10 +28,10 @@ describe("getZcashBranchId", () => {
 
   it("returns latest branch id when block height is unknown", () => {
     expect(getZcashBranchId(undefined)).toEqual(
-      Uint8Array.of(0x30, 0xf3, 0x37, 0x54),
+      Uint8Array.of(0x5b, 0x16, 0xa5, 0x37),
     );
     expect(getZcashBranchId(null)).toEqual(
-      Uint8Array.of(0x30, 0xf3, 0x37, 0x54),
+      Uint8Array.of(0x5b, 0x16, 0xa5, 0x37),
     );
   });
 
@@ -50,6 +50,15 @@ describe("getZcashBranchId", () => {
     );
     expect(getZcashBranchId(3364600)).toEqual(
       Uint8Array.of(0x30, 0xf3, 0x37, 0x54),
+    );
+  });
+
+  it("switches from NU6.2 to NU6.3 branch id at activation height", () => {
+    expect(getZcashBranchId(3428142)).toEqual(
+      Uint8Array.of(0x30, 0xf3, 0x37, 0x54),
+    );
+    expect(getZcashBranchId(3428143)).toEqual(
+      Uint8Array.of(0x5b, 0x16, 0xa5, 0x37),
     );
   });
 });

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/utils/legacyTransactionUtils.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/utils/legacyTransactionUtils.ts
@@ -20,7 +20,7 @@ export const OP_EQUALVERIFY = 0x88;
 export const OP_CHECKSIG = 0xac;
 
 const ZCASH_ACTIVATION_HEIGHTS = {
-  // https://z.cash/upgrade/nu6.2/
+  NU6_3: 3428143,
   NU6_2: 3364600,
   NU6_1: 3146400,
   NU6: 2726400,
@@ -324,9 +324,11 @@ export const getZcashBranchId = (
   if (
     blockHeight === null ||
     blockHeight === undefined ||
-    blockHeight >= ZCASH_ACTIVATION_HEIGHTS.NU6_2
+    blockHeight >= ZCASH_ACTIVATION_HEIGHTS.NU6_3
   ) {
     // NOTE: null and undefined should default to the latest version
+    return uint32ToBytesLE(0x37a5165b);
+  } else if (blockHeight >= ZCASH_ACTIVATION_HEIGHTS.NU6_2) {
     return uint32ToBytesLE(0x5437f330);
   } else if (blockHeight >= ZCASH_ACTIVATION_HEIGHTS.NU6_1) {
     return uint32ToBytesLE(0x4dec4df0);


### PR DESCRIPTION
### 📝 Description

Add the NU6.3 consensus branch id to the Zcash transparent height→branch-id dispatch so transparent ZEC transactions signed after NU6.3 activation are accepted by the network.

`getZcashBranchId` now maps heights ≥ `3_428_143` to `0x37a5165b` (and defaults unknown/`undefined` heights to it, as the latest); the previous NU6.2 mapping (`0x5437f330`) is preserved for heights below the boundary. This is **production continuity** for the primary transparent-send path (coin-bitcoin → Zcash chain-adapter → DMK `signer-zcash` → `signTransaction`) — no new Ironwood feature.

Because the mapping is height-driven, it is safe to merge ahead of activation: the NU6.3 branch id is only emitted once the chain reaches height `3_428_143` (NU6.3 mainnet activation, 2026-07-28). Mirrors the NU6.2 precedent (#1557).

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-34318

- **Feature**: NU6.3 consensus branch id + activation height for transparent Zcash signing (consensus continuity).

### ✅ Checklist

- [x] **Covered by automatic tests** — updated the "unknown height → latest" test and added a NU6.2↔NU6.3 activation-boundary test in `legacyTransactionUtils.test.ts` (`3_428_142` → `0x5437f330`, `3_428_143` → `0x37a5165b`). Full package suite green (158 tests); `legacyTransactionUtils.ts` line coverage 82%.
- [x] **Changeset is provided** — `.changeset/zcash-nu63-branch-id.md` (patch).
- [x] **Documentation is up-to-date** — n/a (internal constant table).
- [ ] **Impact of the changes:**
  - `getZcashBranchId` returns `0x37a5165b` at heights ≥ `3_428_143`, `0x5437f330` just below.
  - Unknown/`undefined`/`null` height now defaults to the NU6.3 branch id.
  - QA focus: transparent ZEC send signing around the NU6.3 activation boundary.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
