### PR TITLE
✨ (signer-trx) [DSDK-1306]: Implement Sign Personal Message device ac…

### DIFF
--- a/.changeset/tron-sign-personal-message.md
+++ b/.changeset/tron-sign-personal-message.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-tron": minor
+---
+
+Implement the Sign Personal Message device action

--- a/apps/sample/playwright/cases/signers/tron/sign-personal-message.spec.ts
+++ b/apps/sample/playwright/cases/signers/tron/sign-personal-message.spec.ts
@@ -1,0 +1,57 @@
+/* eslint-disable no-restricted-imports */
+import { type DeviceConfig } from "@ledgerhq/device-mockserver-client";
+
+import { expect, test } from "../../../fixtures";
+
+const STAX_WITH_TRX: DeviceConfig = {
+  name: "Ledger Stax",
+  device_type: "stax",
+  connectivity_type: "USB",
+  firmware_version: "1.9.1",
+  apps: [
+    { name: "BOLOS", version: "1.9.1" },
+    { name: "Tron", version: "0.7.4" },
+  ],
+  masks: [0x33200000],
+};
+
+const MESSAGE = "Hello World";
+
+// The signature is a 65-byte buffer (r[32] + s[32] + v[1]), rendered by the
+// sample app as a 0x-prefixed hex string.
+const SIGNATURE_RE = /^0x[0-9a-f]{130}$/i;
+
+test.describe("signer tron: sign personal message", () => {
+  test("signs a personal message approved on the device screen", async ({
+    device,
+    trxSigner,
+    speculos,
+  }) => {
+    // Opening the Tron app provisions a real Speculos instance and the
+    // message must be reviewed/approved on screen, so this flow is slow.
+    test.setTimeout(120_000);
+
+    let dev!: Awaited<ReturnType<typeof device.addAndConnect>>;
+    await test.step("Given the device with the Tron app is connected", async () => {
+      dev = await device.addAndConnect(STAX_WITH_TRX);
+    });
+
+    await test.step("When Sign personal message is executed", async () => {
+      await trxSigner.open();
+      await trxSigner.signPersonalMessage(MESSAGE);
+    });
+
+    await test.step("And the message is approved on the Speculos screen", async () => {
+      const emulator = speculos(dev);
+      await emulator.waitReady();
+      await emulator.approveSigning();
+    });
+
+    await test.step("Then a valid signature is returned", async () => {
+      const result = await trxSigner.lastResult<string>();
+
+      expect(result.status).toBe("completed");
+      expect(result.output).toMatch(SIGNATURE_RE);
+    });
+  });
+});

--- a/apps/sample/playwright/utils/drivers/TrxSignerDriver.ts
+++ b/apps/sample/playwright/utils/drivers/TrxSignerDriver.ts
@@ -69,6 +69,25 @@ export class TrxSignerDriver {
   }
 
   /**
+   * Open the Sign personal message action, fill the message (plain text) and
+   * Execute it. The action stays pending until the message is reviewed and
+   * signed on Speculos.
+   */
+  async signPersonalMessage(
+    message: string,
+    { skipOpenApp = false }: { skipOpenApp?: boolean } = {},
+  ): Promise<void> {
+    await this.page.getByTestId("CTA_command-Sign personal message").click();
+    const input = this.page.getByTestId("input-text_message");
+    await input.waitFor({ state: "visible" });
+    await input.fill(message);
+    if (skipOpenApp) {
+      await this.page.getByTestId("input-switch_skipOpenApp").click();
+    }
+    await this.page.getByTestId("CTA_send-device-action").click();
+  }
+
+  /**
    * Wait for the last emitted device-action state to be terminal and return it
    * parsed.
    */

--- a/apps/sample/src/components/SignerTrxView/index.tsx
+++ b/apps/sample/src/components/SignerTrxView/index.tsx
@@ -9,6 +9,9 @@ import {
   type GetAppConfigurationDAIntermediateValue,
   type GetAppConfigurationDAOutput,
   SignerTrxBuilder,
+  type SignPersonalMessageDAError,
+  type SignPersonalMessageDAIntermediateValue,
+  type SignPersonalMessageDAOutput,
   type SignTransactionDAError,
   type SignTransactionDAIntermediateValue,
   type SignTransactionDAOutput,
@@ -89,6 +92,31 @@ export const SignerTrxView: React.FC<{ sessionId: string }> = ({
         },
         SignTransactionDAError,
         SignTransactionDAIntermediateValue
+      >,
+      {
+        title: "Sign personal message",
+        description:
+          "Perform all the actions necessary to sign a personal message with the device",
+        executeDeviceAction: ({ derivationPath, message, skipOpenApp }) => {
+          return signer.signPersonalMessage(derivationPath, message, {
+            skipOpenApp,
+          });
+        },
+        initialValues: {
+          derivationPath: DEFAULT_DERIVATION_PATH,
+          message: "Hello World",
+          skipOpenApp: false,
+        },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        SignPersonalMessageDAOutput,
+        {
+          derivationPath: string;
+          message: string;
+          skipOpenApp?: boolean;
+        },
+        SignPersonalMessageDAError,
+        SignPersonalMessageDAIntermediateValue
       >,
       {
         title: "Get app configuration",

--- a/packages/signer/signer-trx/README.md
+++ b/packages/signer/signer-trx/README.md
@@ -157,6 +157,46 @@ observable.subscribe((state) => {
 });
 ```
 
+### Sign personal message
+
+Signs a personal (TIP-191-style) message. A `string` message is UTF-8 encoded;
+raw bytes can be passed as a `Uint8Array`. The length-prefixed message is
+framed across APDUs and reviewed on the device. Requires the user to approve
+the message on the device screen.
+
+```typescript
+signer.signPersonalMessage(
+  derivationPath: string,
+  // the message to sign: a text string (UTF-8 encoded) or raw bytes
+  message: string | Uint8Array,
+  options?: {
+    // Skip the "open app" step if the Tron app is already open (default: false).
+    skipOpenApp?: boolean;
+  },
+): SignPersonalMessageDAReturnType;
+```
+
+The returned device action resolves to the 65-byte signature
+(`r[32] + s[32] + v[1]`) as a `Uint8Array`.
+
+```typescript
+const { observable, cancel } = signer.signPersonalMessage(
+  "44'/195'/0'/0/0",
+  "Hello Tron",
+);
+
+observable.subscribe((state) => {
+  switch (state.status) {
+    case "completed":
+      console.log(state.output); // Uint8Array(65) signature
+      break;
+    case "error":
+      console.error(state.error);
+      break;
+  }
+});
+```
+
 ## Development
 
 ```bash

--- a/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.test.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.test.ts
@@ -21,6 +21,11 @@ import {
   type GetAppConfigurationDAOutput,
 } from "@api/app-binder/GetAppConfigurationDeviceActionTypes";
 import {
+  type SignPersonalMessageDAError,
+  type SignPersonalMessageDAIntermediateValue,
+  type SignPersonalMessageDAOutput,
+} from "@api/app-binder/SignPersonalMessageDeviceActionTypes";
+import {
   type SignTransactionDAError,
   type SignTransactionDAIntermediateValue,
   type SignTransactionDAOutput,
@@ -285,6 +290,116 @@ describe("TronAppBinder", () => {
           loggerFactoryMock,
         );
         binder.signTransaction({ derivationPath, transaction });
+
+        // THEN
+        expect(executedDeviceAction().input.skipOpenApp).toBe(false);
+      });
+    });
+  });
+
+  describe("signPersonalMessage", () => {
+    const derivationPath = "44'/195'/0'/0/0";
+    const message = Uint8Array.from([0x68, 0x65, 0x6c, 0x6c, 0x6f]);
+
+    it("should return the signature", () =>
+      new Promise<void>((resolve, reject) => {
+        // GIVEN
+        const output: SignPersonalMessageDAOutput = new Uint8Array(65).fill(
+          0xab,
+        );
+
+        vi.spyOn(mockedDmk, "executeDeviceAction").mockReturnValue({
+          observable: from([
+            {
+              status: DeviceActionStatus.Completed,
+              output,
+            } as DeviceActionState<
+              SignPersonalMessageDAOutput,
+              SignPersonalMessageDAError,
+              SignPersonalMessageDAIntermediateValue
+            >,
+          ]),
+          cancel: vi.fn(),
+        });
+
+        // WHEN
+        const binder = new TronAppBinder(
+          mockedDmk,
+          "sessionId",
+          loggerFactoryMock,
+        );
+        const { observable } = binder.signPersonalMessage({
+          derivationPath,
+          message,
+        });
+
+        // THEN
+        const states: DeviceActionState<
+          SignPersonalMessageDAOutput,
+          SignPersonalMessageDAError,
+          SignPersonalMessageDAIntermediateValue
+        >[] = [];
+        observable.subscribe({
+          next: (state) => states.push(state),
+          error: reject,
+          complete: () => {
+            try {
+              expect(states).toEqual([
+                { status: DeviceActionStatus.Completed, output },
+              ]);
+              resolve();
+            } catch (err) {
+              reject(err as Error);
+            }
+          },
+        });
+      }));
+
+    describe("calls executeDeviceAction with the correct params", () => {
+      // The task closure breaks reference equality, so the device action is
+      // asserted field by field instead of with toHaveBeenCalledWith.
+      const executedDeviceAction = () => {
+        const args = vi.mocked(mockedDmk.executeDeviceAction).mock
+          .calls[0]![0]!;
+        expect(args.sessionId).toBe("sessionId");
+        expect(args.deviceAction).toBeInstanceOf(CallTaskInAppDeviceAction);
+        return args.deviceAction as CallTaskInAppDeviceAction<
+          SignPersonalMessageDAOutput,
+          TronAppCommandError,
+          UserInteractionRequired.SignPersonalMessage
+        >;
+      };
+
+      it("requires the SignPersonalMessage interaction", () => {
+        // WHEN
+        const binder = new TronAppBinder(
+          mockedDmk,
+          "sessionId",
+          loggerFactoryMock,
+        );
+        binder.signPersonalMessage({
+          derivationPath,
+          message,
+          skipOpenApp: true,
+        });
+
+        // THEN
+        const deviceAction = executedDeviceAction();
+        expect(deviceAction.input.appName).toBe(APP_NAME);
+        expect(deviceAction.input.requiredUserInteraction).toBe(
+          UserInteractionRequired.SignPersonalMessage,
+        );
+        expect(deviceAction.input.skipOpenApp).toBe(true);
+      });
+
+      it("defaults skipOpenApp to false", () => {
+        // WHEN
+        const binder = new TronAppBinder(
+          mockedDmk,
+          "sessionId",
+          loggerFactoryMock,
+        );
+        binder.signPersonalMessage({ derivationPath, message });
 
         // THEN
         expect(executedDeviceAction().input.skipOpenApp).toBe(false);

--- a/packages/signer/signer-trx/src/internal/app-binder/command/GetAddressCommand.test.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/command/GetAddressCommand.test.ts
@@ -1,6 +1,7 @@
 import {
   ApduBuilder,
   ApduResponse,
+  bufferToHexaString,
   type InvalidStatusWordError,
   isSuccessCommandResult,
 } from "@ledgerhq/device-management-kit";
@@ -13,9 +14,6 @@ import { GetAddressCommand } from "./GetAddressCommand";
 
 const PATH = "44'/195'/0'/0/0";
 const ADDRESS = "TWdnWBzFdBP1b8sqZ5RcFDbkV3sBmnxsYu";
-
-const toHex = (bytes: Uint8Array): string =>
-  Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 
 describe("GetAddressCommand", () => {
   describe("name", () => {
@@ -100,7 +98,9 @@ describe("GetAddressCommand", () => {
 
       expect(isSuccessCommandResult(result)).toBe(true);
       if (isSuccessCommandResult(result)) {
-        expect(result.data.publicKey).toBe(toHex(publicKey));
+        expect(result.data.publicKey).toBe(
+          bufferToHexaString(publicKey, false),
+        );
         expect(result.data.address).toBe(ADDRESS);
         expect(result.data.chainCode).toBeUndefined();
       }
@@ -117,7 +117,9 @@ describe("GetAddressCommand", () => {
 
       expect(isSuccessCommandResult(result)).toBe(true);
       if (isSuccessCommandResult(result)) {
-        expect(result.data.chainCode).toBe(toHex(chainCode));
+        expect(result.data.chainCode).toBe(
+          bufferToHexaString(chainCode, false),
+        );
       }
     });
 

--- a/packages/signer/signer-trx/src/internal/app-binder/command/SignPersonalMessageCommand.test.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/command/SignPersonalMessageCommand.test.ts
@@ -1,6 +1,7 @@
 import {
   ApduBuilder,
   ApduResponse,
+  type InvalidStatusWordError,
   isSuccessCommandResult,
 } from "@ledgerhq/device-management-kit";
 
@@ -13,9 +14,9 @@ describe("SignPersonalMessageCommand", () => {
   const payload = Uint8Array.from({ length: 10 }, (_, i) => i);
 
   describe("name", () => {
-    it("should be 'SignPersonalMessage'", () => {
+    it("should be 'signPersonalMessage'", () => {
       expect(new SignPersonalMessageCommand({ payload, p1: 0x00 }).name).toBe(
-        "SignPersonalMessage",
+        "signPersonalMessage",
       );
     });
   });
@@ -53,6 +54,41 @@ describe("SignPersonalMessageCommand", () => {
       expect(isSuccessCommandResult(result)).toBe(true);
       if (isSuccessCommandResult(result)) {
         expect(result.data).toStrictEqual(signature);
+      }
+    });
+
+    it("should accept an empty payload on an intermediate frame", () => {
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: new Uint8Array(0),
+      });
+      const result = new SignPersonalMessageCommand({
+        payload,
+        p1: 0x00,
+      }).parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data).toStrictEqual(new Uint8Array());
+      }
+    });
+
+    it("should return an InvalidStatusWordError when the signature length is invalid", () => {
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: Uint8Array.from({ length: 64 }, () => 0),
+      });
+      const result = new SignPersonalMessageCommand({
+        payload,
+        p1: 0x00,
+      }).parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidStatusWordError;
+        expect((err.originalError as { message: string }).message).toBe(
+          "Invalid signature length: expected 65, got 64",
+        );
       }
     });
 

--- a/packages/signer/signer-trx/src/internal/app-binder/command/SignPersonalMessageCommand.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/command/SignPersonalMessageCommand.ts
@@ -6,12 +6,18 @@ import {
   type Command,
   type CommandResult,
   CommandResultFactory,
+  InvalidStatusWordError,
 } from "@ledgerhq/device-management-kit";
 import { CommandErrorHelper } from "@ledgerhq/signer-utils";
 import { Maybe } from "purify-ts";
 
 import { type Signature } from "@api/model/Signature";
-import { INS, LEDGER_CLA, P2_NONE } from "@internal/app-binder/constants";
+import {
+  INS,
+  LEDGER_CLA,
+  P2_NONE,
+  SIGNATURE_LENGTH,
+} from "@internal/app-binder/constants";
 
 import {
   TRON_APP_ERRORS,
@@ -43,7 +49,7 @@ export class SignPersonalMessageCommand
       TronAppErrorCodes
     >
 {
-  readonly name = "SignPersonalMessage";
+  readonly name = "signPersonalMessage";
 
   private readonly _args: SignPersonalMessageCommandArgs;
 
@@ -83,6 +89,17 @@ export class SignPersonalMessageCommand
       const remaining = parser.getUnparsedRemainingLength();
       const signature =
         parser.extractFieldByLength(remaining) ?? new Uint8Array();
+
+      // Intermediate frames carry no signature; the final frame must return a
+      // full SIGNATURE_LENGTH-byte signature. Any other length means the
+      // response was truncated or malformed.
+      if (signature.length !== 0 && signature.length !== SIGNATURE_LENGTH) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            `Invalid signature length: expected ${SIGNATURE_LENGTH}, got ${signature.length}`,
+          ),
+        });
+      }
 
       return CommandResultFactory({ data: signature });
     });

--- a/packages/signer/signer-trx/src/internal/app-binder/command/utils/protobuf.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/command/utils/protobuf.ts
@@ -7,6 +7,15 @@
  * transaction field by field to find safe chunk boundaries.
  */
 
+// Base-128 varint bit layout (protobuf).
+const VARINT_CONTINUATION_BIT = 0x80; // high bit set => more bytes follow
+const VARINT_VALUE_MASK = 0x7f; // low 7 bits carry the value
+const VARINT_BITS_PER_BYTE = 7; // value bits contributed by each byte
+const MAX_VARINT_BITS = 64; // guard against a non-terminating varint
+const UINT32_MASK = 0xffffffff; // clamp the decoded value to 32 bits
+const WIRE_TYPE_MASK = 0x07; // low 3 bits of a field key hold the wire type
+const WIRE_TYPE_VARINT = 0; // wire type 0 => varint field (no payload length)
+
 type DecodeResult = {
   value: number;
   pos: number;
@@ -22,17 +31,17 @@ export function decodeVarint(stream: Uint8Array, index: number): DecodeResult {
   let shift = 0;
   let pos = index;
 
-  while (shift < 64) {
+  while (shift < MAX_VARINT_BITS) {
     const b = stream[pos]!;
-    result |= (b & 0x7f) << shift;
+    result |= (b & VARINT_VALUE_MASK) << shift;
     pos += 1;
 
-    if (!(b & 0x80)) {
-      result &= 0xffffffff;
+    if (!(b & VARINT_CONTINUATION_BIT)) {
+      result &= UINT32_MASK;
       return { value: result, pos };
     }
 
-    shift += 7;
+    shift += VARINT_BITS_PER_BYTE;
   }
 
   throw new Error("Too many bytes when decoding varint.");
@@ -47,7 +56,7 @@ export function decodeVarint(stream: Uint8Array, index: number): DecodeResult {
 export function getNextLength(tx: Uint8Array): number {
   const field = decodeVarint(tx, 0);
   const data = decodeVarint(tx, field.pos);
-  if ((field.value & 0x07) === 0) {
+  if ((field.value & WIRE_TYPE_MASK) === WIRE_TYPE_VARINT) {
     return data.pos;
   }
   return data.value + data.pos;

--- a/packages/signer/signer-trx/src/internal/app-binder/command/utils/tronApplicationErrors.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/command/utils/tronApplicationErrors.ts
@@ -15,10 +15,14 @@ import {
 export type TronAppErrorCodes =
   | "6700"
   | "6800"
+  | "6981"
   | "6982"
-  | "6983"
   | "6985"
   | "6a80"
+  | "6a84"
+  | "6a87"
+  | "6a88"
+  | "6a89"
   | "6a8a"
   | "6a8b"
   | "6a8c"
@@ -34,10 +38,14 @@ export type TronAppErrorCodes =
 export const TRON_APP_ERRORS: CommandErrors<TronAppErrorCodes> = {
   "6700": { message: "Incorrect length" },
   "6800": { message: "Missing critical parameter" },
+  "6981": { message: "Command incompatible with file structure" },
   "6982": { message: "Security status not satisfied (canceled by user)" },
-  "6983": { message: "Wrong data length" },
   "6985": { message: "Condition of use not satisfied (rejected by user)" },
   "6a80": { message: "Incorrect data" },
+  "6a84": { message: "Not enough memory space" },
+  "6a87": { message: "Wrong data length" },
+  "6a88": { message: "Referenced data not found" },
+  "6a89": { message: "File already exists" },
   "6a8a": { message: "Incorrect BIP32 path" },
   "6a8b": {
     message: "The 'sign data' setting is required (enable it in the Tron app)",

--- a/packages/signer/signer-trx/src/internal/app-binder/services/TransactionSerializer.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/services/TransactionSerializer.ts
@@ -20,7 +20,7 @@ function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
  * Frame a raw (already protobuf-serialized) Tron transaction into the ordered
  * list of APDU frames expected by the Tron app's SIGN_TRANSACTION instruction.
  *
- * Mirrors `@ledgerhq/hw-app-trx` `signTransaction`:
+ * The framing rules:
  *  - the first frame starts with the encoded derivation path, then transaction
  *    fields are packed onto frames without ever splitting a protobuf field,
  *  - each frame's P1 "start byte" encodes its position.

--- a/packages/signer/signer-trx/src/internal/app-binder/task/SignPersonalMessageTask.test.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/task/SignPersonalMessageTask.test.ts
@@ -13,6 +13,11 @@ import {
 import { SignPersonalMessageTask } from "./SignPersonalMessageTask";
 
 const PATH = "44'/195'/0'/0/0";
+// Encoded "44'/195'/0'/0/0": length byte (05) + 5 BE32 path elements.
+const PATH_HEX = "058000002c800000c3800000000000000000000000";
+
+const toHex = (bytes: Uint8Array): string =>
+  Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 
 const fromHex = (hex: string): Uint8Array =>
   Uint8Array.from(hex.match(/.{1,2}/g)!.map((b) => parseInt(b, 16)));
@@ -35,6 +40,7 @@ describe("SignPersonalMessageTask", () => {
 
   it("signs a single-frame message", async () => {
     // GIVEN a message whose length-prefixed payload fits in one frame
+    const message = new TextEncoder().encode("hello");
     sendCommandMock.mockResolvedValueOnce(
       CommandResultFactory({ data: SIGNATURE }),
     );
@@ -42,18 +48,24 @@ describe("SignPersonalMessageTask", () => {
     // WHEN
     const result = await new SignPersonalMessageTask(api, {
       derivationPath: PATH,
-      message: new TextEncoder().encode("hello"),
+      message,
     }).run();
 
-    // THEN a single FIRST-frame is sent and the signature is returned
+    // THEN a single frame is sent with the path header, the BE32 message
+    // length and the message bytes, and the signature is returned
     expect(sendCommandMock).toHaveBeenCalledTimes(1);
     expect(sentCommand(0).args.p1).toBe(0x00);
+    expect(toHex(sentCommand(0).args.payload)).toBe(
+      PATH_HEX + "00000005" + "68656c6c6f",
+    );
     expect(isSuccessCommandResult(result)).toBe(true);
     expect(isSuccessCommandResult(result) && result.data).toEqual(SIGNATURE);
   });
 
   it("signs a multi-frame message and returns the last frame's signature", async () => {
-    // GIVEN a 300-byte message spanning two frames
+    // GIVEN a 300-byte message: the 304-byte prefixed payload spans two
+    // frames (229 bytes fit alongside the 21-byte path header, 75 remain)
+    const message = fromHex("cd".repeat(300));
     sendCommandMock
       .mockResolvedValueOnce(CommandResultFactory({ data: new Uint8Array() }))
       .mockResolvedValueOnce(CommandResultFactory({ data: SIGNATURE }));
@@ -61,23 +73,28 @@ describe("SignPersonalMessageTask", () => {
     // WHEN
     const result = await new SignPersonalMessageTask(api, {
       derivationPath: PATH,
-      message: fromHex("cd".repeat(300)),
+      message,
     }).run();
 
-    // THEN both frames are sent in order and the signature is returned
+    // THEN both frames are sent in order with the expected start bytes
     expect(sendCommandMock).toHaveBeenCalledTimes(2);
     expect(sentCommand(0).args.p1).toBe(0x00);
+    expect(toHex(sentCommand(0).args.payload)).toBe(
+      PATH_HEX + "0000012c" + "cd".repeat(225),
+    );
     expect(sentCommand(1).args.p1).toBe(0x80);
+    expect(toHex(sentCommand(1).args.payload)).toBe("cd".repeat(75));
     expect(isSuccessCommandResult(result)).toBe(true);
     expect(isSuccessCommandResult(result) && result.data).toEqual(SIGNATURE);
   });
 
   it("aborts on the first failing frame", async () => {
     // GIVEN a two-frame message whose first frame fails
+    const message = fromHex("cd".repeat(300));
     const error = CommandResultFactory({
       error: TronAppCommandErrorFactory({
-        ...TRON_APP_ERRORS["6985"],
-        errorCode: "6985",
+        ...TRON_APP_ERRORS["6a80"],
+        errorCode: "6a80",
       }),
     });
     sendCommandMock.mockResolvedValueOnce(error);
@@ -85,12 +102,37 @@ describe("SignPersonalMessageTask", () => {
     // WHEN
     const result = await new SignPersonalMessageTask(api, {
       derivationPath: PATH,
-      message: fromHex("cd".repeat(300)),
+      message,
     }).run();
 
     // THEN no further frame is sent and the error is returned unchanged
     expect(sendCommandMock).toHaveBeenCalledTimes(1);
     expect(result).toBe(error);
+    expect(isSuccessCommandResult(result)).toBe(false);
+  });
+
+  it("propagates a user rejection (6985) on the final frame", async () => {
+    // GIVEN a two-frame message rejected by the user on the last frame
+    const message = fromHex("cd".repeat(300));
+    const rejection = CommandResultFactory({
+      error: TronAppCommandErrorFactory({
+        ...TRON_APP_ERRORS["6985"],
+        errorCode: "6985",
+      }),
+    });
+    sendCommandMock
+      .mockResolvedValueOnce(CommandResultFactory({ data: new Uint8Array() }))
+      .mockResolvedValueOnce(rejection);
+
+    // WHEN
+    const result = await new SignPersonalMessageTask(api, {
+      derivationPath: PATH,
+      message,
+    }).run();
+
+    // THEN the rejection is propagated
+    expect(sendCommandMock).toHaveBeenCalledTimes(2);
+    expect(result).toBe(rejection);
     expect(isSuccessCommandResult(result)).toBe(false);
   });
 

--- a/packages/signer/signer-trx/src/internal/use-cases/message/SignPersonalMessageUseCase.test.ts
+++ b/packages/signer/signer-trx/src/internal/use-cases/message/SignPersonalMessageUseCase.test.ts
@@ -1,0 +1,49 @@
+import { type TronAppBinder } from "@internal/app-binder/TronAppBinder";
+
+import { SignPersonalMessageUseCase } from "./SignPersonalMessageUseCase";
+
+describe("SignPersonalMessageUseCase", () => {
+  const derivationPath = "44'/195'/0'/0/0";
+  const returnedValue = { observable: "observable", cancel: () => {} };
+  const signPersonalMessageMock = vi.fn().mockReturnValue(returnedValue);
+  const appBinderMock = {
+    signPersonalMessage: signPersonalMessageMock,
+  } as unknown as TronAppBinder;
+  let useCase: SignPersonalMessageUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new SignPersonalMessageUseCase(appBinderMock);
+  });
+
+  it("should UTF-8 encode a string message and forward options to the app binder", () => {
+    // WHEN
+    const result = useCase.execute(derivationPath, "hello", {
+      skipOpenApp: true,
+    });
+
+    // THEN
+    expect(result).toEqual(returnedValue);
+    expect(signPersonalMessageMock).toHaveBeenCalledWith({
+      derivationPath,
+      message: Uint8Array.from([0x68, 0x65, 0x6c, 0x6c, 0x6f]),
+      skipOpenApp: true,
+    });
+  });
+
+  it("should pass a Uint8Array message through unchanged", () => {
+    // GIVEN bytes that are not valid UTF-8 text
+    const message = Uint8Array.from([0x00, 0xff, 0x80, 0x01]);
+
+    // WHEN
+    const result = useCase.execute(derivationPath, message);
+
+    // THEN
+    expect(result).toEqual(returnedValue);
+    expect(signPersonalMessageMock).toHaveBeenCalledWith({
+      derivationPath,
+      message,
+      skipOpenApp: undefined,
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Implements the **Sign Personal Message** device action for the Tron signer
(`@ledgerhq/device-signer-kit-tron`), completing `signPersonalMessage(derivationPath, message, options?)`
end-to-end.

The message accepts `string | Uint8Array` (strings are UTF-8 encoded), is prefixed with its
big-endian 32-bit length and split into 250-byte APDU frames - the derivation path travels on the
first frame - mirroring `@ledgerhq/hw-app-trx`'s `signPersonalMessage`. The multi-APDU exchange is
driven by `SignPersonalMessageTask` through the generic `CallTaskInAppDeviceAction`, and the 65-byte
signature (`r[32] + s[32] + v[1]`) is returned from the final frame. The action requires the
`SignPersonalMessage` user interaction (on-device approval).

Usage:

```typescript
const { observable } = signer.signPersonalMessage("44'/195'/0'/0/0", "Hello Tron");

observable.subscribe((state) => {
  if (state.status === "completed") {
    console.log(state.output); // Uint8Array(65) signature
  }
});
```

The command/serializer scaffold landed in the commands/serialization story; this PR completes and
verifies the use-case → app-binder → task path and adds the missing tests, sample panel, e2e, and docs.

▎ Note: This is part of the stacked Tron Signer Kit chain and targets the DSDK-1305 Sign
▎ Transaction branch (feat/dsdk-1305-trx-sign-transaction), not develop. Please review/merge
▎ bottom-up.

❓ Context

- JIRA or GitHub link: DSDK-1306
- Feature: Sign Personal Message device action for the Tron signer kit (TIP-191-style personal
message signing). Blind-signed on device - no clear-signing context is resolved.

✅ Checklist

- [x] Covered by automatic tests
  - SignPersonalMessageUseCase.test.ts - string → UTF-8 encoding, Uint8Array passthrough, skipOpenApp forwarding
  - SignPersonalMessageTask.test.ts - single-frame, multi-frame ordering/payloads, abort on a failing frame, user rejection (6985)
  - signPersonalMessage block in TronAppBinder.test.ts - correct device action, SignPersonalMessage interaction, skipOpenApp default
  - command + serializer already covered by the commands/serialization story
- [x] Changeset is provided 
- [x] Documentation is up-to-date 
- [ ] Impact of the changes:
  - New public method signPersonalMessage on SignerTrx - purely additive, no changes to existing actions.
  - Adds a "Sign personal message" panel to the sample app's Tron signer view.
  - Adds a Playwright e2e (sign-personal-message.spec.ts, happy path) driven against Speculos/mock server.
  - QA focus: sign a personal message on-device and confirm the returned signature; verify both short (single-frame) and long (multi-frame) messages, and that a device rejection surfaces as an error.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
