### PR TITLE
🔧 (ci) [NO-ISSUE]: Add mock server Docker publish workflow and release skill

### DIFF
--- a/.github/workflows/release_mock_server.yml
+++ b/.github/workflows/release_mock_server.yml
@@ -1,0 +1,55 @@
+name: "[Release] Publish Mock Server Docker Image"
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to build from
+        required: false
+        default: develop
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  JFROG_REGISTRY: ${{ vars.JFROG_REGISTRY }}
+  JFROG_REGISTRY_REPO: ${{ vars.JFROG_REGISTRY_REPO }}
+  IMAGE_NAME: device-mock-server
+  REF: ${{ inputs.ref || 'develop' }}
+
+jobs:
+  publish-mock-server-docker:
+    name: Build and push Mock Server Docker image to JFrog
+    runs-on: ledgerhq-device-sdk
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.REF }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Get token from JFrog
+        id: jfrog-login
+        uses: LedgerHQ/actions-security/actions/jfrog-login@3868be0ef1ec8722fbdb2c6cda90f739cbfc742d # actions/jfrog-login-1
+
+      - name: Login to JFrog OCI Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ${{ env.JFROG_REGISTRY }}/${{ env.JFROG_REGISTRY_REPO }}
+          username: ${{ steps.jfrog-login.outputs.oidc-user }}
+          password: ${{ steps.jfrog-login.outputs.oidc-token }}
+
+      - name: Read mock server version
+        id: version
+        run: echo "tag=$(jq -r '.version' apps/device-mock-server/package.json)" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        run: |
+          docker buildx build --push \
+            --platform linux/amd64 \
+            -f apps/device-mock-server/Dockerfile \
+            -t ${{ env.JFROG_REGISTRY }}/${{ env.JFROG_REGISTRY_REPO }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }} \
+            .

--- a/agent-files/claude/skills/release-mock-server
+++ b/agent-files/claude/skills/release-mock-server
@@ -1,0 +1,1 @@
+../../skills/release-mock-server

--- a/agent-files/cursor/skills/release-mock-server
+++ b/agent-files/cursor/skills/release-mock-server
@@ -1,0 +1,1 @@
+../../skills/release-mock-server

--- a/agent-files/skills/release-mock-server/SKILL.md
+++ b/agent-files/skills/release-mock-server/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: release-mock-server
+description: Bump the mock server version in package.json, commit, push, and trigger the Docker image publish workflow to JFrog. Activate when the user says "release mock server", "/release-mock-server", or asks to release/publish the device mock server Docker image.
+---
+
+# Release mock server
+
+Bump version. Commit. Push. Poke the workflow. It builds the Docker image and
+throws it at JFrog.
+
+Version lives in `apps/device-mock-server/package.json`. Workflow lives in
+`.github/workflows/release_mock_server.yml`.
+
+## Rules to remember
+
+- Need `gh` installed and logged in. Need `pnpm`. Need push rights to
+  `LedgerHQ/device-sdk-ts`.
+- `gh` calls need `required_permissions: ["all"]`.
+- Workflow reads version from package.json AT THE PUSHED REF. So push the bump
+  BEFORE you trigger. No push = old version = wrong tag.
+- Do steps in order. Any step breaks → stop, tell user, do not go on.
+- Collect warnings along the way. Dump them at the end.
+- `$BUMP` = `patch` | `minor` | `major`. No `$BUMP` = `patch`.
+
+## The steps
+
+```bash
+# 1. Bump type. $BUMP or patch. Not one of patch/minor/major → stop.
+
+# 2. On a branch? Empty = detached HEAD → stop.
+git branch --show-current
+
+# 3. Clean tree? Non-empty = dirty → stop, user commits/stashes first.
+git status --porcelain
+
+# 4. Old version (remember it for the summary).
+jq -r '.version' apps/device-mock-server/package.json
+
+# 5. Bump it. Remember new version.
+(cd apps/device-mock-server && pnpm version "$BUMP" --no-git-tag-version --no-commit-hooks)
+jq -r '.version' apps/device-mock-server/package.json
+
+# 6. Commit just the package.json. Gitmoji style.
+git add apps/device-mock-server/package.json
+git commit -m "🔖 (mock-server): Bump version to <new_version>"
+
+# 7. Push. Rejected/non-fast-forward → tell user to `git pull --rebase`
+#    (or `git push --force` if they mean it). Other error → stop, report.
+git push -u origin HEAD
+
+# 8. Fire the workflow at the branch.
+gh workflow run "release_mock_server.yml" -f ref=<branch>
+```
+
+## Find the run
+
+Wait 5s. Then hunt the fresh run:
+
+```bash
+gh run list --workflow=release_mock_server.yml --limit 5 --json url,name,status,createdAt
+```
+
+- No `--branch` filter. `workflow_dispatch` runs hang off the default branch,
+  not your `ref`.
+- Keep runs that are `queued`, `in_progress`, or `pending`. Newest `createdAt`
+  wins.
+- Empty list? Retry up to 6 times, 5s apart.
+
+## Guess the build time
+
+```bash
+gh run list --workflow=release_mock_server.yml --status completed --limit 20 --json conclusion,createdAt,updatedAt
+```
+
+- Keep `conclusion == success`. Take up to 5 newest.
+- Duration = `updatedAt - createdAt` in minutes. Average them, round.
+- No successes = can't guess.
+
+## Tell the user
+
+```
+Mock server Docker image release triggered
+
+- Branch:   <branch>
+- Version:  <old> → <new> (<bump>)
+- Image:    jfrog.ledgerlabs.net/bcs-oci-prod-green/device-mock-server:<new>
+- Run:      [<run name> (<status>)](<run url>)
+- ETA:      ~<avg> min (last 5 good builds)   # or: Unknown (no good builds yet)
+- All runs: https://github.com/LedgerHQ/device-sdk-ts/actions/workflows/release_mock_server.yml
+```
+
+Add a **Warnings** list only if you collected any.
+
+## Things that bite
+
+- Image tag = `jfrog.ledgerlabs.net/bcs-oci-prod-green/device-mock-server:<version>`.
+- Build context is the WHOLE monorepo root. The Dockerfile's pnpm workspace
+  install needs it.
+- Runs on the `ledgerhq-device-sdk` private runner. JFrog is invisible from
+  public runners.


### PR DESCRIPTION
### 📝 Description

Adds a GitHub Actions workflow to build and publish the device mock server Docker image to the JFrog OCI registry, plus a companion agent skill to orchestrate the release.

- **`publish_mock_server.yml`**: A `workflow_dispatch` workflow that checks out a given ref, logs in to JFrog via OIDC, reads the version from `apps/device-mock-server/package.json`, and builds/pushes the `device-mock-server` image tagged with that version. Runs on the `ledgerhq-device-sdk` private runner (JFrog is not reachable from public runners).
- **`release-mock-server` skill**: Documents the full release flow — bump the version, commit, push, trigger the workflow, and report the run URL and estimated build time.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: CI tooling to release the mock server Docker image.

### ✅ Checklist

- [ ] **Covered by automatic tests** — N/A, CI workflow and agent skill changes.
- [ ] **Changeset is provided** — No changeset needed; changes only affect CI workflows and internal tooling (no published packages).
- [x] **Documentation is up-to-date** — The release skill documents the workflow.
- [ ] **Impact of the changes:**
  - Adds a new manual workflow to publish the mock server Docker image to JFrog.
  - Adds a `release-mock-server` agent skill.

Made with [Cursor](https://cursor.com)