### PR TITLE
✨ (signer-solana) [LBD-682]: Expose SignTransaction device action publicly

### DIFF
--- a/.changeset/expose-solana-sign-transaction-da.md
+++ b/.changeset/expose-solana-sign-transaction-da.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": minor
+---
+
+Expose the sign-transaction device action publicly via `SignTransactionDeviceActionFactory` and promote `SignTransactionDAInput`, `signTransactionDAStateSteps`, `SignTransactionDAStateStep` and `ClearSignMode` so consumers can compose their own device action flow (e.g. OpenApp → GetAddress → SignTransaction)

--- a/packages/signer/signer-solana/src/api/app-binder/SignTransactionDeviceActionFactory.ts
+++ b/packages/signer/signer-solana/src/api/app-binder/SignTransactionDeviceActionFactory.ts
@@ -1,0 +1,1 @@
+export { SignTransactionDeviceActionFactory } from "@internal/app-binder/device-action/SignTransactionDeviceActionFactory";

--- a/packages/signer/signer-solana/src/api/index.ts
+++ b/packages/signer/signer-solana/src/api/index.ts
@@ -17,11 +17,16 @@ export type {
   SignMessageDAOutput,
   SignMessageTaskError,
 } from "@api/app-binder/SignMessageDeviceActionTypes";
-export type {
-  SignTransactionDAError,
-  SignTransactionDAIntermediateValue,
-  SignTransactionDAOutput,
-  SignTransactionDAReturnType,
+export { SignTransactionDeviceActionFactory } from "@api/app-binder/SignTransactionDeviceActionFactory";
+export {
+  type ClearSignMode,
+  type SignTransactionDAError,
+  type SignTransactionDAInput,
+  type SignTransactionDAIntermediateValue,
+  type SignTransactionDAOutput,
+  type SignTransactionDAReturnType,
+  type SignTransactionDAStateStep,
+  signTransactionDAStateSteps,
 } from "@api/app-binder/SignTransactionDeviceActionTypes";
 export type { MessageOptions } from "@api/model/MessageOptions";
 export { SignMessageVersion } from "@api/model/MessageOptions";
@@ -44,3 +49,4 @@ export {
   type GetPubKeyCommandResponse,
 } from "@internal/app-binder/command/GetPubKeyCommand";
 export type { SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
+export { SignTransactionDeviceAction } from "@internal/app-binder/device-action/SignTransactionDeviceAction";

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceActionFactory.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceActionFactory.test.ts
@@ -1,0 +1,77 @@
+import { type ContextModule } from "@ledgerhq/context-module";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type SignTransactionDAInput } from "@api/app-binder/SignTransactionDeviceActionTypes";
+
+import { makeDeviceActionInternalApiMock } from "./__test-utils__/makeInternalApi";
+import { SignTransactionDeviceAction } from "./SignTransactionDeviceAction";
+import { SignTransactionDeviceActionFactory } from "./SignTransactionDeviceActionFactory";
+
+const contextModuleStub = {
+  getContexts: vi.fn(),
+} as unknown as ContextModule;
+
+const defaultInput: SignTransactionDAInput = {
+  derivationPath: "44'/501'/0'/0'",
+  transaction: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+  contextModule: contextModuleStub,
+};
+
+const mockLoggerFactory = vi.fn((_tag: string) => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  subscribers: [],
+}));
+
+describe("SignTransactionDeviceActionFactory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should create a SignTransactionDeviceAction from the input", () => {
+    const deviceAction = SignTransactionDeviceActionFactory({
+      input: defaultInput,
+    });
+
+    expect(deviceAction).toBeInstanceOf(SignTransactionDeviceAction);
+  });
+
+  it("should forward the input and inspect to the device action", () => {
+    const deviceAction = SignTransactionDeviceActionFactory({
+      input: defaultInput,
+      inspect: true,
+    });
+
+    expect(deviceAction.input).toBe(defaultInput);
+    expect(deviceAction.inspect).toBe(true);
+  });
+
+  it("should forward the loggerFactory so it is used instead of internalApi.loggerFactory", () => {
+    const internalApi = makeDeviceActionInternalApiMock();
+    const deviceAction = SignTransactionDeviceActionFactory({
+      input: defaultInput,
+      loggerFactory: mockLoggerFactory,
+    });
+
+    deviceAction.makeStateMachine(internalApi);
+
+    expect(mockLoggerFactory).toHaveBeenCalledWith(
+      "SignTransactionDeviceAction",
+    );
+  });
+
+  it("should return a device action usable as an XState actor", () => {
+    const internalApi = makeDeviceActionInternalApiMock();
+    const deviceAction = SignTransactionDeviceActionFactory({
+      input: defaultInput,
+    });
+
+    const stateMachine = deviceAction.makeStateMachine(internalApi);
+
+    expect(stateMachine).toBeDefined();
+    expect(typeof stateMachine.provide).toBe("function");
+    expect(stateMachine.config).toBeDefined();
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceActionFactory.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceActionFactory.ts
@@ -1,0 +1,11 @@
+import type { LoggerPublisherService } from "@ledgerhq/device-management-kit";
+
+import { type SignTransactionDAInput } from "@api/app-binder/SignTransactionDeviceActionTypes";
+
+import { SignTransactionDeviceAction } from "./SignTransactionDeviceAction";
+
+export const SignTransactionDeviceActionFactory = (args: {
+  input: SignTransactionDAInput;
+  inspect?: boolean;
+  loggerFactory?: (tag: string) => LoggerPublisherService;
+}): SignTransactionDeviceAction => new SignTransactionDeviceAction(args);


### PR DESCRIPTION
### 📝 Description

Publicly exposes the Solana sign-transaction device action as a reusable XState actor factory, so consumers (e.g. Ledger Button) can compose their own device action machine chaining `OpenAppWithDependencies` → `GetAddress` → verify address → `SignTransaction` in a single flow, as is already possible for sign-message.

Previously only the DA result types were exported; the `SignTransactionDeviceAction` class stayed internal and was only instantiated by `SolanaAppBinder.signTransaction()`.

**Changes** (all additive, non-breaking):

- New internal `SignTransactionDeviceActionFactory` that instantiates the existing `SignTransactionDeviceAction` class (accepts `{ input, inspect?, loggerFactory? }`; `loggerFactory` is optional).
- New public re-export shim `api/app-binder/SignTransactionDeviceActionFactory.ts`, mirroring `GetAddressDeviceActionFactory` / `SignMessageDeviceActionFactory`.
- Promoted the following in `src/api/index.ts`: `SignTransactionDeviceActionFactory`, plus types `SignTransactionDAInput`, `SignTransactionDAStateStep`, `ClearSignMode` and the const `signTransactionDAStateSteps`.
- README section "Composing the Sign Transaction device action" documenting: mandatory `contextModule` (blind-sign fallback when Solana loaders are absent), the DA's own OpenApp step (`skipOpenApp: true` when chaining upstream), no in-DA address verification, raw 64-byte signature output, and optional `blockhashService`.
- Unit test mirroring `SignMessageDeviceActionFactory.test.ts`, asserting construction, arg forwarding, and that `factory({ input }).makeStateMachine(internalApi)` returns a valid state machine.

**Usage:**

```ts
import { SignTransactionDeviceActionFactory } from "@ledgerhq/device-signer-kit-solana";

const signTransactionDA = SignTransactionDeviceActionFactory({
  input: {
    derivationPath,
    transaction,
    contextModule,
    transactionOptions: { skipOpenApp: true },
  },
});

setup({
  actors: {
    openApp: openAppDA.makeStateMachine(internalApi),
    getAddress: getAddressDA.makeStateMachine(internalApi),
    signTransaction: signTransactionDA.makeStateMachine(internalApi),
  },
});
```

### ❓ Context

- **JIRA or GitHub link**: [LBD-682](https://ledgerhq.atlassian.net/browse/LBD-682)
- **Feature**: Expose the Solana sign-transaction device action factory so consumers can compose their own multi-step device action flows.

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided** <!-- minor bump for @ledgerhq/device-signer-kit-solana -->
- [x] **Documentation is up-to-date** <!-- README updated with composition notes -->
- [ ] **Impact of the changes:**
  - Purely additive new public exports on `@ledgerhq/device-signer-kit-solana` (minor). No existing signatures modified.
  - QA focus: verify `SignTransactionDeviceActionFactory` + promoted types resolve at runtime in both ESM and CJS, and that the returned device action works as an XState actor.

Made with [Cursor](https://cursor.com)

[LBD-682]: https://ledgerhq.atlassian.net/browse/LBD-682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ