### PR TITLE
✨ (mock-server) [DSDK-1347]: Replace SPECULOS_SEED env with per-session seed endpoint

### DIFF
--- a/agent-files/claude/skills/mock-server
+++ b/agent-files/claude/skills/mock-server
@@ -1,0 +1,1 @@
+../../skills/mock-server

--- a/agent-files/cursor/skills/mock-server
+++ b/agent-files/cursor/skills/mock-server
@@ -1,0 +1,1 @@
+../../skills/mock-server

--- a/agent-files/skills/mock-server/SKILL.md
+++ b/agent-files/skills/mock-server/SKILL.md
@@ -73,6 +73,10 @@ curl -s -X DELETE $BASE/devices/<id>/mocks -H "$AUTH"        # kill all
 # Save / load session
 curl -s $BASE/export -H "$AUTH"
 curl -s -X POST $BASE/import -H "$AUTH" -H "$JSON" -d '<SessionExport json>'
+
+# Speculos seed (⚠️ plaintext — test mnemonics only, never real keys)
+curl -s -X PUT $BASE/sessions/current/seed -H "$AUTH" -H "$JSON" \
+  -d '{"seed":"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"}'
 ```
 
 `device_type`: `nanoS`, `nanoSP`, `nanoX`, `stax`, `flex`, `apexp`. `PATCH` keeps
@@ -98,6 +102,19 @@ curl -s -X POST $BASE/devices/<id>/mocks -H "$AUTH" -H "$JSON" \
 ```
 
 Add mock = new behavior. Delete mock = old behavior back.
+
+## Speculos seed
+
+Each session starts with the default test mnemonic. Override it per-session
+before opening an app (the seed is forwarded to Speculinho on every `/acquire`):
+
+```bash
+curl -s -X PUT $BASE/sessions/current/seed -H "$AUTH" -H "$JSON" \
+  -d '{"seed":"glory promote mansion idle axis finger extend february uncover one trip resolve toe"}'
+```
+
+⚠️ **Not secure.** Stored in plaintext in server memory and sent over plain
+HTTP. Use only test/dummy mnemonics — never a real production key.
 
 ## Newest firmware
 

--- a/agent-files/skills/mock-server/SKILL.md
+++ b/agent-files/skills/mock-server/SKILL.md
@@ -82,6 +82,38 @@ curl -s -X PUT $BASE/sessions/current/seed -H "$AUTH" -H "$JSON" \
 `device_type`: `nanoS`, `nanoSP`, `nanoX`, `stax`, `flex`, `apexp`. `PATCH` keeps
 the id and only changes fields you send.
 
+## Open App / Close App
+
+Format: `e0 d8 00 00 <len> <app-name-ascii-hex>` — Close: `b0 a7 00 00 00`.
+
+```bash
+# Open Bitcoin (7 chars → 07, "Bitcoin" = 426974636f696e)
+curl -s -X POST $BASE/devices/<id>/apdu -H "$AUTH" -H "$JSON" \
+  -d '{"apdu":"e0d8000007426974636f696e"}'
+
+# Open Ethereum (8 chars → 08, "Ethereum" = 457468657265756d)
+curl -s -X POST $BASE/devices/<id>/apdu -H "$AUTH" -H "$JSON" \
+  -d '{"apdu":"e0d8000008457468657265756d"}'
+
+# Close App (any app)
+curl -s -X POST $BASE/devices/<id>/apdu -H "$AUTH" -H "$JSON" \
+  -d '{"apdu":"b0a7000000"}'
+```
+
+All three return `{"response":"9000"}` on success. Open App returns `6807` if
+the app is not in the device's `apps` list (add it via `POST /devices` or
+`PATCH /devices/<id>`).
+
+Build the hex for any app on the fly:
+
+```bash
+app="Solana"
+hex=$(printf '%s' "$app" | xxd -p | tr -d '\n')
+len=$(printf '%02x' ${#app})
+curl -s -X POST $BASE/devices/<id>/apdu -H "$AUTH" -H "$JSON" \
+  -d "{\"apdu\":\"e0d800${len}${hex}\"}"
+```
+
 ## Mocks: how they work
 
 - Mock catches any APDU that STARTS WITH `prefix`.

--- a/apps/device-mock-server/.env.example
+++ b/apps/device-mock-server/.env.example
@@ -11,10 +11,6 @@ SPECULINHO_URL=
 # HTTP port the server listens on.
 PORT=9752
 
-# BIP39 seed used when provisioning Speculos emulators via Speculinho.
-# Only relevant when SPECULINHO_URL is set.
-# SPECULOS_SEED=glory promote mansion idle axis finger extend february uncover one trip resolve toe
-
 # Pin a specific Speculos image version (e.g. v0.9.13).
 # Only relevant when SPECULINHO_URL is set.
 # SPECULOS_VERSION=

--- a/apps/device-mock-server/README.md
+++ b/apps/device-mock-server/README.md
@@ -334,38 +334,38 @@ The standalone server (`src/main.ts`) reads environment variables:
 | --------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | `PORT`                      | `9752`                              | HTTP port.                                                                                                          |
 | `SPECULINHO_URL`            | `https://speculinho.ledgerlabs.net` | Speculinho operator base URL. Set to empty (`SPECULINHO_URL=`) to run as a **pure mock** with no Speculos proxying. |
-| `SPECULOS_SEED`             | built-in default seed               | BIP39 seed used for provisioned emulators.                                                                          |
 | `SPECULOS_VERSION`          | _unset_                             | Pin a Speculos version.                                                                                             |
 | `SPECULOS_READY_TIMEOUT_MS` | `120000`                            | How long to wait for an emulator to become ready.                                                                   |
 | `MOCK_SERVER_LOG_LEVEL`     | `info`                              | Console log verbosity. One of `silent`, `error`, `warn`, `info`, `debug`.                                           |
 
 Programmatically, `createMockServer(config)` accepts a `MockServerConfig`:
 
-| Option            | Description                                                                                                       |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `ttlMs`           | Sliding inactivity timeout (refreshed on each authed request).                                                    |
-| `maxLifetimeMs`   | Hard cap on session lifetime regardless of activity.                                                              |
-| `sweepIntervalMs` | Expired-session sweep interval; `0` disables the sweeper.                                                         |
-| `speculos`        | `{ baseUrl, seed, speculosVersion?, readyTimeoutMs?, pollIntervalMs? }`. When omitted, the server is a pure mock. |
+| Option            | Description                                                                                                 |
+| ----------------- | ----------------------------------------------------------------------------------------------------------- |
+| `ttlMs`           | Sliding inactivity timeout (refreshed on each authed request).                                              |
+| `maxLifetimeMs`   | Hard cap on session lifetime regardless of activity.                                                        |
+| `sweepIntervalMs` | Expired-session sweep interval; `0` disables the sweeper.                                                   |
+| `speculos`        | `{ baseUrl, speculosVersion?, readyTimeoutMs?, pollIntervalMs? }`. When omitted, the server is a pure mock. |
 
 ## 🔹 HTTP API
 
 All routes except `POST /auth` and `GET /health` require an `Authorization: Bearer <token>` header.
 
-| Method & path                                 | Description                                                           |
-| --------------------------------------------- | --------------------------------------------------------------------- |
-| `POST /auth`                                  | Create a session, returns `{ token, expires_at }`.                    |
-| `GET /health`                                 | Liveness probe (no auth).                                             |
-| `GET` / `DELETE /sessions/current`            | Inspect / dispose the current session.                                |
-| `GET` / `POST /devices`                       | List / attach devices.                                                |
-| `GET` / `PATCH` / `DELETE /devices/:id`       | Read / edit / remove a device.                                        |
-| `POST /devices/:id/connect` · `/disconnect`   | Toggle connection state.                                              |
-| `POST /devices/:id/apdu`                      | Resolve an APDU (`{ apdu }` → `{ response }`).                        |
-| `GET` / `POST` / `DELETE /devices/:id/mocks`  | List / add / clear device mocks.                                      |
-| `PATCH` / `DELETE /devices/:id/mocks/:mockId` | Edit / remove a single mock.                                          |
-| `GET /devices/:id/speculos`                   | The device's active Speculos instance (`409` if none).                |
-| `ALL /devices/:id/speculos/*`                 | Raw passthrough to the device's emulator.                             |
-| `GET /export` · `POST /import`                | Export / import a portable session snapshot (devices + nested mocks). |
+| Method & path                                 | Description                                                                                                                                                    |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POST /auth`                                  | Create a session, returns `{ token, expires_at }`.                                                                                                             |
+| `GET /health`                                 | Liveness probe (no auth).                                                                                                                                      |
+| `GET` / `DELETE /sessions/current`            | Inspect / dispose the current session.                                                                                                                         |
+| `PUT /sessions/current/seed`                  | Set the BIP39 mnemonic used for Speculos emulators in this session (`{ seed }`). ⚠️ **Not secure** — stored and transmitted in plaintext. Test mnemonics only. |
+| `GET` / `POST /devices`                       | List / attach devices.                                                                                                                                         |
+| `GET` / `PATCH` / `DELETE /devices/:id`       | Read / edit / remove a device.                                                                                                                                 |
+| `POST /devices/:id/connect` · `/disconnect`   | Toggle connection state.                                                                                                                                       |
+| `POST /devices/:id/apdu`                      | Resolve an APDU (`{ apdu }` → `{ response }`).                                                                                                                 |
+| `GET` / `POST` / `DELETE /devices/:id/mocks`  | List / add / clear device mocks.                                                                                                                               |
+| `PATCH` / `DELETE /devices/:id/mocks/:mockId` | Edit / remove a single mock.                                                                                                                                   |
+| `GET /devices/:id/speculos`                   | The device's active Speculos instance (`409` if none).                                                                                                         |
+| `ALL /devices/:id/speculos/*`                 | Raw passthrough to the device's emulator.                                                                                                                      |
+| `GET /export` · `POST /import`                | Export / import a portable session snapshot (devices + nested mocks).                                                                                          |
 
 The full contract is generated as [`openapi.yaml`](./openapi.yaml).
 

--- a/apps/device-mock-server/docker-compose.yml
+++ b/apps/device-mock-server/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - PORT=${PORT:-9752}
       - SPECULINHO_URL=${SPECULINHO_URL:-https://speculinho.ledgerlabs.net}
       - SPECULOS_READY_TIMEOUT_MS=${SPECULOS_READY_TIMEOUT_MS:-120000}
-      - SPECULOS_SEED
       - SPECULOS_VERSION
       - MOCK_SERVER_LOG_LEVEL
     healthcheck:

--- a/apps/device-mock-server/openapi.yaml
+++ b/apps/device-mock-server/openapi.yaml
@@ -244,9 +244,29 @@ components:
       required:
         - status
         - sessions
+    SeedUpdate:
+      type: object
+      description:
+        BIP39 mnemonic for the session's Speculos emulator. ⚠️ Not secure —
+        stored and transmitted in plaintext. Use only test/dummy mnemonics,
+        never real production keys.
+      properties:
+        seed:
+          type: string
+          example:
+            glory promote mansion idle axis finger extend february uncover one trip
+            resolve toe
+      required:
+        - seed
   responses:
     Unauthorized:
       description: Missing, invalid or expired bearer token.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    BadRequest:
+      description: Request body is malformed or failed validation.
       content:
         application/json:
           schema:
@@ -315,6 +335,36 @@ paths:
       responses:
         "204":
           description: Session disposed.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /sessions/current/seed:
+    put:
+      tags:
+        - Sessions
+      summary: Set the Speculos seed for the current session
+      description: |
+        Overrides the BIP39 mnemonic forwarded to Speculos on every
+        subsequent `/acquire` call within this session. Defaults to the
+        well-known test mnemonic on session creation.
+
+        **⚠️ Security warning — not secure.** The seed is stored in
+        plaintext in server memory and transmitted in plaintext HTTP. Use
+        only test/dummy mnemonics. Never supply a real production key.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SeedUpdate"
+      responses:
+        "200":
+          description: Seed updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SeedUpdate"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
   /devices:

--- a/apps/device-mock-server/src/api/createMockServer.speculos.test.ts
+++ b/apps/device-mock-server/src/api/createMockServer.speculos.test.ts
@@ -116,7 +116,6 @@ beforeEach(async () => {
   const built = createMockServer({
     speculos: {
       baseUrl: "https://speculinho.test",
-      seed: "test seed",
       pollIntervalMs: 0,
       readyTimeoutMs: 1000,
     },

--- a/apps/device-mock-server/src/api/createMockServer.test.ts
+++ b/apps/device-mock-server/src/api/createMockServer.test.ts
@@ -370,4 +370,79 @@ describe("createMockServer (HTTP contract)", () => {
       expect(afterDelete.status).toBe(401);
     });
   });
+
+  describe("PUT /sessions/current/seed", () => {
+    it("returns 401 without a bearer token", async () => {
+      const res = await api("/sessions/current/seed", {
+        method: "PUT",
+        body: JSON.stringify({
+          seed: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+        }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 200 and echoes the trimmed seed on success", async () => {
+      const token = await authenticate();
+      const res = await api(
+        "/sessions/current/seed",
+        {
+          method: "PUT",
+          body: JSON.stringify({
+            seed: "  glory promote mansion idle axis finger extend february uncover one trip resolve toe  ",
+          }),
+        },
+        token,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { seed: string };
+      expect(body.seed).toBe(
+        "glory promote mansion idle axis finger extend february uncover one trip resolve toe",
+      );
+    });
+
+    it("returns 400 when seed is missing", async () => {
+      const token = await authenticate();
+      const res = await api(
+        "/sessions/current/seed",
+        { method: "PUT", body: JSON.stringify({}) },
+        token,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when seed is blank", async () => {
+      const token = await authenticate();
+      const res = await api(
+        "/sessions/current/seed",
+        { method: "PUT", body: JSON.stringify({ seed: "   " }) },
+        token,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when seed is not a string", async () => {
+      const token = await authenticate();
+      const res = await api(
+        "/sessions/current/seed",
+        { method: "PUT", body: JSON.stringify({ seed: 42 }) },
+        token,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when Content-Type is not JSON and body is absent", async () => {
+      const token = await authenticate();
+      const res = await api(
+        "/sessions/current/seed",
+        {
+          method: "PUT",
+          headers: { "Content-Type": "text/plain" },
+          body: "glory promote mansion idle axis finger extend february uncover one trip resolve toe",
+        },
+        token,
+      );
+      expect(res.status).toBe(400);
+    });
+  });
 });

--- a/apps/device-mock-server/src/internal/server/openapi/definition.ts
+++ b/apps/device-mock-server/src/internal/server/openapi/definition.ts
@@ -223,10 +223,33 @@ export const openapiDefinition: OAS3Definition = {
         },
         required: ["status", "sessions"],
       },
+      SeedUpdate: {
+        type: "object",
+        description:
+          "BIP39 mnemonic for the session's Speculos emulator. " +
+          "⚠️ Not secure — stored and transmitted in plaintext. " +
+          "Use only test/dummy mnemonics, never real production keys.",
+        properties: {
+          seed: {
+            type: "string",
+            example:
+              "glory promote mansion idle axis finger extend february uncover one trip resolve toe",
+          },
+        },
+        required: ["seed"],
+      },
     },
     responses: {
       Unauthorized: {
         description: "Missing, invalid or expired bearer token.",
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/Error" },
+          },
+        },
+      },
+      BadRequest: {
+        description: "Request body is malformed or failed validation.",
         content: {
           "application/json": {
             schema: { $ref: "#/components/schemas/Error" },

--- a/apps/device-mock-server/src/internal/server/routes/SessionsRoutes.ts
+++ b/apps/device-mock-server/src/internal/server/routes/SessionsRoutes.ts
@@ -63,6 +63,52 @@ export class SessionsRoutes {
       res.status(204).end();
     });
 
+    /**
+     * @openapi
+     * /sessions/current/seed:
+     *   put:
+     *     tags: [Sessions]
+     *     summary: Set the Speculos seed for the current session
+     *     description: |
+     *       Overrides the BIP39 mnemonic forwarded to Speculos on every
+     *       subsequent `/acquire` call within this session. Defaults to the
+     *       well-known test mnemonic on session creation.
+     *
+     *       **⚠️ Security warning — not secure.** The seed is stored in
+     *       plaintext in server memory and transmitted in plaintext HTTP. Use
+     *       only test/dummy mnemonics. Never supply a real production key.
+     *     requestBody:
+     *       required: true
+     *       content:
+     *         application/json:
+     *           schema:
+     *             $ref: '#/components/schemas/SeedUpdate'
+     *     responses:
+     *       200:
+     *         description: Seed updated.
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/SeedUpdate'
+     *       400:
+     *         $ref: '#/components/responses/BadRequest'
+     *       401:
+     *         $ref: '#/components/responses/Unauthorized'
+     */
+    router.put(
+      "/sessions/current/seed",
+      (req: AuthedRequest, res: Response) => {
+        const seed = (req.body as { seed?: unknown } | undefined)?.seed;
+        const trimmed = typeof seed === "string" ? seed.trim() : "";
+        if (!trimmed) {
+          res.status(400).json({ error: "seed must be a non-empty string" });
+          return;
+        }
+        this.repository.updateSeed(getSession(req), trimmed);
+        res.json({ seed: trimmed });
+      },
+    );
+
     return router;
   }
 }

--- a/apps/device-mock-server/src/internal/session/data/InMemorySessionRepository.ts
+++ b/apps/device-mock-server/src/internal/session/data/InMemorySessionRepository.ts
@@ -20,6 +20,7 @@ import {
   type SessionRecord,
   type SpeculosProxySession,
 } from "@internal/session/model/SessionModels";
+import { DEFAULT_SPECULOS_SEED } from "@internal/speculos/model/SpeculosModels";
 
 const DEFAULT_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const DEFAULT_MAX_LIFETIME_MS = 4 * 60 * 60 * 1000; // 4 hours
@@ -47,6 +48,7 @@ export class InMemorySessionRepository implements SessionRepository {
       token: randomUUID(),
       createdAt: now,
       lastSeenAt: now,
+      seed: DEFAULT_SPECULOS_SEED,
       devices: new Map(),
       deviceMocks: new Map(),
       deviceMockCursors: new Map(),
@@ -98,6 +100,10 @@ export class InMemorySessionRepository implements SessionRepository {
       }
     }
     return evicted;
+  }
+
+  updateSeed(record: SessionRecord, seed: string): void {
+    record.seed = seed;
   }
 
   // --- Devices --------------------------------------------------------------

--- a/apps/device-mock-server/src/internal/session/data/SessionRepository.ts
+++ b/apps/device-mock-server/src/internal/session/data/SessionRepository.ts
@@ -31,6 +31,8 @@ export interface SessionRepository {
   size(): number;
   /** Remove expired sessions; returns their active Speculos proxies. */
   sweep(): SpeculosProxySession[];
+  /** Override the BIP39 mnemonic used for Speculos acquires in this session. */
+  updateSeed(record: SessionRecord, seed: string): void;
 
   // --- Devices --------------------------------------------------------------
   listDevices(record: SessionRecord): Device[];

--- a/apps/device-mock-server/src/internal/session/model/SessionModels.ts
+++ b/apps/device-mock-server/src/internal/session/model/SessionModels.ts
@@ -23,6 +23,15 @@ export interface SessionRecord {
   token: string;
   createdAt: number;
   lastSeenAt: number;
+  /**
+   * BIP39 mnemonic forwarded to Speculos on every acquire for this session.
+   * Defaults to the well-known test mnemonic; overridable via PUT
+   * /sessions/current/seed.
+   *
+   * WARNING: stored in plaintext in memory and transmitted in plaintext HTTP.
+   * Use only test mnemonics — never real production keys.
+   */
+  seed: string;
   devices: Map<string, Device>;
   /** Per-device mock table: deviceId -> (mockId -> Mock). */
   deviceMocks: Map<string, Map<string, Mock>>;

--- a/apps/device-mock-server/src/internal/speculos/data/HttpSpeculosOperatorDataSource.test.ts
+++ b/apps/device-mock-server/src/internal/speculos/data/HttpSpeculosOperatorDataSource.test.ts
@@ -10,10 +10,11 @@ const jsonResponse = (body: unknown, ok = true, status = 200): Response =>
     text: () => Promise.resolve(JSON.stringify(body)),
   }) as unknown as Response;
 
+const TEST_SEED = "test seed";
+
 const newOperator = () =>
   new HttpSpeculosOperatorDataSource({
     baseUrl: "https://speculinho.test/",
-    seed: "test seed",
     pollIntervalMs: 0,
     readyTimeoutMs: 1_000,
   });
@@ -37,6 +38,7 @@ describe("HttpSpeculosOperatorDataSource", () => {
           device_os_version: "1.3.0",
         },
         "run-1",
+        TEST_SEED,
       )
       .run();
 
@@ -47,7 +49,7 @@ describe("HttpSpeculosOperatorDataSource", () => {
     expect(JSON.parse((init as RequestInit).body as string)).toMatchObject({
       coin_app: "btc",
       device: "nanox",
-      seed: "test seed",
+      seed: TEST_SEED,
       run_id: "run-1",
     });
   });
@@ -65,6 +67,7 @@ describe("HttpSpeculosOperatorDataSource", () => {
           device_os_version: "1.3.0",
         },
         "run-1",
+        TEST_SEED,
       )
       .run();
     expect(result.isLeft()).toBe(true);

--- a/apps/device-mock-server/src/internal/speculos/data/HttpSpeculosOperatorDataSource.ts
+++ b/apps/device-mock-server/src/internal/speculos/data/HttpSpeculosOperatorDataSource.ts
@@ -44,7 +44,6 @@ export class HttpSpeculosOperatorDataSource
   implements SpeculosOperatorDataSource
 {
   private readonly baseUrl: string;
-  private readonly seed: string;
   private readonly speculosVersion?: string;
   private readonly readyTimeoutMs: number;
   private readonly pollIntervalMs: number;
@@ -53,7 +52,6 @@ export class HttpSpeculosOperatorDataSource
     @inject(speculosTypes.OperatorConfig) config: SpeculosOperatorConfig,
   ) {
     this.baseUrl = stripTrailingSlashes(config.baseUrl);
-    this.seed = config.seed;
     this.speculosVersion = config.speculosVersion;
     this.readyTimeoutMs = config.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS;
     this.pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
@@ -62,11 +60,12 @@ export class HttpSpeculosOperatorDataSource
   acquire(
     req: AcquireRequest,
     runId: string,
+    seed: string,
   ): EitherAsync<SpeculosError, string> {
     return EitherAsync(async ({ throwE }) => {
       const body: Record<string, unknown> = {
         ...req,
-        seed: this.seed,
+        seed,
         run_id: runId,
       };
       if (this.speculosVersion) body["speculos_version"] = this.speculosVersion;

--- a/apps/device-mock-server/src/internal/speculos/data/SpeculosOperatorDataSource.ts
+++ b/apps/device-mock-server/src/internal/speculos/data/SpeculosOperatorDataSource.ts
@@ -12,10 +12,14 @@ import {
  * forwarding APDUs to the per-pod Speculos emulator.
  */
 export interface SpeculosOperatorDataSource {
-  /** Create a Speculos instance; resolves the (echoed) `run_id`. */
+  /**
+   * Create a Speculos instance; resolves the (echoed) `run_id`.
+   * `seed` is the BIP39 mnemonic for this session (see SessionRecord.seed).
+   */
   acquire(
     req: AcquireRequest,
     runId: string,
+    seed: string,
   ): EitherAsync<SpeculosError, string>;
   /** Poll until ready; resolves the emulator URL, or fails on failed/timeout. */
   waitUntilReady(runId: string): EitherAsync<SpeculosError, string>;

--- a/apps/device-mock-server/src/internal/speculos/model/SpeculosModels.ts
+++ b/apps/device-mock-server/src/internal/speculos/model/SpeculosModels.ts
@@ -1,6 +1,9 @@
 /**
- * Well-known Speculos default test mnemonic. Used when no `SPECULOS_SEED` is
- * configured. Speculos derives all keys from this deterministic seed.
+ * Well-known Speculos default test mnemonic. Each new session starts with this
+ * seed; callers can override it per-session via PUT /sessions/current/seed.
+ *
+ * WARNING: not secure — stored in plaintext and transmitted over plain HTTP.
+ * Only use test mnemonics, never real production keys.
  */
 export const DEFAULT_SPECULOS_SEED =
   "glory promote mansion idle axis finger extend february uncover one trip resolve toe";
@@ -9,8 +12,6 @@ export const DEFAULT_SPECULOS_SEED =
 export interface SpeculosOperatorConfig {
   /** Operator base URL, e.g. `https://speculinho.ledgerlabs.net`. */
   readonly baseUrl: string;
-  /** BIP39 mnemonic forwarded to Speculos on every acquire. */
-  readonly seed: string;
   /** Optional speculos-apps image tag (defaults to operator's `latest`). */
   readonly speculosVersion?: string;
   /** Max acquire-to-ready wait before giving up. */

--- a/apps/device-mock-server/src/internal/speculos/use-case/OpenAppViaSpeculosUseCase.test.ts
+++ b/apps/device-mock-server/src/internal/speculos/use-case/OpenAppViaSpeculosUseCase.test.ts
@@ -3,7 +3,10 @@ import { vi } from "vitest";
 
 import { InMemorySessionRepository } from "@internal/session/data/InMemorySessionRepository";
 import { type SpeculosOperatorDataSource } from "@internal/speculos/data/SpeculosOperatorDataSource";
-import { SpeculosError } from "@internal/speculos/model/SpeculosModels";
+import {
+  DEFAULT_SPECULOS_SEED,
+  SpeculosError,
+} from "@internal/speculos/model/SpeculosModels";
 import { OpenAppViaSpeculosUseCase } from "@internal/speculos/use-case/OpenAppViaSpeculosUseCase";
 
 const makeOperator = (
@@ -61,6 +64,7 @@ describe("OpenAppViaSpeculosUseCase", () => {
         device_os_version: "1.3.0",
       },
       expect.any(String),
+      DEFAULT_SPECULOS_SEED,
     );
     expect(repo.findProxy(record, device.id).extract()).toMatchObject({
       speculosUrl: "https://run-1.speculos.test",

--- a/apps/device-mock-server/src/internal/speculos/use-case/OpenAppViaSpeculosUseCase.ts
+++ b/apps/device-mock-server/src/internal/speculos/use-case/OpenAppViaSpeculosUseCase.ts
@@ -63,6 +63,7 @@ export class OpenAppViaSpeculosUseCase {
             device_os_version: device.firmware_version,
           },
           runId,
+          record.seed,
         )
         .chain(() => this.operator.waitUntilReady(runId))
         .run();

--- a/apps/device-mock-server/src/main.ts
+++ b/apps/device-mock-server/src/main.ts
@@ -3,7 +3,6 @@ import "reflect-metadata";
 import { createMockServer } from "@api/createMockServer";
 import { type MockServerConfig } from "@api/model/MockServerConfig";
 import { logger } from "@internal/logger/logger";
-import { DEFAULT_SPECULOS_SEED } from "@internal/speculos/model/SpeculosModels";
 
 const port = Number(process.env["PORT"] ?? 9752);
 
@@ -17,7 +16,6 @@ const speculinhoUrl =
 const speculos: MockServerConfig["speculos"] = speculinhoUrl
   ? {
       baseUrl: speculinhoUrl,
-      seed: process.env["SPECULOS_SEED"] ?? DEFAULT_SPECULOS_SEED,
       speculosVersion: process.env["SPECULOS_VERSION"],
       readyTimeoutMs: process.env["SPECULOS_READY_TIMEOUT_MS"]
         ? Number(process.env["SPECULOS_READY_TIMEOUT_MS"])


### PR DESCRIPTION
## Summary

- **Remove** `SPECULOS_SEED` environment variable — it was baked into the server config at startup and impossible for users to change at runtime without rebuilding the image.
- **Add** `PUT /sessions/current/seed` endpoint — callers can now override the BIP39 mnemonic per-session at any time before or between Open App calls; the seed is forwarded to Speculinho on every `/acquire`.
- Each new session initialises with `DEFAULT_SPECULOS_SEED` (`"glory promote mansion idle axis finger extend february uncover one trip resolve toe"`).
- Update OpenAPI spec, README, `.env.example`, `docker-compose.yml`, and all affected tests.

> ⚠️ **Security note**: the seed is stored in plaintext in server memory and transmitted over plain HTTP. This endpoint is for development and testing only — never use a real production mnemonic.

### Agent-file housekeeping (same PR, no production impact)
- Consolidate the `mock-server` skill into a single canonical file (`agent-files/skills/mock-server/SKILL.md`) with two symlinks — one for Claude Code (`agent-files/claude/skills/`) and one for Cursor (`agent-files/cursor/skills/`).
- Add Open App / Close App APDU examples (Bitcoin, Ethereum) and the new seed endpoint to the skill.

## Test plan

- [ ] `pnpm test` inside `apps/device-mock-server` — all unit tests pass
- [ ] `PUT /sessions/current/seed` returns `{ seed }` on success and `400` for an empty/non-string body
- [ ] End-to-end with live Speculinho: open Ethereum with default seed → get address (`0x47609D32EdF0C2A046D8D1D22680A2F93c78661b`) → close → change seed to `abandon x11 about` → open Ethereum → get address (`0x9858EfFD232B4033E47d90003D41EC34EcaEda94`) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)