### PR TITLE
🐛 (signer-icp) [LIVE-34590]: Fix GET_ADDR and SIGN response parsing

### DIFF
--- a/.changeset/icp-getaddress-sign-response-parsing.md
+++ b/.changeset/icp-getaddress-sign-response-parsing.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-icp": patch
+---
+
+Fix GET_ADDR and SIGN response parsing to match the device wire format. GET_ADDR is decoded as fixed-length fields (publicKey, principal, account identifier, textual principal) instead of a length-prefixed layout, and the textual principal is grouped in 5-character segments. SIGN skips the pre-sign hash that precedes the signature on the last chunk. Also derive `testMode` from a non-zero flag byte.

--- a/packages/signer/signer-icp/src/internal/app-binder/command/GetAddressCommand.test.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/GetAddressCommand.test.ts
@@ -16,24 +16,29 @@ import { IcpErrorCodes } from "@internal/app-binder/command/utils/IcpApplication
 
 const DERIVATION_PATH = "44'/223'/0'/0/0";
 
+// Real device GET_ADDR layout: publicKey(65) · principal(29) · accountId(32) · principalText.
 const buildAddressResponseData = (
   publicKey: Uint8Array,
+  rawPrincipal: Uint8Array,
   accountId: Uint8Array,
-  principal: Uint8Array,
+  principalText: Uint8Array,
 ): Uint8Array => {
-  const data = new Uint8Array(
-    publicKey.length + 1 + accountId.length + 1 + principal.length,
-  );
+  const parts = [publicKey, rawPrincipal, accountId, principalText];
+  const data = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
   let offset = 0;
-  data.set(publicKey, offset);
-  offset += publicKey.length;
-  data[offset++] = accountId.length;
-  data.set(accountId, offset);
-  offset += accountId.length;
-  data[offset++] = principal.length;
-  data.set(principal, offset);
+  for (const part of parts) {
+    data.set(part, offset);
+    offset += part.length;
+  }
   return data;
 };
+
+const hexToBytes = (hex: string): Uint8Array =>
+  Uint8Array.from(Buffer.from(hex, "hex"));
+
+// Captured from a real device GET_ADDR for 44'/223'/0'/0/0 (status word stripped).
+const REAL_GET_ADDR_RESPONSE =
+  "0468f65022f9f3ab8b5e7f6ef8d4c32c6d43d48af6befef190b223418e80a2552718e06a8bf00d29e00219d6f03dec3da8c18dfd96d754e9bae40e00204260d39b2df4ec3628b59d97cbfe0adbca4ac271aeae551965c51688f618b9ab02274dde7febd36b5960153eb5f6c22ea687b17240a5f57b43bc1fea59cf4426897961796a34356a6e367477646d6b667674776c347837716b3370666576717472763278666b676c6679756c69723571797867767165";
 
 describe("GetAddressCommand", () => {
   describe("getApdu", () => {
@@ -98,13 +103,32 @@ describe("GetAddressCommand", () => {
         skipOpenApp: false,
       }).parseResponse(new ApduResponse({ statusCode, data }));
 
-    it("should extract publicKey, accountId and principal on success", () => {
+    it("should parse a real device response into publicKey, accountId and dashed principal", () => {
+      // ACT
+      const result = parse(hexToBytes(REAL_GET_ADDR_RESPONSE));
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data.publicKey).toBe(
+          "0468f65022f9f3ab8b5e7f6ef8d4c32c6d43d48af6befef190b223418e80a2552718e06a8bf00d29e00219d6f03dec3da8c18dfd96d754e9bae40e00204260d39b",
+        );
+        expect(result.data.accountId).toBe(
+          "274dde7febd36b5960153eb5f6c22ea687b17240a5f57b43bc1fea59cf442689",
+        );
+        expect(result.data.principal).toBe(
+          "yayj4-5jn6t-wdmkf-vtwl4-x7qk3-pfevq-trv2x-fkglf-yulir-5qyxg-vqe",
+        );
+      }
+    });
+
+    it("should group the textual principal into 5-char segments", () => {
       // ACT
       const result = parse(
         buildAddressResponseData(
           new Uint8Array(65).fill(0x02),
+          new Uint8Array(29).fill(0x03),
           new Uint8Array(32).fill(0x0a),
-          new TextEncoder().encode("2vxsx-fae"),
+          new TextEncoder().encode("2vxsxfae"),
         ),
       );
       // ASSERT
@@ -116,41 +140,59 @@ describe("GetAddressCommand", () => {
       }
     });
 
-    it.each([
-      {
-        field: "account identifier",
-        accountId: new Uint8Array(0),
-        principal: new TextEncoder().encode("2vxsx-fae"),
-      },
-      {
-        field: "principal",
-        accountId: new Uint8Array(32).fill(0x0a),
-        principal: new Uint8Array(0),
-      },
-    ])(
-      "should reject a response with a zero-length $field",
-      ({ accountId, principal }) => {
-        // ACT
-        const result = parse(
-          buildAddressResponseData(
-            new Uint8Array(65).fill(0x02),
-            accountId,
-            principal,
-          ),
-        );
-        // ASSERT
-        expect(isSuccessCommandResult(result)).toBe(false);
-      },
-    );
-
-    it("should return an error when the principal length is missing", () => {
-      // ARRANGE — public key + account id present, principal length byte absent
-      const truncated = new Uint8Array(65 + 1 + 32);
-      truncated.set(new Uint8Array(65).fill(0x02), 0);
-      truncated[65] = 32;
-      truncated.set(new Uint8Array(32).fill(0x0a), 66);
+    it("should not append a trailing dash when the principal length is a multiple of 5", () => {
       // ACT
-      const result = parse(truncated);
+      const result = parse(
+        buildAddressResponseData(
+          new Uint8Array(65).fill(0x02),
+          new Uint8Array(29).fill(0x03),
+          new Uint8Array(32).fill(0x0a),
+          new TextEncoder().encode("abcdefghij"),
+        ),
+      );
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data.principal).toBe("abcde-fghij");
+      }
+    });
+
+    it("should reject a response whose raw principal is truncated", () => {
+      // ARRANGE — publicKey present, but fewer than the fixed 29 principal bytes
+      const result = parse(
+        new Uint8Array([
+          ...new Uint8Array(65).fill(0x02),
+          ...new Uint8Array(10).fill(0x03),
+        ]),
+      );
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+    });
+
+    it("should reject a response too short to hold the account identifier", () => {
+      // ARRANGE — publicKey + raw principal present, account id + text missing
+      const result = parse(
+        buildAddressResponseData(
+          new Uint8Array(65).fill(0x02),
+          new Uint8Array(29).fill(0x03),
+          new Uint8Array(0),
+          new Uint8Array(0),
+        ),
+      );
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+    });
+
+    it("should reject a response with an empty textual principal", () => {
+      // ARRANGE — everything fixed-length present, but no principal text follows
+      const result = parse(
+        buildAddressResponseData(
+          new Uint8Array(65).fill(0x02),
+          new Uint8Array(29).fill(0x03),
+          new Uint8Array(32).fill(0x0a),
+          new Uint8Array(0),
+        ),
+      );
       // ASSERT
       expect(isSuccessCommandResult(result)).toBe(false);
     });

--- a/packages/signer/signer-icp/src/internal/app-binder/command/GetAddressCommand.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/GetAddressCommand.ts
@@ -41,7 +41,10 @@ export const icpGetAddressApduHeader = (p1: number) => ({
 export const P1_CHECK_ON_DEVICE = 0x01;
 export const P1_NO_CHECK_ON_DEVICE = 0x00;
 const DERIVATION_PATH_LENGTH = 5;
+// GET_ADDR response is fixed-length: publicKey(65) · principal(29) · accountId(32) · principalText.
 const PUBLIC_KEY_LENGTH = 65;
+const PRINCIPAL_LENGTH = 29;
+const ACCOUNT_ID_LENGTH = 32;
 
 export class GetAddressCommand
   implements
@@ -92,23 +95,20 @@ export class GetAddressCommand
       const apduParser = new ApduParser(apduResponse);
 
       const publicKey = apduParser.extractFieldByLength(PUBLIC_KEY_LENGTH);
-      const accountIdLength = apduParser.extract8BitUInt();
-      const accountId =
-        accountIdLength !== undefined
-          ? apduParser.extractFieldByLength(accountIdLength)
-          : undefined;
-      const principalLength = apduParser.extract8BitUInt();
-      const principal =
-        principalLength !== undefined
-          ? apduParser.extractFieldByLength(principalLength)
-          : undefined;
+      // Validate the raw principal's presence; consumers use the account identifier + textual principal.
+      const rawPrincipal = apduParser.extractFieldByLength(PRINCIPAL_LENGTH);
+      const accountId = apduParser.extractFieldByLength(ACCOUNT_ID_LENGTH);
+      const principalText = apduParser.extractFieldByLength(
+        apduParser.getUnparsedRemainingLength(),
+      );
 
       if (
         publicKey === undefined ||
+        rawPrincipal === undefined ||
         accountId === undefined ||
         accountId.length === 0 ||
-        principal === undefined ||
-        principal.length === 0
+        principalText === undefined ||
+        principalText.length === 0
       ) {
         return CommandResultFactory({
           error: new InvalidStatusWordError("Cannot extract address"),
@@ -119,7 +119,10 @@ export class GetAddressCommand
         data: {
           publicKey: apduParser.encodeToHexaString(publicKey),
           accountId: apduParser.encodeToHexaString(accountId),
-          principal: apduParser.encodeToString(principal),
+          // Canonical ICP text form: dash-separated 5-char segments, no trailing dash.
+          principal: apduParser
+            .encodeToString(principalText)
+            .replace(/(.{5})(?=.)/g, "$1-"),
         },
       });
     });

--- a/packages/signer/signer-icp/src/internal/app-binder/command/GetVersionCommand.test.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/GetVersionCommand.test.ts
@@ -56,11 +56,11 @@ describe("GetVersionCommand", () => {
       expect(isSuccessCommandResult(result)).toBe(true);
     });
 
-    it("should report testMode true when TEST byte is 0xFF", () => {
+    it("should report testMode true when the TEST byte is non-zero", () => {
       // ARRANGE
       const response = new ApduResponse({
         statusCode: new Uint8Array([0x90, 0x00]),
-        data: new Uint8Array([0xff, 0x01, 0x02, 0x03, 0x00]),
+        data: new Uint8Array([0x01, 0x01, 0x02, 0x03, 0x00]),
       });
       // ACT
       const result = command.parseResponse(response);

--- a/packages/signer/signer-icp/src/internal/app-binder/command/GetVersionCommand.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/GetVersionCommand.ts
@@ -20,8 +20,6 @@ import {
 
 export type GetVersionCommandResponse = Version;
 
-const TEST_MODE_FLAG = 0xff;
-
 export const icpGetVersionApduHeader = {
   cla: 0x11,
   ins: 0x00,
@@ -71,7 +69,7 @@ export class GetVersionCommand
       return CommandResultFactory({
         data: {
           version: `${major}.${minor}.${patch}`,
-          testMode: test === TEST_MODE_FLAG,
+          testMode: test !== 0,
           locked: locked !== 0,
         },
       });

--- a/packages/signer/signer-icp/src/internal/app-binder/command/SignTransactionCommand.test.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/SignTransactionCommand.test.ts
@@ -122,13 +122,15 @@ describe("SignTransactionCommand", () => {
   describe("parseResponse", () => {
     it("should split the last-chunk response into r, s, v and DER signature", () => {
       // ARRANGE
+      const preSignHash = new Uint8Array(43).fill(0x11);
       const r = new Uint8Array(32).fill(0xaa);
       const s = new Uint8Array(32).fill(0xbb);
       const v = new Uint8Array([0x01]);
       const der = new Uint8Array([
         0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01,
       ]);
-      const data = new Uint8Array([...r, ...s, ...v, ...der]);
+      // Last-chunk layout: preSignHash(43) · r(32) · s(32) · v(1) · DER.
+      const data = new Uint8Array([...preSignHash, ...r, ...s, ...v, ...der]);
       const response = new ApduResponse({
         statusCode: new Uint8Array([0x90, 0x00]),
         data,
@@ -173,12 +175,13 @@ describe("SignTransactionCommand", () => {
 
     it("should reject a response that carries r, s and v but no DER signature", () => {
       // ARRANGE
+      const preSignHash = new Uint8Array(43).fill(0x11);
       const r = new Uint8Array(32).fill(0xaa);
       const s = new Uint8Array(32).fill(0xbb);
       const v = new Uint8Array([0x01]);
       const response = new ApduResponse({
         statusCode: new Uint8Array([0x90, 0x00]),
-        data: new Uint8Array([...r, ...s, ...v]), // 65 bytes, DER missing
+        data: new Uint8Array([...preSignHash, ...r, ...s, ...v]), // DER missing
       });
       const command = new SignTransactionCommand({
         phase: SignPhase.LAST,
@@ -190,9 +193,9 @@ describe("SignTransactionCommand", () => {
       expect(isSuccessCommandResult(result)).toBe(false);
     });
 
-    it("should reject a non-empty response too short to hold r (truncated, not empty)", () => {
-      // ARRANGE — 20 bytes: non-empty but fewer than the 32-byte r; must be
-      // treated as malformed, not as an empty intermediate reply.
+    it("should reject a non-empty response too short to hold the signature (truncated, not empty)", () => {
+      // ARRANGE — 20 bytes: non-empty but shorter than preSignHash+signature; must
+      // be treated as malformed, not as an empty intermediate reply.
       const response = new ApduResponse({
         statusCode: new Uint8Array([0x90, 0x00]),
         data: new Uint8Array(20).fill(0xaa),
@@ -207,13 +210,14 @@ describe("SignTransactionCommand", () => {
       expect(isSuccessCommandResult(result)).toBe(false);
     });
 
-    it("should reject a response that has r but truncates before v/DER", () => {
-      // ARRANGE — 64 bytes: r and s present, v and DER missing
+    it("should reject a response that has r/s but truncates before v/DER", () => {
+      // ARRANGE — preSignHash + r + s present, v and DER missing
+      const preSignHash = new Uint8Array(43).fill(0x11);
       const r = new Uint8Array(32).fill(0xaa);
       const s = new Uint8Array(32).fill(0xbb);
       const response = new ApduResponse({
         statusCode: new Uint8Array([0x90, 0x00]),
-        data: new Uint8Array([...r, ...s]),
+        data: new Uint8Array([...preSignHash, ...r, ...s]),
       });
       const command = new SignTransactionCommand({
         phase: SignPhase.LAST,

--- a/packages/signer/signer-icp/src/internal/app-binder/command/SignTransactionCommand.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/SignTransactionCommand.ts
@@ -29,6 +29,8 @@ export const P1_LAST = 0x02;
 export const P2_NO_STAKE = 0x00;
 
 const DERIVATION_PATH_LENGTH = 5;
+// The last-chunk signature response is prefixed by the pre-sign hash, then r‖s, v, and DER.
+const PRESIGN_HASH_LENGTH = 43;
 const SIGNATURE_R_LENGTH = 32;
 const SIGNATURE_S_LENGTH = 32;
 const SIGNATURE_V_LENGTH = 1;
@@ -96,6 +98,8 @@ export class SignTransactionCommand
         return CommandResultFactory({ data: Nothing });
       }
 
+      // Validate the pre-sign hash's presence; it is not surfaced.
+      const preSignHash = apduParser.extractFieldByLength(PRESIGN_HASH_LENGTH);
       const r = apduParser.extractFieldByLength(SIGNATURE_R_LENGTH);
       const s = apduParser.extractFieldByLength(SIGNATURE_S_LENGTH);
       const v = apduParser.extractFieldByLength(SIGNATURE_V_LENGTH);
@@ -104,6 +108,7 @@ export class SignTransactionCommand
       );
 
       if (
+        preSignHash === undefined ||
         r === undefined ||
         s === undefined ||
         v === undefined ||


### PR DESCRIPTION
### 📝 Description

The ICP command parsers decoded device responses with the wrong wire format, so the receive flow failed on a real device with `InvalidStatusWordError` (`getAddress internet_computer … FAILED`). The unit tests passed because they asserted against the same incorrect assumption rather than a real device response.

This aligns all three parsers with the device format (authoritative reference: `@zondax/ledger-icp` `helper.js` / `consts.js`):

- **`GetAddressCommand`** — decode fixed-length fields `publicKey(65) · principal(29) · accountId(32) · principalText`, instead of a fabricated length-prefixed layout. The textual principal is emitted in the canonical dashed form (5-character segments, no trailing dash). _Before:_ the byte following the public key was misread as a length prefix → `InvalidStatusWordError`. _After:_ a captured device response decodes correctly.
- **`SignTransactionCommand`** — skip the 43-byte pre-sign hash that precedes `r‖s · v · DER` on the last chunk (previously read from offset 0, which would corrupt signing).
- **`GetVersionCommand`** — derive `testMode` from a non-zero flag byte (was compared against `0xff`, always false on real devices).

Every fixed-length field is validated for presence, so a malformed or truncated response is rejected rather than silently misaligning. The `GetAddressCommand` test is grounded in a real captured device response (golden fixture); the sign layout is aligned to the reference lib and is pending on-device confirmation via the send flow.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34590](https://ledgerhq.atlassian.net/browse/LIVE-34590)
- **Feature**: ICP DMK signer (`@ledgerhq/device-signer-kit-icp`)

### ✅ Checklist

- [x] **Covered by automatic tests** — parsers grounded in a captured device response; malformed/truncated responses are rejected. 77 tests pass.
- [x] **Changeset is provided** — patch bump for `@ledgerhq/device-signer-kit-icp`.
- [x] **Documentation is up-to-date** — no public API change.
- [ ] **Impact of the changes:**
  - Fixes ICP address retrieval (receive flow) via the DMK signer.
  - Corrects the transfer-signing response layout; QA should validate the send flow on-device once released.
  - No change to the command/DA public surface.


[LIVE-34590]: https://ledgerhq.atlassian.net/browse/LIVE-34590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ