### PR TITLE
✨ (signer-trx) [DSDK-1305]: Implement Sign Transaction device action

### DIFF
--- a/.changeset/tron-sign-transaction.md
+++ b/.changeset/tron-sign-transaction.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-tron": minor
+---
+
+Implement the Sign Transaction device action

--- a/apps/sample/playwright/cases/signers/tron/sign-transaction.spec.ts
+++ b/apps/sample/playwright/cases/signers/tron/sign-transaction.spec.ts
@@ -1,0 +1,64 @@
+/* eslint-disable no-restricted-imports */
+import { type DeviceConfig } from "@ledgerhq/device-mockserver-client";
+
+import { expect, test } from "../../../fixtures";
+
+const STAX_WITH_TRX: DeviceConfig = {
+  name: "Ledger Stax",
+  device_type: "stax",
+  connectivity_type: "USB",
+  firmware_version: "1.9.1",
+  apps: [
+    { name: "BOLOS", version: "1.9.1" },
+    { name: "Tron", version: "0.7.4" },
+  ],
+  masks: [0x33200000],
+};
+
+// A plain TRX TransferContract with no `data` field (protobuf-serialized
+// `raw_data`, hex-encoded), derived from the hw-app-trx test vector with its
+// memo stripped. The Tron app clear-signs a bare transfer natively, so the
+// review can be approved on screen without enabling the "Allow data in
+// transactions" setting - a transaction carrying `data` is rejected with 6a8b
+// and never shows a review.
+const RAW_TRANSFER_TX =
+  "0a023dce220895da42177db0050740d8e0a5feed2d5a68080112640a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412330a1541c8599111f29c1e1e061265b4af93ea1f274ad78a121541c8599111f29c1e1e061265b4af93ea1f274ad78a1880c2d72f709d94a2feed2d";
+
+// The signature is a 65-byte buffer (r[32] + s[32] + v[1]), rendered by the
+// sample app as a 0x-prefixed hex string.
+const SIGNATURE_RE = /^0x[0-9a-f]{130}$/i;
+
+test.describe("signer tron: sign transaction", () => {
+  test("signs a TRX transfer approved on the device screen", async ({
+    device,
+    trxSigner,
+    speculos,
+  }) => {
+    // Opening the Tron app provisions a real Speculos instance and the
+    // transaction must be reviewed/approved on screen, so this flow is slow.
+    test.setTimeout(120_000);
+
+    let dev!: Awaited<ReturnType<typeof device.addAndConnect>>;
+    await test.step("Given the device with the Tron app is connected", async () => {
+      dev = await device.addAndConnect(STAX_WITH_TRX);
+    });
+
+    await test.step("When Sign transaction is executed for a TRX transfer", async () => {
+      await trxSigner.open();
+      await trxSigner.signTransaction(RAW_TRANSFER_TX);
+    });
+
+    await test.step("And the transaction is approved on the Speculos screen", async () => {
+      const emulator = speculos(dev);
+      await emulator.waitReady();
+      await emulator.approveSigning();
+    });
+
+    await test.step("Then a valid signature is returned", async () => {
+      const result = await trxSigner.lastResult<string>();
+
+      expect(result.status).toBe("completed");
+      expect(result.output).toMatch(SIGNATURE_RE);
+    });
+  });
+});

--- a/apps/sample/playwright/utils/drivers/TrxSignerDriver.ts
+++ b/apps/sample/playwright/utils/drivers/TrxSignerDriver.ts
@@ -50,6 +50,25 @@ export class TrxSignerDriver {
   }
 
   /**
+   * Open the Sign transaction action, fill the raw transaction (hex-encoded
+   * protobuf-serialized `raw_data`) and Execute it. The action stays pending
+   * until the transaction is reviewed and signed on Speculos.
+   */
+  async signTransaction(
+    transaction: string,
+    { skipOpenApp = false }: { skipOpenApp?: boolean } = {},
+  ): Promise<void> {
+    await this.page.getByTestId("CTA_command-Sign transaction").click();
+    const input = this.page.getByTestId("input-text_transaction");
+    await input.waitFor({ state: "visible" });
+    await input.fill(transaction);
+    if (skipOpenApp) {
+      await this.page.getByTestId("input-switch_skipOpenApp").click();
+    }
+    await this.page.getByTestId("CTA_send-device-action").click();
+  }
+
+  /**
    * Wait for the last emitted device-action state to be terminal and return it
    * parsed.
    */

--- a/apps/sample/src/components/SignerTrxView/index.tsx
+++ b/apps/sample/src/components/SignerTrxView/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useMemo } from "react";
+import { hexaStringToBuffer } from "@ledgerhq/device-management-kit";
 import {
   type GetAddressDAError,
   type GetAddressDAIntermediateValue,
@@ -8,6 +9,9 @@ import {
   type GetAppConfigurationDAIntermediateValue,
   type GetAppConfigurationDAOutput,
   SignerTrxBuilder,
+  type SignTransactionDAError,
+  type SignTransactionDAIntermediateValue,
+  type SignTransactionDAOutput,
 } from "@ledgerhq/device-signer-kit-tron";
 
 import { DeviceActionsList } from "@/components/DeviceActionsView/DeviceActionsList";
@@ -58,6 +62,33 @@ export const SignerTrxView: React.FC<{ sessionId: string }> = ({
         },
         GetAddressDAError,
         GetAddressDAIntermediateValue
+      >,
+      {
+        title: "Sign transaction",
+        description:
+          "Perform all the actions necessary to sign a Tron transaction with the device. The transaction is the hex-encoded protobuf-serialized raw_data of the transaction, reviewed and blind-signed on-device.",
+        executeDeviceAction: ({ derivationPath, transaction, skipOpenApp }) => {
+          const tx = hexaStringToBuffer(transaction);
+          if (!tx || tx.length === 0) {
+            throw new Error("Invalid transaction format");
+          }
+          return signer.signTransaction(derivationPath, tx, { skipOpenApp });
+        },
+        initialValues: {
+          derivationPath: DEFAULT_DERIVATION_PATH,
+          transaction: "",
+          skipOpenApp: false,
+        },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        SignTransactionDAOutput,
+        {
+          derivationPath: string;
+          transaction: string;
+          skipOpenApp?: boolean;
+        },
+        SignTransactionDAError,
+        SignTransactionDAIntermediateValue
       >,
       {
         title: "Get app configuration",

--- a/packages/signer/signer-trx/README.md
+++ b/packages/signer/signer-trx/README.md
@@ -117,6 +117,46 @@ observable.subscribe((state) => {
 });
 ```
 
+### Sign transaction
+
+Signs a raw Tron transaction. The transaction is the protobuf-serialized
+`raw_data` bytes of the transaction; it is framed across APDUs, reviewed and
+blind-signed on the device (no clear-signing context is resolved). Requires
+the user to approve the transaction on the device screen.
+
+```typescript
+signer.signTransaction(
+  derivationPath: string,
+  // protobuf-serialized `raw_data` bytes of the transaction
+  transaction: Uint8Array,
+  options?: {
+    // Skip the "open app" step if the Tron app is already open (default: false).
+    skipOpenApp?: boolean;
+  },
+): SignTransactionDAReturnType;
+```
+
+The returned device action resolves to the 65-byte signature
+(`r[32] + s[32] + v[1]`) as a `Uint8Array`.
+
+```typescript
+const { observable, cancel } = signer.signTransaction(
+  "44'/195'/0'/0/0",
+  rawTransaction,
+);
+
+observable.subscribe((state) => {
+  switch (state.status) {
+    case "completed":
+      console.log(state.output); // Uint8Array(65) signature
+      break;
+    case "error":
+      console.error(state.error);
+      break;
+  }
+});
+```
+
 ## Development
 
 ```bash

--- a/packages/signer/signer-trx/src/api/model/TransactionOptions.ts
+++ b/packages/signer/signer-trx/src/api/model/TransactionOptions.ts
@@ -1,8 +1,3 @@
 export type TransactionOptions = {
   skipOpenApp?: boolean;
-  /**
-   * TRC10 token name signatures, as hex strings, appended after the
-   * transaction frames during signing (matches `@ledgerhq/hw-app-trx`).
-   */
-  tokenSignatures?: string[];
 };

--- a/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.test.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.test.ts
@@ -1,4 +1,5 @@
 import {
+  CallTaskInAppDeviceAction,
   type DeviceActionState,
   DeviceActionStatus,
   type DeviceManagementKit,
@@ -19,8 +20,14 @@ import {
   type GetAppConfigurationDAIntermediateValue,
   type GetAppConfigurationDAOutput,
 } from "@api/app-binder/GetAppConfigurationDeviceActionTypes";
+import {
+  type SignTransactionDAError,
+  type SignTransactionDAIntermediateValue,
+  type SignTransactionDAOutput,
+} from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { GetAddressCommand } from "@internal/app-binder/command/GetAddressCommand";
 import { GetAppConfigurationCommand } from "@internal/app-binder/command/GetAppConfigurationCommand";
+import { type TronAppCommandError } from "@internal/app-binder/command/utils/tronApplicationErrors";
 import { APP_NAME } from "@internal/app-binder/constants";
 
 import { TronAppBinder } from "./TronAppBinder";
@@ -173,6 +180,114 @@ describe("TronAppBinder", () => {
             }),
           }),
         );
+      });
+    });
+  });
+
+  describe("signTransaction", () => {
+    const derivationPath = "44'/195'/0'/0/0";
+    const transaction = Uint8Array.from([0x0a, 0x01, 0x00]);
+
+    it("should return the signature", () =>
+      new Promise<void>((resolve, reject) => {
+        // GIVEN
+        const output: SignTransactionDAOutput = new Uint8Array(65).fill(0xab);
+
+        vi.spyOn(mockedDmk, "executeDeviceAction").mockReturnValue({
+          observable: from([
+            {
+              status: DeviceActionStatus.Completed,
+              output,
+            } as DeviceActionState<
+              SignTransactionDAOutput,
+              SignTransactionDAError,
+              SignTransactionDAIntermediateValue
+            >,
+          ]),
+          cancel: vi.fn(),
+        });
+
+        // WHEN
+        const binder = new TronAppBinder(
+          mockedDmk,
+          "sessionId",
+          loggerFactoryMock,
+        );
+        const { observable } = binder.signTransaction({
+          derivationPath,
+          transaction,
+        });
+
+        // THEN
+        const states: DeviceActionState<
+          SignTransactionDAOutput,
+          SignTransactionDAError,
+          SignTransactionDAIntermediateValue
+        >[] = [];
+        observable.subscribe({
+          next: (state) => states.push(state),
+          error: reject,
+          complete: () => {
+            try {
+              expect(states).toEqual([
+                { status: DeviceActionStatus.Completed, output },
+              ]);
+              resolve();
+            } catch (err) {
+              reject(err as Error);
+            }
+          },
+        });
+      }));
+
+    describe("calls executeDeviceAction with the correct params", () => {
+      // The task closure breaks reference equality, so the device action is
+      // asserted field by field instead of with toHaveBeenCalledWith.
+      const executedDeviceAction = () => {
+        const args = vi.mocked(mockedDmk.executeDeviceAction).mock
+          .calls[0]![0]!;
+        expect(args.sessionId).toBe("sessionId");
+        expect(args.deviceAction).toBeInstanceOf(CallTaskInAppDeviceAction);
+        return args.deviceAction as CallTaskInAppDeviceAction<
+          SignTransactionDAOutput,
+          TronAppCommandError,
+          UserInteractionRequired.SignTransaction
+        >;
+      };
+
+      it("requires the SignTransaction interaction", () => {
+        // WHEN
+        const binder = new TronAppBinder(
+          mockedDmk,
+          "sessionId",
+          loggerFactoryMock,
+        );
+        binder.signTransaction({
+          derivationPath,
+          transaction,
+          skipOpenApp: true,
+        });
+
+        // THEN
+        const deviceAction = executedDeviceAction();
+        expect(deviceAction.input.appName).toBe(APP_NAME);
+        expect(deviceAction.input.requiredUserInteraction).toBe(
+          UserInteractionRequired.SignTransaction,
+        );
+        expect(deviceAction.input.skipOpenApp).toBe(true);
+      });
+
+      it("defaults skipOpenApp to false", () => {
+        // WHEN
+        const binder = new TronAppBinder(
+          mockedDmk,
+          "sessionId",
+          loggerFactoryMock,
+        );
+        binder.signTransaction({ derivationPath, transaction });
+
+        // THEN
+        expect(executedDeviceAction().input.skipOpenApp).toBe(false);
       });
     });
   });

--- a/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.ts
@@ -55,7 +55,6 @@ export class TronAppBinder {
   signTransaction(args: {
     derivationPath: string;
     transaction: Uint8Array;
-    tokenSignatures?: string[];
     skipOpenApp?: boolean;
   }): SignTransactionDAReturnType {
     return this.dmk.executeDeviceAction({
@@ -66,7 +65,6 @@ export class TronAppBinder {
             new SignTransactionTask(internalApi, {
               derivationPath: args.derivationPath,
               transaction: args.transaction,
-              tokenSignatures: args.tokenSignatures,
             }).run(),
           appName: APP_NAME,
           requiredUserInteraction: UserInteractionRequired.SignTransaction,

--- a/packages/signer/signer-trx/src/internal/app-binder/command/SignTransactionCommand.test.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/command/SignTransactionCommand.test.ts
@@ -13,9 +13,9 @@ describe("SignTransactionCommand", () => {
   const payload = Uint8Array.from({ length: 10 }, (_, i) => i);
 
   describe("name", () => {
-    it("should be 'SignTransaction'", () => {
+    it("should be 'signTransaction'", () => {
       expect(new SignTransactionCommand({ payload, p1: 0x10 }).name).toBe(
-        "SignTransaction",
+        "signTransaction",
       );
     });
   });

--- a/packages/signer/signer-trx/src/internal/app-binder/command/SignTransactionCommand.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/command/SignTransactionCommand.ts
@@ -24,9 +24,9 @@ import {
  *
  * The Tron app frames a transaction across multiple APDUs; `p1` is the frame's
  * "start byte" (see {@link SIGN_TRANSACTION_P1}) and `payload` is the bytes for
- * this frame (the derivation path on the first frame, then transaction chunks,
- * then optional token signatures). The framing itself is orchestrated by
- * `SignTransactionTask`. The signature is only returned on the last frame.
+ * this frame (the derivation path on the first frame, then transaction chunks).
+ * The framing itself is orchestrated by `SignTransactionTask`. The signature is
+ * only returned on the last frame.
  */
 export type SignTransactionCommandArgs = {
   readonly payload: Uint8Array;
@@ -43,7 +43,7 @@ export class SignTransactionCommand
       TronAppErrorCodes
     >
 {
-  readonly name = "SignTransaction";
+  readonly name = "signTransaction";
 
   private readonly _args: SignTransactionCommandArgs;
 

--- a/packages/signer/signer-trx/src/internal/app-binder/constants.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/constants.ts
@@ -29,8 +29,8 @@ export const CHAIN_CODE_LENGTH = 32;
  * P1 "start byte" values for the SIGN_TRANSACTION instruction.
  *
  * The Tron app frames a transaction across several APDUs and encodes the frame
- * position (and token-signature slots) in P1. The multi-frame chunking and
- * token-signature handling are orchestrated by `SignTransactionTask`.
+ * position in P1. The multi-frame chunking is orchestrated by
+ * `SignTransactionTask`.
  */
 export const SIGN_TRANSACTION_P1 = {
   // First and only frame (transaction fits in a single APDU).
@@ -39,12 +39,8 @@ export const SIGN_TRANSACTION_P1 = {
   FIRST: 0x00,
   // Continuation frame.
   SUBSEQUENT: 0x80,
-  // Last continuation frame when there are no token-signature frames.
+  // Last continuation frame.
   LAST: 0x90,
-  // Token-signature frame; lower nibble carries the token index.
-  TOKEN: 0xa0,
-  // OR'd into the P1 of the final token-signature frame.
-  TOKEN_LAST_FLAG: 0x08,
 } as const;
 
 /**

--- a/packages/signer/signer-trx/src/internal/app-binder/services/TransactionSerializer.test.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/services/TransactionSerializer.test.ts
@@ -46,18 +46,22 @@ describe("serializeTransaction", () => {
     expect(frames[1]!.payload.length % 2).toBe(0);
   });
 
-  it("appends token-signature frames with the correct start bytes", () => {
-    // One length-delimited field "0a0100" (3 bytes) -> single tx frame.
+  it("marks intermediate frames as subsequent on transactions spanning many frames", () => {
+    // 400 two-byte varint fields (0x08 0x01) -> 800 bytes, needing 4 frames.
+    const rawTxHex = "0801".repeat(400);
     const frames = serializeTransaction(
       encodeDerivationPath(PATH),
-      fromHex("0a0100"),
-      [fromHex("aa"), fromHex("bb")],
+      fromHex(rawTxHex),
     );
 
-    expect(frames.map((f) => f.p1)).toEqual([0x00, 0xa0, 0xa9]);
-    expect(toHex(frames[0]!.payload)).toBe(PATH_HEX + "0a0100");
-    expect(toHex(frames[1]!.payload)).toBe("aa");
-    expect(toHex(frames[2]!.payload)).toBe("bb");
+    expect(frames.map((f) => f.p1)).toEqual([0x00, 0x80, 0x80, 0x90]);
+    frames.forEach((f) => expect(f.payload.length).toBeLessThanOrEqual(250));
+    // Reassembled payload (minus the path header on frame 0) equals the rawTx.
+    const reassembled = frames
+      .map((f) => toHex(f.payload))
+      .join("")
+      .slice(PATH_HEX.length);
+    expect(reassembled).toBe(rawTxHex);
   });
 
   it("throws when a single protobuf field exceeds the chunk size", () => {

--- a/packages/signer/signer-trx/src/internal/app-binder/services/TransactionSerializer.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/services/TransactionSerializer.ts
@@ -23,18 +23,15 @@ function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
  * Mirrors `@ledgerhq/hw-app-trx` `signTransaction`:
  *  - the first frame starts with the encoded derivation path, then transaction
  *    fields are packed onto frames without ever splitting a protobuf field,
- *  - token signatures are appended as their own frames,
- *  - each frame's P1 "start byte" encodes its position and token-slot index.
+ *  - each frame's P1 "start byte" encodes its position.
  *
  * @param encodedPath the derivation path bytes (length byte + BE32 elements)
  * @param rawTransaction the protobuf-serialized `raw_data` bytes
- * @param tokenSignatures decoded token (TRC10) signature payloads, in order
  * @throws if a single protobuf field is larger than {@link CHUNK_SIZE}
  */
 export function serializeTransaction(
   encodedPath: Uint8Array,
   rawTransaction: Uint8Array,
-  tokenSignatures: Uint8Array[] = [],
 ): TransactionFrame[] {
   const frames: Uint8Array[] = [];
 
@@ -60,12 +57,6 @@ export function serializeTransaction(
   }
   frames.push(data);
 
-  // Token-signature frames follow the transaction frames.
-  const tokenStartIndex = frames.length;
-  for (const signature of tokenSignatures) {
-    frames.push(signature);
-  }
-
   const startBytes: number[] = [];
   if (frames.length === 1) {
     startBytes.push(SIGN_TRANSACTION_P1.SINGLE);
@@ -73,22 +64,10 @@ export function serializeTransaction(
     startBytes.push(SIGN_TRANSACTION_P1.FIRST);
 
     for (let i = 1; i < frames.length - 1; i += 1) {
-      if (i >= tokenStartIndex) {
-        startBytes.push(SIGN_TRANSACTION_P1.TOKEN | (i - tokenStartIndex));
-      } else {
-        startBytes.push(SIGN_TRANSACTION_P1.SUBSEQUENT);
-      }
+      startBytes.push(SIGN_TRANSACTION_P1.SUBSEQUENT);
     }
 
-    if (tokenSignatures.length > 0) {
-      startBytes.push(
-        SIGN_TRANSACTION_P1.TOKEN |
-          SIGN_TRANSACTION_P1.TOKEN_LAST_FLAG |
-          (tokenSignatures.length - 1),
-      );
-    } else {
-      startBytes.push(SIGN_TRANSACTION_P1.LAST);
-    }
+    startBytes.push(SIGN_TRANSACTION_P1.LAST);
   }
 
   return frames.map((payload, i) => ({ p1: startBytes[i]!, payload }));

--- a/packages/signer/signer-trx/src/internal/app-binder/task/SignTransactionTask.test.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/task/SignTransactionTask.test.ts
@@ -13,6 +13,11 @@ import {
 import { SignTransactionTask } from "./SignTransactionTask";
 
 const PATH = "44'/195'/0'/0/0";
+// Encoded "44'/195'/0'/0/0": length byte (05) + 5 BE32 path elements.
+const PATH_HEX = "058000002c800000c3800000000000000000000000";
+
+const toHex = (bytes: Uint8Array): string =>
+  Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 
 const fromHex = (hex: string): Uint8Array =>
   Uint8Array.from(hex.match(/.{1,2}/g)!.map((b) => parseInt(b, 16)));
@@ -35,6 +40,7 @@ describe("SignTransactionTask", () => {
 
   it("signs a single-frame transaction", async () => {
     // GIVEN a transaction fitting in one frame
+    const rawTxHex = "0a0100";
     sendCommandMock.mockResolvedValueOnce(
       CommandResultFactory({ data: SIGNATURE }),
     );
@@ -42,18 +48,20 @@ describe("SignTransactionTask", () => {
     // WHEN
     const result = await new SignTransactionTask(api, {
       derivationPath: PATH,
-      transaction: fromHex("0a0100"),
+      transaction: fromHex(rawTxHex),
     }).run();
 
-    // THEN a single SINGLE-frame is sent and the signature is returned
+    // THEN a single frame is sent with the path header and the signature returned
     expect(sendCommandMock).toHaveBeenCalledTimes(1);
     expect(sentCommand(0).args.p1).toBe(0x10);
+    expect(toHex(sentCommand(0).args.payload)).toBe(PATH_HEX + rawTxHex);
     expect(isSuccessCommandResult(result)).toBe(true);
     expect(isSuccessCommandResult(result) && result.data).toEqual(SIGNATURE);
   });
 
   it("signs a multi-frame transaction and returns the last frame's signature", async () => {
     // GIVEN a transaction spanning two frames; only the last returns a signature
+    const rawTxHex = "0801".repeat(200);
     sendCommandMock
       .mockResolvedValueOnce(CommandResultFactory({ data: new Uint8Array() }))
       .mockResolvedValueOnce(CommandResultFactory({ data: SIGNATURE }));
@@ -61,10 +69,10 @@ describe("SignTransactionTask", () => {
     // WHEN
     const result = await new SignTransactionTask(api, {
       derivationPath: PATH,
-      transaction: fromHex("0a01" + "01".repeat(400)),
+      transaction: fromHex(rawTxHex),
     }).run();
 
-    // THEN both frames are sent in order and the signature is returned
+    // THEN both frames are sent in order with the expected start bytes
     expect(sendCommandMock).toHaveBeenCalledTimes(2);
     expect(sentCommand(0).args.p1).toBe(0x00);
     expect(sentCommand(1).args.p1).toBe(0x90);
@@ -74,6 +82,7 @@ describe("SignTransactionTask", () => {
 
   it("aborts on the first failing frame", async () => {
     // GIVEN a two-frame transaction whose first frame fails
+    const rawTxHex = "0801".repeat(200);
     const error = CommandResultFactory({
       error: TronAppCommandErrorFactory({
         ...TRON_APP_ERRORS["6a80"],
@@ -85,12 +94,37 @@ describe("SignTransactionTask", () => {
     // WHEN
     const result = await new SignTransactionTask(api, {
       derivationPath: PATH,
-      transaction: fromHex("0a01" + "01".repeat(400)),
+      transaction: fromHex(rawTxHex),
     }).run();
 
     // THEN no further frame is sent and the error is returned unchanged
     expect(sendCommandMock).toHaveBeenCalledTimes(1);
     expect(result).toBe(error);
+    expect(isSuccessCommandResult(result)).toBe(false);
+  });
+
+  it("propagates a user rejection (6985) on the final frame", async () => {
+    // GIVEN a two-frame transaction rejected by the user on the last frame
+    const rawTxHex = "0801".repeat(200);
+    const rejection = CommandResultFactory({
+      error: TronAppCommandErrorFactory({
+        ...TRON_APP_ERRORS["6985"],
+        errorCode: "6985",
+      }),
+    });
+    sendCommandMock
+      .mockResolvedValueOnce(CommandResultFactory({ data: new Uint8Array() }))
+      .mockResolvedValueOnce(rejection);
+
+    // WHEN
+    const result = await new SignTransactionTask(api, {
+      derivationPath: PATH,
+      transaction: fromHex(rawTxHex),
+    }).run();
+
+    // THEN the rejection is propagated
+    expect(sendCommandMock).toHaveBeenCalledTimes(2);
+    expect(result).toBe(rejection);
     expect(isSuccessCommandResult(result)).toBe(false);
   });
 
@@ -129,22 +163,5 @@ describe("SignTransactionTask", () => {
       !isSuccessCommandResult(result) &&
         (result.error as { originalError?: Error }).originalError?.message,
     ).toBe("No signature returned by the device");
-  });
-
-  it("returns a typed error for an invalid token signature hex", async () => {
-    // WHEN a token signature is not valid hex
-    const result = await new SignTransactionTask(api, {
-      derivationPath: PATH,
-      transaction: fromHex("0a0100"),
-      tokenSignatures: ["nothex"],
-    }).run();
-
-    // THEN no command is sent and a typed error is returned
-    expect(sendCommandMock).not.toHaveBeenCalled();
-    expect(isSuccessCommandResult(result)).toBe(false);
-    expect(
-      !isSuccessCommandResult(result) &&
-        (result.error as { originalError?: Error }).originalError?.message,
-    ).toBe("Invalid token signature hex: nothex");
   });
 });

--- a/packages/signer/signer-trx/src/internal/app-binder/task/SignTransactionTask.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/task/SignTransactionTask.ts
@@ -1,7 +1,6 @@
 import {
   type CommandResult,
   DmkResultFactory,
-  hexaStringToBuffer,
   type InternalApi,
   InvalidStatusWordError,
   isSuccessCommandResult,
@@ -19,7 +18,6 @@ import {
 type SignTransactionTaskArgs = {
   derivationPath: string;
   transaction: Uint8Array;
-  tokenSignatures?: string[];
 };
 
 export class SignTransactionTask {
@@ -29,20 +27,7 @@ export class SignTransactionTask {
   ) {}
 
   async run(): Promise<CommandResult<Signature, TronAppErrorCodes>> {
-    const { derivationPath, transaction, tokenSignatures = [] } = this.args;
-
-    const decodedTokenSignatures: Uint8Array[] = [];
-    for (const signature of tokenSignatures) {
-      const decoded = hexaStringToBuffer(signature);
-      if (decoded === null) {
-        return DmkResultFactory({
-          error: new InvalidStatusWordError(
-            `Invalid token signature hex: ${signature}`,
-          ),
-        });
-      }
-      decodedTokenSignatures.push(decoded);
-    }
+    const { derivationPath, transaction } = this.args;
 
     // Serialization can throw (e.g. a single protobuf field exceeds the APDU
     // chunk size). Convert that into a typed command error instead of letting
@@ -52,7 +37,6 @@ export class SignTransactionTask {
       frames = serializeTransaction(
         encodeDerivationPath(derivationPath),
         transaction,
-        decodedTokenSignatures,
       );
     } catch (error) {
       return DmkResultFactory({

--- a/packages/signer/signer-trx/src/internal/use-cases/transaction/SignTransactionUseCase.test.ts
+++ b/packages/signer/signer-trx/src/internal/use-cases/transaction/SignTransactionUseCase.test.ts
@@ -1,0 +1,47 @@
+import { type TronAppBinder } from "@internal/app-binder/TronAppBinder";
+
+import { SignTransactionUseCase } from "./SignTransactionUseCase";
+
+describe("SignTransactionUseCase", () => {
+  const derivationPath = "44'/195'/0'/0/0";
+  const transaction = Uint8Array.from([0x0a, 0x01, 0x00]);
+  const returnedValue = { observable: "observable", cancel: () => {} };
+  const signTransactionMock = vi.fn().mockReturnValue(returnedValue);
+  const appBinderMock = {
+    signTransaction: signTransactionMock,
+  } as unknown as TronAppBinder;
+  let useCase: SignTransactionUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new SignTransactionUseCase(appBinderMock);
+  });
+
+  it("should forward the transaction and options to the app binder", () => {
+    // WHEN
+    const result = useCase.execute(derivationPath, transaction, {
+      skipOpenApp: true,
+    });
+
+    // THEN
+    expect(result).toEqual(returnedValue);
+    expect(signTransactionMock).toHaveBeenCalledWith({
+      derivationPath,
+      transaction,
+      skipOpenApp: true,
+    });
+  });
+
+  it("should work without options", () => {
+    // WHEN
+    const result = useCase.execute(derivationPath, transaction);
+
+    // THEN
+    expect(result).toEqual(returnedValue);
+    expect(signTransactionMock).toHaveBeenCalledWith({
+      derivationPath,
+      transaction,
+      skipOpenApp: undefined,
+    });
+  });
+});

--- a/packages/signer/signer-trx/src/internal/use-cases/transaction/SignTransactionUseCase.ts
+++ b/packages/signer/signer-trx/src/internal/use-cases/transaction/SignTransactionUseCase.ts
@@ -21,7 +21,6 @@ export class SignTransactionUseCase {
     return this._appBinder.signTransaction({
       derivationPath,
       transaction,
-      tokenSignatures: options?.tokenSignatures,
       skipOpenApp: options?.skipOpenApp,
     });
   }


### PR DESCRIPTION
### 📝 Description

This PR completes the **Sign Transaction** device action for the Tron signer kit (`@ledgerhq/device-signer-kit-tron`).

`signer.signTransaction(derivationPath, transaction, options?)` signs a raw Tron transaction. The `transaction` is the protobuf-serialized `raw_data` bytes; it is framed across APDUs on protobuf field boundaries (mirroring `@ledgerhq/hw-app-trx`), driven through `SignTransactionTask` via the DMK's generic `CallTaskInAppDeviceAction`, and reviewed/blind-signed on the device. The action resolves to the 65-byte signature (`r[32] + s[32] + v[1]`) as a `Uint8Array`.

```typescript
const { observable, cancel } = signer.signTransaction(
  "44'/195'/0'/0/0",
  rawTransaction, // protobuf-serialized raw_data bytes
);

observable.subscribe((state) => {
  switch (state.status) {
    case "completed":
      console.log(state.output); // Uint8Array(65) signature
      break;
    case "error":
      console.error(state.error);
      break;
  }
});
```

This PR also **removes the `tokenSignatures` (TRC10 token-name signature) path** carried by the task-2 scaffold — it is clear-signing surface, and this signer does not implement clear signing (no `context-module`). Dropped from `TransactionOptions`, `SignTransactionUseCase`, `TronAppBinder`, `SignTransactionTask`, `TransactionSerializer`, and the `SIGN_TRANSACTION_P1` constants.

Alongside the device action, this PR adds:
- A Sign transaction panel in the sample app (Tron signer view) taking the hex-encoded raw transaction.
- Playwright e2e coverage: a TRX transfer signed against a Speculos-backed Stax running the Tron app, approved on screen (happy path; user-rejection is covered at unit level via 6985 propagation).
- Unit tests for `SignTransactionUseCase`, `SignTransactionTask` (single/multi-frame, abort-on-error, user rejection), a `signTransaction` block in `TronAppBinder`, and updated `TransactionSerializer` chunking tests.
- README documentation for `signTransaction`.

▎ Stacked PR — this targets `feat/dsdk-1304-trx-get-app-configuration` (Get App Configuration, #1624), which targets `feat/dsdk-1264-trx-get-address-device-action` (#1602). Please review/merge bottom-up. The diff shown here is the Sign Transaction work only.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1305]
- **Feature**: Sign Transaction device action for the Tron signer kit — blind-sign a protobuf-serialized Tron transaction and return the 65-byte signature.

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - `@ledgerhq/device-signer-kit-tron` (unreleased, 0.1.0): `signTransaction` completed; `TransactionOptions.tokenSignatures` removed (pre-release API surface, no consumer impact)
  - Sample app: new Sign transaction panel in the Tron signer view
  - E2E: new `signers/tron/sign-transaction.spec.ts`

[DSDK-1305]: https://ledgerhq.atlassian.net/browse/DSDK-1305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ