### PR TITLE
✨ (signer-solana) [NO-ISSUE]: Resolve CAL trusted names for account display field

### DIFF
--- a/.changeset/petite-wombats-sneeze.md
+++ b/.changeset/petite-wombats-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": minor
+---
+
+Resolve CAL trusted names for account display field

--- a/packages/signer/context-module/src/modules/solana/trusted-name/data/HttpTrustedNameDataSource.test.ts
+++ b/packages/signer/context-module/src/modules/solana/trusted-name/data/HttpTrustedNameDataSource.test.ts
@@ -44,13 +44,14 @@ describe("HttpSolanaTrustedNameDataSource", () => {
     datasource = makeDatasource();
   });
 
-  it("calls the names endpoint with network, sources and challenge (no types)", async () => {
+  it("calls the names endpoint with network, types, sources and challenge", async () => {
     httpMock.get.mockResolvedValue(objectResponse({ prod: "aabb" }));
 
     await datasource.getTrustedName({
       address,
       network: String(SolanaTransactionScanChainId.MAINNET),
       challenge,
+      types: ["token", "smart_contract"],
       sources: ["crypto_asset_list"],
     });
 
@@ -58,6 +59,7 @@ describe("HttpSolanaTrustedNameDataSource", () => {
       `https://nft.api.ledger.com/v2/names/solana/${SolanaTransactionScanChainId.MAINNET}/reverse/${address}`,
       {
         params: {
+          types: "token,smart_contract",
           sources: "crypto_asset_list",
           challenge,
         },
@@ -74,6 +76,7 @@ describe("HttpSolanaTrustedNameDataSource", () => {
       address,
       network: String(SolanaTransactionScanChainId.MAINNET),
       challenge,
+      types: ["token", "smart_contract"],
       sources: ["crypto_asset_list"],
     });
 
@@ -98,6 +101,7 @@ describe("HttpSolanaTrustedNameDataSource", () => {
       address,
       network: String(SolanaTransactionScanChainId.MAINNET),
       challenge,
+      types: ["token", "smart_contract"],
       sources: ["crypto_asset_list"],
     });
 
@@ -120,6 +124,7 @@ describe("HttpSolanaTrustedNameDataSource", () => {
       address,
       network: String(SolanaTransactionScanChainId.MAINNET),
       challenge,
+      types: ["token", "smart_contract"],
       sources: ["crypto_asset_list"],
     });
 
@@ -142,6 +147,7 @@ describe("HttpSolanaTrustedNameDataSource", () => {
       address,
       network: String(SolanaTransactionScanChainId.MAINNET),
       challenge,
+      types: [],
       sources: [],
     });
 
@@ -160,6 +166,7 @@ describe("HttpSolanaTrustedNameDataSource", () => {
       address,
       network: String(SolanaTransactionScanChainId.MAINNET),
       challenge,
+      types: [],
       sources: [],
     });
 

--- a/packages/signer/context-module/src/modules/solana/trusted-name/data/HttpTrustedNameDataSource.ts
+++ b/packages/signer/context-module/src/modules/solana/trusted-name/data/HttpTrustedNameDataSource.ts
@@ -44,6 +44,7 @@ export class HttpSolanaTrustedNameDataSource
     address,
     network,
     challenge,
+    types,
     sources,
   }: GetSolanaTrustedNameParams): Promise<
     Either<Error, SolanaTrustedNameResult>
@@ -54,6 +55,7 @@ export class HttpSolanaTrustedNameDataSource
         `${this.config.metadataServiceDomain.url}/v2/names/solana/${network}/reverse/${address}`,
         {
           params: {
+            types: types.join(","),
             sources: sources.join(","),
             challenge,
           },

--- a/packages/signer/context-module/src/modules/solana/trusted-name/data/TrustedNameDataSource.ts
+++ b/packages/signer/context-module/src/modules/solana/trusted-name/data/TrustedNameDataSource.ts
@@ -4,6 +4,7 @@ export type GetSolanaTrustedNameParams = {
   address: string;
   network: string;
   challenge: string;
+  types: string[];
   sources: string[];
 };
 

--- a/packages/signer/context-module/src/modules/solana/trusted-name/domain/TrustedNameContextLoader.test.ts
+++ b/packages/signer/context-module/src/modules/solana/trusted-name/domain/TrustedNameContextLoader.test.ts
@@ -53,6 +53,7 @@ describe("SolanaTrustedNameContextLoader", () => {
               {
                 address: ADDR_A,
                 challenge: "c",
+                types: ["token", "smart_contract"],
                 sources: ["sns"],
               },
             ],
@@ -70,6 +71,7 @@ describe("SolanaTrustedNameContextLoader", () => {
               {
                 address: ADDR_A,
                 challenge: "c",
+                types: ["token", "smart_contract"],
                 sources: ["sns"],
               },
             ],
@@ -86,7 +88,7 @@ describe("SolanaTrustedNameContextLoader", () => {
       expect(
         loader.canHandle(
           {
-            requests: [{ address: "", challenge: "c", sources: [] }],
+            requests: [{ address: "", challenge: "c", types: [], sources: [] }],
           } as any,
           types,
         ),
@@ -94,7 +96,9 @@ describe("SolanaTrustedNameContextLoader", () => {
       expect(
         loader.canHandle(
           {
-            requests: [{ address: ADDR_A, challenge: "", sources: [] }],
+            requests: [
+              { address: ADDR_A, challenge: "", types: [], sources: [] },
+            ],
           } as any,
           types,
         ),
@@ -120,11 +124,13 @@ describe("SolanaTrustedNameContextLoader", () => {
           {
             address: ADDR_A,
             challenge: "c1",
+            types: ["token", "smart_contract"],
             sources: ["sns"],
           },
           {
             address: ADDR_B,
             challenge: "c2",
+            types: ["token", "smart_contract"],
             sources: ["cal"],
           },
         ],
@@ -160,8 +166,8 @@ describe("SolanaTrustedNameContextLoader", () => {
       const out = await makeLoader().load({
         deviceModelId: DeviceModelId.NANO_X,
         requests: [
-          { address: ADDR_A, challenge: "c1", sources: [] },
-          { address: ADDR_B, challenge: "c2", sources: [] },
+          { address: ADDR_A, challenge: "c1", types: [], sources: [] },
+          { address: ADDR_B, challenge: "c2", types: [], sources: [] },
         ],
       });
 
@@ -181,7 +187,7 @@ describe("SolanaTrustedNameContextLoader", () => {
 
       await makeLoader().load({
         deviceModelId: DeviceModelId.NANO_X,
-        requests: [{ address: ADDR_A, challenge: "c", sources: [] }],
+        requests: [{ address: ADDR_A, challenge: "c", types: [], sources: [] }],
       });
 
       expect(spy).toHaveBeenCalledWith(
@@ -204,7 +210,7 @@ describe("SolanaTrustedNameContextLoader", () => {
       await makeLoader().load({
         deviceModelId: DeviceModelId.NANO_X,
         network: "solana-devnet",
-        requests: [{ address: ADDR_A, challenge: "c", sources: [] }],
+        requests: [{ address: ADDR_A, challenge: "c", types: [], sources: [] }],
       });
 
       expect(spy).toHaveBeenCalledWith(

--- a/packages/signer/context-module/src/modules/solana/trusted-name/domain/TrustedNameContextLoader.ts
+++ b/packages/signer/context-module/src/modules/solana/trusted-name/domain/TrustedNameContextLoader.ts
@@ -38,6 +38,7 @@ const NETWORK_DEFAULT = SolanaTransactionScanChainId.MAINNET;
 export type SolanaTrustedNameRequest = {
   address: string;
   challenge: string;
+  types: string[];
   sources: string[];
 };
 
@@ -50,6 +51,7 @@ export type SolanaTrustedNameContextInput = {
 const trustedNameRequestCodec = Codec.interface({
   address: string,
   challenge: string,
+  types: array(string),
   sources: array(string),
 });
 
@@ -107,6 +109,7 @@ export class SolanaTrustedNameContextLoader
         this.dataSource.getTrustedName({
           address: request.address,
           challenge: request.challenge,
+          types: request.types,
           sources: request.sources,
           network,
         }),

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/records.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/records.ts
@@ -30,6 +30,14 @@ export enum OptionalAccountStrategy {
 /** `DISPLAY_FIELD.PARAM_TYPE` value for an address resolved via trusted name. */
 export const PARAM_TYPE_TRUSTED_NAME = 0x07;
 
+/**
+ * `DISPLAY_FIELD.PARAM_TYPE` value for a raw account address (base58 short
+ * form). We attempt a trusted-name lookup for these too, so the device can show
+ * a CAL name (e.g. a token mint's name) instead of an opaque pubkey when one is
+ * available; it falls back to base58 otherwise.
+ */
+export const PARAM_TYPE_ACCOUNT = 0x08;
+
 /** `DISPLAY_FIELD.PARAM_TYPE` value for a token amount with a token reference. */
 export const PARAM_TYPE_TOKEN_AMOUNT = 0x02;
 

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.test.ts
@@ -1,5 +1,6 @@
 import { type RequirementInstruction } from "@internal/app-binder/clear-sign/requirements/model";
 import {
+  PARAM_TYPE_ACCOUNT,
   PARAM_TYPE_TRUSTED_NAME,
   type ParsedDisplayField,
   type ParsedInstruction,
@@ -59,6 +60,45 @@ describe("applyTrustedNameRule", () => {
       [],
     );
     expect(result).toEqual([DefaultBs58Encoder.encode(addr)]);
+  });
+
+  it("resolves an ACCOUNT display field target (best-effort CAL name)", () => {
+    const result = run(
+      [
+        {
+          paramType: PARAM_TYPE_ACCOUNT,
+          value: {
+            source: ValueSource.ACCOUNT_PATH,
+            payload: Uint8Array.of(0),
+          },
+        },
+      ],
+      ["account"],
+    );
+    expect(result).toEqual(["account"]);
+  });
+
+  it("deduplicates an address referenced by ACCOUNT and TRUSTED_NAME fields", () => {
+    const result = run(
+      [
+        {
+          paramType: PARAM_TYPE_ACCOUNT,
+          value: {
+            source: ValueSource.ACCOUNT_PATH,
+            payload: Uint8Array.of(0),
+          },
+        },
+        {
+          paramType: PARAM_TYPE_TRUSTED_NAME,
+          value: {
+            source: ValueSource.ACCOUNT_PATH,
+            payload: Uint8Array.of(0),
+          },
+        },
+      ],
+      ["shared"],
+    );
+    expect(result).toEqual(["shared"]);
   });
 
   it("ignores non-trusted-name fields and unresolved account targets", () => {

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.ts
@@ -1,5 +1,6 @@
 import { type RequirementInstruction } from "@internal/app-binder/clear-sign/requirements/model";
 import {
+  PARAM_TYPE_ACCOUNT,
   PARAM_TYPE_TRUSTED_NAME,
   type ParsedInstruction,
 } from "@internal/app-binder/clear-sign/requirements/records";
@@ -10,7 +11,12 @@ import {
   DefaultBs58Encoder,
 } from "@internal/app-binder/services/bs58Encoder";
 
-/** Each `PARAM_TRUSTED_NAME` display field targets an address needing a name. */
+/**
+ * Each `PARAM_TRUSTED_NAME` or `PARAM_ACCOUNT` display field targets an address
+ * that may have a CAL name. For `PARAM_ACCOUNT` this is best-effort: the device
+ * shows the name if a descriptor is found and falls back to the base58 address
+ * otherwise.
+ */
 export function applyTrustedNameRule(
   parsed: ParsedInstruction,
   instruction: RequirementInstruction,
@@ -19,7 +25,8 @@ export function applyTrustedNameRule(
 ): void {
   for (const field of parsed.displayFields) {
     if (
-      field.paramType !== PARAM_TYPE_TRUSTED_NAME ||
+      (field.paramType !== PARAM_TYPE_TRUSTED_NAME &&
+        field.paramType !== PARAM_TYPE_ACCOUNT) ||
       field.value === undefined
     ) {
       continue;

--- a/packages/signer/signer-solana/src/internal/app-binder/task/ProvideGenericClearSignContextTask.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/ProvideGenericClearSignContextTask.test.ts
@@ -164,6 +164,7 @@ describe("ProvideGenericClearSignContextTask", () => {
           {
             address: "NAME",
             challenge: "deadbeef",
+            types: ["token", "smart_contract"],
             sources: ["crypto_asset_list"],
           },
         ],

--- a/packages/signer/signer-solana/src/internal/app-binder/task/ProvideGenericClearSignContextTask.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/ProvideGenericClearSignContextTask.ts
@@ -154,8 +154,16 @@ export class ProvideGenericClearSignContextTask {
         (challenge) => ({
           deviceModelId,
           network: this.network,
-          // Only the CRYPTO_ASSET_LIST source is supported for now.
-          requests: [{ address, challenge, sources: ["crypto_asset_list"] }],
+          // Only the TOKEN / SMART_CONTRACT types and the CRYPTO_ASSET_LIST
+          // source are supported for now.
+          requests: [
+            {
+              address,
+              challenge,
+              types: ["token", "smart_contract"],
+              sources: ["crypto_asset_list"],
+            },
+          ],
         }),
         ClearSignContextType.SOLANA_TRUSTED_NAME,
       );


### PR DESCRIPTION
### 📝 Description

For each display field of type ACCOUNT, we should try to resolve a trusted name.
This is because the CAL generate a trusted name for each token, so is the account is a mint, we should display it instead.

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**:

<!--- If you are not a Ledger employee, please describe the context of your contribution. For example, explain what feature is being added or how this change will enhance the user experience. -->

<!--- If the PR related to an issue, please include the issue link. -->

- **Feature**:

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
