### PR TITLE
🐛 (signer-zcash) [LIVE-34938]: Sign only real Orchard spends on device

### DIFF
--- a/.changeset/zcash-sign-real-spends.md
+++ b/.changeset/zcash-sign-real-spends.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-zcash": patch
+---
+
+Request a device spend-auth signature only for real Orchard spends. Dummy padding spends (spend value 0) are self-signed host-side by the PCZT IO finalizer, so signing them on-device made the device signature count exceed the finalizer's unsigned-action count and the transaction was rejected. The full bundle is still streamed to the device; only the signing requests are restricted to real spends.

--- a/packages/signer/signer-zcash/src/api/model/PcztSignature.ts
+++ b/packages/signer/signer-zcash/src/api/model/PcztSignature.ts
@@ -25,7 +25,12 @@ export type OrchardActionSignature = {
  * from `bsk = Σ rcv` and never involves the device.
  */
 export type SignPcztTransactionResult = {
-  /** One `spendAuthSig` per Orchard action, in action order. */
+  /**
+   * One `spendAuthSig` per Orchard action the device signs — i.e. per real
+   * spend, in ascending action-index order. Dummy padding spends (value 0) are
+   * self-signed host-side by the PCZT IoFinalizer and are omitted here, so the
+   * count matches the finalizer's unsigned-action count.
+   */
   orchard: OrchardActionSignature[];
   /**
    * One signature per transparent input, in input order. Each entry is the

--- a/packages/signer/signer-zcash/src/api/model/PcztSignature.ts
+++ b/packages/signer/signer-zcash/src/api/model/PcztSignature.ts
@@ -27,8 +27,9 @@ export type OrchardActionSignature = {
 export type SignPcztTransactionResult = {
   /**
    * One `spendAuthSig` per Orchard action the device signs — i.e. per real
-   * spend, in ascending action-index order. Dummy padding spends (value 0) are
-   * self-signed host-side by the PCZT IoFinalizer and are omitted here, so the
+   * spend, in ascending action-index order. Dummy padding spends
+   * (`spendValue === 0n`) are self-signed host-side by the PCZT IoFinalizer
+   * and are omitted here, so the
    * count matches the finalizer's unsigned-action count.
    */
   orchard: OrchardActionSignature[];

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.test.ts
@@ -17,6 +17,7 @@ import { PCZT_P2 } from "@internal/app-binder/command/utils/apduHeaderUtils";
 import {
   allDummyOrchardBundle,
   mixedDummyOrchardBundle,
+  multiRealDummyOrchardBundle,
   privateToPrivateTransaction,
   privateToPublicTransaction,
   publicToPrivateTransaction,
@@ -181,6 +182,22 @@ describe("SignPcztTransactionTask", () => {
     const orchardSigns = calls.filter((c) => c.ins === INS_PCZT_SIGN_ORCHARD);
     expect(orchardSigns).toHaveLength(1);
     expect(orchardSigns[0]!.p2).toBe(1);
+  });
+
+  it("signs multiple real spends in ascending action-index order, skipping dummies", async () => {
+    // Bundle order: dummy (0), real (1), real (2), dummy (3). Indices 1 and 2
+    // are device-signed, strictly in ascending order; the dummies are skipped.
+    const result = await run({
+      ...privateToPrivateTransaction(),
+      orchardBundle: multiRealDummyOrchardBundle(),
+    });
+
+    expect(isSuccessDmkResult(result)).toBe(true);
+    if (isSuccessDmkResult(result)) {
+      expect(result.data.orchard).toHaveLength(2);
+    }
+    const orchardSigns = calls.filter((c) => c.ins === INS_PCZT_SIGN_ORCHARD);
+    expect(orchardSigns.map((c) => c.p2)).toEqual([1, 2]);
   });
 
   it("requests no Orchard signature when every action is dummy padding", async () => {

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.test.ts
@@ -15,6 +15,8 @@ import { INS_PCZT_SIGN_ORCHARD } from "@internal/app-binder/command/SignPcztOrch
 import { INS_PCZT_SIGN_TRANSPARENT } from "@internal/app-binder/command/SignPcztTransparentCommand";
 import { PCZT_P2 } from "@internal/app-binder/command/utils/apduHeaderUtils";
 import {
+  allDummyOrchardBundle,
+  mixedDummyOrchardBundle,
   privateToPrivateTransaction,
   privateToPublicTransaction,
   publicToPrivateTransaction,
@@ -156,6 +158,43 @@ describe("SignPcztTransactionTask", () => {
       }
     },
   );
+
+  it("signs only real spends and skips dummy padding actions", async () => {
+    // Bundle order: dummy (0), real (1), dummy (2). Only index 1 is device-signed.
+    const result = await run({
+      ...privateToPrivateTransaction(),
+      orchardBundle: mixedDummyOrchardBundle(),
+    });
+
+    expect(isSuccessDmkResult(result)).toBe(true);
+    if (isSuccessDmkResult(result)) {
+      expect(result.data.orchard).toHaveLength(1);
+      // spendAuthSig is keyed on the signed action's index (P2) by the mock.
+      expect(result.data.orchard[0]!.spendAuthSig).toEqual(
+        new Uint8Array(64).fill(1),
+      );
+    }
+    // All three actions are still streamed, but only the real spend is signed.
+    expect(
+      calls.filter((c) => c.ins === INS_PCZT_ORCHARD_ACTION).length,
+    ).toBeGreaterThan(0);
+    const orchardSigns = calls.filter((c) => c.ins === INS_PCZT_SIGN_ORCHARD);
+    expect(orchardSigns).toHaveLength(1);
+    expect(orchardSigns[0]!.p2).toBe(1);
+  });
+
+  it("requests no Orchard signature when every action is dummy padding", async () => {
+    const result = await run({
+      ...privateToPrivateTransaction(),
+      orchardBundle: allDummyOrchardBundle(),
+    });
+
+    expect(isSuccessDmkResult(result)).toBe(true);
+    if (isSuccessDmkResult(result)) {
+      expect(result.data.orchard).toHaveLength(0);
+    }
+    expect(calls.some((c) => c.ins === INS_PCZT_SIGN_ORCHARD)).toBe(false);
+  });
 
   it("aborts and surfaces the error when a bundle command fails", async () => {
     vi.mocked(apiMock.sendCommand).mockImplementation((command: unknown) => {

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.ts
@@ -134,8 +134,9 @@ export class SignPcztTransactionTask {
     }
 
     // 2. Collect one spendAuthSig per Orchard action the device must sign.
-    //    Only real spends are signed on-device. Dummy padding spends (value 0)
-    //    are self-signed host-side by the PCZT IoFinalizer at build time, so the
+    //    Only real spends are signed on-device. Dummy padding spends
+    //    (`spendValue === 0n`) are self-signed host-side by the PCZT
+    //    IoFinalizer at build time, so the
     //    finalizer leaves only real spends unsigned and expects exactly one
     //    device signature per unsigned action, applied in action-index order
     //    (zcash-utils finalize.rs). Signing a dummy here would make the device

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.ts
@@ -133,9 +133,21 @@ export class SignPcztTransactionTask {
       }
     }
 
-    // 2. Collect one spendAuthSig per Orchard action.
+    // 2. Collect one spendAuthSig per Orchard action the device must sign.
+    //    Only real spends are signed on-device. Dummy padding spends (value 0)
+    //    are self-signed host-side by the PCZT IoFinalizer at build time, so the
+    //    finalizer leaves only real spends unsigned and expects exactly one
+    //    device signature per unsigned action, applied in action-index order
+    //    (zcash-utils finalize.rs). Signing a dummy here would make the device
+    //    signature count exceed the unsigned-action count and be rejected
+    //    ("Orchard signature count N != unsigned action count M"). Skipping by
+    //    index preserves that ordering: the full bundle is still streamed above,
+    //    only the signing requests are restricted to real spends.
     const orchard: OrchardActionSignature[] = [];
     for (let i = 0; i < bundle.actions.length; i += 1) {
+      if (bundle.actions[i]!.spendValue === 0n) {
+        continue;
+      }
       const result = await this.api.sendCommand(
         new SignPcztOrchardCommand({ actionIndex: i }),
       );

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/__fixtures__/pcztFixtures.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/__fixtures__/pcztFixtures.ts
@@ -92,8 +92,37 @@ export const sampleOrchardAction = (): PcztOrchardAction => ({
   rcv: bytes(32, 0x0c),
 });
 
+/**
+ * A dummy padding spend (spend value 0). The PCZT IoFinalizer self-signs these
+ * host-side, so the device must NOT be asked to sign them.
+ */
+export const dummyOrchardAction = (): PcztOrchardAction => ({
+  ...sampleOrchardAction(),
+  spendValue: 0n,
+  value: 0n,
+});
+
 export const sampleOrchardBundle = (): PcztOrchardBundle => ({
   actions: [sampleOrchardAction()],
+  flags: 2,
+  valueBalance: 0n,
+  anchor: bytes(32, 0x0d),
+});
+
+/**
+ * Orchard bundle with padding: dummy, real, dummy. Only the real spend
+ * (action index 1) is device-signed.
+ */
+export const mixedDummyOrchardBundle = (): PcztOrchardBundle => ({
+  actions: [dummyOrchardAction(), sampleOrchardAction(), dummyOrchardAction()],
+  flags: 2,
+  valueBalance: 0n,
+  anchor: bytes(32, 0x0d),
+});
+
+/** Orchard bundle made only of dummy padding spends (no device signature). */
+export const allDummyOrchardBundle = (): PcztOrchardBundle => ({
+  actions: [dummyOrchardAction(), dummyOrchardAction()],
   flags: 2,
   valueBalance: 0n,
   anchor: bytes(32, 0x0d),

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/__fixtures__/pcztFixtures.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/__fixtures__/pcztFixtures.ts
@@ -128,6 +128,23 @@ export const allDummyOrchardBundle = (): PcztOrchardBundle => ({
   anchor: bytes(32, 0x0d),
 });
 
+/**
+ * Orchard bundle with two real spends interleaved with dummy padding
+ * (dummy, real, real, dummy) — exercises the ascending action-index ordering
+ * of device signing requests when more than one real spend is present.
+ */
+export const multiRealDummyOrchardBundle = (): PcztOrchardBundle => ({
+  actions: [
+    dummyOrchardAction(),
+    sampleOrchardAction(),
+    sampleOrchardAction(),
+    dummyOrchardAction(),
+  ],
+  flags: 2,
+  valueBalance: 0n,
+  anchor: bytes(32, 0x0d),
+});
+
 /** Public → Public: transparent only, no Orchard bundle. */
 export const publicToPublicTransaction = (): PcztTransaction => ({
   global: SAMPLE_GLOBAL,


### PR DESCRIPTION
## Context

DMK signer (`signer-zcash`). For a PCZT with Orchard actions, the signer requested a device spend-auth signature for every action, including dummy padding spends (spend value 0). Dummy spends are self-signed host-side by the PCZT IO finalizer, so signing them on-device made the device signature count exceed the finalizer's unsigned-action count and the transaction was rejected.

JIRA: https://ledgerhq.atlassian.net/browse/LIVE-34938

## Changes

- `SignPcztTransactionTask`: request a device spend-auth signature only for real spends (`spendValue !== 0n`). The full bundle is still streamed to the device; only the signing requests are restricted. Dummy padding spends stay self-signed host-side. For a transparent→shielded transaction (all-dummy spends) the device now produces zero Orchard signatures.

## Tests

- `SignPcztTransactionTask.test.ts` (12 tests) covers dummy / mixed / all-dummy bundles: dummy actions skipped, real spends signed in action-index order.

## Related

- Epic LIVE-34936 (Zcash shielded QA and fixes), initiative LIVE-32703.