### PR TITLE
✨ (signer-icp) [LIVE-34590]: Add Internet Computer signer kit

### DIFF
--- a/.changeset/icp-signer-kit-initial.md
+++ b/.changeset/icp-signer-kit-initial.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-icp": minor
+---
+
+Add the Internet Computer (ICP) signer kit with support for retrieving the address (public key, account identifier and principal), signing a transaction, and reading the app configuration.

--- a/packages/signer/signer-icp/.prettierignore
+++ b/packages/signer/signer-icp/.prettierignore
@@ -1,0 +1,2 @@
+lib/
+node_modules/

--- a/packages/signer/signer-icp/.prettierrc.js
+++ b/packages/signer/signer-icp/.prettierrc.js
@@ -1,0 +1,1 @@
+module.exports = require("@ledgerhq/prettier-config-dsdk");

--- a/packages/signer/signer-icp/README.md
+++ b/packages/signer/signer-icp/README.md
@@ -1,0 +1,186 @@
+# Ledger Internet Computer Signer Implementation
+
+This module provides the implementation of the Ledger Internet Computer (ICP) signer of the Device Management Kit. It enables interaction with the Internet Computer application on a Ledger device including:
+
+- Retrieving the ICP public key, account identifier and principal for a given derivation path;
+- Signing an Internet Computer transaction;
+- Retrieving the app configuration (version);
+
+## 🔹 Index
+
+1. [How it works](#-how-it-works)
+2. [Installation](#-installation)
+3. [Initialisation](#-initialisation)
+4. [Use Cases](#-use-cases)
+   - [Get Address](#use-case-1-get-address)
+   - [Sign Transaction](#use-case-2-sign-transaction)
+   - [Get App Configuration](#use-case-3-get-app-configuration)
+5. [Observable Behavior](#-observable-behavior)
+6. [Example](#-example)
+
+## 🔹 How it works
+
+The Ledger Internet Computer Signer utilizes the advanced capabilities of the Ledger device to provide secure operations for end users. It takes advantage of the interface provided by the Device Management Kit to establish communication with the Ledger device and execute various operations. The communication with the Ledger device is performed using [APDU](https://en.wikipedia.org/wiki/Smart_card_application_protocol_data_unit)s (Application Protocol Data Units), which are encapsulated within the `Command` object. These commands are then organized into tasks, allowing for the execution of complex operations with one or more APDUs. The tasks are further encapsulated within `DeviceAction` objects to handle different real-world scenarios. Finally, the Signer exposes dedicated and independent use cases that can be directly utilized by end users.
+
+## 🔹 Installation
+
+> **Note:** This module is not standalone; it depends on the [@ledgerhq/device-management-kit](https://github.com/LedgerHQ/device-sdk-ts/tree/develop/packages/device-management-kit) package, so you need to install it first.
+
+To install the `device-signer-kit-icp` package, run the following command:
+
+```sh
+npm install @ledgerhq/device-signer-kit-icp
+```
+
+## 🔹 Initialisation
+
+To initialise an ICP signer instance, you need a Ledger Device Management Kit instance and the ID of the session of the connected device. Use the `SignerIcpBuilder`:
+
+```typescript
+const signerIcp = new SignerIcpBuilder({ dmk, sessionId }).build();
+```
+
+## 🔹 Use Cases
+
+The `SignerIcpBuilder.build()` method will return a `SignerIcp` instance that exposes 3 dedicated methods, each of which calls an independent use case. Each use case will return an object that contains an observable and a method called `cancel`.
+
+---
+
+### Use Case 1: Get Address
+
+This method allows users to retrieve the ICP public key, account identifier and principal based on a given `derivationPath`.
+
+```typescript
+const { observable, cancel } = signerIcp.getAddress(derivationPath, options);
+```
+
+#### **Parameters**
+
+- `derivationPath`
+
+  - **Required**
+  - **Type:** `string` (e.g., `"44'/223'/0'/0/0"`)
+  - The derivation path used for the ICP address. See [here](https://www.ledger.com/blog/understanding-crypto-addresses-and-derivation-paths) for more information.
+
+- `options`
+
+  - Optional
+  - Type: `AddressOptions`
+
+    ```typescript
+    type AddressOptions = {
+      checkOnDevice?: boolean;
+      skipOpenApp?: boolean;
+    };
+    ```
+
+  - `checkOnDevice`: An optional boolean indicating whether user confirmation on the device is required (`true`) or not (`false`).
+  - `skipOpenApp`: An optional boolean indicating whether to skip opening the ICP app on the device (`true`) or not (`false`). Use when the app is already open.
+
+#### **Returns**
+
+- `observable` Emits DeviceActionState updates, including the following details:
+
+```typescript
+type Address = {
+  publicKey: string; // hex-encoded secp256k1 public key
+  accountId: string; // hex-encoded account identifier
+  principal: string; // textual principal
+};
+```
+
+- `cancel` A function to cancel the action on the Ledger device.
+
+---
+
+### Use Case 2: Sign Transaction
+
+Securely sign an Internet Computer transaction on Ledger devices.
+
+```typescript
+const { observable, cancel } = signerIcp.signTransaction(
+  derivationPath,
+  transaction,
+  options,
+);
+```
+
+#### **Parameters**
+
+- `derivationPath`
+
+  - **Required**
+  - **Type:** `string` (e.g., `"44'/223'/0'/0/0"`)
+  - The derivation path used for the ICP address.
+
+- `transaction`
+
+  - **Required**
+  - **Type:** `Uint8Array`
+  - The serialized transaction bytes (CBOR request) to sign.
+
+- `options`
+
+  - Optional
+  - Type: `TransactionOptions`
+
+    ```typescript
+    type TransactionOptions = {
+      skipOpenApp?: boolean;
+    };
+    ```
+
+  - `skipOpenApp`: An optional boolean indicating whether to skip opening the ICP app on the device (`true`) or not (`false`). Use when the app is already open.
+
+#### **Returns**
+
+- `observable` Emits DeviceActionState updates, including the following details:
+
+```typescript
+type Signature = {
+  r: string; // hex-encoded 32-byte R value
+  s: string; // hex-encoded 32-byte S value
+  v: number; // recovery id
+  der: string; // hex-encoded DER signature
+};
+```
+
+- `cancel` A function to cancel the action on the Ledger device.
+
+---
+
+### Use Case 3: Get App Configuration
+
+This method allows the user to fetch the current app configuration.
+
+```typescript
+const { observable, cancel } = signerIcp.getAppConfiguration();
+```
+
+#### **Returns**
+
+- `observable` Emits DeviceActionState updates, including the following details:
+
+```typescript
+type Version = {
+  version: string; // "major.minor.patch"
+  testMode: boolean;
+  locked: boolean;
+};
+```
+
+- `cancel` A function to cancel the action on the Ledger device.
+
+## 🔹 Observable Behavior
+
+Each method returns an [Observable](https://rxjs.dev/guide/observable) emitting updates structured as [`DeviceActionState`](https://github.com/LedgerHQ/device-sdk-ts/blob/develop/packages/device-management-kit/src/api/device-action/model/DeviceActionState.ts). These updates reflect the operation's progress and status:
+
+- **NotStarted**: The operation hasn't started.
+- **Pending**: The operation is in progress and may require user interaction.
+- **Stopped**: The operation was canceled or stopped.
+- **Completed**: The operation completed successfully, with results available.
+- **Error**: An error occurred.
+
+## 🔹 Example
+
+We encourage you to explore the Internet Computer Signer by trying it out in our online [sample application](https://app.devicesdk.ledger-test.com/). Experience how it works and see its capabilities in action. Of course, you will need a Ledger device connected.

--- a/packages/signer/signer-icp/eslint.config.mjs
+++ b/packages/signer/signer-icp/eslint.config.mjs
@@ -1,0 +1,13 @@
+import config from "@ledgerhq/eslint-config-dsdk";
+
+export default [
+  ...config,
+  {
+    ignores: ["eslint.config.mjs", "lib", "vitest.*.mjs"],
+    languageOptions: {
+      parserOptions: {
+        project: "./tsconfig.json",
+      },
+    },
+  },
+];

--- a/packages/signer/signer-icp/package.json
+++ b/packages/signer/signer-icp/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@ledgerhq/device-signer-kit-icp",
+  "version": "0.1.0",
+  "private": false,
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LedgerHQ/device-sdk-ts.git"
+  },
+  "exports": {
+    ".": {
+      "types": "./lib/types/index.d.ts",
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    },
+    "./*": {
+      "types": "./lib/types/*",
+      "import": "./lib/esm/*",
+      "require": "./lib/cjs/*"
+    }
+  },
+  "files": [
+    "./lib"
+  ],
+  "scripts": {
+    "prebuild": "rimraf lib",
+    "build": "pnpm ldmk-tool build --entryPoints src/index.ts,src/**/*.ts --tsconfig tsconfig.prod.json",
+    "dev": "concurrently \"pnpm watch:builds\" \"pnpm watch:types\"",
+    "watch:builds": "pnpm ldmk-tool watch --entryPoints src/index.ts,src/**/*.ts --tsconfig tsconfig.prod.json",
+    "watch:types": "concurrently \"tsc --watch -p tsconfig.prod.json\" \"tsc-alias --watch -p tsconfig.prod.json\"",
+    "lint": "eslint",
+    "lint:fix": "pnpm lint --fix",
+    "prettier": "prettier . --check",
+    "prettier:fix": "prettier . --write",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@ledgerhq/signer-utils": "workspace:^",
+    "inversify": "catalog:",
+    "purify-ts": "catalog:",
+    "reflect-metadata": "catalog:",
+    "xstate": "catalog:"
+  },
+  "devDependencies": {
+    "@ledgerhq/device-management-kit": "workspace:^",
+    "@ledgerhq/ldmk-tool": "workspace:^",
+    "@ledgerhq/eslint-config-dsdk": "workspace:^",
+    "@ledgerhq/prettier-config-dsdk": "workspace:^",
+    "@ledgerhq/tsconfig-dsdk": "workspace:^",
+    "@ledgerhq/vitest-config-dmk": "workspace:^",
+    "rxjs": "catalog:",
+    "ts-node": "catalog:"
+  },
+  "peerDependencies": {
+    "@ledgerhq/device-management-kit": "workspace:^"
+  }
+}

--- a/packages/signer/signer-icp/src/api/SignerIcp.ts
+++ b/packages/signer/signer-icp/src/api/SignerIcp.ts
@@ -1,0 +1,27 @@
+import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
+import { type GetVersionDAReturnType } from "@api/app-binder/GetVersionDeviceActionTypes";
+import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
+
+export type AddressOptions = {
+  checkOnDevice?: boolean;
+  skipOpenApp?: boolean;
+};
+
+export type TransactionOptions = {
+  skipOpenApp?: boolean;
+};
+
+export interface SignerIcp {
+  getAppConfiguration: () => GetVersionDAReturnType;
+
+  getAddress: (
+    derivationPath: string,
+    options?: AddressOptions,
+  ) => GetAddressDAReturnType;
+
+  signTransaction: (
+    derivationPath: string,
+    transaction: Uint8Array,
+    options?: TransactionOptions,
+  ) => SignTransactionDAReturnType;
+}

--- a/packages/signer/signer-icp/src/api/SignerIcpBuilder.test.ts
+++ b/packages/signer/signer-icp/src/api/SignerIcpBuilder.test.ts
@@ -1,0 +1,19 @@
+import { type DeviceManagementKit } from "@ledgerhq/device-management-kit";
+
+import { SignerIcpBuilder } from "@api/SignerIcpBuilder";
+import { DefaultSignerIcp } from "@internal/DefaultSignerIcp";
+
+describe("SignerIcpBuilder", () => {
+  it("should build a SignerIcp instance", () => {
+    // ARRANGE
+    const dmk = {} as DeviceManagementKit;
+    const sessionId = "test-session-id";
+    const builder = new SignerIcpBuilder({ dmk, sessionId });
+
+    // ACT
+    const signer = builder.build();
+
+    // ASSERT
+    expect(signer).toBeInstanceOf(DefaultSignerIcp);
+  });
+});

--- a/packages/signer/signer-icp/src/api/SignerIcpBuilder.ts
+++ b/packages/signer/signer-icp/src/api/SignerIcpBuilder.ts
@@ -1,0 +1,37 @@
+import {
+  type DeviceManagementKit,
+  type DeviceSessionId,
+} from "@ledgerhq/device-management-kit";
+
+import { type SignerIcp } from "@api/SignerIcp";
+import { DefaultSignerIcp } from "@internal/DefaultSignerIcp";
+
+type SignerIcpBuilderConstructorArgs = {
+  dmk: DeviceManagementKit;
+  sessionId: DeviceSessionId;
+};
+
+/**
+ * Builder for the `SignerIcp` class.
+ */
+export class SignerIcpBuilder {
+  private readonly _dmk: DeviceManagementKit;
+  private readonly _sessionId: DeviceSessionId;
+
+  constructor({ dmk, sessionId }: SignerIcpBuilderConstructorArgs) {
+    this._dmk = dmk;
+    this._sessionId = sessionId;
+  }
+
+  /**
+   * Build the signer instance
+   *
+   * @returns the signer instance
+   */
+  public build(): SignerIcp {
+    return new DefaultSignerIcp({
+      dmk: this._dmk,
+      sessionId: this._sessionId,
+    });
+  }
+}

--- a/packages/signer/signer-icp/src/api/app-binder/GetAddressDeviceActionTypes.ts
+++ b/packages/signer/signer-icp/src/api/app-binder/GetAddressDeviceActionTypes.ts
@@ -1,0 +1,31 @@
+import {
+  type CommandErrorResult,
+  type ExecuteDeviceActionReturnType,
+  type OpenAppDAError,
+  type SendCommandInAppDAIntermediateValue,
+  type SendCommandInAppDAOutput,
+  type UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import { type GetAddressCommandResponse } from "@internal/app-binder/command/GetAddressCommand";
+import { type IcpErrorCodes } from "@internal/app-binder/command/utils/IcpApplicationErrors";
+
+type GetAddressDAUserInteractionRequired =
+  | UserInteractionRequired.None
+  | UserInteractionRequired.VerifyAddress;
+
+export type GetAddressDAOutput =
+  SendCommandInAppDAOutput<GetAddressCommandResponse>;
+
+export type GetAddressDAError =
+  | OpenAppDAError
+  | CommandErrorResult<IcpErrorCodes>["error"];
+
+export type GetAddressDAIntermediateValue =
+  SendCommandInAppDAIntermediateValue<GetAddressDAUserInteractionRequired>;
+
+export type GetAddressDAReturnType = ExecuteDeviceActionReturnType<
+  GetAddressDAOutput,
+  GetAddressDAError,
+  GetAddressDAIntermediateValue
+>;

--- a/packages/signer/signer-icp/src/api/app-binder/GetVersionDeviceActionTypes.ts
+++ b/packages/signer/signer-icp/src/api/app-binder/GetVersionDeviceActionTypes.ts
@@ -1,0 +1,29 @@
+import {
+  type CommandErrorResult,
+  type ExecuteDeviceActionReturnType,
+  type OpenAppDAError,
+  type SendCommandInAppDAIntermediateValue,
+  type SendCommandInAppDAOutput,
+  type UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import { type GetVersionCommandResponse } from "@internal/app-binder/command/GetVersionCommand";
+import { type IcpErrorCodes } from "@internal/app-binder/command/utils/IcpApplicationErrors";
+
+type GetVersionDAUserInteractionRequired = UserInteractionRequired.None;
+
+export type GetVersionDAOutput =
+  SendCommandInAppDAOutput<GetVersionCommandResponse>;
+
+export type GetVersionDAError =
+  | OpenAppDAError
+  | CommandErrorResult<IcpErrorCodes>["error"];
+
+export type GetVersionDAIntermediateValue =
+  SendCommandInAppDAIntermediateValue<GetVersionDAUserInteractionRequired>;
+
+export type GetVersionDAReturnType = ExecuteDeviceActionReturnType<
+  GetVersionDAOutput,
+  GetVersionDAError,
+  GetVersionDAIntermediateValue
+>;

--- a/packages/signer/signer-icp/src/api/app-binder/SignTransactionDeviceActionTypes.ts
+++ b/packages/signer/signer-icp/src/api/app-binder/SignTransactionDeviceActionTypes.ts
@@ -1,0 +1,31 @@
+import {
+  type CommandErrorResult,
+  type ExecuteDeviceActionReturnType,
+  type OpenAppDAError,
+  type OpenAppDARequiredInteraction,
+  type SendCommandInAppDAOutput,
+  type UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import { type SignTransactionCommandResponse } from "@internal/app-binder/command/SignTransactionCommand";
+import { type IcpErrorCodes } from "@internal/app-binder/command/utils/IcpApplicationErrors";
+
+export type SignTransactionDAOutput =
+  SendCommandInAppDAOutput<SignTransactionCommandResponse>;
+export type SignTransactionDAError =
+  | OpenAppDAError
+  | CommandErrorResult<IcpErrorCodes>["error"];
+
+type SignTransactionDARequiredInteraction =
+  | OpenAppDARequiredInteraction
+  | UserInteractionRequired.SignTransaction;
+
+export type SignTransactionDAIntermediateValue = {
+  requiredUserInteraction: SignTransactionDARequiredInteraction;
+};
+
+export type SignTransactionDAReturnType = ExecuteDeviceActionReturnType<
+  SignTransactionDAOutput,
+  SignTransactionDAError,
+  SignTransactionDAIntermediateValue
+>;

--- a/packages/signer/signer-icp/src/api/index.ts
+++ b/packages/signer/signer-icp/src/api/index.ts
@@ -1,0 +1,27 @@
+export {
+  type GetAddressDAError,
+  type GetAddressDAIntermediateValue,
+  type GetAddressDAOutput,
+  type GetAddressDAReturnType,
+} from "@api/app-binder/GetAddressDeviceActionTypes";
+export {
+  type GetVersionDAError,
+  type GetVersionDAIntermediateValue,
+  type GetVersionDAOutput,
+  type GetVersionDAReturnType,
+} from "@api/app-binder/GetVersionDeviceActionTypes";
+export {
+  type SignTransactionDAError,
+  type SignTransactionDAIntermediateValue,
+  type SignTransactionDAOutput,
+  type SignTransactionDAReturnType,
+} from "@api/app-binder/SignTransactionDeviceActionTypes";
+export { type Address } from "@api/model/Address";
+export { type Signature } from "@api/model/Signature";
+export { type Version } from "@api/model/Version";
+export {
+  type AddressOptions,
+  type SignerIcp,
+  type TransactionOptions,
+} from "@api/SignerIcp";
+export { SignerIcpBuilder } from "@api/SignerIcpBuilder";

--- a/packages/signer/signer-icp/src/api/model/Address.ts
+++ b/packages/signer/signer-icp/src/api/model/Address.ts
@@ -1,0 +1,5 @@
+export type Address = {
+  publicKey: string;
+  accountId: string;
+  principal: string;
+};

--- a/packages/signer/signer-icp/src/api/model/Signature.ts
+++ b/packages/signer/signer-icp/src/api/model/Signature.ts
@@ -1,0 +1,6 @@
+export type Signature = {
+  r: string;
+  s: string;
+  v: number;
+  der: string;
+};

--- a/packages/signer/signer-icp/src/api/model/Version.ts
+++ b/packages/signer/signer-icp/src/api/model/Version.ts
@@ -1,0 +1,5 @@
+export type Version = {
+  version: string;
+  testMode: boolean;
+  locked: boolean;
+};

--- a/packages/signer/signer-icp/src/index.ts
+++ b/packages/signer/signer-icp/src/index.ts
@@ -1,0 +1,4 @@
+// inversify requirement
+import "reflect-metadata";
+
+export * from "@api/index";

--- a/packages/signer/signer-icp/src/internal/DefaultSignerIcp.test.ts
+++ b/packages/signer/signer-icp/src/internal/DefaultSignerIcp.test.ts
@@ -1,0 +1,65 @@
+import {
+  type DeviceManagementKit,
+  type DeviceSessionId,
+} from "@ledgerhq/device-management-kit";
+import { vi } from "vitest";
+
+import { DefaultSignerIcp } from "./DefaultSignerIcp";
+
+describe("DefaultSignerIcp", () => {
+  const sessionId = "test-session-id" as DeviceSessionId;
+  const mockLoggerFactory = () => ({});
+
+  const makeSigner = (executeDeviceActionMock: ReturnType<typeof vi.fn>) => {
+    const dmkMock = {
+      executeDeviceAction: executeDeviceActionMock,
+      getLoggerFactory: vi.fn().mockReturnValue(mockLoggerFactory),
+    } as unknown as DeviceManagementKit;
+    return new DefaultSignerIcp({ dmk: dmkMock, sessionId });
+  };
+
+  it("getAppConfiguration should delegate to the version device action", () => {
+    // ARRANGE
+    const expectedResult = { observable: {}, cancel: vi.fn() };
+    const executeDeviceActionMock = vi.fn().mockReturnValue(expectedResult);
+    const signer = makeSigner(executeDeviceActionMock);
+
+    // ACT
+    const result = signer.getAppConfiguration();
+
+    // ASSERT
+    expect(executeDeviceActionMock).toHaveBeenCalledTimes(1);
+    expect(result).toBe(expectedResult);
+  });
+
+  it("getAddress should delegate to the address device action", () => {
+    // ARRANGE
+    const expectedResult = { observable: {}, cancel: vi.fn() };
+    const executeDeviceActionMock = vi.fn().mockReturnValue(expectedResult);
+    const signer = makeSigner(executeDeviceActionMock);
+
+    // ACT
+    const result = signer.getAddress("44'/223'/0'/0/0");
+
+    // ASSERT
+    expect(executeDeviceActionMock).toHaveBeenCalledTimes(1);
+    expect(result).toBe(expectedResult);
+  });
+
+  it("signTransaction should delegate to the transaction device action", () => {
+    // ARRANGE
+    const expectedResult = { observable: {}, cancel: vi.fn() };
+    const executeDeviceActionMock = vi.fn().mockReturnValue(expectedResult);
+    const signer = makeSigner(executeDeviceActionMock);
+
+    // ACT
+    const result = signer.signTransaction(
+      "44'/223'/0'/0/0",
+      new Uint8Array([0x01, 0x02]),
+    );
+
+    // ASSERT
+    expect(executeDeviceActionMock).toHaveBeenCalledTimes(1);
+    expect(result).toBe(expectedResult);
+  });
+});

--- a/packages/signer/signer-icp/src/internal/DefaultSignerIcp.ts
+++ b/packages/signer/signer-icp/src/internal/DefaultSignerIcp.ts
@@ -1,0 +1,59 @@
+import {
+  type DeviceManagementKit,
+  type DeviceSessionId,
+} from "@ledgerhq/device-management-kit";
+import { type Container } from "inversify";
+
+import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
+import { type GetVersionDAReturnType } from "@api/app-binder/GetVersionDeviceActionTypes";
+import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
+import {
+  type AddressOptions,
+  type SignerIcp,
+  type TransactionOptions,
+} from "@api/SignerIcp";
+import { makeContainer } from "@internal/di";
+import { addressTypes } from "@internal/use-cases/address/di/addressTypes";
+import { type GetAddressUseCase } from "@internal/use-cases/address/GetAddressUseCase";
+import { configTypes } from "@internal/use-cases/config/di/configTypes";
+import { type GetAppConfigurationUseCase } from "@internal/use-cases/config/GetAppConfigurationUseCase";
+import { transactionTypes } from "@internal/use-cases/transaction/di/transactionTypes";
+import { type SignTransactionUseCase } from "@internal/use-cases/transaction/SignTransactionUseCase";
+
+type DefaultSignerIcpConstructorArgs = {
+  dmk: DeviceManagementKit;
+  sessionId: DeviceSessionId;
+};
+
+export class DefaultSignerIcp implements SignerIcp {
+  private readonly _container: Container;
+
+  constructor({ dmk, sessionId }: DefaultSignerIcpConstructorArgs) {
+    this._container = makeContainer({ dmk, sessionId });
+  }
+
+  getAppConfiguration(): GetVersionDAReturnType {
+    return this._container
+      .get<GetAppConfigurationUseCase>(configTypes.GetAppConfigurationUseCase)
+      .execute();
+  }
+
+  getAddress(
+    derivationPath: string,
+    options?: AddressOptions,
+  ): GetAddressDAReturnType {
+    return this._container
+      .get<GetAddressUseCase>(addressTypes.GetAddressUseCase)
+      .execute(derivationPath, options);
+  }
+
+  signTransaction(
+    derivationPath: string,
+    transaction: Uint8Array,
+    options?: TransactionOptions,
+  ): SignTransactionDAReturnType {
+    return this._container
+      .get<SignTransactionUseCase>(transactionTypes.SignTransactionUseCase)
+      .execute(derivationPath, transaction, options);
+  }
+}

--- a/packages/signer/signer-icp/src/internal/app-binder/IcpAppBinder.test.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/IcpAppBinder.test.ts
@@ -1,0 +1,113 @@
+import {
+  CallTaskInAppDeviceAction,
+  type DeviceManagementKit,
+  type LoggerPublisherService,
+  SendCommandInAppDeviceAction,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+import { vi } from "vitest";
+
+import { GetAddressCommand } from "@internal/app-binder/command/GetAddressCommand";
+import { GetVersionCommand } from "@internal/app-binder/command/GetVersionCommand";
+import { APP_NAME } from "@internal/app-binder/constants";
+import { IcpAppBinder } from "@internal/app-binder/IcpAppBinder";
+
+const DERIVATION_PATH = "44'/223'/0'/0/0";
+
+describe("IcpAppBinder", () => {
+  const loggerMock = { debug: vi.fn() } as unknown as LoggerPublisherService;
+  const loggerFactoryMock = vi.fn().mockReturnValue(loggerMock);
+  const sessionId = "test-session-id";
+
+  const makeBinder = (executeDeviceActionMock: ReturnType<typeof vi.fn>) => {
+    const dmkMock = {
+      executeDeviceAction: executeDeviceActionMock,
+    } as unknown as DeviceManagementKit;
+    return new IcpAppBinder(dmkMock, sessionId, loggerFactoryMock);
+  };
+
+  it("getVersion should run a SendCommandInAppDeviceAction with GetVersionCommand", () => {
+    // ARRANGE
+    const expectedResult = { observable: {}, cancel: vi.fn() };
+    const executeDeviceActionMock = vi.fn().mockReturnValue(expectedResult);
+    const binder = makeBinder(executeDeviceActionMock);
+
+    // ACT
+    const result = binder.getVersion({ skipOpenApp: false });
+
+    // ASSERT
+    const args = executeDeviceActionMock.mock.calls[0]![0];
+    expect(args.deviceAction).toBeInstanceOf(SendCommandInAppDeviceAction);
+    expect(args.deviceAction.input.command).toBeInstanceOf(GetVersionCommand);
+    expect(args.deviceAction.input.appName).toBe(APP_NAME);
+    expect(args.deviceAction.input.requiredUserInteraction).toBe(
+      UserInteractionRequired.None,
+    );
+    expect(result).toBe(expectedResult);
+  });
+
+  it("getAddress should request VerifyAddress interaction when checkOnDevice is true", () => {
+    // ARRANGE
+    const expectedResult = { observable: {}, cancel: vi.fn() };
+    const executeDeviceActionMock = vi.fn().mockReturnValue(expectedResult);
+    const binder = makeBinder(executeDeviceActionMock);
+
+    // ACT
+    const result = binder.getAddress({
+      derivationPath: DERIVATION_PATH,
+      checkOnDevice: true,
+      skipOpenApp: false,
+    });
+
+    // ASSERT
+    const args = executeDeviceActionMock.mock.calls[0]![0];
+    expect(args.deviceAction).toBeInstanceOf(SendCommandInAppDeviceAction);
+    expect(args.deviceAction.input.command).toBeInstanceOf(GetAddressCommand);
+    expect(args.deviceAction.input.requiredUserInteraction).toBe(
+      UserInteractionRequired.VerifyAddress,
+    );
+    expect(result).toBe(expectedResult);
+  });
+
+  it("getAddress should require no interaction when checkOnDevice is false", () => {
+    // ARRANGE
+    const executeDeviceActionMock = vi.fn().mockReturnValue({});
+    const binder = makeBinder(executeDeviceActionMock);
+
+    // ACT
+    binder.getAddress({
+      derivationPath: DERIVATION_PATH,
+      checkOnDevice: false,
+      skipOpenApp: false,
+    });
+
+    // ASSERT
+    const args = executeDeviceActionMock.mock.calls[0]![0];
+    expect(args.deviceAction.input.requiredUserInteraction).toBe(
+      UserInteractionRequired.None,
+    );
+  });
+
+  it("signTransaction should run a CallTaskInAppDeviceAction requiring SignTransaction", () => {
+    // ARRANGE
+    const expectedResult = { observable: {}, cancel: vi.fn() };
+    const executeDeviceActionMock = vi.fn().mockReturnValue(expectedResult);
+    const binder = makeBinder(executeDeviceActionMock);
+
+    // ACT
+    const result = binder.signTransaction({
+      derivationPath: DERIVATION_PATH,
+      transaction: new Uint8Array([0x01, 0x02]),
+    });
+
+    // ASSERT
+    const args = executeDeviceActionMock.mock.calls[0]![0];
+    expect(args.deviceAction).toBeInstanceOf(CallTaskInAppDeviceAction);
+    expect(args.deviceAction.input.appName).toBe(APP_NAME);
+    expect(args.deviceAction.input.requiredUserInteraction).toBe(
+      UserInteractionRequired.SignTransaction,
+    );
+    expect(args.deviceAction.input.skipOpenApp).toBe(false);
+    expect(result).toBe(expectedResult);
+  });
+});

--- a/packages/signer/signer-icp/src/internal/app-binder/IcpAppBinder.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/IcpAppBinder.ts
@@ -1,0 +1,87 @@
+import {
+  CallTaskInAppDeviceAction,
+  type DeviceManagementKit,
+  type DeviceSessionId,
+  LoggerPublisherService,
+  SendCommandInAppDeviceAction,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+import { inject, injectable } from "inversify";
+
+import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
+import { type GetVersionDAReturnType } from "@api/app-binder/GetVersionDeviceActionTypes";
+import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
+import {
+  GetAddressCommand,
+  type GetAddressCommandArgs,
+} from "@internal/app-binder/command/GetAddressCommand";
+import { GetVersionCommand } from "@internal/app-binder/command/GetVersionCommand";
+import { APP_NAME } from "@internal/app-binder/constants";
+import { SignTransactionTask } from "@internal/app-binder/task/SignTransactionTask";
+import { externalTypes } from "@internal/externalTypes";
+
+@injectable()
+export class IcpAppBinder {
+  constructor(
+    @inject(externalTypes.Dmk) private dmk: DeviceManagementKit,
+    @inject(externalTypes.SessionId) private sessionId: DeviceSessionId,
+    @inject(externalTypes.DmkLoggerFactory)
+    private dmkLoggerFactory: (tag: string) => LoggerPublisherService,
+  ) {}
+
+  getVersion(args: { skipOpenApp: boolean }): GetVersionDAReturnType {
+    return this.dmk.executeDeviceAction({
+      sessionId: this.sessionId,
+      deviceAction: new SendCommandInAppDeviceAction({
+        input: {
+          command: new GetVersionCommand(),
+          appName: APP_NAME,
+          requiredUserInteraction: UserInteractionRequired.None,
+          skipOpenApp: args.skipOpenApp,
+        },
+        logger: this.dmkLoggerFactory("GetVersionCommand"),
+      }),
+    });
+  }
+
+  getAddress(args: GetAddressCommandArgs): GetAddressDAReturnType {
+    return this.dmk.executeDeviceAction({
+      sessionId: this.sessionId,
+      deviceAction: new SendCommandInAppDeviceAction({
+        input: {
+          command: new GetAddressCommand(args),
+          appName: APP_NAME,
+          requiredUserInteraction: args.checkOnDevice
+            ? UserInteractionRequired.VerifyAddress
+            : UserInteractionRequired.None,
+          skipOpenApp: args.skipOpenApp,
+        },
+        logger: this.dmkLoggerFactory("GetAddressCommand"),
+      }),
+    });
+  }
+
+  signTransaction(args: {
+    derivationPath: string;
+    transaction: Uint8Array;
+    skipOpenApp?: boolean;
+  }): SignTransactionDAReturnType {
+    return this.dmk.executeDeviceAction({
+      sessionId: this.sessionId,
+      deviceAction: new CallTaskInAppDeviceAction({
+        input: {
+          task: async (internalApi) =>
+            new SignTransactionTask(
+              internalApi,
+              args,
+              this.dmkLoggerFactory("SignTransactionTask"),
+            ).run(),
+          appName: APP_NAME,
+          requiredUserInteraction: UserInteractionRequired.SignTransaction,
+          skipOpenApp: args.skipOpenApp ?? false,
+        },
+        logger: this.dmkLoggerFactory("SignTransactionCommand"),
+      }),
+    });
+  }
+}

--- a/packages/signer/signer-icp/src/internal/app-binder/command/GetAddressCommand.test.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/GetAddressCommand.test.ts
@@ -1,0 +1,223 @@
+import {
+  ApduBuilder,
+  ApduResponse,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { DerivationPathUtils } from "@ledgerhq/signer-utils";
+
+import {
+  GetAddressCommand,
+  icpGetAddressApduHeader,
+  P1_CHECK_ON_DEVICE,
+  P1_NO_CHECK_ON_DEVICE,
+} from "@internal/app-binder/command/GetAddressCommand";
+import {
+  type IcpAppCommandError,
+  IcpErrorCodes,
+} from "@internal/app-binder/command/utils/IcpApplicationErrors";
+
+const DERIVATION_PATH = "44'/223'/0'/0/0";
+
+const pathToBuffer = (derivationPath: string): Uint8Array => {
+  const parts = DerivationPathUtils.splitPath(derivationPath);
+  const view = new DataView(new ArrayBuffer(20));
+  for (let i = 0; i < parts.length; i++) {
+    const raw = parts[i]! & 0x7fffffff;
+    const hardened = i < 3 ? (0x80000000 | raw) >>> 0 : raw >>> 0;
+    view.setUint32(i * 4, hardened, true);
+  }
+  return new Uint8Array(view.buffer);
+};
+
+const buildAddressResponseData = (
+  publicKey: Uint8Array,
+  accountId: Uint8Array,
+  principal: Uint8Array,
+): Uint8Array => {
+  const data = new Uint8Array(
+    publicKey.length + 1 + accountId.length + 1 + principal.length,
+  );
+  let offset = 0;
+  data.set(publicKey, offset);
+  offset += publicKey.length;
+  data[offset++] = accountId.length;
+  data.set(accountId, offset);
+  offset += accountId.length;
+  data[offset++] = principal.length;
+  data.set(principal, offset);
+  return data;
+};
+
+describe("GetAddressCommand", () => {
+  describe("getApdu", () => {
+    it("should build APDU with CLA=0x11, INS=0x01, P1=no-check when checkOnDevice is false", () => {
+      // ARRANGE
+      const command = new GetAddressCommand({
+        derivationPath: DERIVATION_PATH,
+        checkOnDevice: false,
+        skipOpenApp: false,
+      });
+      const expected = new ApduBuilder(
+        icpGetAddressApduHeader(P1_NO_CHECK_ON_DEVICE),
+      )
+        .addBufferToData(pathToBuffer(DERIVATION_PATH))
+        .build();
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.getRawApdu());
+    });
+
+    it("should set P1 to check-on-device when checkOnDevice is true", () => {
+      // ARRANGE
+      const command = new GetAddressCommand({
+        derivationPath: DERIVATION_PATH,
+        checkOnDevice: true,
+        skipOpenApp: false,
+      });
+      const expected = new ApduBuilder(
+        icpGetAddressApduHeader(P1_CHECK_ON_DEVICE),
+      )
+        .addBufferToData(pathToBuffer(DERIVATION_PATH))
+        .build();
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.getRawApdu());
+    });
+
+    it("should throw when path does not have 5 elements", () => {
+      // ARRANGE
+      const command = new GetAddressCommand({
+        derivationPath: "44'/223'/0'",
+        checkOnDevice: false,
+        skipOpenApp: false,
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "GetAddressCommand: expected 5 path elements, got 3",
+      );
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("should extract publicKey, accountId and principal on success", () => {
+      // ARRANGE
+      const publicKey = new Uint8Array(65).fill(0x02);
+      const accountId = new Uint8Array(32).fill(0x0a);
+      const principal = new TextEncoder().encode("2vxsx-fae");
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: buildAddressResponseData(publicKey, accountId, principal),
+      });
+      const command = new GetAddressCommand({
+        derivationPath: DERIVATION_PATH,
+        checkOnDevice: false,
+        skipOpenApp: false,
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data.publicKey).toBe("02".repeat(65));
+        expect(result.data.accountId).toBe("0a".repeat(32));
+        expect(result.data.principal).toBe("2vxsx-fae");
+      }
+    });
+
+    it("should reject a response with a zero-length account identifier", () => {
+      // ARRANGE
+      const publicKey = new Uint8Array(65).fill(0x02);
+      const principal = new TextEncoder().encode("2vxsx-fae");
+      const data = buildAddressResponseData(
+        publicKey,
+        new Uint8Array(0),
+        principal,
+      );
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data,
+      });
+      const command = new GetAddressCommand({
+        derivationPath: DERIVATION_PATH,
+        checkOnDevice: false,
+        skipOpenApp: false,
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+    });
+
+    it("should reject a response with a zero-length principal", () => {
+      // ARRANGE
+      const publicKey = new Uint8Array(65).fill(0x02);
+      const accountId = new Uint8Array(32).fill(0x0a);
+      const data = buildAddressResponseData(
+        publicKey,
+        accountId,
+        new Uint8Array(0),
+      );
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data,
+      });
+      const command = new GetAddressCommand({
+        derivationPath: DERIVATION_PATH,
+        checkOnDevice: false,
+        skipOpenApp: false,
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+    });
+
+    it("should return an error when the principal length is missing", () => {
+      // ARRANGE
+      const publicKey = new Uint8Array(65).fill(0x02);
+      const accountId = new Uint8Array(32).fill(0x0a);
+      const truncated = new Uint8Array(65 + 1 + 32);
+      truncated.set(publicKey, 0);
+      truncated[65] = accountId.length;
+      truncated.set(accountId, 66);
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: truncated,
+      });
+      const command = new GetAddressCommand({
+        derivationPath: DERIVATION_PATH,
+        checkOnDevice: false,
+        skipOpenApp: false,
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+    });
+
+    it("should return IcpAppCommandError when status word signals an error", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x69, 0x82]),
+        data: new Uint8Array(0),
+      });
+      const command = new GetAddressCommand({
+        derivationPath: DERIVATION_PATH,
+        checkOnDevice: false,
+        skipOpenApp: false,
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as IcpAppCommandError;
+        expect((err.originalError as { errorCode: string }).errorCode).toBe(
+          IcpErrorCodes.EMPTY_BUFFER.slice(2),
+        );
+      }
+    });
+  });
+});

--- a/packages/signer/signer-icp/src/internal/app-binder/command/GetAddressCommand.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/GetAddressCommand.ts
@@ -1,0 +1,127 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+import {
+  CommandErrorHelper,
+  DerivationPathUtils,
+} from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import { type Address } from "@api/model/Address";
+import {
+  ICP_APP_ERRORS,
+  IcpAppCommandErrorFactory,
+  type IcpErrorCodes,
+} from "@internal/app-binder/command/utils/IcpApplicationErrors";
+
+import { encodeDerivationPath } from "./utils/EncodeDerivationPath";
+
+export type GetAddressCommandArgs = {
+  readonly derivationPath: string;
+  readonly checkOnDevice: boolean;
+  readonly skipOpenApp: boolean;
+};
+
+export type GetAddressCommandResponse = Address;
+
+export const icpGetAddressApduHeader = (p1: number) => ({
+  cla: 0x11,
+  ins: 0x01,
+  p1,
+  p2: 0x00,
+});
+
+export const P1_CHECK_ON_DEVICE = 0x01;
+export const P1_NO_CHECK_ON_DEVICE = 0x00;
+const DERIVATION_PATH_LENGTH = 5;
+const PUBLIC_KEY_LENGTH = 65;
+
+export class GetAddressCommand
+  implements
+    Command<GetAddressCommandResponse, GetAddressCommandArgs, IcpErrorCodes>
+{
+  readonly name = "GetAddress";
+
+  private readonly args: GetAddressCommandArgs;
+
+  private readonly errorHelper = new CommandErrorHelper<
+    GetAddressCommandResponse,
+    IcpErrorCodes
+  >(ICP_APP_ERRORS, IcpAppCommandErrorFactory);
+
+  constructor(args: GetAddressCommandArgs) {
+    this.args = args;
+  }
+
+  getApdu(): Apdu {
+    const apduBuilder = new ApduBuilder(
+      icpGetAddressApduHeader(
+        this.args.checkOnDevice ? P1_CHECK_ON_DEVICE : P1_NO_CHECK_ON_DEVICE,
+      ),
+    );
+
+    const derivationPath = DerivationPathUtils.splitPath(
+      this.args.derivationPath,
+    );
+
+    if (derivationPath.length !== DERIVATION_PATH_LENGTH) {
+      throw new Error(
+        `GetAddressCommand: expected ${DERIVATION_PATH_LENGTH} path elements, got ${derivationPath.length}`,
+      );
+    }
+
+    const encodedDerivationPath = encodeDerivationPath(derivationPath);
+    apduBuilder.addBufferToData(encodedDerivationPath);
+
+    return apduBuilder.build();
+  }
+
+  parseResponse(
+    apduResponse: ApduResponse,
+  ): CommandResult<GetAddressCommandResponse, IcpErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      const apduParser = new ApduParser(apduResponse);
+
+      const publicKey = apduParser.extractFieldByLength(PUBLIC_KEY_LENGTH);
+      const accountIdLength = apduParser.extract8BitUInt();
+      const accountId =
+        accountIdLength !== undefined
+          ? apduParser.extractFieldByLength(accountIdLength)
+          : undefined;
+      const principalLength = apduParser.extract8BitUInt();
+      const principal =
+        principalLength !== undefined
+          ? apduParser.extractFieldByLength(principalLength)
+          : undefined;
+
+      if (
+        publicKey === undefined ||
+        accountId === undefined ||
+        accountId.length === 0 ||
+        principal === undefined ||
+        principal.length === 0
+      ) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Cannot extract address"),
+        });
+      }
+
+      return CommandResultFactory({
+        data: {
+          publicKey: apduParser.encodeToHexaString(publicKey),
+          accountId: apduParser.encodeToHexaString(accountId),
+          principal: apduParser.encodeToString(principal),
+        },
+      });
+    });
+  }
+}

--- a/packages/signer/signer-icp/src/internal/app-binder/command/GetVersionCommand.test.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/GetVersionCommand.test.ts
@@ -1,0 +1,128 @@
+import {
+  ApduBuilder,
+  ApduResponse,
+  CommandResultFactory,
+  InvalidStatusWordError,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import {
+  GetVersionCommand,
+  icpGetVersionApduHeader,
+} from "@internal/app-binder/command/GetVersionCommand";
+import {
+  type IcpAppCommandError,
+  IcpErrorCodes,
+} from "@internal/app-binder/command/utils/IcpApplicationErrors";
+
+describe("GetVersionCommand", () => {
+  let command: GetVersionCommand;
+
+  beforeEach(() => {
+    command = new GetVersionCommand();
+  });
+
+  describe("name", () => {
+    it("should be 'GetVersion'", () => {
+      // ASSERT
+      expect(command.name).toBe("GetVersion");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("should return APDU with CLA=0x11, INS=0x00, P1=0x00, P2=0x00 and no data", () => {
+      // ARRANGE
+      const expected = new ApduBuilder(icpGetVersionApduHeader).build();
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.getRawApdu());
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("should return version, testMode and locked on success", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x00]), // TEST, major=1, minor=2, patch=3, LOCKED=0
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(result).toStrictEqual(
+        CommandResultFactory({
+          data: { version: "1.2.3", testMode: false, locked: false },
+        }),
+      );
+      expect(isSuccessCommandResult(result)).toBe(true);
+    });
+
+    it("should report testMode true when TEST byte is 0xFF", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: new Uint8Array([0xff, 0x01, 0x02, 0x03, 0x00]),
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data.testMode).toBe(true);
+      }
+    });
+
+    it("should report locked true when LOCKED byte is non-zero", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x01]),
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data.locked).toBe(true);
+      }
+    });
+
+    it("should return IcpAppCommandError with error code 0x6984 when status is 0x6984", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x69, 0x84]),
+        data: new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x00]),
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as IcpAppCommandError;
+        expect((err.originalError as { errorCode: string }).errorCode).toBe(
+          IcpErrorCodes.DATA_INVALID.slice(2),
+        );
+      }
+    });
+
+    it("should return InvalidStatusWordError when version bytes are missing", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: new Uint8Array([0x00, 0x01]), // only TEST + major
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidStatusWordError;
+        expect(err).toBeInstanceOf(InvalidStatusWordError);
+        expect((err.originalError as { message: string }).message).toBe(
+          "Cannot extract version",
+        );
+      }
+    });
+  });
+});

--- a/packages/signer/signer-icp/src/internal/app-binder/command/GetVersionCommand.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/GetVersionCommand.ts
@@ -1,0 +1,80 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import { type Version } from "@api/model/Version";
+import {
+  ICP_APP_ERRORS,
+  IcpAppCommandErrorFactory,
+  type IcpErrorCodes,
+} from "@internal/app-binder/command/utils/IcpApplicationErrors";
+
+export type GetVersionCommandResponse = Version;
+
+const TEST_MODE_FLAG = 0xff;
+
+export const icpGetVersionApduHeader = {
+  cla: 0x11,
+  ins: 0x00,
+  p1: 0x00,
+  p2: 0x00,
+};
+
+export class GetVersionCommand
+  implements Command<GetVersionCommandResponse, void, IcpErrorCodes>
+{
+  readonly name = "GetVersion";
+
+  private readonly errorHelper = new CommandErrorHelper<
+    GetVersionCommandResponse,
+    IcpErrorCodes
+  >(ICP_APP_ERRORS, IcpAppCommandErrorFactory);
+
+  getApdu(): Apdu {
+    return new ApduBuilder(icpGetVersionApduHeader).build();
+  }
+
+  parseResponse(
+    apduResponse: ApduResponse,
+  ): CommandResult<GetVersionCommandResponse, IcpErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      const apduParser = new ApduParser(apduResponse);
+      const test = apduParser.extract8BitUInt();
+      const major = apduParser.extract8BitUInt();
+      const minor = apduParser.extract8BitUInt();
+      const patch = apduParser.extract8BitUInt();
+      const locked = apduParser.extract8BitUInt();
+
+      if (
+        test === undefined ||
+        major === undefined ||
+        minor === undefined ||
+        patch === undefined ||
+        locked === undefined
+      ) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Cannot extract version"),
+        });
+      }
+
+      return CommandResultFactory({
+        data: {
+          version: `${major}.${minor}.${patch}`,
+          testMode: test === TEST_MODE_FLAG,
+          locked: locked !== 0,
+        },
+      });
+    });
+  }
+}

--- a/packages/signer/signer-icp/src/internal/app-binder/command/SignTransactionCommand.test.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/SignTransactionCommand.test.ts
@@ -1,0 +1,222 @@
+import {
+  ApduBuilder,
+  ApduResponse,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { DerivationPathUtils } from "@ledgerhq/signer-utils";
+
+import {
+  icpSignTransactionApduHeader,
+  P1_ADD,
+  P1_INIT,
+  P1_LAST,
+  SignPhase,
+  SignTransactionCommand,
+} from "@internal/app-binder/command/SignTransactionCommand";
+import {
+  type IcpAppCommandError,
+  IcpErrorCodes,
+} from "@internal/app-binder/command/utils/IcpApplicationErrors";
+
+const DERIVATION_PATH = "44'/223'/0'/0/0";
+
+const pathToBuffer = (derivationPath: string): Uint8Array => {
+  const parts = DerivationPathUtils.splitPath(derivationPath);
+  const view = new DataView(new ArrayBuffer(20));
+  for (let i = 0; i < parts.length; i++) {
+    const raw = parts[i]! & 0x7fffffff;
+    const hardened = i < 3 ? (0x80000000 | raw) >>> 0 : raw >>> 0;
+    view.setUint32(i * 4, hardened, true);
+  }
+  return new Uint8Array(view.buffer);
+};
+
+describe("SignTransactionCommand", () => {
+  describe("name", () => {
+    it("should be 'SignTransaction'", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath: DERIVATION_PATH,
+      });
+      // ASSERT
+      expect(command.name).toBe("SignTransaction");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("should return the derivation-path packet (P1=INIT, P2=0) when phase is INIT", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath: DERIVATION_PATH,
+      });
+      const expected = new ApduBuilder(icpSignTransactionApduHeader(P1_INIT))
+        .addBufferToData(pathToBuffer(DERIVATION_PATH))
+        .build();
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.getRawApdu());
+    });
+
+    it("should return an add packet (P1=ADD) carrying the chunk when phase is ADD", () => {
+      // ARRANGE
+      const chunk = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+      const command = new SignTransactionCommand({
+        phase: SignPhase.ADD,
+        transactionChunk: chunk,
+      });
+      const expected = new ApduBuilder(icpSignTransactionApduHeader(P1_ADD))
+        .addBufferToData(chunk)
+        .build();
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.getRawApdu());
+    });
+
+    it("should return a last packet (P1=LAST) carrying the chunk when phase is LAST", () => {
+      // ARRANGE
+      const chunk = new Uint8Array([0x01, 0x02, 0x03]);
+      const command = new SignTransactionCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: chunk,
+      });
+      const expected = new ApduBuilder(icpSignTransactionApduHeader(P1_LAST))
+        .addBufferToData(chunk)
+        .build();
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.getRawApdu());
+    });
+
+    it("should throw when phase is INIT and derivationPath is missing", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({ phase: SignPhase.INIT });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "SignTransactionCommand: derivation path is required for 'init' phase.",
+      );
+    });
+
+    it("should throw when phase is INIT and path does not have 5 elements", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath: "44'/223'/0'",
+      });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "SignTransactionCommand: expected 5 path elements, got 3",
+      );
+    });
+
+    it("should throw when phase is ADD and transactionChunk is missing", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({ phase: SignPhase.ADD });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "SignTransactionCommand: transaction chunk is required for 'add' and 'last' phases.",
+      );
+    });
+
+    it("should throw when phase is LAST and transactionChunk is missing", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({ phase: SignPhase.LAST });
+      // ACT & ASSERT
+      expect(() => command.getApdu()).toThrow(
+        "SignTransactionCommand: transaction chunk is required for 'add' and 'last' phases.",
+      );
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("should split the response into r, s, v and DER signature on success", () => {
+      // ARRANGE
+      const r = new Uint8Array(32).fill(0xaa);
+      const s = new Uint8Array(32).fill(0xbb);
+      const v = new Uint8Array([0x01]);
+      const der = new Uint8Array([
+        0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01,
+      ]);
+      const data = new Uint8Array([...r, ...s, ...v, ...der]);
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data,
+      });
+      const command = new SignTransactionCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data.r).toBe("aa".repeat(32));
+        expect(result.data.s).toBe("bb".repeat(32));
+        expect(result.data.v).toBe(1);
+        expect(result.data.der).toBe("3006020101020101");
+      }
+    });
+
+    it("should reject a response that carries r, s and v but no DER signature", () => {
+      // ARRANGE
+      const r = new Uint8Array(32).fill(0xaa);
+      const s = new Uint8Array(32).fill(0xbb);
+      const v = new Uint8Array([0x01]);
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: new Uint8Array([...r, ...s, ...v]), // 65 bytes, DER missing
+      });
+      const command = new SignTransactionCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+    });
+
+    it("should return an error when the signature is incomplete", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: new Uint8Array(10),
+      });
+      const command = new SignTransactionCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+    });
+
+    it("should return IcpAppCommandError when status word signals an error", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x69, 0x84]),
+        data: new Uint8Array(0),
+      });
+      const command = new SignTransactionCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as IcpAppCommandError;
+        expect((err.originalError as { errorCode: string }).errorCode).toBe(
+          IcpErrorCodes.DATA_INVALID.slice(2),
+        );
+      }
+    });
+  });
+});

--- a/packages/signer/signer-icp/src/internal/app-binder/command/SignTransactionCommand.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/SignTransactionCommand.ts
@@ -1,0 +1,170 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+import {
+  CommandErrorHelper,
+  DerivationPathUtils,
+} from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import { type Signature } from "@api/model/Signature";
+import { encodeDerivationPath } from "@internal/app-binder/command/utils/EncodeDerivationPath";
+import {
+  ICP_APP_ERRORS,
+  IcpAppCommandErrorFactory,
+  type IcpErrorCodes,
+} from "@internal/app-binder/command/utils/IcpApplicationErrors";
+
+export const P1_INIT = 0x00;
+export const P1_ADD = 0x01;
+export const P1_LAST = 0x02;
+// P2 carries the neuron-stake flag; plain transfers always use 0.
+export const P2_NO_STAKE = 0x00;
+
+const DERIVATION_PATH_LENGTH = 5;
+const SIGNATURE_R_LENGTH = 32;
+const SIGNATURE_S_LENGTH = 32;
+const SIGNATURE_V_LENGTH = 1;
+
+export enum SignPhase {
+  INIT = "init",
+  ADD = "add",
+  LAST = "last",
+}
+
+export const icpSignTransactionApduHeader = (p1: number) => ({
+  cla: 0x11,
+  ins: 0x02,
+  p1,
+  p2: P2_NO_STAKE,
+});
+
+export type SignTransactionCommandArgs = {
+  phase: SignPhase;
+  derivationPath?: string;
+  transactionChunk?: Uint8Array;
+};
+
+export type SignTransactionCommandResponse = Signature;
+
+export class SignTransactionCommand
+  implements
+    Command<
+      SignTransactionCommandResponse,
+      SignTransactionCommandArgs,
+      IcpErrorCodes
+    >
+{
+  readonly name = "SignTransaction";
+
+  private readonly args: SignTransactionCommandArgs;
+
+  private readonly apduBuilder: ApduBuilder;
+
+  private readonly errorHelper = new CommandErrorHelper<
+    SignTransactionCommandResponse,
+    IcpErrorCodes
+  >(ICP_APP_ERRORS, IcpAppCommandErrorFactory);
+
+  constructor(args: SignTransactionCommandArgs) {
+    this.args = args;
+    this.apduBuilder = new ApduBuilder(icpSignTransactionApduHeader(this.p1()));
+  }
+
+  public getApdu(): Apdu {
+    return this.isFirstChunk() ? this.firstChunk() : this.nextChunk();
+  }
+
+  public parseResponse(
+    apduResponse: ApduResponse,
+  ): CommandResult<SignTransactionCommandResponse, IcpErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      const apduParser = new ApduParser(apduResponse);
+
+      const r = apduParser.extractFieldByLength(SIGNATURE_R_LENGTH);
+      const s = apduParser.extractFieldByLength(SIGNATURE_S_LENGTH);
+      const v = apduParser.extractFieldByLength(SIGNATURE_V_LENGTH);
+      const der = apduParser.extractFieldByLength(
+        apduParser.getUnparsedRemainingLength(),
+      );
+
+      if (
+        r === undefined ||
+        s === undefined ||
+        v === undefined ||
+        v[0] === undefined ||
+        der === undefined ||
+        der.length === 0
+      ) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Signature is missing"),
+        });
+      }
+
+      return CommandResultFactory({
+        data: {
+          r: apduParser.encodeToHexaString(r),
+          s: apduParser.encodeToHexaString(s),
+          v: v[0],
+          der: apduParser.encodeToHexaString(der),
+        },
+      });
+    });
+  }
+
+  private p1(): number {
+    switch (this.args.phase) {
+      case SignPhase.INIT:
+        return P1_INIT;
+      case SignPhase.ADD:
+        return P1_ADD;
+      case SignPhase.LAST:
+        return P1_LAST;
+    }
+  }
+
+  private isFirstChunk(): boolean {
+    return this.args.phase === SignPhase.INIT;
+  }
+
+  private firstChunk(): Apdu {
+    const { derivationPath } = this.args;
+
+    if (!derivationPath) {
+      throw new Error(
+        "SignTransactionCommand: derivation path is required for 'init' phase.",
+      );
+    }
+
+    const paths = DerivationPathUtils.splitPath(derivationPath);
+
+    if (paths.length !== DERIVATION_PATH_LENGTH) {
+      throw new Error(
+        `SignTransactionCommand: expected ${DERIVATION_PATH_LENGTH} path elements, got ${paths.length}`,
+      );
+    }
+
+    this.apduBuilder.addBufferToData(encodeDerivationPath(paths));
+    return this.apduBuilder.build();
+  }
+
+  private nextChunk(): Apdu {
+    if (!this.args.transactionChunk) {
+      throw new Error(
+        "SignTransactionCommand: transaction chunk is required for 'add' and 'last' phases.",
+      );
+    }
+
+    this.apduBuilder.addBufferToData(this.args.transactionChunk);
+    return this.apduBuilder.build();
+  }
+}

--- a/packages/signer/signer-icp/src/internal/app-binder/command/utils/EncodeDerivationPath.test.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/utils/EncodeDerivationPath.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { encodeDerivationPath } from "./EncodeDerivationPath";
+
+describe("encodeDerivationPath", () => {
+  describe("Given a 5-level derivation path", () => {
+    describe("When encoding a standard Internet Computer path (44'/223'/0'/0/0)", () => {
+      it("Then it should return a 20-byte buffer", () => {
+        const result = encodeDerivationPath([44, 223, 0, 0, 0]);
+        expect(result).toBeInstanceOf(Uint8Array);
+        expect(result.length).toBe(20);
+      });
+
+      it("Then it should set hardened bit for the first three levels", () => {
+        const result = encodeDerivationPath([44, 223, 0, 0, 0]);
+        const dataView = new DataView(
+          result.buffer,
+          result.byteOffset,
+          result.byteLength,
+        );
+        expect(dataView.getUint32(0, true)).toBe((0x80000000 | 44) >>> 0);
+        expect(dataView.getUint32(4, true)).toBe((0x80000000 | 223) >>> 0);
+        expect(dataView.getUint32(8, true)).toBe((0x80000000 | 0) >>> 0);
+      });
+
+      it("Then it should not set hardened bit for the last two levels", () => {
+        const result = encodeDerivationPath([44, 223, 0, 0, 0]);
+        const dataView = new DataView(
+          result.buffer,
+          result.byteOffset,
+          result.byteLength,
+        );
+        expect(dataView.getUint32(12, true)).toBe(0);
+        expect(dataView.getUint32(16, true)).toBe(0);
+      });
+
+      it("Then it should encode each level as little-endian uint32", () => {
+        const result = encodeDerivationPath([44, 223, 0, 0, 0]);
+        const expected = new Uint8Array(20);
+        const expectedView = new DataView(expected.buffer);
+        expectedView.setUint32(0, 0x80000000 | 44, true);
+        expectedView.setUint32(4, 0x80000000 | 223, true);
+        expectedView.setUint32(8, 0x80000000 | 0, true);
+        expectedView.setUint32(12, 0, true);
+        expectedView.setUint32(16, 0, true);
+        expect(result).toStrictEqual(expected);
+      });
+    });
+
+    describe("When encoding a path with non-zero account and index", () => {
+      it("Then it should encode account and index without hardened bit", () => {
+        const result = encodeDerivationPath([44, 223, 0, 1, 2]);
+        const dataView = new DataView(
+          result.buffer,
+          result.byteOffset,
+          result.byteLength,
+        );
+        expect(dataView.getUint32(12, true)).toBe(1);
+        expect(dataView.getUint32(16, true)).toBe(2);
+      });
+    });
+
+    describe("When encoding path values with high bits set", () => {
+      it("Then it should mask each level to 31 bits before applying hardened bit", () => {
+        const result = encodeDerivationPath([
+          0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+        ]);
+        const dataView = new DataView(
+          result.buffer,
+          result.byteOffset,
+          result.byteLength,
+        );
+        expect(dataView.getUint32(0, true)).toBe(
+          (0x80000000 | 0x7fffffff) >>> 0,
+        );
+        expect(dataView.getUint32(4, true)).toBe(
+          (0x80000000 | 0x7fffffff) >>> 0,
+        );
+        expect(dataView.getUint32(8, true)).toBe(
+          (0x80000000 | 0x7fffffff) >>> 0,
+        );
+        expect(dataView.getUint32(12, true)).toBe(0x7fffffff >>> 0);
+        expect(dataView.getUint32(16, true)).toBe(0x7fffffff >>> 0);
+      });
+    });
+  });
+});

--- a/packages/signer/signer-icp/src/internal/app-binder/command/utils/EncodeDerivationPath.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/utils/EncodeDerivationPath.ts
@@ -1,0 +1,9 @@
+export const encodeDerivationPath = (paths: number[]): Uint8Array => {
+  const dataView = new DataView(new ArrayBuffer(20));
+  for (let i = 0; i < paths.length; i++) {
+    const raw = paths[i]! & 0x7fffffff;
+    const hardened = i < 3 ? (0x80000000 | raw) >>> 0 : raw >>> 0;
+    dataView.setUint32(i * 4, hardened, true);
+  }
+  return new Uint8Array(dataView.buffer);
+};

--- a/packages/signer/signer-icp/src/internal/app-binder/command/utils/IcpApplicationError.test.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/utils/IcpApplicationError.test.ts
@@ -1,0 +1,63 @@
+import { IcpAppCommandError, IcpErrorCodes } from "./IcpApplicationErrors";
+
+describe("IcpAppCommandError", () => {
+  it('Should have a tag "IcpAppCommandError"', () => {
+    const error = new IcpAppCommandError({
+      message: "Test error message",
+      errorCode: IcpErrorCodes.EXECUTION_ERROR,
+    });
+    expect(error._tag).toBe("IcpAppCommandError");
+  });
+
+  it.each([
+    { errorCode: IcpErrorCodes.EXECUTION_ERROR, message: "Execution Error" },
+    {
+      errorCode: IcpErrorCodes.WRONG_BUFFER_LENGTH,
+      message: "Wrong buffer length",
+    },
+    { errorCode: IcpErrorCodes.EMPTY_BUFFER, message: "Empty buffer" },
+    {
+      errorCode: IcpErrorCodes.OUTPUT_BUFFER_TOO_SMALL,
+      message: "Output buffer too small",
+    },
+    { errorCode: IcpErrorCodes.DATA_INVALID, message: "Data is invalid" },
+    {
+      errorCode: IcpErrorCodes.CONDITIONS_NOT_SATISFIED,
+      message: "Conditions not satisfied",
+    },
+    {
+      errorCode: IcpErrorCodes.COMMAND_NOT_ALLOWED,
+      message: "Command not allowed",
+    },
+    {
+      errorCode: IcpErrorCodes.TX_NOT_INITIALIZED,
+      message: "Tx not initialized",
+    },
+    { errorCode: IcpErrorCodes.BAD_KEY_HANDLE, message: "Bad key handle" },
+    { errorCode: IcpErrorCodes.P1_P2_INVALID, message: "P1 or P2 invalid" },
+    {
+      errorCode: IcpErrorCodes.INS_NOT_SUPPORTED,
+      message: "INS not supported",
+    },
+    {
+      errorCode: IcpErrorCodes.CLA_NOT_SUPPORTED,
+      message: "CLA not supported",
+    },
+    { errorCode: IcpErrorCodes.UNKNOWN_ERROR, message: "Unknown error" },
+    {
+      errorCode: IcpErrorCodes.SIGN_VERIFY_ERROR,
+      message: "Sign/verify error",
+    },
+    { errorCode: IcpErrorCodes.BUSY, message: "Busy" },
+  ])(
+    "Should have correct error code and message for %s",
+    ({ errorCode, message }) => {
+      const error = new IcpAppCommandError({
+        errorCode: errorCode,
+        message: message,
+      });
+      expect(error.errorCode).toBe(errorCode);
+      expect(error.message).toBe(message);
+    },
+  );
+});

--- a/packages/signer/signer-icp/src/internal/app-binder/command/utils/IcpApplicationErrors.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/utils/IcpApplicationErrors.ts
@@ -1,0 +1,51 @@
+import {
+  type CommandErrorArgs,
+  type CommandErrors,
+  DeviceExchangeError,
+} from "@ledgerhq/device-management-kit";
+
+export enum IcpErrorCodes {
+  EXECUTION_ERROR = "0x6400",
+  WRONG_BUFFER_LENGTH = "0x6700",
+  EMPTY_BUFFER = "0x6982",
+  OUTPUT_BUFFER_TOO_SMALL = "0x6983",
+  DATA_INVALID = "0x6984",
+  CONDITIONS_NOT_SATISFIED = "0x6985",
+  COMMAND_NOT_ALLOWED = "0x6986",
+  TX_NOT_INITIALIZED = "0x6987",
+  BAD_KEY_HANDLE = "0x6A80",
+  P1_P2_INVALID = "0x6B00",
+  INS_NOT_SUPPORTED = "0x6D00",
+  CLA_NOT_SUPPORTED = "0x6E00",
+  UNKNOWN_ERROR = "0x6F00",
+  SIGN_VERIFY_ERROR = "0x6F01",
+  BUSY = "0x9001",
+}
+
+export const ICP_APP_ERRORS: CommandErrors<IcpErrorCodes> = {
+  "0x6400": { message: "Execution Error" },
+  "0x6700": { message: "Wrong buffer length" },
+  "0x6982": { message: "Empty buffer" },
+  "0x6983": { message: "Output buffer too small" },
+  "0x6984": { message: "Data is invalid" },
+  "0x6985": { message: "Conditions not satisfied" },
+  "0x6986": { message: "Command not allowed" },
+  "0x6987": { message: "Tx not initialized" },
+  "0x6A80": { message: "Bad key handle" },
+  "0x6B00": { message: "P1 or P2 invalid" },
+  "0x6D00": { message: "INS not supported" },
+  "0x6E00": { message: "CLA not supported" },
+  "0x6F00": { message: "Unknown error" },
+  "0x6F01": { message: "Sign/verify error" },
+  "0x9001": { message: "Busy" },
+};
+
+export class IcpAppCommandError extends DeviceExchangeError<IcpErrorCodes> {
+  constructor(args: CommandErrorArgs<IcpErrorCodes>) {
+    super({ tag: "IcpAppCommandError", ...args });
+  }
+}
+
+export const IcpAppCommandErrorFactory = (
+  args: CommandErrorArgs<IcpErrorCodes>,
+) => new IcpAppCommandError(args);

--- a/packages/signer/signer-icp/src/internal/app-binder/constants.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/constants.ts
@@ -1,0 +1,1 @@
+export const APP_NAME = "InternetComputer";

--- a/packages/signer/signer-icp/src/internal/app-binder/di/appBinderModule.test.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/di/appBinderModule.test.ts
@@ -1,0 +1,15 @@
+import { Container } from "inversify";
+
+import { appBindingModuleFactory } from "./appBinderModule";
+
+describe("appBindingModuleFactory", () => {
+  it("should return the app-binder module", () => {
+    // ARRANGE
+    const mod = appBindingModuleFactory();
+    const container = new Container();
+    // ACT
+    container.loadSync(mod);
+    // ASSERT
+    expect(mod).toBeDefined();
+  });
+});

--- a/packages/signer/signer-icp/src/internal/app-binder/di/appBinderModule.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/di/appBinderModule.ts
@@ -1,0 +1,9 @@
+import { ContainerModule } from "inversify";
+
+import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
+import { IcpAppBinder } from "@internal/app-binder/IcpAppBinder";
+
+export const appBindingModuleFactory = () =>
+  new ContainerModule(({ bind }) => {
+    bind(appBinderTypes.AppBinding).to(IcpAppBinder);
+  });

--- a/packages/signer/signer-icp/src/internal/app-binder/di/appBinderTypes.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/di/appBinderTypes.ts
@@ -1,0 +1,3 @@
+export const appBinderTypes = {
+  AppBinding: Symbol.for("AppBinding"),
+} as const;

--- a/packages/signer/signer-icp/src/internal/app-binder/task/SignTransactionTask.test.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/task/SignTransactionTask.test.ts
@@ -1,0 +1,209 @@
+import {
+  APDU_MAX_PAYLOAD,
+  CommandResultFactory,
+  CommandResultStatus,
+  type InternalApi,
+  InvalidStatusWordError,
+  isSuccessCommandResult,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+import { vi } from "vitest";
+
+import {
+  P1_ADD,
+  P1_INIT,
+  P1_LAST,
+  P2_NO_STAKE,
+  type SignTransactionCommand,
+} from "@internal/app-binder/command/SignTransactionCommand";
+import {
+  IcpAppCommandError,
+  IcpErrorCodes,
+} from "@internal/app-binder/command/utils/IcpApplicationErrors";
+import { SignTransactionTask } from "@internal/app-binder/task/SignTransactionTask";
+
+const DERIVATION_PATH = "44'/223'/0'/0/0";
+const PATH_PAYLOAD_LENGTH = 20;
+const APDU_HEADER_LENGTH = 5; // cla, ins, p1, p2, lc
+const signature = { r: "aa", s: "bb", v: 1, der: "3006" };
+
+// Reads the [cla, ins, p1, p2] header + payload of the command handed to sendCommand.
+const inspect = (command: SignTransactionCommand) => {
+  const raw = command.getApdu().getRawApdu();
+  return {
+    cla: raw[0],
+    ins: raw[1],
+    p1: raw[2],
+    p2: raw[3],
+    payload: raw.slice(APDU_HEADER_LENGTH),
+  };
+};
+
+describe("SignTransactionTask", () => {
+  let sendCommandMock: ReturnType<typeof vi.fn>;
+  let apiMock: InternalApi;
+  let loggerMock: LoggerPublisherService;
+
+  beforeEach(() => {
+    sendCommandMock = vi.fn();
+    apiMock = { sendCommand: sendCommandMock } as unknown as InternalApi;
+    loggerMock = { debug: vi.fn() } as unknown as LoggerPublisherService;
+  });
+
+  describe("run", () => {
+    it("should send INIT(path) then ADD/LAST chunks, all with P2=no-stake, and return the signature", async () => {
+      // ARRANGE
+      // 300 bytes → one full 255-byte ADD chunk + one 45-byte LAST chunk.
+      const transaction = new Uint8Array(300).map((_, i) => i & 0xff);
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(CommandResultFactory({ data: signature })) // ADD
+        .mockResolvedValueOnce(CommandResultFactory({ data: signature })); // LAST
+
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: DERIVATION_PATH, transaction },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data).toStrictEqual(signature);
+      }
+
+      expect(sendCommandMock).toHaveBeenCalledTimes(3);
+      const [init, add, last] = sendCommandMock.mock.calls.map((c) =>
+        inspect(c[0] as SignTransactionCommand),
+      );
+
+      // every packet targets the ICP sign instruction with the stake flag pinned off
+      for (const packet of [init, add, last]) {
+        expect(packet!.cla).toBe(0x11);
+        expect(packet!.ins).toBe(0x02);
+        expect(packet!.p2).toBe(P2_NO_STAKE);
+      }
+
+      // phase sequence is INIT → ADD → LAST
+      expect(init!.p1).toBe(P1_INIT);
+      expect(add!.p1).toBe(P1_ADD);
+      expect(last!.p1).toBe(P1_LAST);
+
+      // INIT carries only the 20-byte path; chunks split the tx at APDU_MAX_PAYLOAD
+      expect(init!.payload.length).toBe(PATH_PAYLOAD_LENGTH);
+      expect(add!.payload.length).toBe(APDU_MAX_PAYLOAD);
+      expect(last!.payload.length).toBe(transaction.length - APDU_MAX_PAYLOAD);
+      expect(new Uint8Array([...add!.payload, ...last!.payload])).toStrictEqual(
+        transaction,
+      );
+    });
+
+    it("should send the whole transaction in a single LAST chunk when it fits one packet", async () => {
+      // ARRANGE
+      const transaction = new Uint8Array(50).fill(0x07);
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(CommandResultFactory({ data: signature })); // LAST
+
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: DERIVATION_PATH, transaction },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(sendCommandMock).toHaveBeenCalledTimes(2);
+      const [, last] = sendCommandMock.mock.calls.map((c) =>
+        inspect(c[0] as SignTransactionCommand),
+      );
+      expect(last!.p1).toBe(P1_LAST);
+      expect(last!.payload).toStrictEqual(transaction);
+      expect(isSuccessCommandResult(result)).toBe(true);
+    });
+
+    it("should refuse an empty transaction without touching the device", async () => {
+      // ARRANGE
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: DERIVATION_PATH, transaction: new Uint8Array(0) },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(sendCommandMock).not.toHaveBeenCalled();
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidStatusWordError;
+        expect(err).toBeInstanceOf(InvalidStatusWordError);
+        expect(err.originalError?.message).toBe("Transaction is empty");
+      }
+    });
+
+    it("should return the init error when the INIT command fails", async () => {
+      // ARRANGE
+      const commandError = CommandResultFactory({
+        error: new IcpAppCommandError({
+          message: "Conditions not satisfied",
+          errorCode: IcpErrorCodes.CONDITIONS_NOT_SATISFIED,
+        }),
+      });
+      sendCommandMock.mockResolvedValueOnce(commandError);
+
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: DERIVATION_PATH, transaction: new Uint8Array(10) },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(IcpAppCommandError);
+      }
+      // INIT is attempted, no chunk is sent after the failure
+      expect(sendCommandMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return the chunk error when a chunk command fails", async () => {
+      // ARRANGE
+      const commandError = CommandResultFactory({
+        error: new IcpAppCommandError({
+          message: "Data Invalid",
+          errorCode: IcpErrorCodes.DATA_INVALID,
+        }),
+      });
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(commandError); // LAST
+
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: DERIVATION_PATH, transaction: new Uint8Array(50) },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect((result.error as IcpAppCommandError).errorCode).toBe(
+          IcpErrorCodes.DATA_INVALID,
+        );
+      }
+    });
+  });
+});

--- a/packages/signer/signer-icp/src/internal/app-binder/task/SignTransactionTask.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/task/SignTransactionTask.ts
@@ -1,0 +1,96 @@
+import {
+  APDU_MAX_PAYLOAD,
+  type CommandResult,
+  CommandResultFactory,
+  type InternalApi,
+  InvalidStatusWordError,
+  isSuccessCommandResult,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+
+import {
+  SignPhase,
+  SignTransactionCommand,
+  type SignTransactionCommandResponse,
+} from "@internal/app-binder/command/SignTransactionCommand";
+import { type IcpErrorCodes } from "@internal/app-binder/command/utils/IcpApplicationErrors";
+
+type SignTransactionTaskArgs = {
+  derivationPath: string;
+  transaction: Uint8Array;
+};
+
+export class SignTransactionTask {
+  constructor(
+    private api: InternalApi,
+    private args: SignTransactionTaskArgs,
+    private logger: LoggerPublisherService,
+  ) {}
+
+  async run(): Promise<
+    CommandResult<SignTransactionCommandResponse, IcpErrorCodes>
+  > {
+    const { derivationPath, transaction } = this.args;
+
+    this.logger.debug("[run] Starting SignTransactionTask", {
+      data: {
+        derivationPath,
+        transactionLength: transaction.length,
+      },
+    });
+
+    if (transaction.length === 0) {
+      // An empty tx would send INIT with no chunk, leaving the app mid-signing.
+      return CommandResultFactory({
+        error: new InvalidStatusWordError("Transaction is empty"),
+      });
+    }
+
+    const initResult = await this.api.sendCommand(
+      new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath,
+      }),
+    );
+
+    if (!isSuccessCommandResult(initResult)) {
+      this.logger.debug("[run] Failed to initialize signing", {
+        data: { error: initResult.error },
+      });
+      return initResult;
+    }
+
+    for (
+      let offset = 0;
+      offset < transaction.length;
+      offset += APDU_MAX_PAYLOAD
+    ) {
+      const isLastChunk = offset + APDU_MAX_PAYLOAD >= transaction.length;
+      const phase = isLastChunk ? SignPhase.LAST : SignPhase.ADD;
+      const transactionChunk = transaction.slice(
+        offset,
+        offset + APDU_MAX_PAYLOAD,
+      );
+
+      const result = await this.api.sendCommand(
+        new SignTransactionCommand({ phase, transactionChunk }),
+      );
+
+      if (!isSuccessCommandResult(result)) {
+        this.logger.debug("[run] Failed to sign transaction chunk", {
+          data: { chunkOffset: offset, error: result.error },
+        });
+        return result;
+      }
+
+      if (isLastChunk) {
+        this.logger.debug("[run] Transaction signed successfully");
+        return CommandResultFactory({ data: result.data });
+      }
+    }
+
+    return CommandResultFactory({
+      error: new InvalidStatusWordError("No signature returned"),
+    });
+  }
+}

--- a/packages/signer/signer-icp/src/internal/di.ts
+++ b/packages/signer/signer-icp/src/internal/di.ts
@@ -1,0 +1,43 @@
+import {
+  type DeviceManagementKit,
+  type DeviceSessionId,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+import { Container } from "inversify";
+
+import { appBindingModuleFactory } from "@internal/app-binder/di/appBinderModule";
+import { externalTypes } from "@internal/externalTypes";
+import { addressModuleFactory } from "@internal/use-cases/address/di/addressModule";
+import { configModuleFactory } from "@internal/use-cases/config/di/configModule";
+import { transactionModuleFactory } from "@internal/use-cases/transaction/di/transactionModule";
+
+type MakeContainerProps = {
+  dmk: DeviceManagementKit;
+  sessionId: DeviceSessionId;
+};
+
+export const makeContainer = ({ dmk, sessionId }: MakeContainerProps) => {
+  const container = new Container();
+
+  container.bind<DeviceManagementKit>(externalTypes.Dmk).toConstantValue(dmk);
+  container
+    .bind<DeviceSessionId>(externalTypes.SessionId)
+    .toConstantValue(sessionId);
+
+  container
+    .bind<
+      (tag: string) => LoggerPublisherService
+    >(externalTypes.DmkLoggerFactory)
+    .toConstantValue((tag: string) =>
+      dmk.getLoggerFactory()(["SignerIcp", tag]),
+    );
+
+  container.loadSync(
+    appBindingModuleFactory(),
+    configModuleFactory(),
+    addressModuleFactory(),
+    transactionModuleFactory(),
+  );
+
+  return container;
+};

--- a/packages/signer/signer-icp/src/internal/externalTypes.ts
+++ b/packages/signer/signer-icp/src/internal/externalTypes.ts
@@ -1,0 +1,5 @@
+export const externalTypes = {
+  Dmk: Symbol.for("Dmk"),
+  SessionId: Symbol.for("SessionId"),
+  DmkLoggerFactory: Symbol.for("DmkLoggerFactory"),
+} as const;

--- a/packages/signer/signer-icp/src/internal/use-cases/address/GetAddressUseCase.test.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/address/GetAddressUseCase.test.ts
@@ -1,0 +1,49 @@
+import { vi } from "vitest";
+
+import { type IcpAppBinder } from "@internal/app-binder/IcpAppBinder";
+
+import { GetAddressUseCase } from "./GetAddressUseCase";
+
+describe("GetAddressUseCase", () => {
+  it("should forward the path and default options to appBinder.getAddress", () => {
+    // ARRANGE
+    const derivationPath = "44'/223'/0'/0/0";
+    const expectedResult = { observable: {}, cancel: vi.fn() };
+    const getAddressMock = vi.fn().mockReturnValue(expectedResult);
+    const appBinderMock = {
+      getAddress: getAddressMock,
+    } as unknown as IcpAppBinder;
+    const useCase = new GetAddressUseCase(appBinderMock);
+
+    // ACT
+    const result = useCase.execute(derivationPath);
+
+    // ASSERT
+    expect(getAddressMock).toHaveBeenCalledWith({
+      derivationPath,
+      checkOnDevice: false,
+      skipOpenApp: false,
+    });
+    expect(result).toBe(expectedResult);
+  });
+
+  it("should forward provided options", () => {
+    // ARRANGE
+    const derivationPath = "44'/223'/0'/0/0";
+    const getAddressMock = vi.fn().mockReturnValue({});
+    const appBinderMock = {
+      getAddress: getAddressMock,
+    } as unknown as IcpAppBinder;
+    const useCase = new GetAddressUseCase(appBinderMock);
+
+    // ACT
+    useCase.execute(derivationPath, { checkOnDevice: true, skipOpenApp: true });
+
+    // ASSERT
+    expect(getAddressMock).toHaveBeenCalledWith({
+      derivationPath,
+      checkOnDevice: true,
+      skipOpenApp: true,
+    });
+  });
+});

--- a/packages/signer/signer-icp/src/internal/use-cases/address/GetAddressUseCase.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/address/GetAddressUseCase.ts
@@ -1,0 +1,26 @@
+import { inject, injectable } from "inversify";
+
+import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
+import { type AddressOptions } from "@api/SignerIcp";
+import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
+import { IcpAppBinder } from "@internal/app-binder/IcpAppBinder";
+
+@injectable()
+export class GetAddressUseCase {
+  private readonly _appBinder: IcpAppBinder;
+
+  constructor(@inject(appBinderTypes.AppBinding) appBinder: IcpAppBinder) {
+    this._appBinder = appBinder;
+  }
+
+  execute(
+    derivationPath: string,
+    options?: AddressOptions,
+  ): GetAddressDAReturnType {
+    return this._appBinder.getAddress({
+      derivationPath,
+      checkOnDevice: options?.checkOnDevice ?? false,
+      skipOpenApp: options?.skipOpenApp ?? false,
+    });
+  }
+}

--- a/packages/signer/signer-icp/src/internal/use-cases/address/di/addressModule.test.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/address/di/addressModule.test.ts
@@ -1,0 +1,15 @@
+import { Container } from "inversify";
+
+import { addressModuleFactory } from "./addressModule";
+
+describe("addressModuleFactory", () => {
+  it("should return the address module", () => {
+    // ARRANGE
+    const mod = addressModuleFactory();
+    const container = new Container();
+    // ACT
+    container.loadSync(mod);
+    // ASSERT
+    expect(mod).toBeDefined();
+  });
+});

--- a/packages/signer/signer-icp/src/internal/use-cases/address/di/addressModule.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/address/di/addressModule.ts
@@ -1,0 +1,9 @@
+import { ContainerModule } from "inversify";
+
+import { addressTypes } from "@internal/use-cases/address/di/addressTypes";
+import { GetAddressUseCase } from "@internal/use-cases/address/GetAddressUseCase";
+
+export const addressModuleFactory = () =>
+  new ContainerModule(({ bind }) => {
+    bind(addressTypes.GetAddressUseCase).to(GetAddressUseCase);
+  });

--- a/packages/signer/signer-icp/src/internal/use-cases/address/di/addressTypes.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/address/di/addressTypes.ts
@@ -1,0 +1,3 @@
+export const addressTypes = {
+  GetAddressUseCase: Symbol.for("GetAddressUseCase"),
+} as const;

--- a/packages/signer/signer-icp/src/internal/use-cases/config/GetAppConfigurationUseCase.test.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/config/GetAppConfigurationUseCase.test.ts
@@ -1,0 +1,24 @@
+import { vi } from "vitest";
+
+import { type IcpAppBinder } from "@internal/app-binder/IcpAppBinder";
+
+import { GetAppConfigurationUseCase } from "./GetAppConfigurationUseCase";
+
+describe("GetAppConfigurationUseCase", () => {
+  it("should call appBinder.getVersion and return its result", () => {
+    // ARRANGE
+    const expectedResult = { observable: {}, cancel: vi.fn() };
+    const getVersionMock = vi.fn().mockReturnValue(expectedResult);
+    const appBinderMock = {
+      getVersion: getVersionMock,
+    } as unknown as IcpAppBinder;
+    const useCase = new GetAppConfigurationUseCase(appBinderMock);
+
+    // ACT
+    const result = useCase.execute();
+
+    // ASSERT
+    expect(getVersionMock).toHaveBeenCalledWith({ skipOpenApp: false });
+    expect(result).toBe(expectedResult);
+  });
+});

--- a/packages/signer/signer-icp/src/internal/use-cases/config/GetAppConfigurationUseCase.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/config/GetAppConfigurationUseCase.ts
@@ -1,0 +1,20 @@
+import { inject, injectable } from "inversify";
+
+import { type GetVersionDAReturnType } from "@api/app-binder/GetVersionDeviceActionTypes";
+import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
+import { IcpAppBinder } from "@internal/app-binder/IcpAppBinder";
+
+@injectable()
+export class GetAppConfigurationUseCase {
+  private readonly _appBinder: IcpAppBinder;
+
+  constructor(@inject(appBinderTypes.AppBinding) appBinder: IcpAppBinder) {
+    this._appBinder = appBinder;
+  }
+
+  execute(): GetVersionDAReturnType {
+    return this._appBinder.getVersion({
+      skipOpenApp: false,
+    });
+  }
+}

--- a/packages/signer/signer-icp/src/internal/use-cases/config/di/configModule.test.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/config/di/configModule.test.ts
@@ -1,0 +1,15 @@
+import { Container } from "inversify";
+
+import { configModuleFactory } from "./configModule";
+
+describe("configModuleFactory", () => {
+  it("should return the config module", () => {
+    // ARRANGE
+    const mod = configModuleFactory();
+    const container = new Container();
+    // ACT
+    container.loadSync(mod);
+    // ASSERT
+    expect(mod).toBeDefined();
+  });
+});

--- a/packages/signer/signer-icp/src/internal/use-cases/config/di/configModule.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/config/di/configModule.ts
@@ -1,0 +1,9 @@
+import { ContainerModule } from "inversify";
+
+import { configTypes } from "@internal/use-cases/config/di/configTypes";
+import { GetAppConfigurationUseCase } from "@internal/use-cases/config/GetAppConfigurationUseCase";
+
+export const configModuleFactory = () =>
+  new ContainerModule(({ bind }) => {
+    bind(configTypes.GetAppConfigurationUseCase).to(GetAppConfigurationUseCase);
+  });

--- a/packages/signer/signer-icp/src/internal/use-cases/config/di/configTypes.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/config/di/configTypes.ts
@@ -1,0 +1,3 @@
+export const configTypes = {
+  GetAppConfigurationUseCase: Symbol.for("GetAppConfigurationUseCase"),
+} as const;

--- a/packages/signer/signer-icp/src/internal/use-cases/transaction/SignTransactionUseCase.test.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/transaction/SignTransactionUseCase.test.ts
@@ -1,0 +1,30 @@
+import { vi } from "vitest";
+
+import { type IcpAppBinder } from "@internal/app-binder/IcpAppBinder";
+
+import { SignTransactionUseCase } from "./SignTransactionUseCase";
+
+describe("SignTransactionUseCase", () => {
+  it("should forward the path and transaction to appBinder.signTransaction", () => {
+    // ARRANGE
+    const derivationPath = "44'/223'/0'/0/0";
+    const transaction = new Uint8Array([0x01, 0x02, 0x03]);
+    const expectedResult = { observable: {}, cancel: vi.fn() };
+    const signTransactionMock = vi.fn().mockReturnValue(expectedResult);
+    const appBinderMock = {
+      signTransaction: signTransactionMock,
+    } as unknown as IcpAppBinder;
+    const useCase = new SignTransactionUseCase(appBinderMock);
+
+    // ACT
+    const result = useCase.execute(derivationPath, transaction);
+
+    // ASSERT
+    expect(signTransactionMock).toHaveBeenCalledWith({
+      derivationPath,
+      transaction,
+      skipOpenApp: undefined,
+    });
+    expect(result).toBe(expectedResult);
+  });
+});

--- a/packages/signer/signer-icp/src/internal/use-cases/transaction/SignTransactionUseCase.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/transaction/SignTransactionUseCase.ts
@@ -1,0 +1,27 @@
+import { inject, injectable } from "inversify";
+
+import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
+import { type TransactionOptions } from "@api/SignerIcp";
+import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
+import { IcpAppBinder } from "@internal/app-binder/IcpAppBinder";
+
+@injectable()
+export class SignTransactionUseCase {
+  private readonly _appBinder: IcpAppBinder;
+
+  constructor(@inject(appBinderTypes.AppBinding) appBinder: IcpAppBinder) {
+    this._appBinder = appBinder;
+  }
+
+  execute(
+    derivationPath: string,
+    transaction: Uint8Array,
+    options?: TransactionOptions,
+  ): SignTransactionDAReturnType {
+    return this._appBinder.signTransaction({
+      derivationPath,
+      transaction,
+      skipOpenApp: options?.skipOpenApp,
+    });
+  }
+}

--- a/packages/signer/signer-icp/src/internal/use-cases/transaction/di/transactionModule.test.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/transaction/di/transactionModule.test.ts
@@ -1,0 +1,15 @@
+import { Container } from "inversify";
+
+import { transactionModuleFactory } from "./transactionModule";
+
+describe("transactionModuleFactory", () => {
+  it("should return the transaction module", () => {
+    // ARRANGE
+    const mod = transactionModuleFactory();
+    const container = new Container();
+    // ACT
+    container.loadSync(mod);
+    // ASSERT
+    expect(mod).toBeDefined();
+  });
+});

--- a/packages/signer/signer-icp/src/internal/use-cases/transaction/di/transactionModule.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/transaction/di/transactionModule.ts
@@ -1,0 +1,9 @@
+import { ContainerModule } from "inversify";
+
+import { transactionTypes } from "@internal/use-cases/transaction/di/transactionTypes";
+import { SignTransactionUseCase } from "@internal/use-cases/transaction/SignTransactionUseCase";
+
+export const transactionModuleFactory = () =>
+  new ContainerModule(({ bind }) => {
+    bind(transactionTypes.SignTransactionUseCase).to(SignTransactionUseCase);
+  });

--- a/packages/signer/signer-icp/src/internal/use-cases/transaction/di/transactionTypes.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/transaction/di/transactionTypes.ts
@@ -1,0 +1,3 @@
+export const transactionTypes = {
+  SignTransactionUseCase: Symbol.for("SignTransactionUseCase"),
+} as const;

--- a/packages/signer/signer-icp/tsconfig.json
+++ b/packages/signer/signer-icp/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@ledgerhq/tsconfig-dsdk/tsconfig.sdk",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "./lib/types",
+    "module": "ES2022",
+    "target": "ES2022",
+    "moduleResolution": "bundler",
+    "emitDeclarationOnly": true,
+    "paths": {
+      "@api/*": ["./src/api/*"],
+      "@internal/*": ["./src/internal/*"],
+      "@root/*": ["./*"]
+    },
+    "resolveJsonModule": true,
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["src", "vitest.*.mjs"]
+}

--- a/packages/signer/signer-icp/tsconfig.prod.json
+++ b/packages/signer/signer-icp/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/signer/signer-icp/vitest.config.mjs
+++ b/packages/signer/signer-icp/vitest.config.mjs
@@ -1,0 +1,29 @@
+import baseConfig from "@ledgerhq/vitest-config-dmk";
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  ...baseConfig,
+  test: {
+    ...baseConfig.test,
+    setupFiles: ["./vitest.setup.mjs"],
+    coverage: {
+      reporter: ["lcov", "text"],
+      provider: "istanbul",
+      include: ["src/**/*.ts"],
+      exclude: [
+        "src/**/*.stub.ts",
+        "src/index.ts",
+        "src/api/index.ts",
+        "src/**/__test-utils__/*",
+      ],
+    },
+  },
+  resolve: {
+    alias: {
+      "@root": path.resolve(__dirname),
+      "@api": path.resolve(__dirname, "src/api"),
+      "@internal": path.resolve(__dirname, "src/internal"),
+    },
+  },
+});

--- a/packages/signer/signer-icp/vitest.setup.mjs
+++ b/packages/signer/signer-icp/vitest.setup.mjs
@@ -1,0 +1,1 @@
+import "reflect-metadata";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1817,6 +1817,49 @@ importers:
         specifier: 'catalog:'
         version: 10.9.2(@types/node@24.13.2)(typescript@5.9.2)
 
+  packages/signer/signer-icp:
+    dependencies:
+      '@ledgerhq/signer-utils':
+        specifier: workspace:^
+        version: link:../signer-utils
+      inversify:
+        specifier: 'catalog:'
+        version: 7.5.1(reflect-metadata@0.2.2)
+      purify-ts:
+        specifier: 'catalog:'
+        version: 2.1.0
+      reflect-metadata:
+        specifier: 'catalog:'
+        version: 0.2.2
+      xstate:
+        specifier: 'catalog:'
+        version: 5.19.2
+    devDependencies:
+      '@ledgerhq/device-management-kit':
+        specifier: workspace:^
+        version: link:../../device-management-kit
+      '@ledgerhq/eslint-config-dsdk':
+        specifier: workspace:^
+        version: link:../../config/eslint
+      '@ledgerhq/ldmk-tool':
+        specifier: workspace:^
+        version: link:../../tools/ldmk-tool
+      '@ledgerhq/prettier-config-dsdk':
+        specifier: workspace:^
+        version: link:../../config/prettier
+      '@ledgerhq/tsconfig-dsdk':
+        specifier: workspace:^
+        version: link:../../config/typescript
+      '@ledgerhq/vitest-config-dmk':
+        specifier: workspace:^
+        version: link:../../config/vitest
+      rxjs:
+        specifier: 'catalog:'
+        version: 7.8.2
+      ts-node:
+        specifier: 'catalog:'
+        version: 10.9.2(@types/node@24.13.2)(typescript@5.9.2)
+
   packages/signer/signer-polkadot:
     dependencies:
       '@ledgerhq/signer-utils':


### PR DESCRIPTION
### 📝 Description

Adds `@ledgerhq/device-signer-kit-icp`, the first-party Device Management Kit signer for the Internet Computer device app (CLA `0x11`). It replaces reliance on the third-party transport and exposes three capabilities, following the `signer-cosmos` architecture:

- **`getAppConfiguration()`** — read the app version (INS `0x00`).
- **`getAddress(path, options)`** — derive the public key, account identifier and textual principal (INS `0x01`, optional on-device confirmation).
- **`signTransaction(path, tx, options)`** — sign a transfer, streaming the payload with chunked `INIT`/`ADD`/`LAST` framing (INS `0x02`).

Response parsing rejects malformed payloads (empty signature/DER, zero-length address fields), and signing refuses an empty transaction before opening a session on the app. The stake flag (P2) is pinned to `0`; combined-signing / staking (INS `0x03`) is intentionally out of scope for a follow-up.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34590](https://ledgerhq.atlassian.net/browse/LIVE-34590)
- **Feature**: First-party DMK signer kit for the Internet Computer, providing address retrieval, transfer signing and app-version reads.

### ✅ Checklist

- [x] **Covered by automatic tests** — 70 tests, 98.4% line coverage (commands, sign task, use-cases, DI and builder).
- [x] **Changeset is provided** — minor bump for `@ledgerhq/device-signer-kit-icp`.
- [x] **Documentation is up-to-date** — package `README.md` documents the three use cases and their return types.
- [x] **Impact of the changes:**
  - New, self-contained package under `packages/signer/signer-icp`; no existing package is modified.
  - QA focus: APDU framing for `getAddress` and the chunked `signTransaction` path against the ICP device app.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[LIVE-34590]: https://ledgerhq.atlassian.net/browse/LIVE-34590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ