### PR TITLE
🐳 (mock-server) [DSDK-1268]: Add Docker deployment and configurable log level

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.turbo
+coverage
+**/node_modules
+**/lib
+**/dist
+**/.next
+**/coverage
+**/*.log
+.env
+.env.*
+!.env.example

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,4 +9,4 @@ coverage
 **/*.log
 .env
 .env.*
-!.env.example
+!**/.env.example

--- a/apps/device-mock-server/.env.example
+++ b/apps/device-mock-server/.env.example
@@ -23,8 +23,5 @@ PORT=9752
 # Only relevant when SPECULINHO_URL is set.
 # SPECULOS_READY_TIMEOUT_MS=120000
 
-# Set to 1 to suppress all console output.
-# MOCK_SERVER_SILENT=1
-
-# Set to 1 to enable verbose debug logging.
-# MOCK_SERVER_DEBUG=1
+# Console log verbosity. Accepts: silent, error, warn, info, debug (default info).
+# MOCK_SERVER_LOG_LEVEL=info

--- a/apps/device-mock-server/.env.example
+++ b/apps/device-mock-server/.env.example
@@ -1,0 +1,30 @@
+# Copy this file to .env and adjust values before running the server.
+
+# ── Required ─────────────────────────────────────────────────────────────────
+
+# Leave SPECULINHO_URL empty to run as a pure mock (no live Speculos proxying).
+# Set it to the Speculinho operator URL to enable real-device emulation.
+SPECULINHO_URL=
+
+# ── Optional ─────────────────────────────────────────────────────────────────
+
+# HTTP port the server listens on.
+PORT=9752
+
+# BIP39 seed used when provisioning Speculos emulators via Speculinho.
+# Only relevant when SPECULINHO_URL is set.
+# SPECULOS_SEED=glory promote mansion idle axis finger extend february uncover one trip resolve toe
+
+# Pin a specific Speculos image version (e.g. v0.9.13).
+# Only relevant when SPECULINHO_URL is set.
+# SPECULOS_VERSION=
+
+# Milliseconds to wait for a Speculos emulator to become ready (default 120000).
+# Only relevant when SPECULINHO_URL is set.
+# SPECULOS_READY_TIMEOUT_MS=120000
+
+# Set to 1 to suppress all console output.
+# MOCK_SERVER_SILENT=1
+
+# Set to 1 to enable verbose debug logging.
+# MOCK_SERVER_DEBUG=1

--- a/apps/device-mock-server/Dockerfile
+++ b/apps/device-mock-server/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+# Build context: monorepo root
+# Standalone:  docker build -f apps/device-mock-server/Dockerfile -t device-mock-server .
+# Compose:     docker compose -f apps/device-mock-server/docker-compose.yml up
+
+# ── install ───────────────────────────────────────────────────────────────────
+FROM node:24-alpine AS install
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+# bash is required by the zx-based ldmk-tool used to build workspace deps
+RUN apk add --no-cache bash \
+ && corepack enable && corepack prepare pnpm@10.34.4 --activate
+
+WORKDIR /repo
+COPY . .
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm install --frozen-lockfile
+
+# ── bundle ────────────────────────────────────────────────────────────────────
+FROM install AS builder
+# Build workspace deps so their lib/ output is available for esbuild to bundle
+RUN pnpm --filter @ledgerhq/device-mockserver-client... build
+
+# Bundle the entire server — including all workspace deps — into one file.
+# bufferutil and utf-8-validate are optional native perf add-ons for ws;
+# ws works without them, so they stay external and are omitted from the image.
+RUN node_modules/.bin/esbuild \
+      apps/device-mock-server/src/main.ts \
+      --bundle \
+      --platform=node \
+      --target=node24 \
+      --outfile=/bundle/server.js \
+      --format=cjs \
+      --tsconfig=apps/device-mock-server/tsconfig.json \
+      --external:bufferutil \
+      --external:utf-8-validate
+
+# ── runner ────────────────────────────────────────────────────────────────────
+FROM node:24-alpine
+WORKDIR /app
+COPY --from=builder /bundle/server.js .
+EXPOSE 9752
+CMD ["node", "server.js"]

--- a/apps/device-mock-server/Dockerfile
+++ b/apps/device-mock-server/Dockerfile
@@ -38,6 +38,8 @@ RUN node_modules/.bin/esbuild \
 # ── runner ────────────────────────────────────────────────────────────────────
 FROM node:24-alpine
 WORKDIR /app
-COPY --from=builder /bundle/server.js .
+# Run as the built-in unprivileged `node` user (uid 1000) instead of root
+COPY --chown=node:node --from=builder /bundle/server.js .
+USER node
 EXPOSE 9752
 CMD ["node", "server.js"]

--- a/apps/device-mock-server/Dockerfile
+++ b/apps/device-mock-server/Dockerfile
@@ -42,4 +42,6 @@ WORKDIR /app
 COPY --chown=node:node --from=builder /bundle/server.js .
 USER node
 EXPOSE 9752
+HEALTHCHECK --interval=10s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "require('http').get('http://127.0.0.1:'+(process.env.PORT||9752)+'/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1));"
 CMD ["node", "server.js"]

--- a/apps/device-mock-server/README.md
+++ b/apps/device-mock-server/README.md
@@ -14,11 +14,12 @@ It is the server-side counterpart of [`@ledgerhq/device-mockserver-client`](../.
 4. [Secure channel WebSocket](#-secure-channel-websocket)
 5. [Speculos integration](#-speculos-integration)
 6. [Getting started](#-getting-started)
-7. [Configuration](#-configuration)
-8. [HTTP API](#-http-api)
-9. [Programmatic usage](#-programmatic-usage)
-10. [Testing](#-testing)
-11. [OpenAPI](#-openapi)
+7. [Docker](#-docker)
+8. [Configuration](#-configuration)
+9. [HTTP API](#-http-api)
+10. [Programmatic usage](#-programmatic-usage)
+11. [Testing](#-testing)
+12. [OpenAPI](#-openapi)
 
 ## 🔹 Overview
 
@@ -283,6 +284,48 @@ curl http://127.0.0.1:9752/health
 # {"status":"ok","sessions":0}
 ```
 
+## 🔹 Docker
+
+A `Dockerfile` and `docker-compose.yml` are provided for running the server as a container. The **build context must be the monorepo root** because the image is built from the full workspace.
+
+### Build and run with Docker Compose (recommended)
+
+```bash
+# From apps/device-mock-server/
+docker compose up --build
+```
+
+To run as a **pure mock** (no Speculinho, fully offline):
+
+```bash
+SPECULINHO_URL= docker compose up --build
+```
+
+Copy `.env.example` to `.env` and edit it to persist your configuration:
+
+```bash
+cp .env.example .env
+# edit .env, then:
+docker compose up --build
+```
+
+### Standalone `docker build`
+
+```bash
+# From the monorepo root:
+docker build -f apps/device-mock-server/Dockerfile -t device-mock-server .
+docker run --rm -p 9752:9752 -e SPECULINHO_URL= device-mock-server
+```
+
+### Health check
+
+```bash
+curl http://127.0.0.1:9752/health
+# {"status":"ok","sessions":0}
+```
+
+The container exposes port `9752` and includes a built-in health check that hits `/health`.
+
 ## 🔹 Configuration
 
 The standalone server (`src/main.ts`) reads environment variables:
@@ -294,6 +337,8 @@ The standalone server (`src/main.ts`) reads environment variables:
 | `SPECULOS_SEED`             | built-in default seed               | BIP39 seed used for provisioned emulators.                                                                          |
 | `SPECULOS_VERSION`          | _unset_                             | Pin a Speculos version.                                                                                             |
 | `SPECULOS_READY_TIMEOUT_MS` | `120000`                            | How long to wait for an emulator to become ready.                                                                   |
+| `MOCK_SERVER_SILENT`        | _unset_                             | Set to `1` to suppress all console output.                                                                          |
+| `MOCK_SERVER_DEBUG`         | _unset_                             | Set to `1` to enable verbose debug logging.                                                                         |
 
 Programmatically, `createMockServer(config)` accepts a `MockServerConfig`:
 

--- a/apps/device-mock-server/README.md
+++ b/apps/device-mock-server/README.md
@@ -337,8 +337,7 @@ The standalone server (`src/main.ts`) reads environment variables:
 | `SPECULOS_SEED`             | built-in default seed               | BIP39 seed used for provisioned emulators.                                                                          |
 | `SPECULOS_VERSION`          | _unset_                             | Pin a Speculos version.                                                                                             |
 | `SPECULOS_READY_TIMEOUT_MS` | `120000`                            | How long to wait for an emulator to become ready.                                                                   |
-| `MOCK_SERVER_SILENT`        | _unset_                             | Set to `1` to suppress all console output.                                                                          |
-| `MOCK_SERVER_DEBUG`         | _unset_                             | Set to `1` to enable verbose debug logging.                                                                         |
+| `MOCK_SERVER_LOG_LEVEL`     | `info`                              | Console log verbosity. One of `silent`, `error`, `warn`, `info`, `debug`.                                           |
 
 Programmatically, `createMockServer(config)` accepts a `MockServerConfig`:
 

--- a/apps/device-mock-server/docker-compose.yml
+++ b/apps/device-mock-server/docker-compose.yml
@@ -6,12 +6,12 @@ services:
     ports:
       - "${PORT:-9752}:${PORT:-9752}"
     environment:
-      PORT: ${PORT:-9752}
-      SPECULINHO_URL: ${SPECULINHO_URL:-https://speculinho.ledgerlabs.net}
-      SPECULOS_SEED:
-      SPECULOS_VERSION:
-      SPECULOS_READY_TIMEOUT_MS: ${SPECULOS_READY_TIMEOUT_MS:-120000}
-      MOCK_SERVER_LOG_LEVEL:
+      - PORT=${PORT:-9752}
+      - SPECULINHO_URL=${SPECULINHO_URL:-https://speculinho.ledgerlabs.net}
+      - SPECULOS_READY_TIMEOUT_MS=${SPECULOS_READY_TIMEOUT_MS:-120000}
+      - SPECULOS_SEED
+      - SPECULOS_VERSION
+      - MOCK_SERVER_LOG_LEVEL
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:${PORT:-9752}/health"]
       interval: 10s

--- a/apps/device-mock-server/docker-compose.yml
+++ b/apps/device-mock-server/docker-compose.yml
@@ -11,8 +11,7 @@ services:
       SPECULOS_SEED:
       SPECULOS_VERSION:
       SPECULOS_READY_TIMEOUT_MS: ${SPECULOS_READY_TIMEOUT_MS:-120000}
-      MOCK_SERVER_SILENT:
-      MOCK_SERVER_DEBUG:
+      MOCK_SERVER_LOG_LEVEL:
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:${PORT:-9752}/health"]
       interval: 10s

--- a/apps/device-mock-server/docker-compose.yml
+++ b/apps/device-mock-server/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  mock-server:
+    build:
+      context: ../..
+      dockerfile: apps/device-mock-server/Dockerfile
+    ports:
+      - "${PORT:-9752}:${PORT:-9752}"
+    environment:
+      PORT: ${PORT:-9752}
+      SPECULINHO_URL: ${SPECULINHO_URL:-https://speculinho.ledgerlabs.net}
+      SPECULOS_SEED:
+      SPECULOS_VERSION:
+      SPECULOS_READY_TIMEOUT_MS: ${SPECULOS_READY_TIMEOUT_MS:-120000}
+      MOCK_SERVER_SILENT:
+      MOCK_SERVER_DEBUG:
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:${PORT:-9752}/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/apps/device-mock-server/src/internal/logger/logger.ts
+++ b/apps/device-mock-server/src/internal/logger/logger.ts
@@ -2,11 +2,12 @@
  * Minimal console logger for the mock server.
  *
  * Kept intentionally simple: it prefixes a timestamp, the originating session
- * tag (when logging within a request) and the level, and is gated by two env
- * vars so test runs (or embedding apps) can stay quiet:
+ * tag (when logging within a request) and the level. Output is gated by a
+ * single env var so test runs (or embedding apps) can control verbosity:
  *
- * - `MOCK_SERVER_SILENT=1` disables all output.
- * - `MOCK_SERVER_DEBUG=1` enables `debug` output (off by default).
+ * - `MOCK_SERVER_LOG_LEVEL` accepts (case-insensitive) `silent`, `error`,
+ *   `warn`, `info` or `debug`. Defaults to `info`. `silent` disables all
+ *   output; `debug` enables verbose debug output.
  */
 import { getSessionToken } from "./requestContext";
 
@@ -15,13 +16,15 @@ type LogMethod = (message: string, ...args: unknown[]) => void;
 /** Number of leading token characters shown as the session tag. */
 const SESSION_TAG_LENGTH = 8;
 
-const isEnabled = (name: string): boolean => {
-  const value = process.env[name];
-  return value === "1" || value === "true";
+const LEVELS = { silent: 0, error: 1, warn: 2, info: 3, debug: 4 } as const;
+type Level = keyof typeof LEVELS;
+
+const parseLevel = (value: string | undefined): Level => {
+  const normalized = value?.toLowerCase();
+  return normalized && normalized in LEVELS ? (normalized as Level) : "info";
 };
 
-const silent = isEnabled("MOCK_SERVER_SILENT");
-const debugEnabled = isEnabled("MOCK_SERVER_DEBUG");
+const currentLevel = LEVELS[parseLevel(process.env["MOCK_SERVER_LOG_LEVEL"])];
 
 const sessionTag = (): string => {
   const token = getSessionToken();
@@ -30,29 +33,28 @@ const sessionTag = (): string => {
 
 const emit = (
   consoleMethod: LogMethod,
-  level: string,
+  level: Exclude<Level, "silent">,
   message: string,
   args: unknown[],
 ): void => {
-  if (silent) return;
+  if (currentLevel < LEVELS[level]) return;
   consoleMethod(
-    `${new Date().toISOString()} ${sessionTag()}${level} ${message}`,
+    `${new Date().toISOString()} ${sessionTag()}${level.toUpperCase()} ${message}`,
     ...args,
   );
 };
 
 export const logger = {
   debug: (message: string, ...args: unknown[]): void => {
-    if (!debugEnabled) return;
-    emit(console.debug, "DEBUG", message, args);
+    emit(console.debug, "debug", message, args);
   },
   info: (message: string, ...args: unknown[]): void => {
-    emit(console.info, "INFO", message, args);
+    emit(console.info, "info", message, args);
   },
   warn: (message: string, ...args: unknown[]): void => {
-    emit(console.warn, "WARN", message, args);
+    emit(console.warn, "warn", message, args);
   },
   error: (message: string, ...args: unknown[]): void => {
-    emit(console.error, "ERROR", message, args);
+    emit(console.error, "error", message, args);
   },
 };


### PR DESCRIPTION
### 📝 Description

Adds container deployment support for the device mock server and makes its log verbosity configurable:

- Dockerfile and docker-compose setup for the mock server, with a `/health` based healthcheck and `.dockerignore`.
- Replaces the boolean `MOCK_SERVER_SILENT` / `MOCK_SERVER_DEBUG` env vars with a single `MOCK_SERVER_LOG_LEVEL` (`silent` | `error` | `warn` | `info` | `debug`, default `info`).
- Updates `.env.example` and README accordingly.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1268](https://ledgerhq.atlassian.net/browse/DSDK-1268)
- **Feature**: Deploy the device mock server

### ✅ Checklist

- [ ] **Covered by automatic tests** — logger/deployment config changes; no automated tests added.
- [x] **Changeset is provided** — N/A: changes only affect `apps/device-mock-server` and repo tooling, not a published package.
- [tation is up-to-date** — README and `.env.example` updated.
- [ ] **Impact of the changes:**
  - Mock server can now be run via Docker/Compose.
  - `MOCK_SERVER_SILENT` / `MOCK_SERVER_DEBUG` are removed in favor of `MOCK_SERVER_LOG_LEVEL`.

[DSDK-1268]: https://ledgerhq.atlassian.net/browse/DSDK-1268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ