### PR TITLE
✨ (signer-trx) [DSDK-1343]: Implement Get ECDH Secret device action

### DIFF
--- a/.changeset/tron-get-ecdh-secret.md
+++ b/.changeset/tron-get-ecdh-secret.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-tron": minor
+---
+
+Implement the Get ECDH Secret device action

--- a/apps/sample/playwright/cases/signers/tron/get-ecdh-secret.spec.ts
+++ b/apps/sample/playwright/cases/signers/tron/get-ecdh-secret.spec.ts
@@ -1,0 +1,64 @@
+/* eslint-disable no-restricted-imports */
+import { type DeviceConfig } from "@ledgerhq/device-mockserver-client";
+
+import { expect, test } from "../../../fixtures";
+
+const STAX_WITH_TRX: DeviceConfig = {
+  name: "Ledger Stax",
+  device_type: "stax",
+  connectivity_type: "USB",
+  firmware_version: "1.9.1",
+  apps: [
+    { name: "BOLOS", version: "1.9.1" },
+    { name: "Tron", version: "0.7.4" },
+  ],
+  masks: [0x33200000],
+};
+
+// The hw-app-trx getECDHPairKey doc vector: a peer's uncompressed secp256k1
+// public key (65 bytes, hex-encoded).
+const PEER_PUBLIC_KEY =
+  "04ff21f8e64d3a3c0198edfbb7afdc79be959432e92e2f8a1984bb436a414b8edcec0345aad0c1bf7da04fd036dd7f9f617e30669224283d950fab9dd84831dc83";
+
+// The ECDH shared point (0x04 || X || Y) is a 65-byte buffer, rendered by the
+// sample app as a 0x-prefixed hex string.
+const SECRET_RE = /^0x[0-9a-f]{130}$/i;
+
+test.describe("signer tron: get ecdh secret", () => {
+  test("computes a shared secret approved on the device screen", async ({
+    device,
+    trxSigner,
+    speculos,
+  }) => {
+    // Opening the Tron app provisions a real Speculos instance and the ECDH
+    // operation must be reviewed/approved on screen, so this flow is slow.
+    test.setTimeout(120_000);
+
+    let dev!: Awaited<ReturnType<typeof device.addAndConnect>>;
+    await test.step("Given the device with the Tron app is connected", async () => {
+      dev = await device.addAndConnect(STAX_WITH_TRX);
+    });
+
+    await test.step("When Get ECDH secret is executed", async () => {
+      await trxSigner.open();
+      await trxSigner.getECDHSecret(PEER_PUBLIC_KEY);
+    });
+
+    await test.step("And the operation is approved on the Speculos screen", async () => {
+      // The Tron app shows the ECDH review as a "Sign transaction to share
+      // ECDH secret" hold-to-sign flow, which approveSigning() drives to the
+      // last page and holds. If the app's review markers ever diverge from the
+      // shared transaction-review markers, this step is where it would surface.
+      const emulator = speculos(dev);
+      await emulator.waitReady();
+      await emulator.approveSigning();
+    });
+
+    await test.step("Then a valid shared secret is returned", async () => {
+      const result = await trxSigner.lastResult<string>();
+
+      expect(result.status).toBe("completed");
+      expect(result.output).toMatch(SECRET_RE);
+    });
+  });
+});

--- a/apps/sample/playwright/utils/drivers/TrxSignerDriver.ts
+++ b/apps/sample/playwright/utils/drivers/TrxSignerDriver.ts
@@ -69,6 +69,25 @@ export class TrxSignerDriver {
   }
 
   /**
+   * Open the Get ECDH secret action, fill the peer public key (hex-encoded
+   * 65-byte uncompressed secp256k1 key) and Execute it. The action stays
+   * pending until the operation is approved on Speculos.
+   */
+  async getECDHSecret(
+    publicKey: string,
+    { skipOpenApp = false }: { skipOpenApp?: boolean } = {},
+  ): Promise<void> {
+    await this.page.getByTestId("CTA_command-Get ECDH secret").click();
+    const input = this.page.getByTestId("input-text_publicKey");
+    await input.waitFor({ state: "visible" });
+    await input.fill(publicKey);
+    if (skipOpenApp) {
+      await this.page.getByTestId("input-switch_skipOpenApp").click();
+    }
+    await this.page.getByTestId("CTA_send-device-action").click();
+  }
+
+  /**
    * Open the Sign transaction hash action, fill the hash (hex-encoded 32-byte
    * hash of the protobuf-serialized `raw_data`) and Execute it. Only accepted
    * by the Tron app when its "sign by hash" setting is enabled.

--- a/apps/sample/src/components/SignerTrxView/index.tsx
+++ b/apps/sample/src/components/SignerTrxView/index.tsx
@@ -8,6 +8,9 @@ import {
   type GetAppConfigurationDAError,
   type GetAppConfigurationDAIntermediateValue,
   type GetAppConfigurationDAOutput,
+  type GetECDHSecretDAError,
+  type GetECDHSecretDAIntermediateValue,
+  type GetECDHSecretDAOutput,
   SignerTrxBuilder,
   type SignPersonalMessageDAError,
   type SignPersonalMessageDAIntermediateValue,
@@ -168,6 +171,34 @@ export const SignerTrxView: React.FC<{ sessionId: string }> = ({
         Record<string, never>,
         GetAppConfigurationDAError,
         GetAppConfigurationDAIntermediateValue
+      >,
+      {
+        title: "Get ECDH secret",
+        description:
+          "Perform all the actions necessary to compute an ECDH shared secret between the device key and a peer's public key (hex-encoded 65-byte uncompressed secp256k1 key). Requires approval on the device.",
+        executeDeviceAction: ({ derivationPath, publicKey, skipOpenApp }) => {
+          const key = hexaStringToBuffer(publicKey);
+          if (!key || key.length === 0) {
+            throw new Error("Invalid public key format");
+          }
+          return signer.getECDHSecret(derivationPath, key, { skipOpenApp });
+        },
+        initialValues: {
+          derivationPath: DEFAULT_DERIVATION_PATH,
+          publicKey:
+            "04ff21f8e64d3a3c0198edfbb7afdc79be959432e92e2f8a1984bb436a414b8edcec0345aad0c1bf7da04fd036dd7f9f617e30669224283d950fab9dd84831dc83",
+          skipOpenApp: false,
+        },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        GetECDHSecretDAOutput,
+        {
+          derivationPath: string;
+          publicKey: string;
+          skipOpenApp?: boolean;
+        },
+        GetECDHSecretDAError,
+        GetECDHSecretDAIntermediateValue
       >,
     ],
     [deviceModelId, signer],

--- a/packages/signer/signer-trx/README.md
+++ b/packages/signer/signer-trx/README.md
@@ -40,6 +40,12 @@ const { observable: messageObservable } = signer.signPersonalMessage(
 
 // Read the Tron app configuration
 const { observable: configObservable } = signer.getAppConfiguration();
+
+// Compute an ECDH shared secret with a peer public key
+const { observable: ecdhObservable } = signer.getECDHSecret(
+  "44'/195'/0'/0/0",
+  peerPublicKey,
+);
 ```
 
 ### Get address
@@ -236,6 +242,45 @@ observable.subscribe((state) => {
   switch (state.status) {
     case "completed":
       console.log(state.output); // Uint8Array(65) signature
+      break;
+    case "error":
+      console.error(state.error);
+      break;
+  }
+});
+```
+
+### Get ECDH secret
+
+Computes an ECDH shared secret between the device key (derived from the BIP32
+path) and a peer's uncompressed secp256k1 public key. The operation is shown on
+the device for approval.
+
+```typescript
+signer.getECDHSecret(
+  derivationPath: string,
+  // the peer's uncompressed secp256k1 public key (65 bytes, 0x04 || X || Y)
+  publicKey: Uint8Array,
+  options?: {
+    // Skip the "open app" step if the Tron app is already open (default: false).
+    skipOpenApp?: boolean;
+  },
+): GetECDHSecretDAReturnType;
+```
+
+The returned device action resolves to the 65-byte ECDH shared point
+(`0x04 || X || Y`) as a `Uint8Array`.
+
+```typescript
+const { observable, cancel } = signer.getECDHSecret(
+  "44'/195'/0'/0/0",
+  peerPublicKey,
+);
+
+observable.subscribe((state) => {
+  switch (state.status) {
+    case "completed":
+      console.log(state.output); // Uint8Array(65) shared point
       break;
     case "error":
       console.error(state.error);

--- a/packages/signer/signer-trx/src/api/SignerTrx.ts
+++ b/packages/signer/signer-trx/src/api/SignerTrx.ts
@@ -1,9 +1,11 @@
 import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
 import { type GetAppConfigurationDAReturnType } from "@api/app-binder/GetAppConfigurationDeviceActionTypes";
+import { type GetECDHSecretDAReturnType } from "@api/app-binder/GetECDHSecretDeviceActionTypes";
 import { type SignPersonalMessageDAReturnType } from "@api/app-binder/SignPersonalMessageDeviceActionTypes";
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { type SignTransactionHashDAReturnType } from "@api/app-binder/SignTransactionHashDeviceActionTypes";
 import { type AddressOptions } from "@api/model/AddressOptions";
+import { type EcdhOptions } from "@api/model/EcdhOptions";
 import { type MessageOptions } from "@api/model/MessageOptions";
 import { type TransactionOptions } from "@api/model/TransactionOptions";
 
@@ -32,4 +34,10 @@ export interface SignerTrx {
   ) => SignPersonalMessageDAReturnType;
 
   getAppConfiguration: () => GetAppConfigurationDAReturnType;
+
+  getECDHSecret: (
+    derivationPath: string,
+    publicKey: Uint8Array,
+    options?: EcdhOptions,
+  ) => GetECDHSecretDAReturnType;
 }

--- a/packages/signer/signer-trx/src/api/app-binder/GetECDHSecretDeviceActionTypes.ts
+++ b/packages/signer/signer-trx/src/api/app-binder/GetECDHSecretDeviceActionTypes.ts
@@ -1,0 +1,30 @@
+import {
+  type CommandErrorResult,
+  type ExecuteDeviceActionReturnType,
+  type OpenAppDAError,
+  type SendCommandInAppDAIntermediateValue,
+  type SendCommandInAppDAOutput,
+  type UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import { type GetECDHSecretCommandResponse } from "@internal/app-binder/command/GetECDHSecretCommand";
+import { type TronAppErrorCodes } from "@internal/app-binder/command/utils/tronApplicationErrors";
+
+type GetECDHSecretDAUserInteractionRequired =
+  UserInteractionRequired.SignTransaction;
+
+export type GetECDHSecretDAOutput =
+  SendCommandInAppDAOutput<GetECDHSecretCommandResponse>;
+
+export type GetECDHSecretDAError =
+  | OpenAppDAError
+  | CommandErrorResult<TronAppErrorCodes>["error"];
+
+export type GetECDHSecretDAIntermediateValue =
+  SendCommandInAppDAIntermediateValue<GetECDHSecretDAUserInteractionRequired>;
+
+export type GetECDHSecretDAReturnType = ExecuteDeviceActionReturnType<
+  GetECDHSecretDAOutput,
+  GetECDHSecretDAError,
+  GetECDHSecretDAIntermediateValue
+>;

--- a/packages/signer/signer-trx/src/api/index.ts
+++ b/packages/signer/signer-trx/src/api/index.ts
@@ -11,6 +11,12 @@ export {
   type GetAppConfigurationDAReturnType,
 } from "@api/app-binder/GetAppConfigurationDeviceActionTypes";
 export {
+  type GetECDHSecretDAError,
+  type GetECDHSecretDAIntermediateValue,
+  type GetECDHSecretDAOutput,
+  type GetECDHSecretDAReturnType,
+} from "@api/app-binder/GetECDHSecretDeviceActionTypes";
+export {
   type SignPersonalMessageDAError,
   type SignPersonalMessageDAIntermediateValue,
   type SignPersonalMessageDAOutput,
@@ -30,6 +36,7 @@ export {
 } from "@api/app-binder/SignTransactionHashDeviceActionTypes";
 export { type AddressOptions } from "@api/model/AddressOptions";
 export { type AppConfiguration } from "@api/model/AppConfiguration";
+export { type EcdhOptions } from "@api/model/EcdhOptions";
 export { type MessageOptions } from "@api/model/MessageOptions";
 export { type Signature } from "@api/model/Signature";
 export { type TransactionOptions } from "@api/model/TransactionOptions";

--- a/packages/signer/signer-trx/src/api/model/EcdhOptions.ts
+++ b/packages/signer/signer-trx/src/api/model/EcdhOptions.ts
@@ -1,0 +1,3 @@
+export type EcdhOptions = {
+  skipOpenApp?: boolean;
+};

--- a/packages/signer/signer-trx/src/internal/DefaultSignerTrx.ts
+++ b/packages/signer/signer-trx/src/internal/DefaultSignerTrx.ts
@@ -6,10 +6,12 @@ import { type Container } from "inversify";
 
 import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
 import { type GetAppConfigurationDAReturnType } from "@api/app-binder/GetAppConfigurationDeviceActionTypes";
+import { type GetECDHSecretDAReturnType } from "@api/app-binder/GetECDHSecretDeviceActionTypes";
 import { type SignPersonalMessageDAReturnType } from "@api/app-binder/SignPersonalMessageDeviceActionTypes";
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { type SignTransactionHashDAReturnType } from "@api/app-binder/SignTransactionHashDeviceActionTypes";
 import { type AddressOptions } from "@api/model/AddressOptions";
+import { type EcdhOptions } from "@api/model/EcdhOptions";
 import { type MessageOptions } from "@api/model/MessageOptions";
 import { type TransactionOptions } from "@api/model/TransactionOptions";
 import { type SignerTrx } from "@api/SignerTrx";
@@ -18,6 +20,8 @@ import { addressTypes } from "@internal/use-cases/address/di/addressTypes";
 import { type GetAddressUseCase } from "@internal/use-cases/address/GetAddressUseCase";
 import { appConfigurationTypes } from "@internal/use-cases/app-configuration/di/appConfigurationTypes";
 import { type GetAppConfigurationUseCase } from "@internal/use-cases/app-configuration/GetAppConfigurationUseCase";
+import { ecdhTypes } from "@internal/use-cases/ecdh/di/ecdhTypes";
+import { type GetECDHSecretUseCase } from "@internal/use-cases/ecdh/GetECDHSecretUseCase";
 import { messageTypes } from "@internal/use-cases/message/di/messageTypes";
 import { type SignPersonalMessageUseCase } from "@internal/use-cases/message/SignPersonalMessageUseCase";
 import { transactionTypes } from "@internal/use-cases/transaction/di/transactionTypes";
@@ -83,5 +87,15 @@ export class DefaultSignerTrx implements SignerTrx {
         appConfigurationTypes.GetAppConfigurationUseCase,
       )
       .execute();
+  }
+
+  getECDHSecret(
+    derivationPath: string,
+    publicKey: Uint8Array,
+    options?: EcdhOptions,
+  ): GetECDHSecretDAReturnType {
+    return this._container
+      .get<GetECDHSecretUseCase>(ecdhTypes.GetECDHSecretUseCase)
+      .execute(derivationPath, publicKey, options);
   }
 }

--- a/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.test.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.test.ts
@@ -21,6 +21,11 @@ import {
   type GetAppConfigurationDAOutput,
 } from "@api/app-binder/GetAppConfigurationDeviceActionTypes";
 import {
+  type GetECDHSecretDAError,
+  type GetECDHSecretDAIntermediateValue,
+  type GetECDHSecretDAOutput,
+} from "@api/app-binder/GetECDHSecretDeviceActionTypes";
+import {
   type SignPersonalMessageDAError,
   type SignPersonalMessageDAIntermediateValue,
   type SignPersonalMessageDAOutput,
@@ -37,6 +42,7 @@ import {
 } from "@api/app-binder/SignTransactionHashDeviceActionTypes";
 import { GetAddressCommand } from "@internal/app-binder/command/GetAddressCommand";
 import { GetAppConfigurationCommand } from "@internal/app-binder/command/GetAppConfigurationCommand";
+import { GetECDHSecretCommand } from "@internal/app-binder/command/GetECDHSecretCommand";
 import { SignTransactionHashCommand } from "@internal/app-binder/command/SignTransactionHashCommand";
 import { type TronAppCommandError } from "@internal/app-binder/command/utils/tronApplicationErrors";
 import { APP_NAME } from "@internal/app-binder/constants";
@@ -618,6 +624,124 @@ describe("TronAppBinder", () => {
           }),
         }),
       );
+    });
+  });
+
+  describe("getECDHSecret", () => {
+    const derivationPath = "44'/195'/0'/0/0";
+    const publicKey = new Uint8Array(65).fill(0x04);
+
+    it("should return the shared secret", () =>
+      new Promise<void>((resolve, reject) => {
+        // GIVEN
+        const output: GetECDHSecretDAOutput = new Uint8Array(65).fill(0xcd);
+
+        vi.spyOn(mockedDmk, "executeDeviceAction").mockReturnValue({
+          observable: from([
+            {
+              status: DeviceActionStatus.Completed,
+              output,
+            } as DeviceActionState<
+              GetECDHSecretDAOutput,
+              GetECDHSecretDAError,
+              GetECDHSecretDAIntermediateValue
+            >,
+          ]),
+          cancel: vi.fn(),
+        });
+
+        // WHEN
+        const binder = new TronAppBinder(
+          mockedDmk,
+          "sessionId",
+          loggerFactoryMock,
+        );
+        const { observable } = binder.getECDHSecret({
+          derivationPath,
+          publicKey,
+        });
+
+        // THEN
+        const states: DeviceActionState<
+          GetECDHSecretDAOutput,
+          GetECDHSecretDAError,
+          GetECDHSecretDAIntermediateValue
+        >[] = [];
+        observable.subscribe({
+          next: (state) => states.push(state),
+          error: reject,
+          complete: () => {
+            try {
+              expect(states).toEqual([
+                { status: DeviceActionStatus.Completed, output },
+              ]);
+              resolve();
+            } catch (err) {
+              reject(err as Error);
+            }
+          },
+        });
+      }));
+
+    describe("calls executeDeviceAction with the correct params", () => {
+      it("requires the SignTransaction interaction", () => {
+        // WHEN
+        const binder = new TronAppBinder(
+          mockedDmk,
+          "sessionId",
+          loggerFactoryMock,
+        );
+        binder.getECDHSecret({ derivationPath, publicKey, skipOpenApp: true });
+
+        // THEN
+        expect(mockedDmk.executeDeviceAction).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sessionId: "sessionId",
+            deviceAction: new SendCommandInAppDeviceAction({
+              input: {
+                command: new GetECDHSecretCommand({
+                  derivationPath,
+                  publicKey,
+                }),
+                appName: APP_NAME,
+                requiredUserInteraction:
+                  UserInteractionRequired.SignTransaction,
+                skipOpenApp: true,
+              },
+              logger: loggerMock,
+            }),
+          }),
+        );
+      });
+
+      it("defaults skipOpenApp to false", () => {
+        // WHEN
+        const binder = new TronAppBinder(
+          mockedDmk,
+          "sessionId",
+          loggerFactoryMock,
+        );
+        binder.getECDHSecret({ derivationPath, publicKey });
+
+        // THEN
+        expect(mockedDmk.executeDeviceAction).toHaveBeenCalledWith(
+          expect.objectContaining({
+            deviceAction: new SendCommandInAppDeviceAction({
+              input: {
+                command: new GetECDHSecretCommand({
+                  derivationPath,
+                  publicKey,
+                }),
+                appName: APP_NAME,
+                requiredUserInteraction:
+                  UserInteractionRequired.SignTransaction,
+                skipOpenApp: false,
+              },
+              logger: loggerMock,
+            }),
+          }),
+        );
+      });
     });
   });
 });

--- a/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/TronAppBinder.ts
@@ -10,11 +10,13 @@ import { inject, injectable } from "inversify";
 
 import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
 import { type GetAppConfigurationDAReturnType } from "@api/app-binder/GetAppConfigurationDeviceActionTypes";
+import { type GetECDHSecretDAReturnType } from "@api/app-binder/GetECDHSecretDeviceActionTypes";
 import { type SignPersonalMessageDAReturnType } from "@api/app-binder/SignPersonalMessageDeviceActionTypes";
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { type SignTransactionHashDAReturnType } from "@api/app-binder/SignTransactionHashDeviceActionTypes";
 import { GetAddressCommand } from "@internal/app-binder/command/GetAddressCommand";
 import { GetAppConfigurationCommand } from "@internal/app-binder/command/GetAppConfigurationCommand";
+import { GetECDHSecretCommand } from "@internal/app-binder/command/GetECDHSecretCommand";
 import { SignTransactionHashCommand } from "@internal/app-binder/command/SignTransactionHashCommand";
 import { APP_NAME } from "@internal/app-binder/constants";
 import { SignPersonalMessageTask } from "@internal/app-binder/task/SignPersonalMessageTask";
@@ -73,6 +75,28 @@ export class TronAppBinder {
           skipOpenApp: args.skipOpenApp ?? false,
         },
         logger: this.dmkLoggerFactory("SignTransactionTask"),
+      }),
+    });
+  }
+
+  getECDHSecret(args: {
+    derivationPath: string;
+    publicKey: Uint8Array;
+    skipOpenApp?: boolean;
+  }): GetECDHSecretDAReturnType {
+    return this.dmk.executeDeviceAction({
+      sessionId: this.sessionId,
+      deviceAction: new SendCommandInAppDeviceAction({
+        input: {
+          command: new GetECDHSecretCommand({
+            derivationPath: args.derivationPath,
+            publicKey: args.publicKey,
+          }),
+          appName: APP_NAME,
+          requiredUserInteraction: UserInteractionRequired.SignTransaction,
+          skipOpenApp: args.skipOpenApp ?? false,
+        },
+        logger: this.dmkLoggerFactory("GetECDHSecretCommand"),
       }),
     });
   }

--- a/packages/signer/signer-trx/src/internal/app-binder/command/GetECDHSecretCommand.test.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/command/GetECDHSecretCommand.test.ts
@@ -1,0 +1,88 @@
+import {
+  ApduResponse,
+  bufferToHexaString,
+  hexaStringToBuffer,
+  type InvalidResponseFormatError,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { type TronAppCommandError } from "./utils/tronApplicationErrors";
+import { GetECDHSecretCommand } from "./GetECDHSecretCommand";
+
+const PATH = "44'/195'/0'/0/0";
+// Encoded "44'/195'/0'/0/0": length byte (05) + 5 BE32 path elements.
+const PATH_HEX = "058000002c800000c3800000000000000000000000";
+// The hw-app-trx getECDHPairKey doc vector: uncompressed secp256k1 pubkey.
+const PUBKEY_HEX =
+  "04ff21f8e64d3a3c0198edfbb7afdc79be959432e92e2f8a1984bb436a414b8edcec0345aad0c1bf7da04fd036dd7f9f617e30669224283d950fab9dd84831dc83";
+
+// The ECDH shared point (0x04 || X || Y), 65 bytes.
+const SECRET = hexaStringToBuffer("04" + "cd".repeat(64))!;
+
+describe("GetECDHSecretCommand", () => {
+  const command = new GetECDHSecretCommand({
+    derivationPath: PATH,
+    publicKey: hexaStringToBuffer(PUBKEY_HEX)!,
+  });
+
+  describe("name", () => {
+    it("should be 'GetECDHSecret'", () => {
+      expect(command.name).toBe("GetECDHSecret");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("should build the APDU with CLA=0xe0, INS=0x0a, P1=0, P2=1 and the path + peer pubkey as data", () => {
+      // 0x56 = 86 bytes of data: 21-byte encoded path + 65-byte pubkey.
+      expect(bufferToHexaString(command.getApdu().getRawApdu(), false)).toBe(
+        "e00a000156" + PATH_HEX + PUBKEY_HEX,
+      );
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("should return the 65-byte shared secret", () => {
+      const response = new ApduResponse({
+        statusCode: Uint8Array.of(0x90, 0x00),
+        data: SECRET,
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(true);
+      expect(isSuccessCommandResult(result) && result.data).toEqual(SECRET);
+    });
+
+    it("should return an error when the shared secret is missing", () => {
+      const response = new ApduResponse({
+        statusCode: Uint8Array.of(0x90, 0x00),
+        data: hexaStringToBuffer("04" + "cd".repeat(63))!,
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidResponseFormatError;
+        expect((err.originalError as { message: string }).message).toBe(
+          "ECDH shared secret is missing",
+        );
+      }
+    });
+
+    it("should return a TronAppCommandError on a device error status", () => {
+      const response = new ApduResponse({
+        statusCode: Uint8Array.of(0x69, 0x85),
+        data: new Uint8Array(),
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      expect(
+        !isSuccessCommandResult(result) &&
+          (result.error as TronAppCommandError).errorCode,
+      ).toBe("6985");
+    });
+  });
+});

--- a/packages/signer/signer-trx/src/internal/app-binder/command/GetECDHSecretCommand.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/command/GetECDHSecretCommand.ts
@@ -1,0 +1,98 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  InvalidResponseFormatError,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import {
+  ECDH_SECRET_LENGTH,
+  INS,
+  LEDGER_CLA,
+} from "@internal/app-binder/constants";
+
+import { encodeDerivationPath } from "./utils/encodeDerivationPath";
+import {
+  TRON_APP_ERRORS,
+  TronAppCommandErrorFactory,
+  type TronAppErrorCodes,
+} from "./utils/tronApplicationErrors";
+
+export type GetECDHSecretCommandArgs = {
+  readonly derivationPath: string;
+  // The peer's uncompressed secp256k1 public key (65 bytes, 0x04 || X || Y).
+  readonly publicKey: Uint8Array;
+};
+
+// The ECDH shared point (0x04 || X || Y), 65 bytes.
+export type GetECDHSecretCommandResponse = Uint8Array;
+
+/**
+ * Computes an ECDH shared secret between the device key (derived from the
+ * BIP32 path) and a peer public key (ECDH_SECRET instruction), in a single
+ * APDU. The operation is shown on the device for user approval.
+ */
+export class GetECDHSecretCommand
+  implements
+    Command<
+      GetECDHSecretCommandResponse,
+      GetECDHSecretCommandArgs,
+      TronAppErrorCodes
+    >
+{
+  readonly name = "GetECDHSecret";
+
+  private readonly _args: GetECDHSecretCommandArgs;
+
+  private readonly errorHelper = new CommandErrorHelper<
+    GetECDHSecretCommandResponse,
+    TronAppErrorCodes
+  >(TRON_APP_ERRORS, TronAppCommandErrorFactory);
+
+  constructor(args: GetECDHSecretCommandArgs) {
+    this._args = args;
+  }
+
+  get args(): GetECDHSecretCommandArgs {
+    return this._args;
+  }
+
+  getApdu(): Apdu {
+    return new ApduBuilder({
+      cla: LEDGER_CLA,
+      ins: INS.ECDH_SECRET,
+      p1: 0x00,
+      p2: 0x01,
+    })
+      .addBufferToData(encodeDerivationPath(this._args.derivationPath))
+      .addBufferToData(this._args.publicKey)
+      .build();
+  }
+
+  parseResponse(
+    apduResponse: ApduResponse,
+  ): CommandResult<GetECDHSecretCommandResponse, TronAppErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      const parser = new ApduParser(apduResponse);
+
+      const secret = parser.extractFieldByLength(ECDH_SECRET_LENGTH);
+      if (secret === undefined) {
+        return CommandResultFactory({
+          error: new InvalidResponseFormatError(
+            "ECDH shared secret is missing",
+          ),
+        });
+      }
+
+      return CommandResultFactory({ data: secret });
+    });
+  }
+}

--- a/packages/signer/signer-trx/src/internal/app-binder/constants.ts
+++ b/packages/signer/signer-trx/src/internal/app-binder/constants.ts
@@ -25,6 +25,9 @@ export const SIGNATURE_LENGTH = 65;
 // Length of a chain code returned by the GetAddress command.
 export const CHAIN_CODE_LENGTH = 32;
 
+// Length of the ECDH shared point (0x04 || X || Y) returned by ECDH_SECRET.
+export const ECDH_SECRET_LENGTH = 65;
+
 /**
  * P1 "start byte" values for the SIGN_TRANSACTION instruction.
  *

--- a/packages/signer/signer-trx/src/internal/di.ts
+++ b/packages/signer/signer-trx/src/internal/di.ts
@@ -9,6 +9,7 @@ import { appBindingModuleFactory } from "@internal/app-binder/di/appBinderModule
 import { externalTypes } from "@internal/externalTypes";
 import { addressModuleFactory } from "@internal/use-cases/address/di/addressModule";
 import { appConfigurationModuleFactory } from "@internal/use-cases/app-configuration/di/appConfigurationModule";
+import { ecdhModuleFactory } from "@internal/use-cases/ecdh/di/ecdhModule";
 import { messageModuleFactory } from "@internal/use-cases/message/di/messageModule";
 import { transactionModuleFactory } from "@internal/use-cases/transaction/di/transactionModule";
 
@@ -39,6 +40,7 @@ export const makeContainer = ({ dmk, sessionId }: MakeContainerProps) => {
     transactionModuleFactory(),
     messageModuleFactory(),
     appConfigurationModuleFactory(),
+    ecdhModuleFactory(),
   );
 
   return container;

--- a/packages/signer/signer-trx/src/internal/use-cases/ecdh/GetECDHSecretUseCase.test.ts
+++ b/packages/signer/signer-trx/src/internal/use-cases/ecdh/GetECDHSecretUseCase.test.ts
@@ -1,0 +1,47 @@
+import { type TronAppBinder } from "@internal/app-binder/TronAppBinder";
+
+import { GetECDHSecretUseCase } from "./GetECDHSecretUseCase";
+
+describe("GetECDHSecretUseCase", () => {
+  const derivationPath = "44'/195'/0'/0/0";
+  const publicKey = new Uint8Array(65).fill(0x04);
+  const returnedValue = { observable: "observable", cancel: () => {} };
+  const getECDHSecretMock = vi.fn().mockReturnValue(returnedValue);
+  const appBinderMock = {
+    getECDHSecret: getECDHSecretMock,
+  } as unknown as TronAppBinder;
+  let useCase: GetECDHSecretUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new GetECDHSecretUseCase(appBinderMock);
+  });
+
+  it("should forward the public key and options to the app binder", () => {
+    // WHEN
+    const result = useCase.execute(derivationPath, publicKey, {
+      skipOpenApp: true,
+    });
+
+    // THEN
+    expect(result).toEqual(returnedValue);
+    expect(getECDHSecretMock).toHaveBeenCalledWith({
+      derivationPath,
+      publicKey,
+      skipOpenApp: true,
+    });
+  });
+
+  it("should work without options", () => {
+    // WHEN
+    const result = useCase.execute(derivationPath, publicKey);
+
+    // THEN
+    expect(result).toEqual(returnedValue);
+    expect(getECDHSecretMock).toHaveBeenCalledWith({
+      derivationPath,
+      publicKey,
+      skipOpenApp: undefined,
+    });
+  });
+});

--- a/packages/signer/signer-trx/src/internal/use-cases/ecdh/GetECDHSecretUseCase.ts
+++ b/packages/signer/signer-trx/src/internal/use-cases/ecdh/GetECDHSecretUseCase.ts
@@ -1,0 +1,27 @@
+import { inject, injectable } from "inversify";
+
+import { type GetECDHSecretDAReturnType } from "@api/app-binder/GetECDHSecretDeviceActionTypes";
+import { type EcdhOptions } from "@api/model/EcdhOptions";
+import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
+import { TronAppBinder } from "@internal/app-binder/TronAppBinder";
+
+@injectable()
+export class GetECDHSecretUseCase {
+  private readonly _appBinder: TronAppBinder;
+
+  constructor(@inject(appBinderTypes.AppBinding) appBinder: TronAppBinder) {
+    this._appBinder = appBinder;
+  }
+
+  execute(
+    derivationPath: string,
+    publicKey: Uint8Array,
+    options?: EcdhOptions,
+  ): GetECDHSecretDAReturnType {
+    return this._appBinder.getECDHSecret({
+      derivationPath,
+      publicKey,
+      skipOpenApp: options?.skipOpenApp,
+    });
+  }
+}

--- a/packages/signer/signer-trx/src/internal/use-cases/ecdh/di/ecdhModule.ts
+++ b/packages/signer/signer-trx/src/internal/use-cases/ecdh/di/ecdhModule.ts
@@ -1,0 +1,9 @@
+import { ContainerModule } from "inversify";
+
+import { ecdhTypes } from "@internal/use-cases/ecdh/di/ecdhTypes";
+import { GetECDHSecretUseCase } from "@internal/use-cases/ecdh/GetECDHSecretUseCase";
+
+export const ecdhModuleFactory = () =>
+  new ContainerModule(({ bind }) => {
+    bind(ecdhTypes.GetECDHSecretUseCase).to(GetECDHSecretUseCase);
+  });

--- a/packages/signer/signer-trx/src/internal/use-cases/ecdh/di/ecdhTypes.ts
+++ b/packages/signer/signer-trx/src/internal/use-cases/ecdh/di/ecdhTypes.ts
@@ -1,0 +1,3 @@
+export const ecdhTypes = {
+  GetECDHSecretUseCase: Symbol.for("GetECDHSecretUseCase"),
+} as const;


### PR DESCRIPTION
### 📝 Description

Implements the **Get ECDH Secret** device action for the Tron signer
(`@ledgerhq/device-signer-kit-tron`), adding `getECDHSecret(derivationPath, publicKey, options?)`.

Computes an ECDH shared secret between the device key (derived from a BIP32 path) and a peer's
uncompressed secp256k1 public key (65 bytes, `0x04 || X || Y`). It's a single-APDU exchange
(`ECDH_SECRET`, INS `0x0a`, **P1 `0x00` / P2 `0x01`**): the encoded derivation path and the peer key
are sent, and the 65-byte shared point (`0x04 || X || Y`) comes back. Implemented with the generic
`SendCommandInAppDeviceAction` (like Get Address). The operation is shown on the device for approval
(hold-to-sign, "Sign transaction to Share ECDH Secret"), so it requires the `SignTransaction` user
interaction - DMK has no ECDH-specific interaction value and the app frames it as a sign-to-share
flow. It is **not** gated by any app setting.

Usage:

```typescript
const { observable } = signer.getECDHSecret("44'/195'/0'/0/0", peerPublicKey);

observable.subscribe((state) => {
  if (state.status === "completed") {
    console.log(state.output); // Uint8Array(65) shared point
  }
});
```

❓ Context

- JIRA or GitHub link: DSDK-1343
- Feature: Get ECDH Secret device action for the Tron signer kit - ECDH shared-secret derivation
against a peer public key, mirroring @ledgerhq/hw-app-trx's getECDHPairKey.

✅ Checklist

- [x] Covered by automatic tests
- [x] Changeset is provided 
- [x] Documentation is up-to-date 
- [ ] Impact of the changes