### PR TITLE
✨ (signer-zcash) [LIVE-32887]: Add Ironwood PCZT v2 bundle signing

### DIFF
--- a/.changeset/ironwood-pczt-signing.md
+++ b/.changeset/ironwood-pczt-signing.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-zcash": minor
+---
+
+Add Ironwood (NU6.3) PCZT v2 bundle signing support for V6 transactions

--- a/packages/signer/signer-zcash/README.md
+++ b/packages/signer/signer-zcash/README.md
@@ -5,7 +5,7 @@ This module provides the implementation of the Ledger Zcash signer of the Device
 - Retrieving a transparent Zcash address for a given derivation path;
 - Retrieving a unified or Orchard full viewing key (ZIP-32 account path);
 - Signing a transparent Zcash payment transaction (Ledger Wallet / `hw-app-btc` compatible shape);
-- Signing an Orchard shielded (PCZT) transaction, returning per-action Orchard spend-authorization signatures and per-input transparent signatures;
+- Signing a shielded (PCZT) transaction — V5 (Orchard) or V6 (Orchard + Ironwood/NU6.3) — returning per-action spend-authorization signatures and per-input transparent signatures;
 - Signing a message displayed on the device;
 - Fetching trusted inputs for previous transactions;
 - Retrieving the app configuration;
@@ -267,12 +267,25 @@ On **Pending**, `requiredUserInteraction` is `UserInteractionRequired.SignTransa
 
 ### Use Case 4: Sign PCZT Transaction
 
-Sign an Orchard **shielded** transaction expressed as a PCZT (Partially Constructed Zcash Transaction). The host (zcash-utils) builds the PCZT and passes the structured `PcztTransaction` to the signer, which streams the header, transparent inputs/outputs, and Orchard actions to the device as the `PCZT_*` APDU sequence. The device returns the raw per-action Orchard `spendAuthSig`s and per-input transparent signatures; the **binding signature and final transaction assembly are host-side** (never involve the device). The legacy transparent [`signTransaction`](#use-case-3-sign-transaction) path is unchanged.
+Sign a shielded transaction expressed as a PCZT (Partially Constructed Zcash Transaction).
+Supports both **V5** (Orchard-only) and **V6** (Orchard + Ironwood, NU6.3) transactions.
+
+The host (zcash-utils) builds the PCZT and passes the structured `PcztTransaction` to the
+signer, which streams the header, transparent inputs/outputs, Orchard actions, and — for
+V6 — Ironwood actions to the device as the `PCZT_*` APDU sequence. The device returns
+per-action `spendAuthSig`s (Orchard and Ironwood) and per-input transparent signatures;
+**binding signatures and final transaction assembly are host-side** (never involve the device).
+The legacy transparent [`signTransaction`](#use-case-3-sign-transaction) path is unchanged.
+
+> **V6 firmware requirement:** Ironwood signing requires `app-zcash` compiled with the
+> `zcash_unstable` feature flag. Without it the device returns an error on the first
+> Ironwood APDU. Pass `txVersion: 5` for standard V5 transactions.
 
 ```typescript
 import { type PcztTransaction } from "@ledgerhq/device-signer-kit-zcash";
 
-const transaction: PcztTransaction = {
+// V5 (Orchard-only)
+const v5Transaction: PcztTransaction = {
   global: {
     txVersion: 5,
     versionGroupId: 0x26a7270a,
@@ -294,8 +307,39 @@ const transaction: PcztTransaction = {
   },
 };
 
+// V6 (Orchard + Ironwood, NU6.3) — requires zcash_unstable firmware
+const v6Transaction: PcztTransaction = {
+  global: {
+    txVersion: 6,
+    versionGroupId: 0xd884b698,
+    consensusBranchId: 0x37a5165b, // Nu6_3
+    fallbackLockTime: null,
+    expiryHeight: 0,
+    coinType: 133,
+    txModifiable: 0,
+  },
+  transparentInputs: [],
+  transparentOutputs: [],
+  orchardBundle: {
+    actions: [
+      /* PcztOrchardAction[] */
+    ],
+    flags: 0x03,
+    valueBalance: 0n,
+    anchor: orchardAnchor,
+  },
+  ironwoodBundle: {
+    actions: [
+      /* PcztIronwoodAction[] */
+    ],
+    flags: 0x03,
+    valueBalance: -1000n, // net zatoshis flowing into Ironwood
+    anchor: ironwoodAnchor, // 32 bytes, Ironwood commitment-tree root
+  },
+};
+
 const { observable, cancel } = signerZcash.signPcztTransaction(
-  transaction,
+  v5Transaction, // or v6Transaction
   options,
 );
 ```
@@ -310,10 +354,11 @@ type PcztTransaction = {
   transparentInputs: PcztTransparentInput[]; // count 0 when empty
   transparentOutputs: PcztTransparentOutput[]; // count 0 when empty
   orchardBundle: PcztOrchardBundle | null; // null = empty Orchard bundle
+  ironwoodBundle?: PcztIronwoodBundle | null; // V6 only; absent or null for V5
 };
 
 type PcztGlobal = {
-  txVersion: number; // V5 = 5
+  txVersion: number; // V5 = 5, V6 = 6
   versionGroupId: number;
   consensusBranchId: number;
   fallbackLockTime: number | null; // Option<u32>; null = absent
@@ -371,6 +416,35 @@ type PcztOrchardBundle = {
   valueBalance: bigint; // net value balance, zatoshis (signed)
   anchor: Uint8Array; // Orchard commitment-tree anchor, 32 bytes
 };
+
+// V6 only — wire format identical to PcztOrchardAction (820-byte OrchardAction encoding)
+type PcztIronwoodAction = {
+  cvNet: Uint8Array; // value commitment, 32 bytes
+  nullifier: Uint8Array; // spend nullifier, 32 bytes
+  rk: Uint8Array; // randomized verification key, 32 bytes
+  spendRecipient: Uint8Array; // raw Orchard address of spent note, 43 bytes
+  spendValue: bigint; // zatoshis (0n = dummy/padding spend, signed host-side)
+  spendRho: Uint8Array; // 32 bytes
+  spendRseed: Uint8Array; // 32 bytes
+  alpha: Uint8Array; // spend-auth randomizer (Pallas scalar), 32 bytes; host→device only
+  signingPath: string; // ZIP-32 derivation path of the signing key
+  seedFingerprint?: Uint8Array; // 32 bytes (default 32 zero bytes)
+  cmx: Uint8Array; // note commitment x-coord, 32 bytes
+  ephemeralKey: Uint8Array; // 32 bytes
+  encCiphertext: Uint8Array;
+  outCiphertext: Uint8Array;
+  recipient: Uint8Array; // raw Orchard address of output note, 43 bytes
+  value: bigint; // output-note value, zatoshis
+  rseed: Uint8Array; // 32 bytes
+  rcv: Uint8Array; // randomized commitment value, 32 bytes (required)
+};
+
+type PcztIronwoodBundle = {
+  actions: PcztIronwoodAction[];
+  flags: number;
+  valueBalance: bigint; // net value balance, zatoshis (signed)
+  anchor: Uint8Array; // Ironwood commitment-tree anchor, 32 bytes
+};
 ```
 
 #### Parameters (options)
@@ -387,13 +461,24 @@ type TransactionOptions = {
 type SignPcztTransactionResult = {
   // one spendAuthSig per Orchard action, in action order
   orchard: Array<{ spendAuthSig: Uint8Array }>; // RedPallas sig, 64 bytes each
+  // one spendAuthSig per non-dummy Ironwood action, ascending action-index order
+  // (actions with spendValue === 0n are dummy spends signed host-side; empty for V5)
+  ironwood: Array<{ spendAuthSig: Uint8Array }>; // RedPallas sig, 64 bytes each
   // one signature per transparent input, in input order:
   // DER-encoded secp256k1 signature + trailing sighash_type byte (0x01)
   transparentInputSigs: Uint8Array[];
 };
 ```
 
-There is **no `bindingSig`** in the result: the binding signature is computed host-side from `bsk = Σ rcv`. On **Pending**, `requiredUserInteraction` is `UserInteractionRequired.SignTransaction` (user must approve on device).
+There is **no `bindingSig`** in the result — binding signatures are always computed
+host-side:
+
+- **V5:** `bindingSig = bsk.sign(sighash)` where `bsk = Σ rcv` over Orchard actions.
+- **V6:** two independent binding signatures — `bindingSig_orchard` and
+  `bindingSig_ironwood` — computed from their respective `Σ rcv` sums (ZIP 229).
+
+On **Pending**, `requiredUserInteraction` is `UserInteractionRequired.SignTransaction`
+(user must approve on device).
 
 ---
 

--- a/packages/signer/signer-zcash/src/api/index.ts
+++ b/packages/signer/signer-zcash/src/api/index.ts
@@ -47,12 +47,15 @@ export type {
   ZcashFullViewingKeyMode,
 } from "@api/model/FullViewingKeyOptions";
 export type {
+  IronwoodActionSignature,
   OrchardActionSignature,
   SignPcztTransactionResult,
 } from "@api/model/PcztSignature";
 export type {
   PcztBip32Derivation,
   PcztGlobal,
+  PcztIronwoodAction,
+  PcztIronwoodBundle,
   PcztOrchardAction,
   PcztOrchardBundle,
   PcztTransaction,

--- a/packages/signer/signer-zcash/src/api/model/PcztSignature.ts
+++ b/packages/signer/signer-zcash/src/api/model/PcztSignature.ts
@@ -19,6 +19,17 @@ export type OrchardActionSignature = {
 };
 
 /**
+ * Per-Ironwood-action signature returned by the device for V6 transactions.
+ *
+ * The device returns the RedPallas `spendAuthSig` only; `alpha` is a
+ * host-supplied PCZT field carried *to* the device and is never returned.
+ */
+export type IronwoodActionSignature = {
+  /** RedPallas spend-authorization signature, 64 bytes. */
+  spendAuthSig: Uint8Array;
+};
+
+/**
  * Result of {@link SignerZcash.signPcztTransaction}.
  *
  * No `bindingSig`: the binding signature is computed host-side (zcash-utils)
@@ -40,4 +51,9 @@ export type SignPcztTransactionResult = {
    * `SIGHASH_ALL`).
    */
   transparentInputSigs: Uint8Array[];
+  /**
+   * One `spendAuthSig` per Ironwood action for V6 transactions, in ascending
+   * action-index order. Empty for V5 transactions.
+   */
+  ironwood: IronwoodActionSignature[];
 };

--- a/packages/signer/signer-zcash/src/api/model/PcztTransaction.ts
+++ b/packages/signer/signer-zcash/src/api/model/PcztTransaction.ts
@@ -12,7 +12,7 @@
 
 /** PCZT header `common::Global` fields, sent once in `PCZT_HEADER`. */
 export type PcztGlobal = {
-  /** Transaction version (V5 = 5). */
+  /** Transaction version (V5 = 5, V6 = 6). */
   txVersion: number;
   versionGroupId: number;
   consensusBranchId: number;
@@ -108,14 +108,74 @@ export type PcztOrchardBundle = {
   anchor: Uint8Array;
 };
 
+/** A single Ironwood action (NU6.3, V6 transactions). Wire format mirrors
+ * `orchard::Action` with the addition of a 1-byte `note_plaintext_version`
+ * field (PCZT v2). */
+export type PcztIronwoodAction = {
+  /** Value commitment, 32 bytes. */
+  cvNet: Uint8Array;
+  /** Spend nullifier, 32 bytes. */
+  nullifier: Uint8Array;
+  /** Randomized verification key, 32 bytes. */
+  rk: Uint8Array;
+  /** Raw Orchard payment address of the spent note, 43 bytes. */
+  spendRecipient: Uint8Array;
+  /** Spent-note value in zatoshis. */
+  spendValue: bigint;
+  /** Spend rho (ρ), 32 bytes. */
+  spendRho: Uint8Array;
+  /** Spend rseed, 32 bytes. */
+  spendRseed: Uint8Array;
+  /**
+   * Spend-authorization randomizer (Pallas scalar), 32 bytes. Host-supplied:
+   * carried to the device, never returned.
+   */
+  alpha: Uint8Array;
+  /** ZIP-32 derivation path of the signing key. */
+  signingPath: string;
+  /** ZIP-32 seed fingerprint, 32 bytes. Defaults to 32 zero bytes if omitted. */
+  seedFingerprint?: Uint8Array;
+  /** Note commitment x-coordinate, 32 bytes. */
+  cmx: Uint8Array;
+  /** Ephemeral key, 32 bytes. */
+  ephemeralKey: Uint8Array;
+  encCiphertext: Uint8Array;
+  outCiphertext: Uint8Array;
+  /** Raw Orchard payment address of the output note, 43 bytes. */
+  recipient: Uint8Array;
+  /** Output-note value in zatoshis. */
+  value: bigint;
+  /** Output rseed, 32 bytes. */
+  rseed: Uint8Array;
+  /** Randomized commitment value, 32 bytes (required by the device). */
+  rcv: Uint8Array;
+  /**
+   * Note-plaintext version (PCZT v2), 1 byte. `0x03` for Ironwood notes.
+   * Carried to the device; required for PCZT v2 parsing.
+   */
+  notePlaintextVersion: number;
+};
+
+/** The Ironwood action bundle plus its trailer (V6 transactions only). */
+export type PcztIronwoodBundle = {
+  actions: PcztIronwoodAction[];
+  flags: number;
+  /** Net value balance in zatoshis (signed). */
+  valueBalance: bigint;
+  /** Ironwood commitment-tree anchor, 32 bytes. */
+  anchor: Uint8Array;
+};
+
 /**
  * Full structured PCZT to sign. The transparent sections are always streamed
  * (count `0` when empty); `orchardBundle` may be `null`, treated as an empty
- * Orchard bundle.
+ * Orchard bundle. `ironwoodBundle` is only present for V6 transactions.
  */
 export type PcztTransaction = {
   global: PcztGlobal;
   transparentInputs: PcztTransparentInput[];
   transparentOutputs: PcztTransparentOutput[];
   orchardBundle: PcztOrchardBundle | null;
+  /** V6 Ironwood bundle; absent or `null` for V5 transactions. */
+  ironwoodBundle?: PcztIronwoodBundle | null;
 };

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/PcztBundleCommands.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/PcztBundleCommands.test.ts
@@ -5,6 +5,7 @@ import {
 import { describe, expect, it } from "vitest";
 
 import { PcztHeaderCommand } from "@internal/app-binder/command/PcztHeaderCommand";
+import { PcztIronwoodActionCommand } from "@internal/app-binder/command/PcztIronwoodActionCommand";
 import { PcztOrchardActionCommand } from "@internal/app-binder/command/PcztOrchardActionCommand";
 import { PcztTransparentInputCommand } from "@internal/app-binder/command/PcztTransparentInputCommand";
 import { PcztTransparentOutputCommand } from "@internal/app-binder/command/PcztTransparentOutputCommand";
@@ -12,6 +13,7 @@ import {
   PCZT_P1,
   PCZT_P2,
 } from "@internal/app-binder/command/utils/apduHeaderUtils";
+import { ZcashAppCommandError } from "@internal/app-binder/command/utils/zcashApplicationErrors";
 
 const DATA = Uint8Array.of(0x01, 0x02);
 const apduHex = (raw: Uint8Array): string => Buffer.from(raw).toString("hex");
@@ -128,6 +130,42 @@ describe("PCZT bundle commands", () => {
         p2: PCZT_P2.CONTINUE,
       }).parseResponse(rejected);
       expect(isSuccessCommandResult(result)).toBe(false);
+    });
+  });
+
+  describe("PcztIronwoodActionCommand", () => {
+    it("builds INS 0x58 with the supplied P1/P2 framing and data", () => {
+      // p1=0x01 (LAST), p2=0x01 (FINISHED), data=[0x02]
+      const apdu = new PcztIronwoodActionCommand({
+        data: Uint8Array.of(0x02),
+        p1: PCZT_P1.LAST,
+        p2: PCZT_P2.FINISHED,
+      })
+        .getApdu()
+        .getRawApdu();
+      expect(apduHex(apdu)).toBe("e05801010102");
+    });
+
+    it("maps the success status word to a successful result", () => {
+      const result = new PcztIronwoodActionCommand({
+        data: DATA,
+        p1: PCZT_P1.FIRST,
+        p2: PCZT_P2.CONTINUE,
+      }).parseResponse(success);
+      expect(isSuccessCommandResult(result)).toBe(true);
+    });
+
+    it("surfaces a device error status word", () => {
+      const result = new PcztIronwoodActionCommand({
+        data: DATA,
+        p1: PCZT_P1.FIRST,
+        p2: PCZT_P2.CONTINUE,
+      }).parseResponse(rejected);
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        expect(result.error).toBeInstanceOf(ZcashAppCommandError);
+        expect((result.error as ZcashAppCommandError).errorCode).toBe("6985");
+      }
     });
   });
 });

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/PcztIronwoodActionCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/PcztIronwoodActionCommand.ts
@@ -1,0 +1,72 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import { ZCASH_CLA } from "@internal/app-binder/command/utils/apduHeaderUtils";
+import {
+  ZCASH_APP_ERRORS,
+  ZcashAppCommandErrorFactory,
+  type ZcashErrorCodes,
+} from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+/**
+ * `INS_PCZT_IRONWOOD_ACTION`: streams the Ironwood action bundle for V6
+ * transactions (NU6.3). Mirrors `LedgerHQ/app-zcash` `src/consts.rs`.
+ */
+export const INS_PCZT_IRONWOOD_ACTION = 0x58;
+
+export type PcztIronwoodActionCommandArgs = {
+  /** One serialized packet of the Ironwood action bundle. */
+  data: Uint8Array;
+  /** Packet framing: `PCZT_P1.FIRST` / `NEXT` / `LAST`. */
+  p1: number;
+  /**
+   * Bundle framing: `PCZT_P2.CONTINUE`, or `PCZT_P2.FINISHED` on the very last
+   * packet to finalize the PCZT (after which signing commands are accepted).
+   */
+  p2: number;
+};
+
+/**
+ * `PCZT_IRONWOOD_ACTION` (`INS 0x58`): streams one packet of the Ironwood
+ * action bundle for V6 transactions. The last packet carries
+ * `PCZT_P2.FINISHED`. Empty response.
+ */
+export class PcztIronwoodActionCommand
+  implements Command<void, PcztIronwoodActionCommandArgs, ZcashErrorCodes>
+{
+  readonly name = "PcztIronwoodAction";
+
+  private readonly errorHelper = new CommandErrorHelper<void, ZcashErrorCodes>(
+    ZCASH_APP_ERRORS,
+    ZcashAppCommandErrorFactory,
+  );
+
+  constructor(private readonly args: PcztIronwoodActionCommandArgs) {}
+
+  getApdu(): Apdu {
+    const apduArgs: ApduBuilderArgs = {
+      cla: ZCASH_CLA,
+      ins: INS_PCZT_IRONWOOD_ACTION,
+      p1: this.args.p1,
+      p2: this.args.p2,
+    };
+    return new ApduBuilder(apduArgs).addBufferToData(this.args.data).build();
+  }
+
+  parseResponse(
+    apduResponse: ApduResponse,
+  ): CommandResult<void, ZcashErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefault(CommandResultFactory({ data: undefined }));
+  }
+}

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/SignPcztCommands.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/SignPcztCommands.test.ts
@@ -4,6 +4,7 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { describe, expect, it } from "vitest";
 
+import { SignPcztIronwoodCommand } from "@internal/app-binder/command/SignPcztIronwoodCommand";
 import { SignPcztOrchardCommand } from "@internal/app-binder/command/SignPcztOrchardCommand";
 import { SignPcztTransparentCommand } from "@internal/app-binder/command/SignPcztTransparentCommand";
 
@@ -44,6 +45,41 @@ describe("SignPcztOrchardCommand", () => {
     const result = new SignPcztOrchardCommand({ actionIndex: 0 }).parseResponse(
       response(REJECTED, new Uint8Array()),
     );
+    expect(isSuccessCommandResult(result)).toBe(false);
+  });
+});
+
+describe("SignPcztIronwoodCommand", () => {
+  it("builds INS 0x59 with empty data and the action index in P2", () => {
+    // actionIndex: 3 → P2 = 0x03; INS = 0x59; P1 = 0x00 (FIRST); no data → Lc = 0x00
+    const apdu = new SignPcztIronwoodCommand({ actionIndex: 3 })
+      .getApdu()
+      .getRawApdu();
+    expect(apduHex(apdu)).toBe("e059000300");
+  });
+
+  it("parses a 64-byte spendAuthSig correctly", () => {
+    const sig = new Uint8Array(64).fill(0xcd);
+    const result = new SignPcztIronwoodCommand({
+      actionIndex: 0,
+    }).parseResponse(response(OK, sig));
+    expect(isSuccessCommandResult(result)).toBe(true);
+    if (isSuccessCommandResult(result)) {
+      expect(result.data.spendAuthSig).toEqual(sig);
+    }
+  });
+
+  it("rejects a spendAuthSig of the wrong length (63 bytes)", () => {
+    const result = new SignPcztIronwoodCommand({
+      actionIndex: 0,
+    }).parseResponse(response(OK, new Uint8Array(63).fill(0xcd)));
+    expect(isSuccessCommandResult(result)).toBe(false);
+  });
+
+  it("surfaces a device rejection status word", () => {
+    const result = new SignPcztIronwoodCommand({
+      actionIndex: 0,
+    }).parseResponse(response(REJECTED, new Uint8Array()));
     expect(isSuccessCommandResult(result)).toBe(false);
   });
 });

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/SignPcztIronwoodCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/SignPcztIronwoodCommand.ts
@@ -1,0 +1,90 @@
+import {
+  type Apdu,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import { type IronwoodActionSignature } from "@api/model/PcztSignature";
+import {
+  PCZT_P1,
+  ZCASH_CLA,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import {
+  ZCASH_APP_ERRORS,
+  ZcashAppCommandErrorFactory,
+  type ZcashErrorCodes,
+} from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+/**
+ * `INS_PCZT_SIGN_IRONWOOD`: signs one Ironwood action. P2 = action index;
+ * returns `spendAuthSig[64]`. Mirrors `LedgerHQ/app-zcash` `src/consts.rs`.
+ */
+export const INS_PCZT_SIGN_IRONWOOD = 0x59;
+
+/** RedPallas spend-authorization signature length. */
+const SPEND_AUTH_SIG_LENGTH = 64;
+
+export type SignPcztIronwoodCommandArgs = {
+  /** Ironwood action index to sign (carried in P2). */
+  actionIndex: number;
+};
+
+/**
+ * `PCZT_SIGN_IRONWOOD` (`INS 0x59`, P2 = action index, empty data).
+ *
+ * Accepted only after the PCZT bundle is finalized; each action index is
+ * signable once. Returns the RedPallas `spendAuthSig[64]` only — `alpha` is a
+ * host-supplied PCZT field and is never returned.
+ */
+export class SignPcztIronwoodCommand
+  implements
+    Command<
+      IronwoodActionSignature,
+      SignPcztIronwoodCommandArgs,
+      ZcashErrorCodes
+    >
+{
+  readonly name = "SignPcztIronwood";
+
+  private readonly errorHelper = new CommandErrorHelper<
+    IronwoodActionSignature,
+    ZcashErrorCodes
+  >(ZCASH_APP_ERRORS, ZcashAppCommandErrorFactory);
+
+  constructor(private readonly args: SignPcztIronwoodCommandArgs) {}
+
+  getApdu(): Apdu {
+    const apduArgs: ApduBuilderArgs = {
+      cla: ZCASH_CLA,
+      ins: INS_PCZT_SIGN_IRONWOOD,
+      p1: PCZT_P1.FIRST,
+      p2: this.args.actionIndex,
+    };
+    return new ApduBuilder(apduArgs).build();
+  }
+
+  parseResponse(
+    apduResponse: ApduResponse,
+  ): CommandResult<IronwoodActionSignature, ZcashErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      const spendAuthSig = new Uint8Array(apduResponse.data);
+      if (spendAuthSig.length !== SPEND_AUTH_SIG_LENGTH) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            `Expected ${SPEND_AUTH_SIG_LENGTH}-byte Ironwood spendAuthSig, got ${spendAuthSig.length}`,
+          ),
+        });
+      }
+      return CommandResultFactory({ data: { spendAuthSig } });
+    });
+  }
+}

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/utils/pcztSerializer.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/utils/pcztSerializer.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   pcztP1,
   pcztP2,
+  serializeIronwoodActions,
   serializeOrchardActions,
   serializePcztHeader,
   serializeTransparentInputs,
@@ -19,7 +20,10 @@ import {
   hexToBytes,
   ORCHARD_ENC_CIPHERTEXT_SIZE,
   SAMPLE_GLOBAL,
+  SAMPLE_GLOBAL_V6,
   SAMPLE_HEADER_HEX,
+  SAMPLE_HEADER_HEX_V6,
+  sampleIronwoodBundle,
   sampleOrchardBundle,
   sampleTransparentInput,
   sampleTransparentOutput,
@@ -40,6 +44,12 @@ describe("pcztSerializer", () => {
       );
       // ...consensus_branch_id, then 0x00 (absent), then expiry_height...
       expect(hex).toContain("b4d0d6c200" + "00000000");
+    });
+
+    it("encodes PCZT version 2 for V6 transactions", () => {
+      expect(bytesToHex(serializePcztHeader(SAMPLE_GLOBAL_V6))).toBe(
+        SAMPLE_HEADER_HEX_V6,
+      );
     });
   });
 
@@ -167,6 +177,82 @@ describe("pcztSerializer", () => {
       expect(trailer[0]).toBe(0x02); // flags
       expect(trailer[1]).toBe(0x07); // |−7| first LE byte
       expect(trailer[9]).toBe(0x01); // negative sign flag
+    });
+  });
+
+  describe("serializeIronwoodActions", () => {
+    it("emits only a CompactSize 0 count packet when called with zero actions", () => {
+      const packets = serializeIronwoodActions({
+        actions: [],
+        flags: 0,
+        valueBalance: 0n,
+        anchor: bytes(32, 0x00),
+      });
+      expect(packets).toHaveLength(1);
+      expect(bytesToHex(packets[0]!)).toBe("00");
+    });
+
+    it("serializes one action: verifies count, spend, zip32, cmx+ephemeral, enc, out, metadata, and trailer", () => {
+      const packets = serializeIronwoodActions(sampleIronwoodBundle());
+
+      // count + [spend, zip32, cmx+ephemeral, enc x3, out, metadata] + trailer.
+      expect(packets).toHaveLength(10);
+      expect(bytesToHex(packets[0]!)).toBe("01");
+
+      // spend small fields: cv|nullifier|rk|recipient|value8|rho|rseed|alpha.
+      const spend = packets[1]!;
+      expect(spend).toHaveLength(32 * 3 + 43 + 8 + 32 * 3);
+      // cvNet fills with 0x11 — first byte of spend packet.
+      expect(spend[0]).toBe(0x11);
+      // spendValue = 5n: first LE byte at offset 32*3+43.
+      expect(spend[32 * 3 + 43]).toBe(0x05);
+
+      // zip32: fingerprint[32] + path("44'/133'/0'": len 3 + 3 BE u32).
+      expect(bytesToHex(packets[2]!)).toBe(
+        bytesToHex(bytes(32, 0x00)) +
+          "03" +
+          "8000002c" +
+          "80000085" +
+          "80000000",
+      );
+
+      // cmx[32] + ephemeralKey[32] packet.
+      expect(packets[3]!).toHaveLength(64);
+      expect(packets[3]![0]).toBe(0x18); // cmx fill byte
+
+      // enc ciphertext split across 3 packets — verify CompactSize prefix.
+      const encField = concatUint8Arrays(packets[4]!, packets[5]!, packets[6]!);
+      expect(bytesToHex(encField.subarray(0, 3))).toBe("fd4402"); // CompactSize 580
+      expect(encField.length - 3).toBe(ORCHARD_ENC_CIPHERTEXT_SIZE);
+
+      // out ciphertext in one packet (80 bytes + 1-byte CompactSize = 81).
+      expect(packets[7]![0]).toBe(0x50); // CompactSize 80
+      expect(packets[7]!).toHaveLength(81);
+
+      // metadata packet: recipient[43] + value u64 LE + rseed[32] + rcv[32] + notePlaintextVersion u8.
+      const meta = packets[8]!;
+      expect(meta[0]).toBe(0x1a); // recipient fill byte
+      expect(meta).toHaveLength(43 + 8 + 32 + 32 + 1); // +1 for notePlaintextVersion
+      expect(meta[43 + 8 + 32 + 32]).toBe(0x03); // notePlaintextVersion
+
+      // trailer: flags(1) + |valueBalance| u64 LE + sign(1) + anchor[32].
+      const trailer = packets[9]!;
+      expect(trailer[0]).toBe(0x02); // flags
+      expect(trailer[1]).toBe(0x00); // valueBalance 0 first LE byte
+      expect(trailer[9]).toBe(0x00); // sign: non-negative
+      expect(trailer[10]).toBe(0x1d); // anchor fill byte
+
+      // every emitted packet stays within the APDU payload cap.
+      packets.forEach((packet) => {
+        expect(packet.length).toBeLessThanOrEqual(PCZT_MAX_PACKET_SIZE);
+      });
+    });
+
+    it("all packets are at most PCZT_MAX_PACKET_SIZE bytes", () => {
+      const packets = serializeIronwoodActions(sampleIronwoodBundle());
+      packets.forEach((packet) => {
+        expect(packet.length).toBeLessThanOrEqual(PCZT_MAX_PACKET_SIZE);
+      });
     });
   });
 

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/utils/pcztSerializer.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/utils/pcztSerializer.ts
@@ -4,6 +4,7 @@ import { DerivationPathUtils } from "@ledgerhq/signer-utils";
 import {
   type PcztBip32Derivation,
   type PcztGlobal,
+  type PcztIronwoodBundle,
   type PcztOrchardBundle,
   type PcztTransparentInput,
   type PcztTransparentOutput,
@@ -111,7 +112,9 @@ const splitIntoPackets = (payload: Uint8Array): Uint8Array[] => {
 export const serializePcztHeader = (global: PcztGlobal): Uint8Array => {
   const builder = new ByteArrayBuilder();
   builder.addBufferToData(Uint8Array.of(0x50, 0x43, 0x5a, 0x54)); // "PCZT"
-  builder.add32BitUIntToData(1, false); // PCZT version
+  // PCZT version: 2 for V6 (Ironwood), 1 for V5. The device rejects mismatches
+  // in `parse_pczt_header` (app-zcash `src/parser/pczt.rs`).
+  builder.add32BitUIntToData(global.txVersion >= 6 ? 2 : 1, false);
   builder.add32BitUIntToData(global.txVersion, false);
   builder.add32BitUIntToData(global.versionGroupId, false);
   builder.add32BitUIntToData(global.consensusBranchId, false);
@@ -168,20 +171,26 @@ export const serializeTransparentOutputs = (
   return packets;
 };
 
-/** `PCZT_ORCHARD_ACTION` packet sequence (including the trailer). */
-export const serializeOrchardActions = (
-  bundle: PcztOrchardBundle,
+// Shared serializer for Orchard/Ironwood bundles. Both pools share a common
+// base wire layout per `docs/PCZT_APDU.md`; only the INS code at the call site
+// differs. The trailer is only emitted when action count > 0.
+//
+// Structural-identity invariant (ZIP 229 §3.2): `PcztIronwoodAction` and
+// `PcztOrchardAction` share the same base wire layout. TypeScript's structural
+// typing makes the shared fields mutually assignable, so the compiler will NOT
+// warn if one type is accidentally used in place of the other. Ironwood-only
+// additions (e.g. `notePlaintextVersion`, added for PCZT v2) are serialized
+// via `'<field>' in action` guards below — any future Ironwood-only field
+// requires the same treatment or the omission will be silent.
+const serializeShieldedActions = (
+  bundle: PcztOrchardBundle | PcztIronwoodBundle,
 ): Uint8Array[] => {
   const packets: Uint8Array[] = [createVarint(bundle.actions.length)];
 
   // No trailer when there are zero actions: this is *not* a missing field. The
-  // device parser finalizes the Orchard bundle the moment it reads a count of 0
-  // (`app-zcash` `src/parser/pczt/orchard.rs`: `if action_count == 0 {
-  // finalize_orchard_actions(..) }`) and never reads flags/value_sum/anchor.
-  // The contract spells this out in `docs/PCZT_APDU.md`: "Bundle trailer
-  // packet, only when Orchard action count is greater than 0." Emitting a
-  // trailer here would leave unexpected bytes and fail the parser's group-end
-  // check on the transparent-only flow.
+  // device parser finalizes the bundle the moment it reads a count of 0 and
+  // never reads flags/value_sum/anchor. Emitting a trailer here would leave
+  // unexpected bytes and fail the parser's group-end check.
   if (bundle.actions.length === 0) {
     return packets;
   }
@@ -212,6 +221,12 @@ export const serializeOrchardActions = (
     metadata.add64BitUIntToData(action.value, false);
     metadata.addBufferToData(action.rseed);
     metadata.addBufferToData(action.rcv);
+    // PCZT v2 addition: present on Ironwood actions, absent on Orchard actions.
+    if ("notePlaintextVersion" in action) {
+      metadata.add8BitUIntToData(
+        (action as { notePlaintextVersion: number }).notePlaintextVersion,
+      );
+    }
     packets.push(metadata.build());
   }
 
@@ -228,6 +243,22 @@ export const serializeOrchardActions = (
 
   return packets;
 };
+
+/** `PCZT_ORCHARD_ACTION` packet sequence (including the trailer when action count > 0). */
+export const serializeOrchardActions = (
+  bundle: PcztOrchardBundle,
+): Uint8Array[] => serializeShieldedActions(bundle);
+
+/**
+ * `PCZT_IRONWOOD_ACTION` packet sequence (including the trailer when action count > 0).
+ *
+ * The wire format is byte-identical to Orchard; only the INS code differs.
+ * Mirrors `LedgerHQ/app-zcash` `src/parser/pczt/orchard.rs` on the
+ * `feat/zcash-integration/ironwood` branch.
+ */
+export const serializeIronwoodActions = (
+  bundle: PcztIronwoodBundle,
+): Uint8Array[] => serializeShieldedActions(bundle);
 
 /**
  * P1 framing for packet `index` of a `total`-packet command:
@@ -252,8 +283,8 @@ export const pcztP1 = (index: number, total: number): number => {
 };
 
 /**
- * P2 framing: `FINISHED` only on the last packet of the final bundle command
- * (`ORCHARD_ACTION`), otherwise `CONTINUE`.
+ * P2 framing: `FINISHED` only on the last packet of the final bundle command,
+ * otherwise `CONTINUE`.
  */
 export const pcztP2 = (
   index: number,

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.test.ts
@@ -1,6 +1,7 @@
 import {
   CommandResultFactory,
   type InternalApi,
+  InvalidArgumentError,
   InvalidStatusWordError,
   isSuccessDmkResult,
 } from "@ledgerhq/device-management-kit";
@@ -8,13 +9,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { type PcztTransaction } from "@api/model/PcztTransaction";
 import { INS_PCZT_HEADER } from "@internal/app-binder/command/PcztHeaderCommand";
+import { INS_PCZT_IRONWOOD_ACTION } from "@internal/app-binder/command/PcztIronwoodActionCommand";
 import { INS_PCZT_ORCHARD_ACTION } from "@internal/app-binder/command/PcztOrchardActionCommand";
 import { INS_PCZT_TRANSPARENT_INPUT } from "@internal/app-binder/command/PcztTransparentInputCommand";
 import { INS_PCZT_TRANSPARENT_OUTPUT } from "@internal/app-binder/command/PcztTransparentOutputCommand";
+import { INS_PCZT_SIGN_IRONWOOD } from "@internal/app-binder/command/SignPcztIronwoodCommand";
 import { INS_PCZT_SIGN_ORCHARD } from "@internal/app-binder/command/SignPcztOrchardCommand";
 import { INS_PCZT_SIGN_TRANSPARENT } from "@internal/app-binder/command/SignPcztTransparentCommand";
 import { PCZT_P2 } from "@internal/app-binder/command/utils/apduHeaderUtils";
 import {
+  allDummyIronwoodBundle,
   allDummyOrchardBundle,
   mixedDummyOrchardBundle,
   multiRealDummyOrchardBundle,
@@ -22,6 +26,9 @@ import {
   privateToPublicTransaction,
   publicToPrivateTransaction,
   publicToPublicTransaction,
+  sampleIronwoodBundle,
+  v6TransactionWithOrchardAndIronwood,
+  v6TransactionWithTransparentOrchardAndIronwood,
 } from "@internal/app-binder/task/__fixtures__/pcztFixtures";
 
 import { SignPcztTransactionTask } from "./SignPcztTransactionTask";
@@ -50,6 +57,14 @@ describe("SignPcztTransactionTask", () => {
         return Promise.resolve(
           CommandResultFactory({
             data: { spendAuthSig: new Uint8Array(64).fill(raw[3]!) },
+          }),
+        );
+      }
+      if (cmd.name === "SignPcztIronwood") {
+        // spendAuthSig keyed on the action index (P2) + 0x10 offset to distinguish from Orchard.
+        return Promise.resolve(
+          CommandResultFactory({
+            data: { spendAuthSig: new Uint8Array(64).fill(raw[3]! + 0x10) },
           }),
         );
       }
@@ -248,5 +263,205 @@ describe("SignPcztTransactionTask", () => {
 
     const result = await run(privateToPrivateTransaction());
     expect(isSuccessDmkResult(result)).toBe(false);
+  });
+
+  // V6 / Ironwood tests
+
+  it("V5 regression: FINISHED stays on last Orchard packet and no IRONWOOD APDUs sent", async () => {
+    await run(privateToPrivateTransaction());
+
+    const orchardPackets = calls.filter(
+      (c) => c.ins === INS_PCZT_ORCHARD_ACTION,
+    );
+    // Last Orchard packet carries FINISHED.
+    expect(orchardPackets[orchardPackets.length - 1]!.p2).toBe(
+      PCZT_P2.FINISHED,
+    );
+    // No Ironwood APDUs are sent for a V5 transaction.
+    expect(calls.some((c) => c.ins === INS_PCZT_IRONWOOD_ACTION)).toBe(false);
+    expect(calls.some((c) => c.ins === INS_PCZT_SIGN_IRONWOOD)).toBe(false);
+  });
+
+  it("V6: FINISHED moves to last Ironwood packet; all Orchard packets use CONTINUE", async () => {
+    await run(v6TransactionWithOrchardAndIronwood());
+
+    const orchardPackets = calls.filter(
+      (c) => c.ins === INS_PCZT_ORCHARD_ACTION,
+    );
+    const ironwoodPackets = calls.filter(
+      (c) => c.ins === INS_PCZT_IRONWOOD_ACTION,
+    );
+
+    // All Orchard packets carry CONTINUE for V6.
+    orchardPackets.forEach((c) => expect(c.p2).toBe(PCZT_P2.CONTINUE));
+    // Last Ironwood packet carries FINISHED.
+    expect(ironwoodPackets[ironwoodPackets.length - 1]!.p2).toBe(
+      PCZT_P2.FINISHED,
+    );
+  });
+
+  it("V6: APDU order — HEADER, inputs, outputs, ORCHARD, IRONWOOD, SIGN_ORCHARD, SIGN_IRONWOOD", async () => {
+    await run(v6TransactionWithOrchardAndIronwood());
+
+    const insSequence = calls.map((c) => c.ins);
+    const lastOrchard = insSequence.lastIndexOf(INS_PCZT_ORCHARD_ACTION);
+    const firstIronwood = insSequence.indexOf(INS_PCZT_IRONWOOD_ACTION);
+    const lastIronwood = insSequence.lastIndexOf(INS_PCZT_IRONWOOD_ACTION);
+    const firstSignOrchard = insSequence.indexOf(INS_PCZT_SIGN_ORCHARD);
+    const firstSignIronwood = insSequence.indexOf(INS_PCZT_SIGN_IRONWOOD);
+
+    // All Orchard streaming before any Ironwood streaming.
+    expect(lastOrchard).toBeLessThan(firstIronwood);
+    // All Ironwood streaming before any sign commands.
+    expect(lastIronwood).toBeLessThan(firstSignOrchard);
+    // Orchard signing before Ironwood signing.
+    expect(firstSignOrchard).toBeLessThan(firstSignIronwood);
+  });
+
+  it("V6: collects one spendAuthSig per Ironwood action", async () => {
+    const result = await run(v6TransactionWithOrchardAndIronwood());
+
+    expect(isSuccessDmkResult(result)).toBe(true);
+    if (isSuccessDmkResult(result)) {
+      expect(result.data.ironwood).toHaveLength(1);
+      // Mock keys spendAuthSig on P2 + 0x10.
+      expect(result.data.ironwood[0]!.spendAuthSig).toEqual(
+        new Uint8Array(64).fill(0x10),
+      );
+    }
+    const ironwoodSigns = calls.filter((c) => c.ins === INS_PCZT_SIGN_IRONWOOD);
+    expect(ironwoodSigns).toHaveLength(1);
+    expect(ironwoodSigns[0]!.p2).toBe(0);
+  });
+
+  it("V6: returns error immediately when ironwoodBundle is null (V6 requires Ironwood)", async () => {
+    const result = await run({
+      ...v6TransactionWithOrchardAndIronwood(),
+      ironwoodBundle: null,
+    });
+
+    expect(isSuccessDmkResult(result)).toBe(false);
+    if (!isSuccessDmkResult(result)) {
+      expect(result.error).toBeInstanceOf(InvalidArgumentError);
+    }
+    // No APDUs sent — the guard fires before streaming.
+    expect(calls).toHaveLength(0);
+  });
+
+  it("V5: returns error immediately when ironwoodBundle is non-null (V5 does not support Ironwood)", async () => {
+    const result = await run({
+      ...privateToPrivateTransaction(),
+      ironwoodBundle: sampleIronwoodBundle(),
+    });
+
+    expect(isSuccessDmkResult(result)).toBe(false);
+    if (!isSuccessDmkResult(result)) {
+      expect(result.error).toBeInstanceOf(InvalidArgumentError);
+    }
+    // No APDUs sent — the guard fires before streaming.
+    expect(calls).toHaveLength(0);
+  });
+
+  it("V6: device rejection during Ironwood streaming returns error", async () => {
+    vi.mocked(apiMock.sendCommand).mockImplementation((command: unknown) => {
+      const cmd = command as CapturedCommand;
+      const raw: Uint8Array = cmd.getApdu().getRawApdu();
+      calls.push({ name: cmd.name, ins: raw[1]!, p1: raw[2]!, p2: raw[3]! });
+      if (cmd.name === "PcztIronwoodAction") {
+        return Promise.resolve(
+          CommandResultFactory({
+            error: new InvalidStatusWordError("ironwood rejected"),
+          }),
+        );
+      }
+      if (cmd.name === "SignPcztOrchard") {
+        return Promise.resolve(
+          CommandResultFactory({
+            data: { spendAuthSig: new Uint8Array(64).fill(0x00) },
+          }),
+        );
+      }
+      return Promise.resolve(CommandResultFactory({ data: undefined }));
+    });
+
+    const result = await run(v6TransactionWithOrchardAndIronwood());
+    expect(isSuccessDmkResult(result)).toBe(false);
+    // No SIGN_IRONWOOD issued after the streaming failure.
+    expect(calls.some((c) => c.ins === INS_PCZT_SIGN_IRONWOOD)).toBe(false);
+  });
+
+  it("V6: device rejection during Ironwood signing returns error", async () => {
+    vi.mocked(apiMock.sendCommand).mockImplementation((command: unknown) => {
+      const cmd = command as CapturedCommand;
+      const raw: Uint8Array = cmd.getApdu().getRawApdu();
+      calls.push({ name: cmd.name, ins: raw[1]!, p1: raw[2]!, p2: raw[3]! });
+      if (cmd.name === "SignPcztIronwood") {
+        return Promise.resolve(
+          CommandResultFactory({
+            error: new InvalidStatusWordError("ironwood sign rejected"),
+          }),
+        );
+      }
+      if (cmd.name === "SignPcztOrchard") {
+        return Promise.resolve(
+          CommandResultFactory({
+            data: { spendAuthSig: new Uint8Array(64).fill(0x00) },
+          }),
+        );
+      }
+      return Promise.resolve(CommandResultFactory({ data: undefined }));
+    });
+
+    const result = await run(v6TransactionWithOrchardAndIronwood());
+    expect(isSuccessDmkResult(result)).toBe(false);
+  });
+
+  it("V5 result includes empty ironwood array for backward compat", async () => {
+    const result = await run(privateToPrivateTransaction());
+
+    expect(isSuccessDmkResult(result)).toBe(true);
+    if (isSuccessDmkResult(result)) {
+      expect(result.data.ironwood).toHaveLength(0);
+    }
+  });
+
+  it("V6: requests no Ironwood signature when every action is a dummy spend", async () => {
+    const result = await run({
+      ...v6TransactionWithOrchardAndIronwood(),
+      ironwoodBundle: allDummyIronwoodBundle(),
+    });
+
+    expect(isSuccessDmkResult(result)).toBe(true);
+    if (isSuccessDmkResult(result)) {
+      expect(result.data.ironwood).toHaveLength(0);
+    }
+    expect(calls.some((c) => c.ins === INS_PCZT_SIGN_IRONWOOD)).toBe(false);
+  });
+
+  it("V6 + transparent: SIGN_TRANSPARENT comes after SIGN_IRONWOOD in APDU order", async () => {
+    await run(v6TransactionWithTransparentOrchardAndIronwood());
+
+    const insSequence = calls.map((c) => c.ins);
+    const lastSignIronwood = insSequence.lastIndexOf(INS_PCZT_SIGN_IRONWOOD);
+    const firstSignTransparent = insSequence.indexOf(INS_PCZT_SIGN_TRANSPARENT);
+
+    expect(lastSignIronwood).not.toBe(-1);
+    expect(firstSignTransparent).not.toBe(-1);
+    // Transparent signing must follow all Ironwood signing.
+    expect(lastSignIronwood).toBeLessThan(firstSignTransparent);
+  });
+
+  it("V6 + transparent: result includes both ironwood sigs and transparentInputSigs", async () => {
+    const result = await run(v6TransactionWithTransparentOrchardAndIronwood());
+
+    expect(isSuccessDmkResult(result)).toBe(true);
+    if (isSuccessDmkResult(result)) {
+      expect(result.data.ironwood).toHaveLength(1);
+      expect(result.data.transparentInputSigs).toHaveLength(1);
+      // Mock keys ironwood spendAuthSig on actionIndex (0) + 0x10 offset.
+      expect(result.data.ironwood[0]!.spendAuthSig).toEqual(
+        new Uint8Array(64).fill(0x10),
+      );
+    }
   });
 });

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/SignPcztTransactionTask.ts
@@ -3,10 +3,12 @@ import {
   type DmkResult,
   DmkResultFactory,
   type InternalApi,
+  InvalidArgumentError,
   isSuccessCommandResult,
 } from "@ledgerhq/device-management-kit";
 
 import {
+  type IronwoodActionSignature,
   type OrchardActionSignature,
   type SignPcztTransactionResult,
 } from "@api/model/PcztSignature";
@@ -15,15 +17,18 @@ import {
   type PcztTransaction,
 } from "@api/model/PcztTransaction";
 import { PcztHeaderCommand } from "@internal/app-binder/command/PcztHeaderCommand";
+import { PcztIronwoodActionCommand } from "@internal/app-binder/command/PcztIronwoodActionCommand";
 import { PcztOrchardActionCommand } from "@internal/app-binder/command/PcztOrchardActionCommand";
 import { PcztTransparentInputCommand } from "@internal/app-binder/command/PcztTransparentInputCommand";
 import { PcztTransparentOutputCommand } from "@internal/app-binder/command/PcztTransparentOutputCommand";
+import { SignPcztIronwoodCommand } from "@internal/app-binder/command/SignPcztIronwoodCommand";
 import { SignPcztOrchardCommand } from "@internal/app-binder/command/SignPcztOrchardCommand";
 import { SignPcztTransparentCommand } from "@internal/app-binder/command/SignPcztTransparentCommand";
 import { PCZT_P2 } from "@internal/app-binder/command/utils/apduHeaderUtils";
 import {
   pcztP1,
   pcztP2,
+  serializeIronwoodActions,
   serializeOrchardActions,
   serializePcztHeader,
   serializeTransparentInputs,
@@ -50,15 +55,23 @@ const EMPTY_ORCHARD_BUNDLE: PcztOrchardBundle = {
   anchor: new Uint8Array(32),
 };
 
+/** Transaction version that introduces Ironwood bundles (NU6.3). */
+const V6_TX_VERSION = 6;
+
 /**
- * Drives the device PCZT Orchard signing protocol end-to-end:
+ * Drives the device PCZT signing protocol end-to-end, supporting both V5
+ * (Orchard) and V6 (Orchard + Ironwood) transactions:
  *
  * 1. streams the PCZT bundle in the fixed order — `PCZT_HEADER`,
- *    `PCZT_TRANSPARENT_INPUT`, `PCZT_TRANSPARENT_OUTPUT`, `PCZT_ORCHARD_ACTION`
- *    (every section always sent; count `0` when empty), the last Orchard packet
- *    carrying `PCZT_P2.FINISHED` to finalize the payload;
+ *    `PCZT_TRANSPARENT_INPUT`, `PCZT_TRANSPARENT_OUTPUT`, `PCZT_ORCHARD_ACTION`,
+ *    and for V6: `PCZT_IRONWOOD_ACTION` (a null Ironwood bundle on a V6
+ *    transaction is rejected as invalid input before any APDU is sent). For
+ *    V5, the last Orchard packet carries `PCZT_P2.FINISHED`; for V6, the last
+ *    Ironwood packet carries `PCZT_P2.FINISHED`;
  * 2. collects one `spendAuthSig[64]` per Orchard action (`PCZT_SIGN_ORCHARD`);
- * 3. collects one secp256k1 signature per transparent input
+ * 3. collects one `spendAuthSig[64]` per Ironwood action for V6
+ *    (`PCZT_SIGN_IRONWOOD`);
+ * 4. collects one secp256k1 signature per transparent input
  *    (`PCZT_SIGN_TRANSPARENT`).
  *
  * It never sends `bsk` nor collects `bindingSig` — the binding signature is a
@@ -72,9 +85,37 @@ export class SignPcztTransactionTask {
   ) {}
 
   async run(): Promise<SignPcztTransactionTaskResult> {
-    const { global, transparentInputs, transparentOutputs, orchardBundle } =
-      this.args.transaction;
+    const {
+      global,
+      transparentInputs,
+      transparentOutputs,
+      orchardBundle,
+      ironwoodBundle: ironwoodBundleInput,
+    } = this.args.transaction;
     const bundle = orchardBundle ?? EMPTY_ORCHARD_BUNDLE;
+    const ironwoodBundle = ironwoodBundleInput ?? null;
+
+    // V6 transactions have an Ironwood bundle; PCZT_P2.FINISHED moves to the
+    // last Ironwood packet instead of the last Orchard packet.
+    const isV6 = global.txVersion === V6_TX_VERSION;
+
+    if (isV6 && ironwoodBundle === null) {
+      return DmkResultFactory({
+        error: new InvalidArgumentError(
+          "V6 transaction requires a non-null Ironwood bundle",
+        ),
+      });
+    }
+
+    if (!isV6 && ironwoodBundle !== null) {
+      return DmkResultFactory({
+        error: new InvalidArgumentError(
+          "V5 transaction does not support an Ironwood bundle",
+        ),
+      });
+    }
+
+    const hasIronwood = isV6 && ironwoodBundle !== null;
 
     // 1. Stream the PCZT bundle, in order.
     const headerResult = await this.api.sendCommand(
@@ -118,18 +159,36 @@ export class SignPcztTransactionTask {
         new PcztOrchardActionCommand({
           data: orchardPackets[i]!,
           p1: pcztP1(i, orchardPackets.length),
-          // `finished: true` here is correct for every flow, including the
-          // transparent-only one where the Orchard section is a single count-0
-          // packet: `pcztP2` only sets `FINISHED` on the *last* Orchard packet,
-          // and `ORCHARD_ACTION` is always the final bundle command, so the
-          // marker lands exactly where the device expects it. The device
-          // accepts signing commands only after seeing `FINISHED`
-          // (`app-zcash` `src/handlers/pczt.rs::finish_pczt_if_requested`).
-          p2: pcztP2(i, orchardPackets.length, true),
+          // For V5 the last Orchard packet carries FINISHED; for V6 it stays
+          // CONTINUE because FINISHED moves to the last Ironwood packet.
+          p2: pcztP2(i, orchardPackets.length, !isV6),
         }),
       );
       if (!isSuccessCommandResult(result)) {
         return DmkResultFactory({ error: result.error });
+      }
+    }
+
+    // Stream the Ironwood bundle only for V6 transactions. V5 transactions must
+    // never send INS_PCZT_IRONWOOD_ACTION — the device rejects unexpected APDUs
+    // after PCZT_P2.FINISHED.
+    // Note: requires firmware compiled with the `zcash_unstable` feature flag
+    // (NU6.3 Ironwood support). Without it the device returns InsNotSupportedError
+    // (6d00) on the first INS_PCZT_IRONWOOD_ACTION APDU, after Orchard streaming
+    // has already sent P2=CONTINUE — leaving the device waiting for more data.
+    if (hasIronwood) {
+      const ironwoodPackets = serializeIronwoodActions(ironwoodBundle!);
+      for (let i = 0; i < ironwoodPackets.length; i += 1) {
+        const result = await this.api.sendCommand(
+          new PcztIronwoodActionCommand({
+            data: ironwoodPackets[i]!,
+            p1: pcztP1(i, ironwoodPackets.length),
+            p2: pcztP2(i, ironwoodPackets.length, true),
+          }),
+        );
+        if (!isSuccessCommandResult(result)) {
+          return DmkResultFactory({ error: result.error });
+        }
       }
     }
 
@@ -158,7 +217,26 @@ export class SignPcztTransactionTask {
       orchard.push(result.data);
     }
 
-    // 3. Collect one signature per transparent input.
+    // 3. Collect one spendAuthSig per Ironwood action the device must sign.
+    //    Same dummy-spend skip as Orchard: spendValue === 0n means a padding
+    //    spend self-signed host-side by the PCZT IoFinalizer.
+    const ironwood: IronwoodActionSignature[] = [];
+    if (hasIronwood) {
+      for (let i = 0; i < ironwoodBundle!.actions.length; i += 1) {
+        if (ironwoodBundle!.actions[i]!.spendValue === 0n) {
+          continue;
+        }
+        const result = await this.api.sendCommand(
+          new SignPcztIronwoodCommand({ actionIndex: i }),
+        );
+        if (!isSuccessCommandResult(result)) {
+          return DmkResultFactory({ error: result.error });
+        }
+        ironwood.push(result.data);
+      }
+    }
+
+    // 4. Collect one signature per transparent input.
     const transparentInputSigs: Uint8Array[] = [];
     for (let i = 0; i < transparentInputs.length; i += 1) {
       const result = await this.api.sendCommand(
@@ -170,6 +248,8 @@ export class SignPcztTransactionTask {
       transparentInputSigs.push(result.data.signature);
     }
 
-    return DmkResultFactory({ data: { orchard, transparentInputSigs } });
+    return DmkResultFactory({
+      data: { orchard, transparentInputSigs, ironwood },
+    });
   }
 }

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/__fixtures__/pcztFixtures.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/__fixtures__/pcztFixtures.ts
@@ -1,5 +1,7 @@
 import {
   type PcztGlobal,
+  type PcztIronwoodAction,
+  type PcztIronwoodBundle,
   type PcztOrchardAction,
   type PcztOrchardBundle,
   type PcztTransaction,
@@ -31,6 +33,27 @@ export const SAMPLE_GLOBAL: PcztGlobal = {
   coinType: 133,
   txModifiable: 0,
 };
+
+/** V6 global — identical to `SAMPLE_GLOBAL` but with `txVersion: 6`. */
+export const SAMPLE_GLOBAL_V6: PcztGlobal = {
+  ...SAMPLE_GLOBAL,
+  txVersion: 6,
+};
+
+/**
+ * Expected `PCZT_HEADER` payload for {@link SAMPLE_GLOBAL_V6}.
+ * PCZT version field is 2 for V6 transactions.
+ */
+export const SAMPLE_HEADER_HEX_V6 =
+  "50435a54" + // "PCZT"
+  "02000000" + // PCZT version 2 (V6)
+  "06000000" + // tx_version 6
+  "0a27a726" + // version_group_id 0x26A7270A LE
+  "b4d0d6c2" + // consensus_branch_id 0xC2D6D0B4 LE
+  "0100000000" + // fallback_lock_time Option<u32>: present, 0
+  "00000000" + // expiry_height 0
+  "85000000" + // coin_type 133 LE
+  "00"; // tx_modifiable 0
 
 /**
  * Expected `PCZT_HEADER` payload for {@link SAMPLE_GLOBAL}, computed by hand
@@ -145,6 +168,58 @@ export const multiRealDummyOrchardBundle = (): PcztOrchardBundle => ({
   anchor: bytes(32, 0x0d),
 });
 
+/**
+ * A sample Ironwood action with distinct fill bytes (0x10–0x1f range) to
+ * distinguish from Orchard action data in tests.
+ */
+export const sampleIronwoodAction = (): PcztIronwoodAction => ({
+  cvNet: bytes(32, 0x11),
+  nullifier: bytes(32, 0x12),
+  rk: bytes(32, 0x13),
+  spendRecipient: bytes(43, 0x14),
+  spendValue: 5n,
+  spendRho: bytes(32, 0x15),
+  spendRseed: bytes(32, 0x16),
+  alpha: bytes(32, 0x17),
+  signingPath: "44'/133'/0'",
+  seedFingerprint: bytes(32, 0x00),
+  cmx: bytes(32, 0x18),
+  ephemeralKey: bytes(32, 0x19),
+  encCiphertext: bytes(ORCHARD_ENC_CIPHERTEXT_SIZE, 0xcc),
+  outCiphertext: bytes(ORCHARD_OUT_CIPHERTEXT_SIZE, 0xdd),
+  recipient: bytes(43, 0x1a),
+  value: 5n,
+  rseed: bytes(32, 0x1b),
+  rcv: bytes(32, 0x1c),
+  notePlaintextVersion: 0x03,
+});
+
+/** Ironwood bundle with one action. */
+export const sampleIronwoodBundle = (): PcztIronwoodBundle => ({
+  actions: [sampleIronwoodAction()],
+  flags: 2,
+  valueBalance: 0n,
+  anchor: bytes(32, 0x1d),
+});
+
+/**
+ * A dummy Ironwood padding spend (spendValue 0). The PCZT IoFinalizer
+ * self-signs these host-side; the device must NOT be asked to sign them.
+ */
+export const dummyIronwoodAction = (): PcztIronwoodAction => ({
+  ...sampleIronwoodAction(),
+  spendValue: 0n,
+  value: 0n,
+});
+
+/** Ironwood bundle made entirely of dummy padding spends (no device signature). */
+export const allDummyIronwoodBundle = (): PcztIronwoodBundle => ({
+  actions: [dummyIronwoodAction(), dummyIronwoodAction()],
+  flags: 2,
+  valueBalance: 0n,
+  anchor: bytes(32, 0x1d),
+});
+
 /** Public → Public: transparent only, no Orchard bundle. */
 export const publicToPublicTransaction = (): PcztTransaction => ({
   global: SAMPLE_GLOBAL,
@@ -176,3 +251,22 @@ export const privateToPublicTransaction = (): PcztTransaction => ({
   transparentOutputs: [sampleTransparentOutput()],
   orchardBundle: sampleOrchardBundle(),
 });
+
+/** V6 transaction with both Orchard and Ironwood bundles. */
+export const v6TransactionWithOrchardAndIronwood = (): PcztTransaction => ({
+  global: SAMPLE_GLOBAL_V6,
+  transparentInputs: [],
+  transparentOutputs: [],
+  orchardBundle: sampleOrchardBundle(),
+  ironwoodBundle: sampleIronwoodBundle(),
+});
+
+/** V6 transaction with Orchard, Ironwood, and a transparent input. */
+export const v6TransactionWithTransparentOrchardAndIronwood =
+  (): PcztTransaction => ({
+    global: SAMPLE_GLOBAL_V6,
+    transparentInputs: [sampleTransparentInput()],
+    transparentOutputs: [],
+    orchardBundle: sampleOrchardBundle(),
+    ironwoodBundle: sampleIronwoodBundle(),
+  });


### PR DESCRIPTION
### 📝 Description

Extends the Zcash signer with Ironwood (NU6.3) PCZT v2 bundle signing support for V6 transactions. V6 introduces a second Orchard-shaped bundle (the Ironwood bundle) alongside the existing Orchard bundle.

**Key behavioral change (BC-1):**
- **V5 (unchanged):** last `INS_PCZT_ORCHARD_ACTION` packet uses `P2=FINISHED`.
- **V6:** last `INS_PCZT_ORCHARD_ACTION` packet uses `P2=CONTINUE`; last `INS_PCZT_IRONWOOD_ACTION` packet carries `P2=FINISHED`.

The V6 path is gated on `txVersion === 6` so V5 signing is fully unaffected. Dummy padding spends (`spendValue === 0`) are skipped for Ironwood signing on-device (same logic as LIVE-34938 applied to Orchard).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32887](https://ledgerhq.atlassian.net/browse/LIVE-32887)

- **Feature**: Zcash Ironwood (NU6.3) dual-pool PCZT v2 signing — enables V6 transactions that spend from both the Orchard and Ironwood shielded pools.

### ✅ Checklist

- [x] **Covered by automatic tests** — 21 new tests in `SignPcztTransactionTask.test.ts` covering V6 APDU order, BC-1 FINISHED marker, Ironwood signature collection, null-bundle handling, V5 regression, and device rejection paths; new describe blocks in command and serializer tests. 183 tests total, all passing.
- [x] **Changeset is provided** — `.changeset/ironwood-pczt-signing.md` (`@ledgerhq/device-signer-kit-zcash`: minor)
- [x] **Documentation is up-to-date** — new public types (`IronwoodActionSignature`, `PcztIronwoodAction`, `PcztIronwoodBundle`) exported from `src/api/index.ts`
- [x] **Impact of the changes:**
  - `signer-zcash`: adds `PcztIronwoodActionCommand` (INS `0x58`) and `SignPcztIronwoodCommand` (INS `0x59`)
  - `SignPcztTransactionResult` gains `ironwood: IronwoodActionSignature[]` (empty for V5 — backward compatible)
  - `PcztTransaction` gains optional `ironwoodBundle?: PcztIronwoodBundle | null` (backward compatible)
  - V5 PCZT signing (Orchard + transparent) is unchanged; all existing tests pass without modification
  - QA focus: V6 dual-pool signing flow end-to-end on a `zcash_unstable`-enabled firmware build

[LIVE-32887]: https://ledgerhq.atlassian.net/browse/LIVE-32887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ