### PR TITLE
🔬 (signer-eth) [NO-ISSUE]: Probe turbo --affected scoping on CI

### DIFF
--- a/packages/signer/signer-eth/src/index.ts
+++ b/packages/signer/signer-eth/src/index.ts
@@ -2,3 +2,5 @@
 import "reflect-metadata";
 
 export * from "@api/index";
+
+// CI probe: verify turbo --affected scopes a signer-eth change (throwaway)


### PR DESCRIPTION
**Throwaway verification PR — do not merge, close after inspecting CI.**

Base is `feat/no-issue-improve-ci-speed` (not develop) on purpose: the diff is a single no-op comment in `signer-eth`, and the base already has the root-deps fix with an identical lockfile. So `turbo run build --affected` (base = this PR's base ref) sees only the signer-eth change and should scope down.

### How to read it
Open the **checks** job → **Build** step and look for:
```
• Packages in scope: … (~4 packages)
• Running build in N packages
```
Expected ~4 (signer-eth, clear-signing-tester, sample, ldmk-cli) instead of 47. That proves `--affected` scopes correctly on CI once the root-deps fix is in place.

Note: touching signer-eth also triggers the Ethereum cs-tester matrix via `detect-changes` — those can be cancelled; they're irrelevant to this check.