### PR TITLE
👷 feat(INFRAPRJ-13088): Add workflows for build/deploy mock-server

### DIFF
--- a/.github/workflows/mock-server-build-prod.yml
+++ b/.github/workflows/mock-server-build-prod.yml
@@ -1,0 +1,58 @@
+name: "[mock-server] build-prod"
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - apps/device-mock-server/**
+      - packages/mockserver-client/**
+      - pnpm-lock.yaml
+
+concurrency:
+  group: mock-server-build-prod-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write # GitHub OIDC -> JFrog
+  contents: read
+
+env:
+  REGISTRY: jfrog.ledgerlabs.net
+  IMAGE: infra-oci-web-apps-prod-green/device-mock-server/prod
+
+jobs:
+  build:
+    runs-on: ledgerhq-device-sdk
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Read version
+        id: ver
+        run: |
+          echo "semver=$(jq -r '.version' apps/device-mock-server/package.json)" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Get token from JFrog (OIDC)
+        id: jfrog-login
+        uses: LedgerHQ/actions-security/actions/jfrog-login@3868be0ef1ec8722fbdb2c6cda90f739cbfc742d # actions/jfrog-login-1
+
+      - name: Login to JFrog OCI registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ steps.jfrog-login.outputs.oidc-user }}
+          password: ${{ steps.jfrog-login.outputs.oidc-token }}
+
+      - name: Build and push
+        run: |
+          docker buildx build --push \
+            --platform linux/amd64 \
+            -f apps/device-mock-server/Dockerfile \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.ver.outputs.semver }} \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.ver.outputs.semver }}-${{ steps.ver.outputs.sha }} \
+            .

--- a/.github/workflows/mock-server-deploy-prod.yml
+++ b/.github/workflows/mock-server-deploy-prod.yml
@@ -1,0 +1,47 @@
+name: "[mock-server] deploy-prod"
+
+# Manual prod deploy. Sets the image tag + chart version on the prod ArgoCD app
+# and syncs it. Auth uses an ArgoCD project token (create it + store as secrets
+# ARGOCD_TOKEN / var ARGOCD_SERVER — done outside this repo).
+on:
+  workflow_dispatch:
+    inputs:
+      app_version:
+        description: "Image tag to deploy (version pushed by build-prod, e.g. 0.1.0)"
+        required: true
+      chart_version:
+        description: "web-app chart version (targetRevision)"
+        required: true
+        default: "0.1.3"
+
+permissions:
+  contents: read
+
+env:
+  # Apps are split by label proj=device-mock-server.
+  ARGOCD_APP: device-mock-server-prod
+
+jobs:
+  deploy:
+    runs-on: ledgerhq-shared-small
+    timeout-minutes: 15
+    steps:
+      - name: Install ArgoCD CLI
+        run: |
+          curl -fsSL -o /usr/local/bin/argocd \
+            https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+          chmod +x /usr/local/bin/argocd
+
+      - name: Deploy
+        env:
+          ARGOCD_SERVER: ${{ vars.ARGOCD_SERVER }}
+          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+          APP_VERSION: ${{ inputs.app_version }}
+          CHART_VERSION: ${{ inputs.chart_version }}
+        run: |
+          argocd app set "$ARGOCD_APP" \
+            --revision "$CHART_VERSION" \
+            -p image.tag="$APP_VERSION" \
+            --grpc-web
+          argocd app sync "$ARGOCD_APP" --grpc-web
+          argocd app wait "$ARGOCD_APP" --health --timeout 300 --grpc-web

--- a/.github/workflows/mock-server-preview.yml
+++ b/.github/workflows/mock-server-preview.yml
@@ -1,0 +1,73 @@
+name: "[mock-server] preview"
+
+on:
+  pull_request:
+    branches: [develop]
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - apps/device-mock-server/**
+      - packages/mockserver-client/**
+      - pnpm-lock.yaml
+
+concurrency:
+  group: mock-server-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write # GitHub OIDC -> JFrog
+  contents: read
+  pull-requests: write # label + comment
+
+env:
+  REGISTRY: jfrog.ledgerlabs.net
+  IMAGE: infra-oci-web-apps-sandbox-green/device-mock-server/dev
+  PREVIEW_HOST: device-mock-server-pr-${{ github.event.pull_request.number }}.aws.sbx.ldg-tech.com
+
+jobs:
+  build:
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
+    runs-on: ledgerhq-device-sdk
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Get token from JFrog (OIDC)
+        id: jfrog-login
+        uses: LedgerHQ/actions-security/actions/jfrog-login@3868be0ef1ec8722fbdb2c6cda90f739cbfc742d # actions/jfrog-login-1
+
+      - name: Login to JFrog OCI registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ steps.jfrog-login.outputs.oidc-user }}
+          password: ${{ steps.jfrog-login.outputs.oidc-token }}
+
+      - name: Build and push
+        run: |
+          docker buildx build --push \
+            --platform linux/amd64 \
+            -f apps/device-mock-server/Dockerfile \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE }}:pr-${{ github.event.pull_request.number }} \
+            .
+
+      - name: Comment preview URL
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          body=$(cat <<EOF
+🚀 **Preview environment**
+
+**URL:** https://${PREVIEW_HOST}
+**Image:** \`${REGISTRY}/${IMAGE}:pr-${PR}\`
+**Commit:** \`${{ github.event.pull_request.head.sha }}\`
+
+ArgoCD syncs the env within ~30-60s after this image is pushed.
+EOF
+          )
+          # Upsert: edit our last comment if present, else create a new one.
+          gh pr comment "$PR" --edit-last --body "$body" || gh pr comment "$PR" --body "$body"


### PR DESCRIPTION
### 📝 Description

Adds the CI/CD workflows to build, preview and deploy **device-mock-server** through the shared web-apps flow: image → JFrog `infra-oci-web-apps-*` (GitHub OIDC, no static secrets), deployed via the central `web-app` Helm chart in ArgoCD.

Three workflows — all scoped to `apps/device-mock-server/**` (+ `packages/mockserver-client`), reusing the existing multi-stage Dockerfile, auth via `LedgerHQ/actions-security/actions/jfrog-login`:

- **`mock-server-build-prod.yml`** — push to `develop` → build + push `infra-oci-web-apps-prod-green/device-mock-server/prod:<version>`.
- **`mock-server-preview.yml`** — PRs labelled `preview` → build + push `…-sandbox-green/device-mock-server/dev:pr-<n>` and comment the preview URL (picked up by the ArgoCD ApplicationSet).
- **`mock-server-deploy-prod.yml`** — manual dispatch → set image tag + chart version on the prod ArgoCD app and sync.

No app/runtime/Dockerfile changes — CI only.

### ❓ Context

- **JIRA**: [INFRAPRJ-13088](https://ledgerhq.atlassian.net/browse/INFRAPRJ-13088) (child of INFRAPRJ-12943)

### ✅ Checklist

- **Tests**: N/A — GitHub Actions workflows; validated by running the pipeline (preview build on a labelled PR).
- **Changeset**: N/A — CI only, no package version bump.
- **Impact**: 3 new workflows under `apps/device-mock-server`; no changes to app code, Dockerfile or published packages. Requires a `preview` label in the repo for the preview workflow to trigger.


[INFRAPRJ-13088]: https://ledgerhq.atlassian.net/browse/INFRAPRJ-13088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ