### PR TITLE
✨ (signer-trx) [DSDK-1342]: Implement Sign Transaction Hash device ac…

### DIFF
--- a/.changeset/tron-sign-transaction-hash.md
+++ b/.changeset/tron-sign-transaction-hash.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-tron": minor
+---
+
+Implement the Sign Transaction Hash device action

--- a/apps/sample/playwright/cases/signers/tron/sign-transaction-hash.spec.ts
+++ b/apps/sample/playwright/cases/signers/tron/sign-transaction-hash.spec.ts
@@ -1,0 +1,59 @@
+/* eslint-disable no-restricted-imports */
+import { type DeviceConfig } from "@ledgerhq/device-mockserver-client";
+
+import { expect, test } from "../../../fixtures";
+
+const STAX_WITH_TRX: DeviceConfig = {
+  name: "Ledger Stax",
+  device_type: "stax",
+  connectivity_type: "USB",
+  firmware_version: "1.9.1",
+  apps: [
+    { name: "BOLOS", version: "1.9.1" },
+    { name: "Tron", version: "0.7.4" },
+  ],
+  masks: [0x33200000],
+};
+
+// The hw-app-trx signTransactionHash doc vector (32-byte hash, hex-encoded).
+const TX_HASH =
+  "25b18a55f86afb10e7aca38d0073d04c80397c6636069193953fdefaea0b8369";
+
+test.describe("signer tron: sign transaction hash", () => {
+  // Hash signing is gated by the Tron app's "sign by hash" setting, which is
+  // disabled by default and cannot be toggled from the e2e driver. This case
+  // documents the gating behavior: the app refuses the command outright.
+  test("fails when the 'sign by hash' setting is disabled on the device", async ({
+    device,
+    trxSigner,
+    speculos,
+    deviceActions,
+  }) => {
+    // Opening the Tron app provisions a real Speculos instance, so this flow
+    // is slow even though the command itself is refused without interaction.
+    test.setTimeout(120_000);
+
+    let dev!: Awaited<ReturnType<typeof device.addAndConnect>>;
+    await test.step("Given the device with the Tron app is connected", async () => {
+      dev = await device.addAndConnect(STAX_WITH_TRX);
+    });
+
+    await test.step("When Sign transaction hash is executed", async () => {
+      await trxSigner.open();
+      await trxSigner.signTransactionHash(TX_HASH);
+      await speculos(dev).waitReady();
+    });
+
+    await test.step("Then the device action ends in error", async () => {
+      // The app refuses hash signing when "sign by hash" is disabled, so the
+      // device action fails with a TronAppCommandError (6a8c). Device-action
+      // errors are rendered via util.inspect (not the JSON status envelope), so
+      // assert on the rendered error text rather than a "status" field.
+      const error = await deviceActions.expectError("TronAppCommandError", {
+        timeout: 90_000,
+      });
+
+      expect(error).toContain("6a8c");
+    });
+  });
+});

--- a/apps/sample/playwright/utils/drivers/TrxSignerDriver.ts
+++ b/apps/sample/playwright/utils/drivers/TrxSignerDriver.ts
@@ -69,6 +69,25 @@ export class TrxSignerDriver {
   }
 
   /**
+   * Open the Sign transaction hash action, fill the hash (hex-encoded 32-byte
+   * hash of the protobuf-serialized `raw_data`) and Execute it. Only accepted
+   * by the Tron app when its "sign by hash" setting is enabled.
+   */
+  async signTransactionHash(
+    transactionHash: string,
+    { skipOpenApp = false }: { skipOpenApp?: boolean } = {},
+  ): Promise<void> {
+    await this.page.getByTestId("CTA_command-Sign transaction hash").click();
+    const input = this.page.getByTestId("input-text_transactionHash");
+    await input.waitFor({ state: "visible" });
+    await input.fill(transactionHash);
+    if (skipOpenApp) {
+      await this.page.getByTestId("input-switch_skipOpenApp").click();
+    }
+    await this.page.getByTestId("CTA_send-device-action").click();
+  }
+
+  /**
    * Open the Sign personal message action, fill the message (plain text) and
    * Execute it. The action stays pending until the message is reviewed and
    * signed on Speculos.

--- a/apps/sample/src/components/SignerTrxView/index.tsx
+++ b/apps/sample/src/components/SignerTrxView/index.tsx
@@ -15,6 +15,9 @@ import {
   type SignTransactionDAError,
   type SignTransactionDAIntermediateValue,
   type SignTransactionDAOutput,
+  type SignTransactionHashDAError,
+  type SignTransactionHashDAIntermediateValue,
+  type SignTransactionHashDAOutput,
 } from "@ledgerhq/device-signer-kit-tron";
 
 import { DeviceActionsList } from "@/components/DeviceActionsView/DeviceActionsList";
@@ -92,6 +95,39 @@ export const SignerTrxView: React.FC<{ sessionId: string }> = ({
         },
         SignTransactionDAError,
         SignTransactionDAIntermediateValue
+      >,
+      {
+        title: "Sign transaction hash",
+        description:
+          "Perform all the actions necessary to sign a transaction hash (hex-encoded 32-byte hash of the protobuf-serialized raw_data) with the device. Requires the 'sign by hash' setting to be enabled in the Tron app.",
+        executeDeviceAction: ({
+          derivationPath,
+          transactionHash,
+          skipOpenApp,
+        }) => {
+          const hash = hexaStringToBuffer(transactionHash);
+          if (!hash || hash.length === 0) {
+            throw new Error("Invalid transaction hash format");
+          }
+          return signer.signTransactionHash(derivationPath, hash, {
+            skipOpenApp,
+          });
+        },
+        initialValues: {
+          derivationPath: DEFAULT_DERIVATION_PATH,
+          transactionHash: "",
+          skipOpenApp: false,
+        },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        SignTransactionHashDAOutput,
+        {
+          derivationPath: string;
+          transactionHash: string;
+          skipOpenApp?: boolean;
+        },
+        SignTransactionHashDAError,
+        SignTransactionHashDAIntermediateValue
       >,
       {
         title: "Sign personal message",

--- a/packages/signer/signer-trx/README.md
+++ b/packages/signer/signer-trx/README.md
@@ -26,6 +26,12 @@ const { observable: signObservable } = signer.signTransaction(
   rawTransaction,
 );
 
+// Sign a transaction hash (requires the "Sign by hash" app setting)
+const { observable: hashObservable } = signer.signTransactionHash(
+  "44'/195'/0'/0/0",
+  transactionHash,
+);
+
 // Sign a personal message
 const { observable: messageObservable } = signer.signPersonalMessage(
   "44'/195'/0'/0/0",
@@ -143,6 +149,47 @@ The returned device action resolves to the 65-byte signature
 const { observable, cancel } = signer.signTransaction(
   "44'/195'/0'/0/0",
   rawTransaction,
+);
+
+observable.subscribe((state) => {
+  switch (state.status) {
+    case "completed":
+      console.log(state.output); // Uint8Array(65) signature
+      break;
+    case "error":
+      console.error(state.error);
+      break;
+  }
+});
+```
+
+### Sign transaction hash
+
+Signs a transaction hash directly, without transmitting (or reviewing) the
+transaction itself — the device only displays the hash. Use with care: the
+signer cannot verify what is being signed. Only accepted by the Tron app when
+its **"Sign by hash"** setting is enabled on the device (see the `signByHash`
+flag returned by `getAppConfiguration()`); otherwise the device action fails.
+
+```typescript
+signer.signTransactionHash(
+  derivationPath: string,
+  // the 32-byte hash of the protobuf-serialized `raw_data` of the transaction
+  transactionHash: Uint8Array,
+  options?: {
+    // Skip the "open app" step if the Tron app is already open (default: false).
+    skipOpenApp?: boolean;
+  },
+): SignTransactionHashDAReturnType;
+```
+
+The returned device action resolves to the 65-byte signature
+(`r[32] + s[32] + v[1]`) as a `Uint8Array`.
+
+```typescript
+const { observable, cancel } = signer.signTransactionHash(
+  "44'/195'/0'/0/0",
+  transactionHash,
 );
 
 observable.subscribe((state) => {

--- a/packages/signer/signer-trx/src/api/SignerTrx.ts
+++ b/packages/signer/signer-trx/src/api/SignerTrx.ts
@@ -2,6 +2,7 @@ import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceAct
 import { type GetAppConfigurationDAReturnType } from "@api/app-binder/GetAppConfigurationDeviceActionTypes";
 import { type SignPersonalMessageDAReturnType } from "@api/app-binder/SignPersonalMessageDeviceActionTypes";
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
+import { type SignTransactionHashDAReturnType } from "@api/app-binder/SignTransactionHashDeviceActionTypes";
 import { type AddressOptions } from "@api/model/AddressOptions";
 import { type MessageOptions } from "@api/model/MessageOptions";
 import { type TransactionOptions } from "@api/model/TransactionOptions";
@@ -17,6 +18,12 @@ export interface SignerTrx {
     transaction: Uint8Array,
     options?: TransactionOptions,
   ) => SignTransactionDAReturnType;
+
+  signTransactionHash: (
+    derivationPath: string,
+    transactionHash: Uint8Array,
+    options?: TransactionOptions,
+  ) => SignTransactionHashDAReturnType;
 
   signPersonalMessage: (
     derivationPath: string,

--- a/packages/signer/signer-trx/src/api/app-binder/SignTransactionHashDeviceActionTypes.ts
+++ b/packages/signer/signer-trx/src/api/app-binder/SignTransactionHashDeviceActionTypes.ts
@@ -1,0 +1,29 @@
+import {
+  type CommandErrorResult,
+  type ExecuteDeviceActionReturnType,
+  type OpenAppDAError,
+  type SendCommandInAppDAIntermediateValue,
+  type SendCommandInAppDAOutput,
+  type UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import { type Signature } from "@api/model/Signature";
+import { type TronAppErrorCodes } from "@internal/app-binder/command/utils/tronApplicationErrors";
+
+type SignTransactionHashDAUserInteractionRequired =
+  UserInteractionRequired.SignTransaction;
+
+export type SignTransactionHashDAOutput = SendCommandInAppDAOutput<Signature>;
+
+export type SignTransactionHashDAError =
+  | OpenAppDAError
+  | CommandErrorResult<TronAppErrorCodes>["error"];
+
+export type SignTransactionHashDAIntermediateValue =
+  SendCommandInAppDAIntermediateValue<SignTransactionHashDAUserInteractionRequired>;
+
+export type SignTransactionHashDAReturnType = ExecuteDeviceActionReturnType<
+  SignTransactionHashDAOutput,
+  SignTransactionHashDAError,
+  SignTransactionHashDAIntermediateValue
+>;

--- a/packages/signer/signer-trx/src/api/index.ts
+++ b/packages/signer/signer-trx/src/api/index.ts
@@ -22,6 +22,12 @@ export {
   type SignTransactionDAOutput,
   type SignTransactionDAReturnType,
 } from "@api/app-binder/SignTransactionDeviceActionTypes";
+export {
+  type SignTransactionHashDAError,
+  type SignTransactionHashDAIntermediateValue,
+  type SignTransactionHashDAOutput,
+  type SignTransactionHashDAReturnType,
+} from "@api/app-binder/SignTransactionHashDeviceActionTypes";
 export { type AddressOptions } from "@api/model/AddressOptions";
 export { type AppConfiguration } from "@api/model/AppConfiguration";
 export { type MessageOptions } from "@api/model/MessageOptions";

--- a/packages/signer/signer-trx/src/internal/DefaultSignerTrx.ts
+++ b/packages/signer/signer-trx/src/internal/DefaultSignerTrx.ts
@@ -8,6 +8,7 @@ import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceAct
 import { type GetAppConfigurationDAReturnType } from "@api/app-binder/GetAppConfigurationDeviceActionTypes";
 import { type SignPersonalMessageDAReturnType } from "@api/app-binder/SignPersonalMessageDeviceActionTypes";
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
+import { type SignTransactionHashDAReturnType } from "@api/app-binder/SignTransactionHashDeviceActionTypes";
 import { type AddressOptions } from "@api/model/AddressOptions";
 import { type MessageOptions } from "@api/model/MessageOptions";
 import { type TransactionOptions } from "@api/model/TransactionOptions";
@@ -20,6 +21,7 @@ import { type GetAppConfigurationUseCase } from "@internal/use-cases/app-configu
 import { messageTypes } from "@internal/use-cases/message/di/messageTypes";
 import { type SignPersonalMessageUseCase } from "@internal/use-cases/message/SignPersonalMessageUseCase";
 import { transactionTypes } from "@internal/use-cases/transaction/di/transactionTypes";
+import { type SignTransactionHashUseCase } from "@internal/use-cases/transaction/SignTransactionHashUseCase";
 import { type SignTransactionUseCase } from "@internal/use-cases/transaction/SignTransactionUseCase";
 
 type DefaultSignerTrxConstructorArgs = {
@@ -51,6 +53,18 @@ export class DefaultSignerTrx implements SignerTrx {
     return this._container
       .get<SignTransactionUseCase>(transactionTypes.SignTransactionUseCase)
       .execute(derivationPath, transaction, options);
+  }
+
+  signTransactionHash(
+    derivationPath: string,
+    transactionHash: Uint8Array,
+    options?: TransactionOptions,
+  ): SignTransactionHashDAReturnType {
+    return this._container
+      .get<SignTransactionHashUseCase>(
+        transactionTypes.SignTransactionHashUseCase,
+      )
+      .execute(derivationPath, transactionHash, options);
   }
 
   signPersonalMessage(

--- a/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.test.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.test.ts
@@ -30,8 +30,14 @@ import {
   type SignTransactionDAIntermediateValue,
   type SignTransactionDAOutput,
 } from "@api/app-binder/SignTransactionDeviceActionTypes";
+import {
+  type SignTransactionHashDAError,
+  type SignTransactionHashDAIntermediateValue,
+  type SignTransactionHashDAOutput,
+} from "@api/app-binder/SignTransactionHashDeviceActionTypes";
 import { GetAddressCommand } from "@internal/app-binder/command/GetAddressCommand";
 import { GetAppConfigurationCommand } from "@internal/app-binder/command/GetAppConfigurationCommand";
+import { SignTransactionHashCommand } from "@internal/app-binder/command/SignTransactionHashCommand";
 import { type TronAppCommandError } from "@internal/app-binder/command/utils/tronApplicationErrors";
 import { APP_NAME } from "@internal/app-binder/constants";
 
@@ -293,6 +299,130 @@ describe("TronAppBinder", () => {
 
         // THEN
         expect(executedDeviceAction().input.skipOpenApp).toBe(false);
+      });
+    });
+  });
+
+  describe("signTransactionHash", () => {
+    const derivationPath = "44'/195'/0'/0/0";
+    const transactionHash = new Uint8Array(32).fill(0x25);
+
+    it("should return the signature", () =>
+      new Promise<void>((resolve, reject) => {
+        // GIVEN
+        const output: SignTransactionHashDAOutput = new Uint8Array(65).fill(
+          0xab,
+        );
+
+        vi.spyOn(mockedDmk, "executeDeviceAction").mockReturnValue({
+          observable: from([
+            {
+              status: DeviceActionStatus.Completed,
+              output,
+            } as DeviceActionState<
+              SignTransactionHashDAOutput,
+              SignTransactionHashDAError,
+              SignTransactionHashDAIntermediateValue
+            >,
+          ]),
+          cancel: vi.fn(),
+        });
+
+        // WHEN
+        const binder = new TronAppBinder(
+          mockedDmk,
+          "sessionId",
+          loggerFactoryMock,
+        );
+        const { observable } = binder.signTransactionHash({
+          derivationPath,
+          transactionHash,
+        });
+
+        // THEN
+        const states: DeviceActionState<
+          SignTransactionHashDAOutput,
+          SignTransactionHashDAError,
+          SignTransactionHashDAIntermediateValue
+        >[] = [];
+        observable.subscribe({
+          next: (state) => states.push(state),
+          error: reject,
+          complete: () => {
+            try {
+              expect(states).toEqual([
+                { status: DeviceActionStatus.Completed, output },
+              ]);
+              resolve();
+            } catch (err) {
+              reject(err as Error);
+            }
+          },
+        });
+      }));
+
+    describe("calls executeDeviceAction with the correct params", () => {
+      it("requires the SignTransaction interaction", () => {
+        // WHEN
+        const binder = new TronAppBinder(
+          mockedDmk,
+          "sessionId",
+          loggerFactoryMock,
+        );
+        binder.signTransactionHash({
+          derivationPath,
+          transactionHash,
+          skipOpenApp: true,
+        });
+
+        // THEN
+        expect(mockedDmk.executeDeviceAction).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sessionId: "sessionId",
+            deviceAction: new SendCommandInAppDeviceAction({
+              input: {
+                command: new SignTransactionHashCommand({
+                  derivationPath,
+                  transactionHash,
+                }),
+                appName: APP_NAME,
+                requiredUserInteraction:
+                  UserInteractionRequired.SignTransaction,
+                skipOpenApp: true,
+              },
+              logger: loggerMock,
+            }),
+          }),
+        );
+      });
+
+      it("defaults skipOpenApp to false", () => {
+        // WHEN
+        const binder = new TronAppBinder(
+          mockedDmk,
+          "sessionId",
+          loggerFactoryMock,
+        );
+        binder.signTransactionHash({ derivationPath, transactionHash });
+
+        // THEN
+        expect(mockedDmk.executeDeviceAction).toHaveBeenCalledWith(
+          expect.objectContaining({
+            deviceAction: new SendCommandInAppDeviceAction({
+              input: {
+                command: new SignTransactionHashCommand({
+                  derivationPath,
+                  transactionHash,
+                }),
+                appName: APP_NAME,
+                requiredUserInteraction:
+                  UserInteractionRequired.SignTransaction,
+                skipOpenApp: false,
+              },
+              logger: loggerMock,
+            }),
+          }),
+        );
       });
     });
   });

--- a/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.ts
@@ -12,8 +12,10 @@ import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceAct
 import { type GetAppConfigurationDAReturnType } from "@api/app-binder/GetAppConfigurationDeviceActionTypes";
 import { type SignPersonalMessageDAReturnType } from "@api/app-binder/SignPersonalMessageDeviceActionTypes";
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
+import { type SignTransactionHashDAReturnType } from "@api/app-binder/SignTransactionHashDeviceActionTypes";
 import { GetAddressCommand } from "@internal/app-binder/command/GetAddressCommand";
 import { GetAppConfigurationCommand } from "@internal/app-binder/command/GetAppConfigurationCommand";
+import { SignTransactionHashCommand } from "@internal/app-binder/command/SignTransactionHashCommand";
 import { APP_NAME } from "@internal/app-binder/constants";
 import { SignPersonalMessageTask } from "@internal/app-binder/task/SignPersonalMessageTask";
 import { SignTransactionTask } from "@internal/app-binder/task/SignTransactionTask";
@@ -71,6 +73,28 @@ export class TronAppBinder {
           skipOpenApp: args.skipOpenApp ?? false,
         },
         logger: this.dmkLoggerFactory("SignTransactionTask"),
+      }),
+    });
+  }
+
+  signTransactionHash(args: {
+    derivationPath: string;
+    transactionHash: Uint8Array;
+    skipOpenApp?: boolean;
+  }): SignTransactionHashDAReturnType {
+    return this.dmk.executeDeviceAction({
+      sessionId: this.sessionId,
+      deviceAction: new SendCommandInAppDeviceAction({
+        input: {
+          command: new SignTransactionHashCommand({
+            derivationPath: args.derivationPath,
+            transactionHash: args.transactionHash,
+          }),
+          appName: APP_NAME,
+          requiredUserInteraction: UserInteractionRequired.SignTransaction,
+          skipOpenApp: args.skipOpenApp ?? false,
+        },
+        logger: this.dmkLoggerFactory("SignTransactionHashCommand"),
       }),
     });
   }

--- a/packages/signer/signer-trx/src/internal/app-binder/command/SignTransactionHashCommand.test.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/command/SignTransactionHashCommand.test.ts
@@ -1,0 +1,87 @@
+import {
+  ApduResponse,
+  bufferToHexaString,
+  hexaStringToBuffer,
+  type InvalidResponseFormatError,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { type TronAppCommandError } from "./utils/tronApplicationErrors";
+import { SignTransactionHashCommand } from "./SignTransactionHashCommand";
+
+const PATH = "44'/195'/0'/0/0";
+// Encoded "44'/195'/0'/0/0": length byte (05) + 5 BE32 path elements.
+const PATH_HEX = "058000002c800000c3800000000000000000000000";
+// The hw-app-trx signTransactionHash doc vector.
+const HASH_HEX =
+  "25b18a55f86afb10e7aca38d0073d04c80397c6636069193953fdefaea0b8369";
+
+const SIGNATURE = hexaStringToBuffer("ab".repeat(65))!;
+
+describe("SignTransactionHashCommand", () => {
+  const command = new SignTransactionHashCommand({
+    derivationPath: PATH,
+    transactionHash: hexaStringToBuffer(HASH_HEX)!,
+  });
+
+  describe("name", () => {
+    it("should be 'signTransactionHash'", () => {
+      expect(command.name).toBe("signTransactionHash");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("should build the APDU with CLA=0xe0, INS=0x05, P1=0, P2=0 and the path + hash as data", () => {
+      // 0x35 = 53 bytes of data: 21-byte encoded path + 32-byte hash.
+      expect(bufferToHexaString(command.getApdu().getRawApdu(), false)).toBe(
+        "e005000035" + PATH_HEX + HASH_HEX,
+      );
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("should return the 65-byte signature", () => {
+      const response = new ApduResponse({
+        statusCode: Uint8Array.of(0x90, 0x00),
+        data: SIGNATURE,
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(true);
+      expect(isSuccessCommandResult(result) && result.data).toEqual(SIGNATURE);
+    });
+
+    it("should return an error when the signature is missing", () => {
+      const response = new ApduResponse({
+        statusCode: Uint8Array.of(0x90, 0x00),
+        data: hexaStringToBuffer("ab".repeat(64))!,
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidResponseFormatError;
+        expect((err.originalError as { message: string }).message).toBe(
+          "Signature is missing",
+        );
+      }
+    });
+
+    it("should return a TronAppCommandError on a device error status", () => {
+      const response = new ApduResponse({
+        statusCode: Uint8Array.of(0x69, 0x85),
+        data: new Uint8Array(),
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      expect(
+        !isSuccessCommandResult(result) &&
+          (result.error as TronAppCommandError).errorCode,
+      ).toBe("6985");
+    });
+  });
+});

--- a/packages/signer/signer-trx/src/internal/app-binder/command/SignTransactionHashCommand.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/command/SignTransactionHashCommand.ts
@@ -1,0 +1,97 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  InvalidResponseFormatError,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import { type Signature } from "@api/model/Signature";
+import {
+  INS,
+  LEDGER_CLA,
+  P2_NONE,
+  SIGNATURE_LENGTH,
+} from "@internal/app-binder/constants";
+
+import { encodeDerivationPath } from "./utils/encodeDerivationPath";
+import {
+  TRON_APP_ERRORS,
+  TronAppCommandErrorFactory,
+  type TronAppErrorCodes,
+} from "./utils/tronApplicationErrors";
+
+export type SignTransactionHashCommandArgs = {
+  readonly derivationPath: string;
+  // The 32-byte hash of the protobuf-serialized `raw_data` of the transaction.
+  readonly transactionHash: Uint8Array;
+};
+
+export type SignTransactionHashCommandResponse = Signature;
+
+/**
+ * Signs a transaction hash directly (SIGN_TRANSACTION_HASH instruction), in a
+ * single APDU. Only accepted by the Tron app when its "sign by hash" setting
+ * is enabled (see `signByHash` in the app configuration).
+ */
+export class SignTransactionHashCommand
+  implements
+    Command<
+      SignTransactionHashCommandResponse,
+      SignTransactionHashCommandArgs,
+      TronAppErrorCodes
+    >
+{
+  readonly name = "signTransactionHash";
+
+  private readonly _args: SignTransactionHashCommandArgs;
+
+  private readonly errorHelper = new CommandErrorHelper<
+    SignTransactionHashCommandResponse,
+    TronAppErrorCodes
+  >(TRON_APP_ERRORS, TronAppCommandErrorFactory);
+
+  constructor(args: SignTransactionHashCommandArgs) {
+    this._args = args;
+  }
+
+  get args(): SignTransactionHashCommandArgs {
+    return this._args;
+  }
+
+  getApdu(): Apdu {
+    return new ApduBuilder({
+      cla: LEDGER_CLA,
+      ins: INS.SIGN_TRANSACTION_HASH,
+      p1: 0x00,
+      p2: P2_NONE,
+    })
+      .addBufferToData(encodeDerivationPath(this._args.derivationPath))
+      .addBufferToData(this._args.transactionHash)
+      .build();
+  }
+
+  parseResponse(
+    apduResponse: ApduResponse,
+  ): CommandResult<SignTransactionHashCommandResponse, TronAppErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      const parser = new ApduParser(apduResponse);
+
+      const signature = parser.extractFieldByLength(SIGNATURE_LENGTH);
+      if (signature === undefined) {
+        return CommandResultFactory({
+          error: new InvalidResponseFormatError("Signature is missing"),
+        });
+      }
+
+      return CommandResultFactory({ data: signature });
+    });
+  }
+}

--- a/packages/signer/signer-trx/src/internal/use-cases/transaction/SignTransactionHashUseCase.test.ts
+++ b/packages/signer/signer-trx/src/internal/use-cases/transaction/SignTransactionHashUseCase.test.ts
@@ -1,0 +1,47 @@
+import { type TronAppBinder } from "@internal/app-binder/TronAppBinder";
+
+import { SignTransactionHashUseCase } from "./SignTransactionHashUseCase";
+
+describe("SignTransactionHashUseCase", () => {
+  const derivationPath = "44'/195'/0'/0/0";
+  const transactionHash = new Uint8Array(32).fill(0x25);
+  const returnedValue = { observable: "observable", cancel: () => {} };
+  const signTransactionHashMock = vi.fn().mockReturnValue(returnedValue);
+  const appBinderMock = {
+    signTransactionHash: signTransactionHashMock,
+  } as unknown as TronAppBinder;
+  let useCase: SignTransactionHashUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new SignTransactionHashUseCase(appBinderMock);
+  });
+
+  it("should forward the transaction hash and options to the app binder", () => {
+    // WHEN
+    const result = useCase.execute(derivationPath, transactionHash, {
+      skipOpenApp: true,
+    });
+
+    // THEN
+    expect(result).toEqual(returnedValue);
+    expect(signTransactionHashMock).toHaveBeenCalledWith({
+      derivationPath,
+      transactionHash,
+      skipOpenApp: true,
+    });
+  });
+
+  it("should work without options", () => {
+    // WHEN
+    const result = useCase.execute(derivationPath, transactionHash);
+
+    // THEN
+    expect(result).toEqual(returnedValue);
+    expect(signTransactionHashMock).toHaveBeenCalledWith({
+      derivationPath,
+      transactionHash,
+      skipOpenApp: undefined,
+    });
+  });
+});

--- a/packages/signer/signer-trx/src/internal/use-cases/transaction/SignTransactionHashUseCase.ts
+++ b/packages/signer/signer-trx/src/internal/use-cases/transaction/SignTransactionHashUseCase.ts
@@ -1,0 +1,27 @@
+import { inject, injectable } from "inversify";
+
+import { type SignTransactionHashDAReturnType } from "@api/app-binder/SignTransactionHashDeviceActionTypes";
+import { type TransactionOptions } from "@api/model/TransactionOptions";
+import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
+import { TronAppBinder } from "@internal/app-binder/TronAppBinder";
+
+@injectable()
+export class SignTransactionHashUseCase {
+  private readonly _appBinder: TronAppBinder;
+
+  constructor(@inject(appBinderTypes.AppBinding) appBinder: TronAppBinder) {
+    this._appBinder = appBinder;
+  }
+
+  execute(
+    derivationPath: string,
+    transactionHash: Uint8Array,
+    options?: TransactionOptions,
+  ): SignTransactionHashDAReturnType {
+    return this._appBinder.signTransactionHash({
+      derivationPath,
+      transactionHash,
+      skipOpenApp: options?.skipOpenApp,
+    });
+  }
+}

--- a/packages/signer/signer-trx/src/internal/use-cases/transaction/di/transactionModule.ts
+++ b/packages/signer/signer-trx/src/internal/use-cases/transaction/di/transactionModule.ts
@@ -1,9 +1,13 @@
 import { ContainerModule } from "inversify";
 
 import { transactionTypes } from "@internal/use-cases/transaction/di/transactionTypes";
+import { SignTransactionHashUseCase } from "@internal/use-cases/transaction/SignTransactionHashUseCase";
 import { SignTransactionUseCase } from "@internal/use-cases/transaction/SignTransactionUseCase";
 
 export const transactionModuleFactory = () =>
   new ContainerModule(({ bind }) => {
     bind(transactionTypes.SignTransactionUseCase).to(SignTransactionUseCase);
+    bind(transactionTypes.SignTransactionHashUseCase).to(
+      SignTransactionHashUseCase,
+    );
   });

--- a/packages/signer/signer-trx/src/internal/use-cases/transaction/di/transactionTypes.ts
+++ b/packages/signer/signer-trx/src/internal/use-cases/transaction/di/transactionTypes.ts
@@ -1,3 +1,4 @@
 export const transactionTypes = {
   SignTransactionUseCase: Symbol.for("SignTransactionUseCase"),
+  SignTransactionHashUseCase: Symbol.for("SignTransactionHashUseCase"),
 } as const;


### PR DESCRIPTION
### 📝 Description

Implements the **Sign Transaction Hash** device action for the Tron signer
(`@ledgerhq/device-signer-kit-tron`), adding `signTransactionHash(derivationPath, transactionHash, options?)`.

Unlike Sign Transaction (which transmits and reviews the full `raw_data`), this signs a pre-computed
32-byte transaction hash directly - the device only displays the hash, not the transaction contents.
It's a single-APDU exchange (`SIGN_TRANSACTION_HASH`, INS `0x05`, P1/P2 `0x00`): the encoded
derivation path and the hash are sent, and the 65-byte signature (`r[32] + s[32] + v[1]`) comes back.
Implemented with the generic `SendCommandInAppDeviceAction` (like Get Address), requiring the
`SignTransaction` user interaction.

⚠️ **Sign-at-your-own-risk:** because the transaction itself is never transmitted, the signer cannot
verify what is being signed. The Tron app only accepts this instruction when its **"Sign by hash"**
setting is enabled on the device (surfaced by `getAppConfiguration().signByHash`); otherwise the
device action fails.

Usage:

```typescript
const { observable } = signer.signTransactionHash("44'/195'/0'/0/0", transactionHash);

observable.subscribe((state) => {
  if (state.status === "completed") {
    console.log(state.output); // Uint8Array(65) signature
  }
});
```

❓ Context

- JIRA or GitHub link: DSDK-1342
- Feature: Sign Transaction Hash device action for the Tron signer kit - direct hash signing,
gated by the app's "Sign by hash" setting.

✅ Checklist

- [x] Covered by automatic tests
- [x] Changeset is provided
- [x] Documentation is up-to-date 
- [ ] Impact of the changes:
  - New public method signTransactionHash on SignerTrx - purely additive, no changes to existing actions.
  - Adds a "Sign transaction hash" panel to the sample app's Tron signer view.
  - Adds a Playwright e2e (sign-transaction-hash.spec.ts) driven against Speculos/mock server.
  - QA focus: verify the action fails when "Sign by hash" is off, and (with the setting enabled) that a 32-byte hash is signed on-device and returns a valid 65-byte signature. Emphasise the security caveat - the transaction contents are not shown, only the hash.
