### PR TITLE
fix(zcash): fix ufvk export

### DIFF
--- a/.changeset/strong-pens-do.md
+++ b/.changeset/strong-pens-do.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-zcash": patch
+---
+
+Fix UFVK export to support orchard + transparent paths

--- a/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.test.ts
+++ b/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.test.ts
@@ -117,6 +117,7 @@ describe("DefaultSignerZcash", () => {
       new GetFullViewingKeyCommand({
         isContinue: false,
         derivationPath,
+        transparentDerivationPath: derivationPath.replace(/^32'\//, "44'/"),
         p2: zcashFvkP2FromMode("ufvk"),
       }).getApdu(),
     );

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.test.ts
@@ -35,12 +35,44 @@ const GET_FVK_PATH_BYTES = Uint8Array.from([
   0x00,
 ]);
 
+// UFVK export (app-zcash >= v3.8.0): orchard ZIP-32 path 32'/133'/0' followed
+// by the transparent account path 44'/133'/0'.
+const GET_FVK_UFVK_PATH_BYTES = Uint8Array.from([
+  0x1a, // Data length: 26
+  0x03, // orchard path length: 3
+  0x80,
+  0x00,
+  0x00,
+  0x20, // 32'
+  0x80,
+  0x00,
+  0x00,
+  0x85, // 133'
+  0x80,
+  0x00,
+  0x00,
+  0x00, // 0'
+  0x03, // transparent path length: 3
+  0x80,
+  0x00,
+  0x00,
+  0x2c, // 44'
+  0x80,
+  0x00,
+  0x00,
+  0x85, // 133'
+  0x80,
+  0x00,
+  0x00,
+  0x00, // 0'
+]);
+
 const GET_FVK_UFVK_FIRST_APDU = Uint8Array.from([
   0xe0,
   0x50,
   0x00,
   P2_VK.UFVK,
-  ...GET_FVK_PATH_BYTES,
+  ...GET_FVK_UFVK_PATH_BYTES,
 ]);
 
 const GET_FVK_ORCHARD_FIRST_APDU = Uint8Array.from([
@@ -61,6 +93,8 @@ const GET_FVK_CONTINUE_UFVK_APDU = Uint8Array.from([
 
 describe("GetFullViewingKeyCommand", () => {
   const path = "44'/133'/0'/0/0";
+  const orchardPath = "32'/133'/0'";
+  const transparentPath = "44'/133'/0'";
 
   describe("name", () => {
     it("should be 'GetFullViewingKey'", () => {
@@ -74,11 +108,12 @@ describe("GetFullViewingKeyCommand", () => {
   });
 
   describe("getApdu", () => {
-    it("should return first GET_VK APDU for UFVK (P2=0)", () => {
+    it("should return first GET_VK APDU for UFVK (P2=0) with orchard + transparent paths", () => {
       const command = new GetFullViewingKeyCommand({
         isContinue: false,
         p2: P2_VK.UFVK,
-        derivationPath: path,
+        derivationPath: orchardPath,
+        transparentDerivationPath: transparentPath,
       });
       expect(command.getApdu().getRawApdu()).toStrictEqual(
         GET_FVK_UFVK_FIRST_APDU,

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetFullViewingKeyCommand.ts
@@ -36,6 +36,11 @@ export type GetFullViewingKeyCommandArgs =
       /** First GET_VK exchange: P1=FIRST and path in APDU data. */
       readonly isContinue: false;
       readonly derivationPath: string;
+      /**
+       * Transparent account path serialized after the orchard path for UFVK
+       * export (app-zcash >= v3.8.0). Required for UFVK; unused for OrchardFvk.
+       */
+      readonly transparentDerivationPath?: string;
       /** See app `P2VkMode` (UFVK string vs raw Orchard FVK bytes). */
       readonly p2: ZcashFvkP2;
     }
@@ -90,6 +95,18 @@ export class GetFullViewingKeyCommand
       path.forEach((element) => {
         builder.add32BitUIntToData(element);
       });
+
+      // app-zcash >= v3.8.0 expects UFVK export to carry a second prefixed path
+      // for the transparent account key (44'/133'/<account>').
+      if (this.args.p2 === P2_VK.UFVK && this.args.transparentDerivationPath) {
+        const transparentPath = DerivationPathUtils.splitPath(
+          this.args.transparentDerivationPath,
+        );
+        builder.add8BitUIntToData(transparentPath.length);
+        transparentPath.forEach((element) => {
+          builder.add32BitUIntToData(element);
+        });
+      }
     }
 
     return builder.build();

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
@@ -153,11 +153,21 @@ export class GetFullViewingKeyTask {
   async run(): Promise<GetFullViewingKeyTaskResult> {
     const p2: ZcashFvkP2 = zcashFvkP2FromMode(this.args.mode);
 
+    // app-zcash >= v3.8.0 requires both the orchard and transparent account
+    // paths for UFVK export. `derivationPath` is always the ZIP-32 account path
+    // (32'/coin'/account') at this point, so the transparent path is the same
+    // account under BIP-44 purpose (44'/coin'/account').
+    const transparentDerivationPath =
+      this.args.mode === "ufvk"
+        ? this.args.derivationPath.replace(/^32'\//, "44'/")
+        : undefined;
+
     const firstResult = await this.api.sendCommand(
       new GetFullViewingKeyCommand({
         isContinue: false,
         p2,
         derivationPath: this.args.derivationPath,
+        transparentDerivationPath,
       }),
     );
     if (!isSuccessCommandResult(firstResult)) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The device runs app-zcash v3.8.0, which changed the GET_VK (INS=0x50) APDU format for UFVK export: it now expects two length-prefixed BIP-32 paths (orchard + transparent), whereas the signer was only sending one. That produced Lc=13, and the firmware's second Bip32Path::from_prefixed_bytes on the empty remainder returned 6700 (WrongApduLength). This PR fixes this issue.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-34444

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Changeset is provided** <!-- Please provide a changeset -->
- [x] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - @ledgerhq/device-signer-kit-zcash

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
