### PR TITLE
🐛 (signer-eth): Fall back to legacy signing when the typed data flow throws

### DIFF
--- a/.changeset/typed-data-legacy-fallback-on-thrown-errors.md
+++ b/.changeset/typed-data-legacy-fallback-on-thrown-errors.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": patch
+---
+
+Fall back to legacy hash signing when the typed data flow throws instead of returning a failed command result (e.g. transport errors while streaming large EIP-712 payloads). Previously, thrown errors during ProvideContext and SignTypedData bypassed the SignTypedDataLegacy fallback and terminated the device action, leaving oversized typed data unsignable. User refusals (0x6985) still surface as errors without fallback.

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.test.ts
@@ -932,7 +932,7 @@ describe("SignTypedDataDeviceAction", () => {
         });
       }));
 
-    it("Error thrown while providing context", () =>
+    it("Error thrown while providing context should fallback to legacy signing", () =>
       new Promise<void>((resolve, reject) => {
         setupOpenAppDAMock();
         setupAppConfig("1.15.0", false, false);
@@ -960,6 +960,15 @@ describe("SignTypedDataDeviceAction", () => {
         );
         buildContextMock.mockResolvedValueOnce(TEST_BUILT_CONTEXT);
         provideContextMock.mockRejectedValueOnce(new UnknownDAError("Error"));
+        signTypedDataLegacyMock.mockResolvedValueOnce(
+          CommandResultFactory({
+            data: {
+              v: 0x1c,
+              r: "0x8a540510e13b0f2b11a451275716d29e08caad07e89a1c84964782fb5e1ad788",
+              s: "0x64a0de235b270fbe81e8e40688f4a9f9ad9d283d690552c9331d7773ceafa513",
+            },
+          }),
+        );
 
         const expectedStates: Array<SignTypedDataDAState> = [
           {
@@ -1005,7 +1014,113 @@ describe("SignTypedDataDeviceAction", () => {
             status: DeviceActionStatus.Pending,
           },
           {
-            error: new UnknownDAError("Error"),
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.SignTypedData,
+              step: SignTypedDataDAStateStep.SIGN_TYPED_DATA_LEGACY,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.DETECT_BLIND_SIGNING,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            output: {
+              v: 0x1c,
+              r: "0x8a540510e13b0f2b11a451275716d29e08caad07e89a1c84964782fb5e1ad788",
+              s: "0x64a0de235b270fbe81e8e40688f4a9f9ad9d283d690552c9331d7773ceafa513",
+            },
+            status: DeviceActionStatus.Completed,
+          },
+        ];
+
+        testDeviceActionStates(deviceAction, expectedStates, apiMock, {
+          onError: reject,
+          onDone: resolve,
+        });
+      }));
+
+    it("Error thrown while providing context with a user refusal should not fallback", () =>
+      new Promise<void>((resolve, reject) => {
+        setupOpenAppDAMock();
+        setupAppConfig("1.15.0", false, false);
+        getAddressMock.mockResolvedValueOnce(
+          CommandResultFactory({
+            data: { address: FROM },
+          }),
+        );
+
+        const deviceAction = new SignTypedDataDeviceAction({
+          input: {
+            derivationPath: "44'/60'/0'/0/0",
+            data: TEST_MESSAGE,
+            contextModule: mockContextModule as unknown as ContextModule,
+            parser: mockParser,
+            transactionParser: mockTransactionParser,
+            transactionMapper: mockTransactionMapper,
+            skipOpenApp: false,
+          },
+        });
+
+        // Mock a refusal raised while providing the context
+        const refusalError = EthAppCommandErrorFactory({
+          errorCode: "6985",
+          message: "Condition of use not satisfied",
+        });
+        vi.spyOn(deviceAction, "extractDependencies").mockReturnValue(
+          extractDependenciesMock(),
+        );
+        buildContextMock.mockResolvedValueOnce(TEST_BUILT_CONTEXT);
+        provideContextMock.mockRejectedValueOnce(refusalError);
+
+        const expectedStates: Array<SignTypedDataDAState> = [
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.OPEN_APP,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+              step: SignTypedDataDAStateStep.OPEN_APP,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.GET_APP_CONFIG,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.GET_ADDRESS,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.BUILD_CONTEXT,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.SignTypedData,
+              step: SignTypedDataDAStateStep.PROVIDE_CONTEXT,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            error: refusalError,
             status: DeviceActionStatus.Error,
           },
         ];
@@ -1054,6 +1169,127 @@ describe("SignTypedDataDeviceAction", () => {
             }),
           }),
         );
+        signTypedDataLegacyMock.mockResolvedValueOnce(
+          CommandResultFactory({
+            data: {
+              v: 0x1c,
+              r: "0x8a540510e13b0f2b11a451275716d29e08caad07e89a1c84964782fb5e1ad788",
+              s: "0x64a0de235b270fbe81e8e40688f4a9f9ad9d283d690552c9331d7773ceafa513",
+            },
+          }),
+        );
+
+        const expectedStates: Array<SignTypedDataDAState> = [
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.OPEN_APP,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+              step: SignTypedDataDAStateStep.OPEN_APP,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.GET_APP_CONFIG,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.GET_ADDRESS,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.BUILD_CONTEXT,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.SignTypedData,
+              step: SignTypedDataDAStateStep.PROVIDE_CONTEXT,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.SignTypedData,
+              step: SignTypedDataDAStateStep.SIGN_TYPED_DATA,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.SignTypedData,
+              step: SignTypedDataDAStateStep.SIGN_TYPED_DATA_LEGACY,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: SignTypedDataDAStateStep.DETECT_BLIND_SIGNING,
+            },
+            status: DeviceActionStatus.Pending,
+          },
+          {
+            output: {
+              v: 0x1c,
+              r: "0x8a540510e13b0f2b11a451275716d29e08caad07e89a1c84964782fb5e1ad788",
+              s: "0x64a0de235b270fbe81e8e40688f4a9f9ad9d283d690552c9331d7773ceafa513",
+            },
+            status: DeviceActionStatus.Completed,
+          },
+        ];
+
+        testDeviceActionStates(deviceAction, expectedStates, apiMock, {
+          onError: reject,
+          onDone: resolve,
+        });
+      }));
+
+    it("Error thrown while signing should fallback to legacy signing", () =>
+      new Promise<void>((resolve, reject) => {
+        setupOpenAppDAMock();
+        setupAppConfig("1.15.0", false, false);
+        getAddressMock.mockResolvedValueOnce(
+          CommandResultFactory({
+            data: { address: FROM },
+          }),
+        );
+
+        const deviceAction = new SignTypedDataDeviceAction({
+          input: {
+            derivationPath: "44'/60'/0'/0/0",
+            data: TEST_MESSAGE,
+            contextModule: mockContextModule as unknown as ContextModule,
+            parser: mockParser,
+            transactionParser: mockTransactionParser,
+            transactionMapper: mockTransactionMapper,
+            skipOpenApp: false,
+          },
+        });
+
+        // Mock a signing error thrown instead of returned
+        vi.spyOn(deviceAction, "extractDependencies").mockReturnValue(
+          extractDependenciesMock(),
+        );
+        buildContextMock.mockResolvedValueOnce(TEST_BUILT_CONTEXT);
+        provideContextMock.mockResolvedValueOnce(
+          CommandResultFactory({ data: undefined }),
+        );
+        signTypedDataMock.mockRejectedValueOnce(new UnknownDAError("Error"));
         signTypedDataLegacyMock.mockResolvedValueOnce(
           CommandResultFactory({
             data: {

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction.ts
@@ -472,7 +472,10 @@ export class SignTypedDataDeviceAction extends XStateDeviceAction<
               target: "ProvideContextResultCheck",
             },
             onError: {
-              target: "Error",
+              // Thrown errors (e.g. transport failures while streaming a
+              // large payload) take the same fallback route as failed
+              // command results.
+              target: "ProvideContextResultCheck",
               actions: "assignErrorFromEvent",
             },
           },
@@ -517,7 +520,9 @@ export class SignTypedDataDeviceAction extends XStateDeviceAction<
               ],
             },
             onError: {
-              target: "DetectBlindSigning",
+              // Same fallback route as failed command results, so a thrown
+              // error can still be recovered by legacy signing.
+              target: "SignTypedDataResultCheck",
               actions: "assignErrorFromEvent",
             },
           },


### PR DESCRIPTION
## 📝 Description

Thrown (non-`CommandResult`) errors in the typed-data flow bypass the `SignTypedDataLegacy` fallback and terminate the device action:

- `ProvideContext.onError` targeted the terminal `Error` state directly, while a *failed command result* from the same task routes through `ProvideContextResultCheck` → `notRefusedByUser` → `SignTypedDataLegacy`.
- `SignTypedData.onError` targeted `DetectBlindSigning` (error reporting) with no fallback attempt, while a failed command result routes through `SignTypedDataResultCheck` → `notRefusedByUser` → `SignTypedDataLegacy`.

The asymmetry matters most for **large EIP-712 payloads** (e.g. Safe multisig confirmations embedding tens of KB of calldata): providing the context streams the struct in many APDU chunks plus clear-signing context fetches, and failures on that path frequently surface as thrown transport/timeout errors rather than failed command results. The result is that oversized typed data is unsignable in DMK-based wallets, with no recovery, even though `SignTypedDataLegacyTask` handles exactly this case (Rabby ≥ v0.93.98 users hit this in production; report with reproduction details in the companion PR RabbyHub/Rabby#3930).

This PR routes both `onError` transitions through the same result-check states used for failed command results, so:

- thrown errors that are not a user refusal now fall back to legacy hash signing,
- user refusals (`0x6985`) keep their current behaviour (no fallback, error surfaces),
- errors during the fallback itself keep their current behaviour.

## ❓ Context

- No JIRA/issue — external contribution (`no-issue`). Happy to file a GitHub issue with full reproduction data if preferred.

## ✅ Checklist

- [x] Changeset added (`@ledgerhq/device-signer-kit-ethereum`, patch)
- [x] Tests updated/added:
  - `Error thrown while providing context should fallback to legacy signing` (updated from the previous terminal-error expectation)
  - `Error thrown while providing context with a user refusal should not fallback` (new — pins the 0x6985 guard)
  - `Error thrown while signing should fallback to legacy signing` (new)
- [x] `vitest` green for the package, lint/prettier pass on changed files

## 🧐 Checklist for the PR Reviewers

- The fallback semantics are unchanged for failed command results; this only makes thrown errors take the same route.
- `assignErrorFromEvent` stores the thrown error in `_internalState.error`, which is exactly what the `notRefusedByUser` guard inspects, so refusal detection behaves identically for both error shapes.
