### PR TITLE
✨ (signer-icp) [LIVE-34592]: Add update-call signing and neuron-stake flag

### DIFF
--- a/.changeset/icp-signer-update-call.md
+++ b/.changeset/icp-signer-update-call.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-icp": minor
+---
+
+Add update-call signing (`signUpdateCall`) for neuron management: signs an IC update call together with its companion read-state request and returns both signatures with the read-state body. Add a `stake` flag to `signTransaction` to sign a neuron-creation transfer.

--- a/packages/signer/signer-icp/README.md
+++ b/packages/signer/signer-icp/README.md
@@ -4,6 +4,7 @@ This module provides the implementation of the Ledger Internet Computer (ICP) si
 
 - Retrieving the ICP public key, account identifier and principal for a given derivation path;
 - Signing an Internet Computer transaction;
+- Signing an update call together with its read-state request (neuron management);
 - Retrieving the app configuration (version);
 
 ## 🔹 Index
@@ -14,7 +15,8 @@ This module provides the implementation of the Ledger Internet Computer (ICP) si
 4. [Use Cases](#-use-cases)
    - [Get Address](#use-case-1-get-address)
    - [Sign Transaction](#use-case-2-sign-transaction)
-   - [Get App Configuration](#use-case-3-get-app-configuration)
+   - [Sign Update Call](#use-case-3-sign-update-call)
+   - [Get App Configuration](#use-case-4-get-app-configuration)
 5. [Observable Behavior](#-observable-behavior)
 6. [Example](#-example)
 
@@ -42,7 +44,7 @@ const signerIcp = new SignerIcpBuilder({ dmk, sessionId }).build();
 
 ## 🔹 Use Cases
 
-The `SignerIcpBuilder.build()` method will return a `SignerIcp` instance that exposes 3 dedicated methods, each of which calls an independent use case. Each use case will return an object that contains an observable and a method called `cancel`.
+The `SignerIcpBuilder.build()` method will return a `SignerIcp` instance that exposes 4 dedicated methods, each of which calls an independent use case. Each use case will return an object that contains an observable and a method called `cancel`.
 
 ---
 
@@ -127,10 +129,12 @@ const { observable, cancel } = signerIcp.signTransaction(
     ```typescript
     type TransactionOptions = {
       skipOpenApp?: boolean;
+      stake?: boolean;
     };
     ```
 
   - `skipOpenApp`: An optional boolean indicating whether to skip opening the ICP app on the device (`true`) or not (`false`). Use when the app is already open.
+  - `stake`: An optional boolean signing a neuron-creation transfer (a governance-subaccount transfer, `true`) instead of a plain transfer (`false`, default).
 
 #### **Returns**
 
@@ -149,7 +153,71 @@ type Signature = {
 
 ---
 
-### Use Case 3: Get App Configuration
+### Use Case 3: Sign Update Call
+
+Sign an Internet Computer update call together with its companion read-state request. Most neuron-management operations (dissolve, follow, split, hot-keys, maturity, …) are update calls to the NNS governance canister signed this way.
+
+```typescript
+const { observable, cancel } = signerIcp.signUpdateCall(
+  derivationPath,
+  callRequest,
+  readStateRequest,
+  options,
+);
+```
+
+#### **Parameters**
+
+- `derivationPath`
+
+  - **Required**
+  - **Type:** `string` (e.g., `"44'/223'/0'/0/0"`)
+  - The derivation path used for the ICP address.
+
+- `callRequest`
+
+  - **Required**
+  - **Type:** `Uint8Array`
+  - The serialized update-call request bytes (CBOR envelope) to sign.
+
+- `readStateRequest`
+
+  - **Required**
+  - **Type:** `Uint8Array`
+  - The serialized read-state request bytes (CBOR envelope) signed alongside the call, used afterwards to poll the call's status.
+
+- `options`
+
+  - Optional
+  - Type: `CommonOptions`
+
+    ```typescript
+    type CommonOptions = {
+      skipOpenApp?: boolean;
+    };
+    ```
+
+  - `skipOpenApp`: An optional boolean indicating whether to skip opening the ICP app on the device (`true`) or not (`false`). Use when the app is already open.
+
+#### **Returns**
+
+- `observable` Emits DeviceActionState updates, including the following details:
+
+```typescript
+type UpdateCallSignature = {
+  requestHash: string; // hex-encoded signed request digest
+  requestSignature: { r: string; s: string }; // hex-encoded r‖s over the call
+  readStateHash: string; // hex-encoded signed read-state digest
+  readStateSignature: { r: string; s: string }; // hex-encoded r‖s over the read-state
+  readStateBody: Uint8Array; // the read-state request that was signed
+};
+```
+
+- `cancel` A function to cancel the action on the Ledger device.
+
+---
+
+### Use Case 4: Get App Configuration
 
 This method allows the user to fetch the current app configuration.
 

--- a/packages/signer/signer-icp/src/api/SignerIcp.ts
+++ b/packages/signer/signer-icp/src/api/SignerIcp.ts
@@ -1,14 +1,20 @@
 import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
 import { type GetVersionDAReturnType } from "@api/app-binder/GetVersionDeviceActionTypes";
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
+import { type SignUpdateCallDAReturnType } from "@api/app-binder/SignUpdateCallDeviceActionTypes";
 
 export type AddressOptions = {
   checkOnDevice?: boolean;
   skipOpenApp?: boolean;
 };
 
-export type TransactionOptions = {
+export type CommonOptions = {
   skipOpenApp?: boolean;
+};
+
+export type TransactionOptions = CommonOptions & {
+  // Sign a neuron-creation transfer (governance-subaccount) instead of a plain transfer.
+  stake?: boolean;
 };
 
 export interface SignerIcp {
@@ -24,4 +30,13 @@ export interface SignerIcp {
     transaction: Uint8Array,
     options?: TransactionOptions,
   ) => SignTransactionDAReturnType;
+
+  // Sign an IC update call together with its companion read-state request
+  // (neuron management). Returns both signatures with the read-state body.
+  signUpdateCall: (
+    derivationPath: string,
+    callRequest: Uint8Array,
+    readStateRequest: Uint8Array,
+    options?: CommonOptions,
+  ) => SignUpdateCallDAReturnType;
 }

--- a/packages/signer/signer-icp/src/api/app-binder/SignUpdateCallDeviceActionTypes.ts
+++ b/packages/signer/signer-icp/src/api/app-binder/SignUpdateCallDeviceActionTypes.ts
@@ -1,0 +1,30 @@
+import {
+  type CallTaskInAppDAOutput,
+  type CommandErrorResult,
+  type ExecuteDeviceActionReturnType,
+  type OpenAppDAError,
+  type OpenAppDARequiredInteraction,
+  type UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import { type UpdateCallSignature } from "@api/model/UpdateCallSignature";
+import { type IcpErrorCodes } from "@internal/app-binder/command/utils/IcpApplicationErrors";
+
+export type SignUpdateCallDAOutput = CallTaskInAppDAOutput<UpdateCallSignature>;
+export type SignUpdateCallDAError =
+  | OpenAppDAError
+  | CommandErrorResult<IcpErrorCodes>["error"];
+
+type SignUpdateCallDARequiredInteraction =
+  | OpenAppDARequiredInteraction
+  | UserInteractionRequired.SignTransaction;
+
+export type SignUpdateCallDAIntermediateValue = {
+  requiredUserInteraction: SignUpdateCallDARequiredInteraction;
+};
+
+export type SignUpdateCallDAReturnType = ExecuteDeviceActionReturnType<
+  SignUpdateCallDAOutput,
+  SignUpdateCallDAError,
+  SignUpdateCallDAIntermediateValue
+>;

--- a/packages/signer/signer-icp/src/api/index.ts
+++ b/packages/signer/signer-icp/src/api/index.ts
@@ -16,11 +16,23 @@ export {
   type SignTransactionDAOutput,
   type SignTransactionDAReturnType,
 } from "@api/app-binder/SignTransactionDeviceActionTypes";
+export {
+  type SignUpdateCallDAError,
+  type SignUpdateCallDAIntermediateValue,
+  type SignUpdateCallDAOutput,
+  type SignUpdateCallDAReturnType,
+} from "@api/app-binder/SignUpdateCallDeviceActionTypes";
 export { type Address } from "@api/model/Address";
 export { type Signature } from "@api/model/Signature";
+export {
+  type CombinedSignature,
+  type DeviceUpdateCallSignature,
+  type UpdateCallSignature,
+} from "@api/model/UpdateCallSignature";
 export { type Version } from "@api/model/Version";
 export {
   type AddressOptions,
+  type CommonOptions,
   type SignerIcp,
   type TransactionOptions,
 } from "@api/SignerIcp";

--- a/packages/signer/signer-icp/src/api/model/UpdateCallSignature.ts
+++ b/packages/signer/signer-icp/src/api/model/UpdateCallSignature.ts
@@ -1,0 +1,23 @@
+// A combined-sign signature: raw r‖s only. Unlike the transfer path, the ICP
+// app's SIGN_COMBINED response carries no recovery byte or DER encoding.
+export type CombinedSignature = {
+  r: string;
+  s: string;
+};
+
+// Raw device response of update-call signing (INS 0x03). The device signs the
+// call request together with its companion read-state request and returns the
+// signed digest and r‖s signature of each.
+export type DeviceUpdateCallSignature = {
+  requestHash: string;
+  requestSignature: CombinedSignature;
+  readStateHash: string;
+  readStateSignature: CombinedSignature;
+};
+
+// Result surfaced to the caller: the device response plus the read-state
+// request that was signed, so the caller can submit the call and poll its
+// status while keeping the request ↔ read-state pairing intact.
+export type UpdateCallSignature = DeviceUpdateCallSignature & {
+  readStateBody: Uint8Array;
+};

--- a/packages/signer/signer-icp/src/internal/DefaultSignerIcp.test.ts
+++ b/packages/signer/signer-icp/src/internal/DefaultSignerIcp.test.ts
@@ -62,4 +62,22 @@ describe("DefaultSignerIcp", () => {
     expect(executeDeviceActionMock).toHaveBeenCalledTimes(1);
     expect(result).toBe(expectedResult);
   });
+
+  it("signUpdateCall should delegate to the update-call device action", () => {
+    // ARRANGE
+    const expectedResult = { observable: {}, cancel: vi.fn() };
+    const executeDeviceActionMock = vi.fn().mockReturnValue(expectedResult);
+    const signer = makeSigner(executeDeviceActionMock);
+
+    // ACT
+    const result = signer.signUpdateCall(
+      "44'/223'/0'/0/0",
+      new Uint8Array([0x01, 0x02]),
+      new Uint8Array([0x03, 0x04]),
+    );
+
+    // ASSERT
+    expect(executeDeviceActionMock).toHaveBeenCalledTimes(1);
+    expect(result).toBe(expectedResult);
+  });
 });

--- a/packages/signer/signer-icp/src/internal/DefaultSignerIcp.ts
+++ b/packages/signer/signer-icp/src/internal/DefaultSignerIcp.ts
@@ -7,8 +7,10 @@ import { type Container } from "inversify";
 import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
 import { type GetVersionDAReturnType } from "@api/app-binder/GetVersionDeviceActionTypes";
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
+import { type SignUpdateCallDAReturnType } from "@api/app-binder/SignUpdateCallDeviceActionTypes";
 import {
   type AddressOptions,
+  type CommonOptions,
   type SignerIcp,
   type TransactionOptions,
 } from "@api/SignerIcp";
@@ -19,6 +21,7 @@ import { configTypes } from "@internal/use-cases/config/di/configTypes";
 import { type GetAppConfigurationUseCase } from "@internal/use-cases/config/GetAppConfigurationUseCase";
 import { transactionTypes } from "@internal/use-cases/transaction/di/transactionTypes";
 import { type SignTransactionUseCase } from "@internal/use-cases/transaction/SignTransactionUseCase";
+import { type SignUpdateCallUseCase } from "@internal/use-cases/transaction/SignUpdateCallUseCase";
 
 type DefaultSignerIcpConstructorArgs = {
   dmk: DeviceManagementKit;
@@ -55,5 +58,16 @@ export class DefaultSignerIcp implements SignerIcp {
     return this._container
       .get<SignTransactionUseCase>(transactionTypes.SignTransactionUseCase)
       .execute(derivationPath, transaction, options);
+  }
+
+  signUpdateCall(
+    derivationPath: string,
+    callRequest: Uint8Array,
+    readStateRequest: Uint8Array,
+    options?: CommonOptions,
+  ): SignUpdateCallDAReturnType {
+    return this._container
+      .get<SignUpdateCallUseCase>(transactionTypes.SignUpdateCallUseCase)
+      .execute(derivationPath, callRequest, readStateRequest, options);
   }
 }

--- a/packages/signer/signer-icp/src/internal/app-binder/IcpAppBinder.test.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/IcpAppBinder.test.ts
@@ -110,4 +110,28 @@ describe("IcpAppBinder", () => {
     expect(args.deviceAction.input.skipOpenApp).toBe(false);
     expect(result).toBe(expectedResult);
   });
+
+  it("signUpdateCall should run a CallTaskInAppDeviceAction requiring SignTransaction", () => {
+    // ARRANGE
+    const expectedResult = { observable: {}, cancel: vi.fn() };
+    const executeDeviceActionMock = vi.fn().mockReturnValue(expectedResult);
+    const binder = makeBinder(executeDeviceActionMock);
+
+    // ACT
+    const result = binder.signUpdateCall({
+      derivationPath: DERIVATION_PATH,
+      callRequest: new Uint8Array([0x01, 0x02]),
+      readStateRequest: new Uint8Array([0x03, 0x04]),
+    });
+
+    // ASSERT
+    const args = executeDeviceActionMock.mock.calls[0]![0];
+    expect(args.deviceAction).toBeInstanceOf(CallTaskInAppDeviceAction);
+    expect(args.deviceAction.input.appName).toBe(APP_NAME);
+    expect(args.deviceAction.input.requiredUserInteraction).toBe(
+      UserInteractionRequired.SignTransaction,
+    );
+    expect(args.deviceAction.input.skipOpenApp).toBe(false);
+    expect(result).toBe(expectedResult);
+  });
 });

--- a/packages/signer/signer-icp/src/internal/app-binder/IcpAppBinder.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/IcpAppBinder.ts
@@ -11,6 +11,7 @@ import { inject, injectable } from "inversify";
 import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
 import { type GetVersionDAReturnType } from "@api/app-binder/GetVersionDeviceActionTypes";
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
+import { type SignUpdateCallDAReturnType } from "@api/app-binder/SignUpdateCallDeviceActionTypes";
 import {
   GetAddressCommand,
   type GetAddressCommandArgs,
@@ -18,6 +19,7 @@ import {
 import { GetVersionCommand } from "@internal/app-binder/command/GetVersionCommand";
 import { APP_NAME } from "@internal/app-binder/constants";
 import { SignTransactionTask } from "@internal/app-binder/task/SignTransactionTask";
+import { SignUpdateCallTask } from "@internal/app-binder/task/SignUpdateCallTask";
 import { externalTypes } from "@internal/externalTypes";
 
 @injectable()
@@ -64,6 +66,7 @@ export class IcpAppBinder {
   signTransaction(args: {
     derivationPath: string;
     transaction: Uint8Array;
+    stake?: boolean;
     skipOpenApp?: boolean;
   }): SignTransactionDAReturnType {
     return this.dmk.executeDeviceAction({
@@ -81,6 +84,31 @@ export class IcpAppBinder {
           skipOpenApp: args.skipOpenApp ?? false,
         },
         logger: this.dmkLoggerFactory("SignTransactionCommand"),
+      }),
+    });
+  }
+
+  signUpdateCall(args: {
+    derivationPath: string;
+    callRequest: Uint8Array;
+    readStateRequest: Uint8Array;
+    skipOpenApp?: boolean;
+  }): SignUpdateCallDAReturnType {
+    return this.dmk.executeDeviceAction({
+      sessionId: this.sessionId,
+      deviceAction: new CallTaskInAppDeviceAction({
+        input: {
+          task: async (internalApi) =>
+            new SignUpdateCallTask(
+              internalApi,
+              args,
+              this.dmkLoggerFactory("SignUpdateCallTask"),
+            ).run(),
+          appName: APP_NAME,
+          requiredUserInteraction: UserInteractionRequired.SignTransaction,
+          skipOpenApp: args.skipOpenApp ?? false,
+        },
+        logger: this.dmkLoggerFactory("SignUpdateCallTask"),
       }),
     });
   }

--- a/packages/signer/signer-icp/src/internal/app-binder/command/SignTransactionCommand.test.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/SignTransactionCommand.test.ts
@@ -8,13 +8,17 @@ import { expectStatusWordError } from "@internal/app-binder/command/__test-utils
 import { pathToBuffer } from "@internal/app-binder/command/__test-utils__/pathToBuffer";
 import {
   icpSignTransactionApduHeader,
+  P2_NO_STAKE,
+  P2_STAKE,
+  SignTransactionCommand,
+} from "@internal/app-binder/command/SignTransactionCommand";
+import { IcpErrorCodes } from "@internal/app-binder/command/utils/IcpApplicationErrors";
+import {
   P1_ADD,
   P1_INIT,
   P1_LAST,
   SignPhase,
-  SignTransactionCommand,
-} from "@internal/app-binder/command/SignTransactionCommand";
-import { IcpErrorCodes } from "@internal/app-binder/command/utils/IcpApplicationErrors";
+} from "@internal/app-binder/constants";
 
 const DERIVATION_PATH = "44'/223'/0'/0/0";
 
@@ -38,7 +42,9 @@ describe("SignTransactionCommand", () => {
         phase: SignPhase.INIT,
         derivationPath: DERIVATION_PATH,
       });
-      const expected = new ApduBuilder(icpSignTransactionApduHeader(P1_INIT))
+      const expected = new ApduBuilder(
+        icpSignTransactionApduHeader(P1_INIT, P2_NO_STAKE),
+      )
         .addBufferToData(pathToBuffer(DERIVATION_PATH))
         .build();
       // ACT
@@ -54,7 +60,9 @@ describe("SignTransactionCommand", () => {
         phase: SignPhase.ADD,
         transactionChunk: chunk,
       });
-      const expected = new ApduBuilder(icpSignTransactionApduHeader(P1_ADD))
+      const expected = new ApduBuilder(
+        icpSignTransactionApduHeader(P1_ADD, P2_NO_STAKE),
+      )
         .addBufferToData(chunk)
         .build();
       // ACT
@@ -70,13 +78,34 @@ describe("SignTransactionCommand", () => {
         phase: SignPhase.LAST,
         transactionChunk: chunk,
       });
-      const expected = new ApduBuilder(icpSignTransactionApduHeader(P1_LAST))
+      const expected = new ApduBuilder(
+        icpSignTransactionApduHeader(P1_LAST, P2_NO_STAKE),
+      )
         .addBufferToData(chunk)
         .build();
       // ACT
       const apdu = command.getApdu();
       // ASSERT
       expect(apdu.getRawApdu()).toStrictEqual(expected.getRawApdu());
+    });
+
+    it("should set P2=stake on the INIT packet when the stake flag is set", () => {
+      // ARRANGE
+      const command = new SignTransactionCommand({
+        phase: SignPhase.INIT,
+        derivationPath: DERIVATION_PATH,
+        stake: true,
+      });
+      const expected = new ApduBuilder(
+        icpSignTransactionApduHeader(P1_INIT, P2_STAKE),
+      )
+        .addBufferToData(pathToBuffer(DERIVATION_PATH))
+        .build();
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.getRawApdu());
+      expect(apdu.getRawApdu()[3]).toBe(P2_STAKE);
     });
 
     it("should throw when phase is INIT and derivationPath is missing", () => {

--- a/packages/signer/signer-icp/src/internal/app-binder/command/SignUpdateCallCommand.test.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/SignUpdateCallCommand.test.ts
@@ -1,0 +1,236 @@
+import {
+  ApduBuilder,
+  ApduResponse,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { expectStatusWordError } from "@internal/app-binder/command/__test-utils__/expectStatusWordError";
+import { pathToBuffer } from "@internal/app-binder/command/__test-utils__/pathToBuffer";
+import {
+  icpSignUpdateCallApduHeader,
+  SignUpdateCallCommand,
+} from "@internal/app-binder/command/SignUpdateCallCommand";
+import { IcpErrorCodes } from "@internal/app-binder/command/utils/IcpApplicationErrors";
+import {
+  P1_ADD,
+  P1_INIT,
+  P1_LAST,
+  SignPhase,
+} from "@internal/app-binder/constants";
+
+const DERIVATION_PATH = "44'/223'/0'/0/0";
+
+// Last-chunk layout of the app's SIGN_COMBINED response, per crypto_sign_combined:
+// DIGEST_REQUEST(32) · SIG_REQUEST r‖s(64) · DIGEST_STATEREAD(32) · SIG_STATEREAD r‖s(64).
+// Each field uses a distinct fill so any mis-slice is caught.
+const requestHash = new Uint8Array(32).fill(0x11);
+const requestR = new Uint8Array(32).fill(0xaa);
+const requestS = new Uint8Array(32).fill(0xbb);
+const readStateHash = new Uint8Array(32).fill(0x22);
+const readStateR = new Uint8Array(32).fill(0xcc);
+const readStateS = new Uint8Array(32).fill(0xdd);
+const COMBINED_RESPONSE = new Uint8Array([
+  ...requestHash,
+  ...requestR,
+  ...requestS,
+  ...readStateHash,
+  ...readStateR,
+  ...readStateS,
+]);
+
+describe("SignUpdateCallCommand", () => {
+  describe("name", () => {
+    it("should be 'SignUpdateCall'", () => {
+      const command = new SignUpdateCallCommand({
+        phase: SignPhase.INIT,
+        derivationPath: DERIVATION_PATH,
+      });
+      expect(command.name).toBe("SignUpdateCall");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("should return the derivation-path packet (INS=0x03, P1=INIT, P2=0) when phase is INIT", () => {
+      // ARRANGE
+      const command = new SignUpdateCallCommand({
+        phase: SignPhase.INIT,
+        derivationPath: DERIVATION_PATH,
+      });
+      const expected = new ApduBuilder(icpSignUpdateCallApduHeader(P1_INIT))
+        .addBufferToData(pathToBuffer(DERIVATION_PATH))
+        .build();
+      // ACT
+      const apdu = command.getApdu();
+      // ASSERT
+      expect(apdu.getRawApdu()).toStrictEqual(expected.getRawApdu());
+      expect(apdu.getRawApdu()[1]).toBe(0x03);
+    });
+
+    it("should return an add packet (P1=ADD) carrying the chunk when phase is ADD", () => {
+      // ARRANGE
+      const chunk = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+      const command = new SignUpdateCallCommand({
+        phase: SignPhase.ADD,
+        transactionChunk: chunk,
+      });
+      const expected = new ApduBuilder(icpSignUpdateCallApduHeader(P1_ADD))
+        .addBufferToData(chunk)
+        .build();
+      // ACT & ASSERT
+      expect(command.getApdu().getRawApdu()).toStrictEqual(
+        expected.getRawApdu(),
+      );
+    });
+
+    it("should return a last packet (P1=LAST) carrying the chunk when phase is LAST", () => {
+      // ARRANGE
+      const chunk = new Uint8Array([0x01, 0x02, 0x03]);
+      const command = new SignUpdateCallCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: chunk,
+      });
+      const expected = new ApduBuilder(icpSignUpdateCallApduHeader(P1_LAST))
+        .addBufferToData(chunk)
+        .build();
+      // ACT & ASSERT
+      expect(command.getApdu().getRawApdu()).toStrictEqual(
+        expected.getRawApdu(),
+      );
+    });
+
+    it("should throw when phase is INIT and derivationPath is missing", () => {
+      const command = new SignUpdateCallCommand({ phase: SignPhase.INIT });
+      expect(() => command.getApdu()).toThrow(
+        "SignUpdateCallCommand: derivation path is required for 'init' phase.",
+      );
+    });
+
+    it("should throw when phase is INIT and path does not have 5 elements", () => {
+      const command = new SignUpdateCallCommand({
+        phase: SignPhase.INIT,
+        derivationPath: "44'/223'/0'",
+      });
+      expect(() => command.getApdu()).toThrow(
+        "SignUpdateCallCommand: expected 5 path elements, got 3",
+      );
+    });
+
+    it("should throw when phase is ADD and transactionChunk is missing", () => {
+      const command = new SignUpdateCallCommand({ phase: SignPhase.ADD });
+      expect(() => command.getApdu()).toThrow(
+        "SignUpdateCallCommand: transaction chunk is required for 'add' and 'last' phases.",
+      );
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("should split the last-chunk response into request/read-state digests and r‖s signatures", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: COMBINED_RESPONSE,
+      });
+      const command = new SignUpdateCallCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data.extract()).toEqual({
+          requestHash: "11".repeat(32),
+          requestSignature: { r: "aa".repeat(32), s: "bb".repeat(32) },
+          readStateHash: "22".repeat(32),
+          readStateSignature: { r: "cc".repeat(32), s: "dd".repeat(32) },
+        });
+      }
+    });
+
+    it("should return Nothing for an empty intermediate-chunk response", () => {
+      // ARRANGE — INIT and ADD chunks reply 0x9000 with no data
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: new Uint8Array(0),
+      });
+      const command = new SignUpdateCallCommand({
+        phase: SignPhase.ADD,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT
+      const result = command.parseResponse(response);
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data.isNothing()).toBe(true);
+      }
+    });
+
+    it("should reject a non-empty response too short to hold both signatures", () => {
+      // ARRANGE — 128 bytes: request block present, read-state signature missing
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: COMBINED_RESPONSE.slice(0, 128),
+      });
+      const command = new SignUpdateCallCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT & ASSERT
+      expect(isSuccessCommandResult(command.parseResponse(response))).toBe(
+        false,
+      );
+    });
+
+    it("should reject a response longer than the fixed 192-byte block", () => {
+      // ARRANGE — trailing bytes beyond the two signatures signal a malformed reply
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: new Uint8Array([...COMBINED_RESPONSE, 0x00]),
+      });
+      const command = new SignUpdateCallCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT & ASSERT
+      expect(isSuccessCommandResult(command.parseResponse(response))).toBe(
+        false,
+      );
+    });
+
+    it("should return IcpAppCommandError when status word signals an error", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x69, 0x84]),
+        data: new Uint8Array(0),
+      });
+      const command = new SignUpdateCallCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT & ASSERT
+      expectStatusWordError(
+        command.parseResponse(response),
+        IcpErrorCodes.DATA_INVALID,
+      );
+    });
+
+    it("should map a user-refusal status word (0x6986) to a typed error", () => {
+      // ARRANGE
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x69, 0x86]),
+        data: new Uint8Array(0),
+      });
+      const command = new SignUpdateCallCommand({
+        phase: SignPhase.LAST,
+        transactionChunk: new Uint8Array(1),
+      });
+      // ACT & ASSERT
+      expectStatusWordError(
+        command.parseResponse(response),
+        IcpErrorCodes.COMMAND_NOT_ALLOWED,
+      );
+    });
+  });
+});

--- a/packages/signer/signer-icp/src/internal/app-binder/command/SignUpdateCallCommand.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/command/SignUpdateCallCommand.ts
@@ -14,7 +14,7 @@ import {
 } from "@ledgerhq/signer-utils";
 import { Just, Maybe, Nothing } from "purify-ts";
 
-import { type Signature } from "@api/model/Signature";
+import { type DeviceUpdateCallSignature } from "@api/model/UpdateCallSignature";
 import { encodeDerivationPath } from "@internal/app-binder/command/utils/EncodeDerivationPath";
 import {
   ICP_APP_ERRORS,
@@ -28,63 +28,54 @@ import {
   SignPhase,
 } from "@internal/app-binder/constants";
 
-// P2 carries the transaction-type flag: a plain transfer uses 0x00, a
-// neuron-creation (governance-subaccount) transfer uses 0x01. The device reads
-// it on the first chunk and requires the same value on every following chunk.
-export const P2_NO_STAKE = 0x00;
-export const P2_STAKE = 0x01;
+// Update calls always sign the normal transaction type; the stake flag is a
+// transfer-path concern (INS 0x02).
+export const P2_UPDATE_CALL = 0x00;
 
 const DERIVATION_PATH_LENGTH = 5;
-// The last-chunk signature response is prefixed by the pre-sign hash, then r‖s, v, and DER.
-const PRESIGN_HASH_LENGTH = 43;
+// The last-chunk response is a fixed 192-byte block: for the request and the
+// read-state each, a 32-byte signed digest followed by a 64-byte r‖s signature.
+const HASH_LENGTH = 32;
 const SIGNATURE_R_LENGTH = 32;
 const SIGNATURE_S_LENGTH = 32;
-const SIGNATURE_V_LENGTH = 1;
 
-export const icpSignTransactionApduHeader = (p1: number, p2: number) => ({
+export const icpSignUpdateCallApduHeader = (p1: number) => ({
   cla: 0x11,
-  ins: 0x02,
+  ins: 0x03,
   p1,
-  p2,
+  p2: P2_UPDATE_CALL,
 });
 
-export type SignTransactionCommandArgs = {
+export type SignUpdateCallCommandArgs = {
   phase: SignPhase;
   derivationPath?: string;
   transactionChunk?: Uint8Array;
-  // Sign a neuron-creation transfer (P2=0x01) instead of a plain transfer.
-  stake?: boolean;
 };
 
-export type SignTransactionCommandResponse = Maybe<Signature>;
+export type SignUpdateCallCommandResponse = Maybe<DeviceUpdateCallSignature>;
 
-export class SignTransactionCommand
+export class SignUpdateCallCommand
   implements
     Command<
-      SignTransactionCommandResponse,
-      SignTransactionCommandArgs,
+      SignUpdateCallCommandResponse,
+      SignUpdateCallCommandArgs,
       IcpErrorCodes
     >
 {
-  readonly name = "SignTransaction";
+  readonly name = "SignUpdateCall";
 
-  private readonly args: SignTransactionCommandArgs;
+  private readonly args: SignUpdateCallCommandArgs;
 
   private readonly apduBuilder: ApduBuilder;
 
   private readonly errorHelper = new CommandErrorHelper<
-    SignTransactionCommandResponse,
+    SignUpdateCallCommandResponse,
     IcpErrorCodes
   >(ICP_APP_ERRORS, IcpAppCommandErrorFactory);
 
-  constructor(args: SignTransactionCommandArgs) {
+  constructor(args: SignUpdateCallCommandArgs) {
     this.args = args;
-    this.apduBuilder = new ApduBuilder(
-      icpSignTransactionApduHeader(
-        this.p1(),
-        this.args.stake ? P2_STAKE : P2_NO_STAKE,
-      ),
-    );
+    this.apduBuilder = new ApduBuilder(icpSignUpdateCallApduHeader(this.p1()));
   }
 
   public getApdu(): Apdu {
@@ -93,35 +84,33 @@ export class SignTransactionCommand
 
   public parseResponse(
     apduResponse: ApduResponse,
-  ): CommandResult<SignTransactionCommandResponse, IcpErrorCodes> {
+  ): CommandResult<SignUpdateCallCommandResponse, IcpErrorCodes> {
     return Maybe.fromNullable(
       this.errorHelper.getError(apduResponse),
     ).orDefaultLazy(() => {
       const apduParser = new ApduParser(apduResponse);
 
-      // Only the last chunk carries the signature; INIT/ADD reply 0x9000 empty.
+      // Only the last chunk carries the signatures; INIT/ADD reply 0x9000 empty.
       // Empty ⇒ not-yet (Nothing); non-empty-but-incomplete ⇒ malformed.
       if (apduParser.getUnparsedRemainingLength() === 0) {
         return CommandResultFactory({ data: Nothing });
       }
 
-      // Validate the pre-sign hash's presence; it is not surfaced.
-      const preSignHash = apduParser.extractFieldByLength(PRESIGN_HASH_LENGTH);
-      const r = apduParser.extractFieldByLength(SIGNATURE_R_LENGTH);
-      const s = apduParser.extractFieldByLength(SIGNATURE_S_LENGTH);
-      const v = apduParser.extractFieldByLength(SIGNATURE_V_LENGTH);
-      const der = apduParser.extractFieldByLength(
-        apduParser.getUnparsedRemainingLength(),
-      );
+      const requestHash = apduParser.extractFieldByLength(HASH_LENGTH);
+      const requestR = apduParser.extractFieldByLength(SIGNATURE_R_LENGTH);
+      const requestS = apduParser.extractFieldByLength(SIGNATURE_S_LENGTH);
+      const readStateHash = apduParser.extractFieldByLength(HASH_LENGTH);
+      const readStateR = apduParser.extractFieldByLength(SIGNATURE_R_LENGTH);
+      const readStateS = apduParser.extractFieldByLength(SIGNATURE_S_LENGTH);
 
       if (
-        preSignHash === undefined ||
-        r === undefined ||
-        s === undefined ||
-        v === undefined ||
-        v[0] === undefined ||
-        der === undefined ||
-        der.length === 0
+        requestHash === undefined ||
+        requestR === undefined ||
+        requestS === undefined ||
+        readStateHash === undefined ||
+        readStateR === undefined ||
+        readStateS === undefined ||
+        apduParser.getUnparsedRemainingLength() !== 0
       ) {
         return CommandResultFactory({
           error: new InvalidStatusWordError("Signature is malformed"),
@@ -130,10 +119,16 @@ export class SignTransactionCommand
 
       return CommandResultFactory({
         data: Just({
-          r: apduParser.encodeToHexaString(r),
-          s: apduParser.encodeToHexaString(s),
-          v: v[0],
-          der: apduParser.encodeToHexaString(der),
+          requestHash: apduParser.encodeToHexaString(requestHash),
+          requestSignature: {
+            r: apduParser.encodeToHexaString(requestR),
+            s: apduParser.encodeToHexaString(requestS),
+          },
+          readStateHash: apduParser.encodeToHexaString(readStateHash),
+          readStateSignature: {
+            r: apduParser.encodeToHexaString(readStateR),
+            s: apduParser.encodeToHexaString(readStateS),
+          },
         }),
       });
     });
@@ -159,7 +154,7 @@ export class SignTransactionCommand
 
     if (!derivationPath) {
       throw new Error(
-        "SignTransactionCommand: derivation path is required for 'init' phase.",
+        "SignUpdateCallCommand: derivation path is required for 'init' phase.",
       );
     }
 
@@ -167,7 +162,7 @@ export class SignTransactionCommand
 
     if (paths.length !== DERIVATION_PATH_LENGTH) {
       throw new Error(
-        `SignTransactionCommand: expected ${DERIVATION_PATH_LENGTH} path elements, got ${paths.length}`,
+        `SignUpdateCallCommand: expected ${DERIVATION_PATH_LENGTH} path elements, got ${paths.length}`,
       );
     }
 
@@ -178,7 +173,7 @@ export class SignTransactionCommand
   private nextChunk(): Apdu {
     if (!this.args.transactionChunk) {
       throw new Error(
-        "SignTransactionCommand: transaction chunk is required for 'add' and 'last' phases.",
+        "SignUpdateCallCommand: transaction chunk is required for 'add' and 'last' phases.",
       );
     }
 

--- a/packages/signer/signer-icp/src/internal/app-binder/constants.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/constants.ts
@@ -1,1 +1,14 @@
 export const APP_NAME = "InternetComputer";
+
+// Chunk-sequence P1 values shared by the ICP chunked-sign commands
+// (INS 0x02 / 0x03): the first packet carries the derivation path, then the
+// payload is split across ADD packets and closed by a LAST packet.
+export const P1_INIT = 0x00;
+export const P1_ADD = 0x01;
+export const P1_LAST = 0x02;
+
+export enum SignPhase {
+  INIT = "init",
+  ADD = "add",
+  LAST = "last",
+}

--- a/packages/signer/signer-icp/src/internal/app-binder/task/SignTransactionTask.test.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/task/SignTransactionTask.test.ts
@@ -11,16 +11,15 @@ import { Just, Nothing } from "purify-ts";
 import { vi } from "vitest";
 
 import {
-  P1_ADD,
-  P1_INIT,
-  P1_LAST,
   P2_NO_STAKE,
+  P2_STAKE,
   type SignTransactionCommand,
 } from "@internal/app-binder/command/SignTransactionCommand";
 import {
   IcpAppCommandError,
   IcpErrorCodes,
 } from "@internal/app-binder/command/utils/IcpApplicationErrors";
+import { P1_ADD, P1_INIT, P1_LAST } from "@internal/app-binder/constants";
 import { SignTransactionTask } from "@internal/app-binder/task/SignTransactionTask";
 
 const DERIVATION_PATH = "44'/223'/0'/0/0";
@@ -100,6 +99,33 @@ describe("SignTransactionTask", () => {
       expect(new Uint8Array([...add!.payload, ...last!.payload])).toStrictEqual(
         transaction,
       );
+    });
+
+    it("should pin P2=stake on every packet when the stake flag is set", async () => {
+      // ARRANGE — 300 bytes → INIT + one ADD + one LAST, all must carry P2=stake
+      const transaction = new Uint8Array(300).map((_, i) => i & 0xff);
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(CommandResultFactory({ data: Nothing })) // ADD
+        .mockResolvedValueOnce(CommandResultFactory({ data: Just(signature) })); // LAST
+
+      const task = new SignTransactionTask(
+        apiMock,
+        { derivationPath: DERIVATION_PATH, transaction, stake: true },
+        loggerMock,
+      );
+
+      // ACT
+      await task.run();
+
+      // ASSERT
+      const packets = sendCommandMock.mock.calls.map((c) =>
+        inspect(c[0] as SignTransactionCommand),
+      );
+      expect(packets).toHaveLength(3);
+      for (const packet of packets) {
+        expect(packet!.p2).toBe(P2_STAKE);
+      }
     });
 
     it("should send the whole transaction in a single LAST chunk when it fits one packet", async () => {

--- a/packages/signer/signer-icp/src/internal/app-binder/task/SignTransactionTask.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/task/SignTransactionTask.ts
@@ -10,15 +10,14 @@ import {
 import { type Maybe, Nothing } from "purify-ts";
 
 import { type Signature } from "@api/model/Signature";
-import {
-  SignPhase,
-  SignTransactionCommand,
-} from "@internal/app-binder/command/SignTransactionCommand";
+import { SignTransactionCommand } from "@internal/app-binder/command/SignTransactionCommand";
 import { type IcpErrorCodes } from "@internal/app-binder/command/utils/IcpApplicationErrors";
+import { SignPhase } from "@internal/app-binder/constants";
 
 type SignTransactionTaskArgs = {
   derivationPath: string;
   transaction: Uint8Array;
+  stake?: boolean;
 };
 
 export class SignTransactionTask {
@@ -29,7 +28,7 @@ export class SignTransactionTask {
   ) {}
 
   async run(): Promise<CommandResult<Signature, IcpErrorCodes>> {
-    const { derivationPath, transaction } = this.args;
+    const { derivationPath, transaction, stake } = this.args;
 
     this.logger.debug("[run] Starting SignTransactionTask", {
       data: {
@@ -49,6 +48,7 @@ export class SignTransactionTask {
       new SignTransactionCommand({
         phase: SignPhase.INIT,
         derivationPath,
+        stake,
       }),
     );
 
@@ -73,7 +73,7 @@ export class SignTransactionTask {
       );
 
       const result = await this.api.sendCommand(
-        new SignTransactionCommand({ phase, transactionChunk }),
+        new SignTransactionCommand({ phase, transactionChunk, stake }),
       );
 
       if (!isSuccessCommandResult(result)) {

--- a/packages/signer/signer-icp/src/internal/app-binder/task/SignUpdateCallTask.test.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/task/SignUpdateCallTask.test.ts
@@ -1,0 +1,298 @@
+import {
+  APDU_MAX_PAYLOAD,
+  CommandResultFactory,
+  CommandResultStatus,
+  type InternalApi,
+  InvalidStatusWordError,
+  isSuccessCommandResult,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+import { Just, Nothing } from "purify-ts";
+import { vi } from "vitest";
+
+import { type DeviceUpdateCallSignature } from "@api/model/UpdateCallSignature";
+import { type SignUpdateCallCommand } from "@internal/app-binder/command/SignUpdateCallCommand";
+import {
+  IcpAppCommandError,
+  IcpErrorCodes,
+} from "@internal/app-binder/command/utils/IcpApplicationErrors";
+import { P1_ADD, P1_INIT, P1_LAST } from "@internal/app-binder/constants";
+import { SignUpdateCallTask } from "@internal/app-binder/task/SignUpdateCallTask";
+
+const DERIVATION_PATH = "44'/223'/0'/0/0";
+const PATH_PAYLOAD_LENGTH = 20;
+const APDU_HEADER_LENGTH = 5; // cla, ins, p1, p2, lc
+
+const deviceSignature: DeviceUpdateCallSignature = {
+  requestHash: "11".repeat(32),
+  requestSignature: { r: "aa".repeat(32), s: "bb".repeat(32) },
+  readStateHash: "22".repeat(32),
+  readStateSignature: { r: "cc".repeat(32), s: "dd".repeat(32) },
+};
+
+const inspect = (command: SignUpdateCallCommand) => {
+  const raw = command.getApdu().getRawApdu();
+  return {
+    cla: raw[0],
+    ins: raw[1],
+    p1: raw[2],
+    p2: raw[3],
+    payload: raw.slice(APDU_HEADER_LENGTH),
+  };
+};
+
+describe("SignUpdateCallTask", () => {
+  let sendCommandMock: ReturnType<typeof vi.fn>;
+  let apiMock: InternalApi;
+  let loggerMock: LoggerPublisherService;
+
+  beforeEach(() => {
+    sendCommandMock = vi.fn();
+    apiMock = { sendCommand: sendCommandMock } as unknown as InternalApi;
+    loggerMock = { debug: vi.fn() } as unknown as LoggerPublisherService;
+  });
+
+  describe("run", () => {
+    it("should frame the message as [u32LE readStateLen][readState][u32LE callLen][call] with the read-state first", async () => {
+      // ARRANGE — distinct small bodies fit a single LAST chunk
+      const callRequest = new Uint8Array([0x01, 0x02, 0x03]);
+      const readStateRequest = new Uint8Array([0x09, 0x08]);
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(
+          CommandResultFactory({ data: Just(deviceSignature) }),
+        ); // LAST
+
+      const task = new SignUpdateCallTask(
+        apiMock,
+        { derivationPath: DERIVATION_PATH, callRequest, readStateRequest },
+        loggerMock,
+      );
+
+      // ACT
+      await task.run();
+
+      // ASSERT — INS 0x03, phase INIT then LAST
+      const [init, last] = sendCommandMock.mock.calls.map((c) =>
+        inspect(c[0] as SignUpdateCallCommand),
+      );
+      expect(init!.ins).toBe(0x03);
+      expect(init!.p1).toBe(P1_INIT);
+      expect(init!.payload.length).toBe(PATH_PAYLOAD_LENGTH);
+      expect(last!.p1).toBe(P1_LAST);
+
+      // read-state length (2, LE) · read-state · call length (3, LE) · call
+      const expected = new Uint8Array([
+        0x02, 0x00, 0x00, 0x00, 0x09, 0x08, 0x03, 0x00, 0x00, 0x00, 0x01, 0x02,
+        0x03,
+      ]);
+      expect(last!.payload).toStrictEqual(expected);
+    });
+
+    it("should return both signatures and echo the read-state body on success", async () => {
+      // ARRANGE
+      const callRequest = new Uint8Array([0xca, 0x11]);
+      const readStateRequest = new Uint8Array([0x5e, 0xed]);
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(
+          CommandResultFactory({ data: Just(deviceSignature) }),
+        ); // LAST
+
+      const task = new SignUpdateCallTask(
+        apiMock,
+        { derivationPath: DERIVATION_PATH, callRequest, readStateRequest },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT — both request ids surface, read-state body kept alongside
+      expect(isSuccessCommandResult(result)).toBe(true);
+      if (isSuccessCommandResult(result)) {
+        expect(result.data).toStrictEqual({
+          ...deviceSignature,
+          readStateBody: readStateRequest,
+        });
+      }
+    });
+
+    it("should split a large combined message across ADD/LAST chunks", async () => {
+      // ARRANGE — 8-byte prefix + 300 + 300 = 608 bytes → ADD (255) + ADD (255) + LAST (98)
+      const callRequest = new Uint8Array(300).fill(0x01);
+      const readStateRequest = new Uint8Array(300).fill(0x02);
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(CommandResultFactory({ data: Nothing })) // ADD
+        .mockResolvedValueOnce(CommandResultFactory({ data: Nothing })) // ADD
+        .mockResolvedValueOnce(
+          CommandResultFactory({ data: Just(deviceSignature) }),
+        ); // LAST
+
+      const task = new SignUpdateCallTask(
+        apiMock,
+        { derivationPath: DERIVATION_PATH, callRequest, readStateRequest },
+        loggerMock,
+      );
+
+      // ACT
+      await task.run();
+
+      // ASSERT — chunk phases and reassembled body match the framed message
+      const [, ...chunks] = sendCommandMock.mock.calls.map((c) =>
+        inspect(c[0] as SignUpdateCallCommand),
+      );
+      expect(chunks.map((c) => c!.p1)).toStrictEqual([P1_ADD, P1_ADD, P1_LAST]);
+      expect(chunks[0]!.payload.length).toBe(APDU_MAX_PAYLOAD);
+
+      const reassembled = new Uint8Array([
+        ...chunks[0]!.payload,
+        ...chunks[1]!.payload,
+        ...chunks[2]!.payload,
+      ]);
+      const expected = new Uint8Array(8 + 600);
+      new DataView(expected.buffer).setUint32(0, 300, true);
+      expected.set(readStateRequest, 4);
+      new DataView(expected.buffer).setUint32(304, 300, true);
+      expected.set(callRequest, 308);
+      expect(reassembled).toStrictEqual(expected);
+    });
+
+    it("should refuse a missing call request without touching the device", async () => {
+      // ARRANGE
+      const task = new SignUpdateCallTask(
+        apiMock,
+        {
+          derivationPath: DERIVATION_PATH,
+          callRequest: new Uint8Array(0),
+          readStateRequest: new Uint8Array([0x01]),
+        },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(sendCommandMock).not.toHaveBeenCalled();
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidStatusWordError;
+        expect(err).toBeInstanceOf(InvalidStatusWordError);
+        expect(err.originalError?.message).toBe(
+          "Both call and read-state requests are required",
+        );
+      }
+    });
+
+    it("should refuse a missing read-state request without touching the device", async () => {
+      // ARRANGE
+      const task = new SignUpdateCallTask(
+        apiMock,
+        {
+          derivationPath: DERIVATION_PATH,
+          callRequest: new Uint8Array([0x01]),
+          readStateRequest: new Uint8Array(0),
+        },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(sendCommandMock).not.toHaveBeenCalled();
+      expect(isSuccessCommandResult(result)).toBe(false);
+    });
+
+    it("should return the init error when the INIT command fails", async () => {
+      // ARRANGE
+      const commandError = CommandResultFactory({
+        error: new IcpAppCommandError({
+          message: "Conditions not satisfied",
+          errorCode: IcpErrorCodes.CONDITIONS_NOT_SATISFIED,
+        }),
+      });
+      sendCommandMock.mockResolvedValueOnce(commandError);
+
+      const task = new SignUpdateCallTask(
+        apiMock,
+        {
+          derivationPath: DERIVATION_PATH,
+          callRequest: new Uint8Array([0x01]),
+          readStateRequest: new Uint8Array([0x02]),
+        },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT — INIT attempted, no chunk sent afterwards
+      expect(isSuccessCommandResult(result)).toBe(false);
+      expect(sendCommandMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return the chunk error when a chunk command fails", async () => {
+      // ARRANGE
+      const commandError = CommandResultFactory({
+        error: new IcpAppCommandError({
+          message: "Data Invalid",
+          errorCode: IcpErrorCodes.DATA_INVALID,
+        }),
+      });
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(commandError); // LAST
+
+      const task = new SignUpdateCallTask(
+        apiMock,
+        {
+          derivationPath: DERIVATION_PATH,
+          callRequest: new Uint8Array([0x01]),
+          readStateRequest: new Uint8Array([0x02]),
+        },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect((result.error as IcpAppCommandError).errorCode).toBe(
+          IcpErrorCodes.DATA_INVALID,
+        );
+      }
+    });
+
+    it("should error when the last chunk succeeds but returns no signature", async () => {
+      // ARRANGE
+      sendCommandMock
+        .mockResolvedValueOnce({ status: CommandResultStatus.Success }) // INIT
+        .mockResolvedValueOnce(CommandResultFactory({ data: Nothing })); // LAST
+
+      const task = new SignUpdateCallTask(
+        apiMock,
+        {
+          derivationPath: DERIVATION_PATH,
+          callRequest: new Uint8Array([0x01]),
+          readStateRequest: new Uint8Array([0x02]),
+        },
+        loggerMock,
+      );
+
+      // ACT
+      const result = await task.run();
+
+      // ASSERT
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as InvalidStatusWordError;
+        expect(err.originalError?.message).toBe("No signature returned");
+      }
+    });
+  });
+});

--- a/packages/signer/signer-icp/src/internal/app-binder/task/SignUpdateCallTask.ts
+++ b/packages/signer/signer-icp/src/internal/app-binder/task/SignUpdateCallTask.ts
@@ -1,0 +1,126 @@
+import {
+  APDU_MAX_PAYLOAD,
+  type CommandResult,
+  CommandResultFactory,
+  type InternalApi,
+  InvalidStatusWordError,
+  isSuccessCommandResult,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+import { type Maybe, Nothing } from "purify-ts";
+
+import {
+  type DeviceUpdateCallSignature,
+  type UpdateCallSignature,
+} from "@api/model/UpdateCallSignature";
+import { SignUpdateCallCommand } from "@internal/app-binder/command/SignUpdateCallCommand";
+import { type IcpErrorCodes } from "@internal/app-binder/command/utils/IcpApplicationErrors";
+import { SignPhase } from "@internal/app-binder/constants";
+
+// Length prefix carried before each of the two envelopes in the combined
+// message (little-endian uint32).
+const LENGTH_PREFIX_SIZE = 4;
+
+type SignUpdateCallTaskArgs = {
+  derivationPath: string;
+  // The IC update call to sign.
+  callRequest: Uint8Array;
+  // The companion read-state request signed alongside the call.
+  readStateRequest: Uint8Array;
+};
+
+export class SignUpdateCallTask {
+  constructor(
+    private api: InternalApi,
+    private args: SignUpdateCallTaskArgs,
+    private logger: LoggerPublisherService,
+  ) {}
+
+  // Combined-sign message: [u32LE readStateLen][readState][u32LE callLen][call].
+  // The device parses the read-state envelope first, then the call.
+  private buildCombinedMessage(): Uint8Array {
+    const { callRequest, readStateRequest } = this.args;
+    const message = new Uint8Array(
+      2 * LENGTH_PREFIX_SIZE + readStateRequest.length + callRequest.length,
+    );
+    const view = new DataView(message.buffer);
+
+    view.setUint32(0, readStateRequest.length, true);
+    message.set(readStateRequest, LENGTH_PREFIX_SIZE);
+
+    const callLenOffset = LENGTH_PREFIX_SIZE + readStateRequest.length;
+    view.setUint32(callLenOffset, callRequest.length, true);
+    message.set(callRequest, callLenOffset + LENGTH_PREFIX_SIZE);
+
+    return message;
+  }
+
+  async run(): Promise<CommandResult<UpdateCallSignature, IcpErrorCodes>> {
+    const { derivationPath, callRequest, readStateRequest } = this.args;
+
+    this.logger.debug("[run] Starting SignUpdateCallTask", {
+      data: {
+        derivationPath,
+        callRequestLength: callRequest.length,
+        readStateRequestLength: readStateRequest.length,
+      },
+    });
+
+    if (callRequest.length === 0 || readStateRequest.length === 0) {
+      // A missing envelope would break the device's request ↔ read-state check.
+      return CommandResultFactory({
+        error: new InvalidStatusWordError(
+          "Both call and read-state requests are required",
+        ),
+      });
+    }
+
+    const message = this.buildCombinedMessage();
+
+    const initResult = await this.api.sendCommand(
+      new SignUpdateCallCommand({
+        phase: SignPhase.INIT,
+        derivationPath,
+      }),
+    );
+
+    if (!isSuccessCommandResult(initResult)) {
+      this.logger.debug("[run] Failed to initialize signing", {
+        data: { error: initResult.error },
+      });
+      return initResult;
+    }
+
+    let signature: Maybe<DeviceUpdateCallSignature> = Nothing;
+    for (let offset = 0; offset < message.length; offset += APDU_MAX_PAYLOAD) {
+      const isLastChunk = offset + APDU_MAX_PAYLOAD >= message.length;
+      const phase = isLastChunk ? SignPhase.LAST : SignPhase.ADD;
+      const transactionChunk = message.slice(offset, offset + APDU_MAX_PAYLOAD);
+
+      const result = await this.api.sendCommand(
+        new SignUpdateCallCommand({ phase, transactionChunk }),
+      );
+
+      if (!isSuccessCommandResult(result)) {
+        this.logger.debug("[run] Failed to sign update-call chunk", {
+          data: { chunkOffset: offset, error: result.error },
+        });
+        return result;
+      }
+
+      signature = result.data;
+    }
+
+    return signature.mapOrDefault(
+      (data) => {
+        this.logger.debug("[run] Update call signed successfully");
+        return CommandResultFactory<UpdateCallSignature, IcpErrorCodes>({
+          data: { ...data, readStateBody: readStateRequest },
+        });
+      },
+      CommandResultFactory({
+        error: new InvalidStatusWordError("No signature returned"),
+      }),
+    );
+  }
+}

--- a/packages/signer/signer-icp/src/internal/use-cases/transaction/SignTransactionUseCase.test.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/transaction/SignTransactionUseCase.test.ts
@@ -23,8 +23,31 @@ describe("SignTransactionUseCase", () => {
     expect(signTransactionMock).toHaveBeenCalledWith({
       derivationPath,
       transaction,
+      stake: undefined,
       skipOpenApp: undefined,
     });
     expect(result).toBe(expectedResult);
+  });
+
+  it("should forward the stake flag from options to appBinder.signTransaction", () => {
+    // ARRANGE
+    const derivationPath = "44'/223'/0'/0/0";
+    const transaction = new Uint8Array([0x01, 0x02, 0x03]);
+    const signTransactionMock = vi.fn().mockReturnValue({});
+    const appBinderMock = {
+      signTransaction: signTransactionMock,
+    } as unknown as IcpAppBinder;
+    const useCase = new SignTransactionUseCase(appBinderMock);
+
+    // ACT
+    useCase.execute(derivationPath, transaction, { stake: true });
+
+    // ASSERT
+    expect(signTransactionMock).toHaveBeenCalledWith({
+      derivationPath,
+      transaction,
+      stake: true,
+      skipOpenApp: undefined,
+    });
   });
 });

--- a/packages/signer/signer-icp/src/internal/use-cases/transaction/SignUpdateCallUseCase.test.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/transaction/SignUpdateCallUseCase.test.ts
@@ -1,0 +1,37 @@
+import { vi } from "vitest";
+
+import { type IcpAppBinder } from "@internal/app-binder/IcpAppBinder";
+
+import { SignUpdateCallUseCase } from "./SignUpdateCallUseCase";
+
+describe("SignUpdateCallUseCase", () => {
+  it("should forward the path, call and read-state requests to appBinder.signUpdateCall", () => {
+    // ARRANGE
+    const derivationPath = "44'/223'/0'/0/0";
+    const callRequest = new Uint8Array([0x01, 0x02]);
+    const readStateRequest = new Uint8Array([0x03, 0x04]);
+    const expectedResult = { observable: {}, cancel: vi.fn() };
+    const signUpdateCallMock = vi.fn().mockReturnValue(expectedResult);
+    const appBinderMock = {
+      signUpdateCall: signUpdateCallMock,
+    } as unknown as IcpAppBinder;
+    const useCase = new SignUpdateCallUseCase(appBinderMock);
+
+    // ACT
+    const result = useCase.execute(
+      derivationPath,
+      callRequest,
+      readStateRequest,
+      { skipOpenApp: true },
+    );
+
+    // ASSERT
+    expect(signUpdateCallMock).toHaveBeenCalledWith({
+      derivationPath,
+      callRequest,
+      readStateRequest,
+      skipOpenApp: true,
+    });
+    expect(result).toBe(expectedResult);
+  });
+});

--- a/packages/signer/signer-icp/src/internal/use-cases/transaction/SignUpdateCallUseCase.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/transaction/SignUpdateCallUseCase.ts
@@ -1,12 +1,12 @@
 import { inject, injectable } from "inversify";
 
-import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
-import { type TransactionOptions } from "@api/SignerIcp";
+import { type SignUpdateCallDAReturnType } from "@api/app-binder/SignUpdateCallDeviceActionTypes";
+import { type CommonOptions } from "@api/SignerIcp";
 import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
 import { IcpAppBinder } from "@internal/app-binder/IcpAppBinder";
 
 @injectable()
-export class SignTransactionUseCase {
+export class SignUpdateCallUseCase {
   private readonly _appBinder: IcpAppBinder;
 
   constructor(@inject(appBinderTypes.AppBinding) appBinder: IcpAppBinder) {
@@ -15,13 +15,14 @@ export class SignTransactionUseCase {
 
   execute(
     derivationPath: string,
-    transaction: Uint8Array,
-    options?: TransactionOptions,
-  ): SignTransactionDAReturnType {
-    return this._appBinder.signTransaction({
+    callRequest: Uint8Array,
+    readStateRequest: Uint8Array,
+    options?: CommonOptions,
+  ): SignUpdateCallDAReturnType {
+    return this._appBinder.signUpdateCall({
       derivationPath,
-      transaction,
-      stake: options?.stake,
+      callRequest,
+      readStateRequest,
       skipOpenApp: options?.skipOpenApp,
     });
   }

--- a/packages/signer/signer-icp/src/internal/use-cases/transaction/di/transactionModule.test.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/transaction/di/transactionModule.test.ts
@@ -1,15 +1,21 @@
 import { Container } from "inversify";
 
 import { transactionModuleFactory } from "./transactionModule";
+import { transactionTypes } from "./transactionTypes";
 
 describe("transactionModuleFactory", () => {
-  it("should return the transaction module", () => {
+  it("should bind the transaction use-cases", () => {
     // ARRANGE
     const mod = transactionModuleFactory();
     const container = new Container();
     // ACT
     container.loadSync(mod);
     // ASSERT
-    expect(mod).toBeDefined();
+    expect(container.isBound(transactionTypes.SignTransactionUseCase)).toBe(
+      true,
+    );
+    expect(container.isBound(transactionTypes.SignUpdateCallUseCase)).toBe(
+      true,
+    );
   });
 });

--- a/packages/signer/signer-icp/src/internal/use-cases/transaction/di/transactionModule.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/transaction/di/transactionModule.ts
@@ -2,8 +2,10 @@ import { ContainerModule } from "inversify";
 
 import { transactionTypes } from "@internal/use-cases/transaction/di/transactionTypes";
 import { SignTransactionUseCase } from "@internal/use-cases/transaction/SignTransactionUseCase";
+import { SignUpdateCallUseCase } from "@internal/use-cases/transaction/SignUpdateCallUseCase";
 
 export const transactionModuleFactory = () =>
   new ContainerModule(({ bind }) => {
     bind(transactionTypes.SignTransactionUseCase).to(SignTransactionUseCase);
+    bind(transactionTypes.SignUpdateCallUseCase).to(SignUpdateCallUseCase);
   });

--- a/packages/signer/signer-icp/src/internal/use-cases/transaction/di/transactionTypes.ts
+++ b/packages/signer/signer-icp/src/internal/use-cases/transaction/di/transactionTypes.ts
@@ -1,3 +1,4 @@
 export const transactionTypes = {
   SignTransactionUseCase: Symbol.for("SignTransactionUseCase"),
+  SignUpdateCallUseCase: Symbol.for("SignUpdateCallUseCase"),
 } as const;


### PR DESCRIPTION
### 📝 Description

Extends `@ledgerhq/device-signer-kit-icp` with the two signing shapes ICP staking (neuron management) needs, on top of the transfer surface. Nothing existing changes behaviour; both additions are opt-in.

**1. Update-call signing (`signUpdateCall`)** — most neuron operations (dissolve, follow, split, hot-keys, maturity, …) are IC update calls to the NNS governance canister. Each must be signed together with its companion read-state request. The new capability takes the call body and the read-state body as **separate inputs**, drives the device's combined-sign path (`INS 0x03`, chunked), and returns **two signatures** (request + read-state) plus the read-state body, so the caller can submit the call and poll its status while keeping the request ↔ read-state pairing intact.

**2. Neuron-creation flag on `signTransaction`** — neuron creation is a governance-subaccount transfer, the same device sign instruction as a plain transfer (`INS 0x02`) distinguished by a transaction-type flag. `signTransaction` gains an optional `stake` flag that sets P2 accordingly.

Implementation follows the existing kit structure and the `signer-eth` precedents: the same-INS P2 sub-mode stays a parameter on `SignTransactionCommand`; the different-INS combined-sign is a new `SignUpdateCallCommand` with its own response parser (the `0x03` response is a fixed 192-byte block — two 32-byte digests each with a 64-byte r‖s signature, no `v`/DER — distinct from the `0x02` layout). Wire format and response layout were verified against the device app source (`LedgerHQ/app-icp`) and the reference host library.

```ts
// neuron management
const { requestSignature, readStateSignature, readStateBody } =
  await signer.signUpdateCall(path, callRequest, readStateRequest);
// neuron creation
await signer.signTransaction(path, transferBlob, { stake: true });
```


### ❓ Context

- **JIRA or GitHub link**: [LIVE-34592](https://ledgerhq.atlassian.net/browse/LIVE-34592)

### ✅ Checklist

- [x] **Covered by automatic tests** — unit tests for the new command (response split incl. per-field golden fixture, chunk boundaries, malformed/short/long rejection, refusal status word), the task (combined-message framing vector asserting read-state-first ordering and LE lengths, chunk boundaries, missing-body rejection, error paths), use-case, app-binder, DI binding, and the stake flag across command/task/use-case. 104 tests, 99.3% line coverage.
- [x] **Changeset is provided** — `device-signer-kit-icp` minor (additive; consistent with the `signer-eth` EIP-7702 method addition shipped as minor).
- [x] **Documentation is up-to-date** — public API surfaced through the `SignerIcp` interface and barrel exports.
- [ ] **Impact of the changes:**
  - New `signUpdateCall` capability (`INS 0x03`) — no effect on existing transfer/address/version flows.
  - New optional `stake` flag on `signTransaction` — defaults to off (P2 unchanged).
  - QA focus: on-device update-call signing for a neuron-management operation, and a neuron-creation transfer.


[LIVE-34592]: https://ledgerhq.atlassian.net/browse/LIVE-34592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ