### PR TITLE
🔧 (context-module) [NO-ISSUE]: Update CAL and transaction-checks to Gravitee URLs

### DIFF
--- a/.changeset/context-module-gravitee-urls.md
+++ b/.changeset/context-module-gravitee-urls.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/context-module": patch
+---
+
+Update default CAL and transaction-checks endpoints to the Gravitee gateway URLs

--- a/apps/clear-signing-tester/src/cli/EthereumTransactionTesterCli.ts
+++ b/apps/clear-signing-tester/src/cli/EthereumTransactionTesterCli.ts
@@ -106,7 +106,7 @@ export class EthereumTransactionTesterCli {
         blindSigningEnabled: config.blindSigningEnabled ?? false,
       },
       cal: {
-        url: "https://crypto-assets-service.api.ledger.com/v1",
+        url: "https://global.api.prd.ledger.com/cal/v1",
         mode: calMode,
         branch: "main",
       },

--- a/apps/clear-signing-tester/src/cli/SolanaTransactionTesterCli.ts
+++ b/apps/clear-signing-tester/src/cli/SolanaTransactionTesterCli.ts
@@ -94,7 +94,7 @@ export class SolanaTransactionTesterCli {
         blindSigningEnabled: false,
       },
       cal: {
-        url: "https://crypto-assets-service.api.ledger.com/v1",
+        url: "https://global.api.prd.ledger.com/cal/v1",
         mode: "prod",
         branch: "main",
       },

--- a/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpCalAdapter.ts
+++ b/apps/clear-signing-tester/src/infrastructure/adapters/external/HttpCalAdapter.ts
@@ -8,10 +8,10 @@ import { TYPES } from "@root/src/di/types";
 import { type CalAdapter } from "@root/src/domain/adapters/CalAdapter";
 import { type SignerConfig } from "@root/src/domain/models/config/SignerConfig";
 
-const CAL_BASE_URL = "https://crypto-assets-service.api.ledger.com/v1";
+const CAL_BASE_URL = "https://global.api.prd.ledger.com/cal/v1";
 
 /**
- * Response DTO from the crypto-assets-service API
+ * Response DTO from the CAL (Crypto Assets List) API
  */
 type CalldataDto = {
   descriptors_calldata: {

--- a/apps/sample/api/index.py
+++ b/apps/sample/api/index.py
@@ -39,7 +39,7 @@ from erc7730.convert.calldata.convert_erc7730_v2_input_to_calldata import (
 from erc7730.model.input.v2.descriptor import InputERC7730Descriptor as InputERC7730DescriptorV2
 
 # Constants
-DEFAULT_CAL_URL = "https://crypto-assets-service.api.ledger.com/v1"
+DEFAULT_CAL_URL = "https://global.api.prd.ledger.com/cal/v1"
 DEFAULT_METADATA_SERVICE_URL = "https://nft.api.live.ledger.com"
 SIGNATURE_TLV_TAG = 0x15
 TEST_SIGNING_KEY = "b1ed47ef58f782e2bc4d5abe70ef66d9009c2957967017054470e0f3e10f5833"

--- a/apps/sample/src/components/SettingsView/CalUrlSetting.tsx
+++ b/apps/sample/src/components/SettingsView/CalUrlSetting.tsx
@@ -34,7 +34,7 @@ export const CalUrlSetting: React.FC = () => {
           renderLeft={<InputLabel>CAL URL</InputLabel>}
           value={calUrl}
           onChange={onValueChange}
-          placeholder="https://crypto-assets-service.api.ledger.com/v1"
+          placeholder="https://global.api.prd.ledger.com/cal/v1"
         />
       </Flex>
       <ResetSettingCTA

--- a/apps/sample/src/components/SettingsView/Web3ChecksUrlSetting.tsx
+++ b/apps/sample/src/components/SettingsView/Web3ChecksUrlSetting.tsx
@@ -34,7 +34,7 @@ export const Web3ChecksUrlSetting: React.FC = () => {
           renderLeft={<InputLabel>Web3Checks Provider URL</InputLabel>}
           value={web3ChecksUrl}
           onChange={onValueChange}
-          placeholder="https://web3checks-backend.api.ledger.com/v3"
+          placeholder="https://global.api.prd.ledger.com/transaction-checks/v3"
         />
       </Flex>
       <ResetSettingCTA

--- a/apps/sample/src/state/settings/schema.ts
+++ b/apps/sample/src/state/settings/schema.ts
@@ -71,12 +71,12 @@ export const initialState: SettingsState = {
 
   // Context module config objects
   calConfig: {
-    url: "https://crypto-assets-service.api.ledger.com/v1",
+    url: "https://global.api.prd.ledger.com/cal/v1",
     mode: "prod",
     branch: "main",
   },
   web3ChecksConfig: {
-    url: "https://web3checks-backend.api.ledger.com/v3",
+    url: "https://global.api.prd.ledger.com/transaction-checks/v3",
   },
   metadataServiceConfig: {
     url: "https://nft.api.live.ledger.com",

--- a/packages/signer/context-module/src/ContextModuleBuilder.test.ts
+++ b/packages/signer/context-module/src/ContextModuleBuilder.test.ts
@@ -200,7 +200,7 @@ describe("ContextModuleBuilder", () => {
       expect(config.cal.mode).toBe(customCalConfig.mode);
       expect(config.cal.branch).toBe(customCalConfig.branch);
       expect(config.cal.url).not.toBe(
-        "https://crypto-assets-service.api.ledger.com/v1",
+        "https://global.api.prd.ledger.com/cal/v1",
       );
     });
   });
@@ -240,7 +240,7 @@ describe("ContextModuleBuilder", () => {
 
       expect(config.web3checks.url).toBe(customWeb3ChecksConfig.url);
       expect(config.web3checks.url).not.toBe(
-        "https://web3checks-backend.api.ledger.com/v3",
+        "https://global.api.prd.ledger.com/transaction-checks/v3",
       );
     });
   });

--- a/packages/signer/context-module/src/ContextModuleBuilder.ts
+++ b/packages/signer/context-module/src/ContextModuleBuilder.ts
@@ -22,8 +22,9 @@ import { type ContextModuleChainID } from "./shared/domain/ContextModuleChainID"
 import { type ContextModule } from "./ContextModule";
 import { DefaultContextModule } from "./DefaultContextModule";
 
-const DEFAULT_CAL_URL = "https://crypto-assets-service.api.ledger.com/v1";
-const DEFAULT_WEB3_CHECKS_URL = "https://web3checks-backend.api.ledger.com/v3";
+const DEFAULT_CAL_URL = "https://global.api.prd.ledger.com/cal/v1";
+const DEFAULT_WEB3_CHECKS_URL =
+  "https://global.api.prd.ledger.com/transaction-checks/v3";
 const DEFAULT_METADATA_SERVICE_DOMAIN = "https://nft.api.live.ledger.com";
 const DEFAULT_REPORTER_URL = "https://blind-signing.api.ledger.com/ingest/v1";
 

--- a/packages/signer/context-module/src/modules/ethereum/calldata/data/HttpCalldataDescriptorDataSource.test.ts
+++ b/packages/signer/context-module/src/modules/ethereum/calldata/data/HttpCalldataDescriptorDataSource.test.ts
@@ -18,7 +18,7 @@ import { HttpCalldataDescriptorDataSource } from "./HttpCalldataDescriptorDataSo
 
 const config = {
   cal: {
-    url: "https://crypto-assets-service.api.ledger.com/v1",
+    url: "https://global.api.prd.ledger.com/cal/v1",
     mode: "test",
     branch: "main",
   },

--- a/packages/signer/context-module/src/modules/ethereum/dynamic-network/data/HttpDynamicNetworkDataSource.test.ts
+++ b/packages/signer/context-module/src/modules/ethereum/dynamic-network/data/HttpDynamicNetworkDataSource.test.ts
@@ -11,7 +11,7 @@ describe("HttpNetworkDataSource", () => {
   let httpMock: { get: ReturnType<typeof vi.fn> };
   const mockConfig: ContextModuleServiceConfig = {
     cal: {
-      url: "https://crypto-assets-service.api.ledger.com",
+      url: "https://global.api.prd.ledger.com/cal/v1",
       mode: "prod",
       branch: "main",
     },

--- a/packages/signer/context-module/src/modules/ethereum/dynamic-network/domain/DynamicNetworkContextLoader.test.ts
+++ b/packages/signer/context-module/src/modules/ethereum/dynamic-network/domain/DynamicNetworkContextLoader.test.ts
@@ -32,7 +32,7 @@ describe("DynamicNetworkContextLoader", () => {
 
   const mockConfig = {
     cal: {
-      url: "https://crypto-assets-service.api.ledger.com",
+      url: "https://global.api.prd.ledger.com/cal/v1",
       mode: "prod",
       branch: "main",
     },

--- a/packages/signer/context-module/src/modules/ethereum/external-plugin/data/HttpExternalPluginDataSource.test.ts
+++ b/packages/signer/context-module/src/modules/ethereum/external-plugin/data/HttpExternalPluginDataSource.test.ts
@@ -16,7 +16,7 @@ const config = {
     url: "web3checksUrl",
   },
   cal: {
-    url: "https://crypto-assets-service.api.ledger.com/v1",
+    url: "https://global.api.prd.ledger.com/cal/v1",
   },
   originToken: "originToken",
 } as ContextModuleServiceConfig;
@@ -95,7 +95,7 @@ describe("HttpExternalPuginDataSource", () => {
 
     // THEN
     expect(httpMock.get).toHaveBeenCalledWith(
-      "https://crypto-assets-service.api.ledger.com/v1/dapps",
+      "https://global.api.prd.ledger.com/cal/v1/dapps",
       {
         params: {
           output: "b2c,b2c_signatures,abis",

--- a/packages/signer/context-module/src/modules/ethereum/gated-signing/data/HttpGatedDescriptorDataSource.test.ts
+++ b/packages/signer/context-module/src/modules/ethereum/gated-signing/data/HttpGatedDescriptorDataSource.test.ts
@@ -7,7 +7,7 @@ import { HttpGatedDescriptorDataSource } from "@/modules/ethereum/gated-signing/
 describe("HttpGatedDescriptorDataSource", () => {
   const config: ContextModuleServiceConfig = {
     cal: {
-      url: "https://crypto-assets-service.api.ledger.com/v1",
+      url: "https://global.api.prd.ledger.com/cal/v1",
       branch: "next",
       mode: "prod",
     },

--- a/packages/signer/context-module/src/modules/ethereum/token/data/HttpTokenDataSource.test.ts
+++ b/packages/signer/context-module/src/modules/ethereum/token/data/HttpTokenDataSource.test.ts
@@ -14,7 +14,7 @@ describe("HttpTokenDataSource", () => {
     vi.clearAllMocks();
     const config = {
       cal: {
-        url: "https://crypto-assets-service.api.ledger.com/v1",
+        url: "https://global.api.prd.ledger.com/cal/v1",
         mode: "prod",
         branch: "main",
       },
@@ -35,7 +35,7 @@ describe("HttpTokenDataSource", () => {
 
     // THEN
     expect(httpMock.get).toHaveBeenCalledWith(
-      "https://crypto-assets-service.api.ledger.com/v1/tokens",
+      "https://global.api.prd.ledger.com/cal/v1/tokens",
       {
         params: {
           contract_address: "0x00",

--- a/packages/signer/context-module/src/modules/ethereum/trusted-name/data/HttpTrustedNameDataSource.test.ts
+++ b/packages/signer/context-module/src/modules/ethereum/trusted-name/data/HttpTrustedNameDataSource.test.ts
@@ -7,7 +7,7 @@ import { type TrustedNameDataSource } from "@/modules/ethereum/trusted-name/data
 
 const config = {
   cal: {
-    url: "https://crypto-assets-service.api.ledger.com/v1",
+    url: "https://global.api.prd.ledger.com/cal/v1",
     mode: "prod",
     branch: "main",
   },

--- a/packages/signer/context-module/src/modules/ethereum/typed-data/data/HttpTypedDataDataSource.test.ts
+++ b/packages/signer/context-module/src/modules/ethereum/typed-data/data/HttpTypedDataDataSource.test.ts
@@ -41,7 +41,7 @@ const config = {
     url: "web3checksUrl",
   },
   cal: {
-    url: "https://crypto-assets-service.api.ledger.com/v1",
+    url: "https://global.api.prd.ledger.com/cal/v1",
     mode: "prod",
   },
   originToken: "originToken",
@@ -122,7 +122,7 @@ describe("HttpTypedDataDataSource", () => {
 
     // THEN
     expect(httpMock.get).toHaveBeenCalledWith(
-      "https://crypto-assets-service.api.ledger.com/v1/dapps",
+      "https://global.api.prd.ledger.com/cal/v1/dapps",
       expect.objectContaining({
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         params: expect.objectContaining({

--- a/packages/signer/context-module/src/modules/solana/enum-variant/domain/EnumVariantContextLoader.test.ts
+++ b/packages/signer/context-module/src/modules/solana/enum-variant/domain/EnumVariantContextLoader.test.ts
@@ -28,7 +28,7 @@ const mockCertificate = {
 
 const mockConfig = {
   cal: {
-    url: "https://crypto-assets-service.api.ledger.com/v1",
+    url: "https://global.api.prd.ledger.com/cal/v1",
     mode: "prod",
     branch: "main",
   },

--- a/packages/signer/context-module/src/modules/solana/instruction-info/data/HttpInstructionInfoDataSource.test.ts
+++ b/packages/signer/context-module/src/modules/solana/instruction-info/data/HttpInstructionInfoDataSource.test.ts
@@ -16,7 +16,7 @@ describe("HttpInstructionInfoDataSource", () => {
   const network = "solana-mainnet";
   const config: ContextModuleServiceConfig = {
     cal: {
-      url: "https://crypto-assets-service.api.ledger.com/v1",
+      url: "https://global.api.prd.ledger.com/cal/v1",
       mode: "prod",
       branch: "main",
     },
@@ -59,7 +59,7 @@ describe("HttpInstructionInfoDataSource", () => {
 
     expect(httpMock.get).toHaveBeenCalledTimes(1);
     expect(httpMock.get).toHaveBeenCalledWith(
-      "https://crypto-assets-service.api.ledger.com/v1/solana_programs",
+      "https://global.api.prd.ledger.com/cal/v1/solana_programs",
       {
         params: {
           id: programId,
@@ -80,7 +80,7 @@ describe("HttpInstructionInfoDataSource", () => {
     });
 
     expect(httpMock.get).toHaveBeenCalledWith(
-      "https://crypto-assets-service.api.ledger.com/v1/solana_programs",
+      "https://global.api.prd.ledger.com/cal/v1/solana_programs",
       expect.objectContaining({
         params: expect.objectContaining({ chain_id: 901 }),
       }),

--- a/packages/signer/context-module/src/modules/solana/lifi/data/HttpLifiDataSource.test.ts
+++ b/packages/signer/context-module/src/modules/solana/lifi/data/HttpLifiDataSource.test.ts
@@ -26,7 +26,7 @@ describe("HttpLifiDataSource", () => {
   const templateId = "tpl-123";
   const config: ContextModuleServiceConfig = {
     cal: {
-      url: "https://crypto-assets-service.api.ledger.com/v1",
+      url: "https://global.api.prd.ledger.com/cal/v1",
       mode: "prod",
       branch: "main",
     },
@@ -52,7 +52,7 @@ describe("HttpLifiDataSource", () => {
     // then
     expect(httpMock.get).toHaveBeenCalledTimes(1);
     expect(httpMock.get).toHaveBeenCalledWith(
-      "https://crypto-assets-service.api.ledger.com/v1/swap_templates",
+      "https://global.api.prd.ledger.com/cal/v1/swap_templates",
       {
         params: {
           template_id: templateId,

--- a/packages/signer/context-module/src/modules/solana/lifi/domain/LifiContextLoader.test.ts
+++ b/packages/signer/context-module/src/modules/solana/lifi/domain/LifiContextLoader.test.ts
@@ -35,7 +35,7 @@ const mockCertificate = {
 
 const mockConfig = {
   cal: {
-    url: "https://crypto-assets-service.api.ledger.com",
+    url: "https://global.api.prd.ledger.com/cal/v1",
     mode: "test",
     branch: "main",
   },

--- a/packages/signer/context-module/src/modules/solana/token-info/data/HttpTokenInfoDataSource.test.ts
+++ b/packages/signer/context-module/src/modules/solana/token-info/data/HttpTokenInfoDataSource.test.ts
@@ -15,7 +15,7 @@ describe("HttpTokenInfoDataSource", () => {
   const network = "solana-mainnet";
   const config: ContextModuleServiceConfig = {
     cal: {
-      url: "https://crypto-assets-service.api.ledger.com/v1",
+      url: "https://global.api.prd.ledger.com/cal/v1",
       mode: "prod",
       branch: "main",
     },
@@ -42,7 +42,7 @@ describe("HttpTokenInfoDataSource", () => {
     await datasource.getTokenInfo({ mint, network });
 
     expect(httpMock.get).toHaveBeenCalledWith(
-      "https://crypto-assets-service.api.ledger.com/v1/tokens",
+      "https://global.api.prd.ledger.com/cal/v1/tokens",
       {
         params: {
           contract_address: mint,

--- a/packages/signer/context-module/src/modules/solana/token-info/domain/TokenInfoContextLoader.test.ts
+++ b/packages/signer/context-module/src/modules/solana/token-info/domain/TokenInfoContextLoader.test.ts
@@ -25,7 +25,7 @@ const mockCertificate = {
 
 const mockConfig = {
   cal: {
-    url: "https://crypto-assets-service.api.ledger.com/v1",
+    url: "https://global.api.prd.ledger.com/cal/v1",
     mode: "prod",
     branch: "main",
   },

--- a/packages/signer/context-module/src/modules/solana/token/data/HttpTokenDataSource.test.ts
+++ b/packages/signer/context-module/src/modules/solana/token/data/HttpTokenDataSource.test.ts
@@ -18,7 +18,7 @@ describe("HttpTokenDataSource", () => {
   const tokenInternalId = "sol:usdc";
   const config: ContextModuleServiceConfig = {
     cal: {
-      url: "https://crypto-assets-service.api.ledger.com/v1",
+      url: "https://global.api.prd.ledger.com/cal/v1",
       mode: "prod",
       branch: "main",
     },

--- a/packages/tools/cal-interceptor/src/CalInterceptor.ts
+++ b/packages/tools/cal-interceptor/src/CalInterceptor.ts
@@ -166,7 +166,7 @@ export class CalInterceptor {
       }
 
       // Check if it's a CAL request
-      if (!parsedUrl.origin.includes("crypto-assets-service")) {
+      if (!parsedUrl.pathname.startsWith("/cal")) {
         return null;
       }
 


### PR DESCRIPTION
### 📝 Description

Updates the default endpoints used by the context-module (and related apps/tools) to the new Gravitee API gateway URLs:

- CAL: `https://crypto-assets-service.api.ledger.com/v1` → `https://global.api.prd.ledger.com/cal/v1`
- Transaction checks (web3 checks): `https://web3checks-backend.api.ledger.com/v3` → `https://global.api.prd.ledger.com/transaction-checks/v3`

All hardcoded references across the context-module package, sample app, clear-signing-tester and cal-interceptor tool have been aligned, along with their tests.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [ ] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - Default CAL and transaction-checks base URLs now point to the Gravitee gateway. Consumers relying on the previous defaults will now hit the new endpoints.

---

### 🧐 Checklist for the PR Reviewers

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.

Made with [Cursor](https://cursor.com)