### PR TITLE
⚡ (ci) [DSDK-1402]: Speed up CI with a single Turbo job and --affected

### DIFF
--- a/.github/actions/cs-tester-composite/action.yml
+++ b/.github/actions/cs-tester-composite/action.yml
@@ -61,7 +61,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+    - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+
+    # Build only the clear-signing-tester dependency chain, cold. Avoids the
+    # slow **/lib build-cache upload/download and the full build:libs.
+    - name: Build clear-signing-tester dependencies
+      shell: bash
+      run: pnpm turbo run build --filter=@ledgerhq/clear-signing-tester...
 
     - name: Generate token
       id: generate-token

--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -10,71 +10,100 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-libraries:
-    name: Build libraries
+  checks:
+    name: Checks (build, prettier, lint, typecheck, test)
+    # Single job running each Turbo task as its own step. Build output stays on
+    # disk between steps (no cross-job build-cache upload/download) and
+    # `--affected` restricts every task to the packages changed in the group.
     runs-on: "ledgerhq-device-sdk"
+    env:
+      # Base commit used by `turbo run --affected` to detect changed packages.
+      TURBO_SCM_BASE: ${{ github.event.merge_group.base_sha }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # Full history is required so Turbo can compute the merge-base for
+          # `--affected`.
+          fetch-depth: 0
 
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
 
-  prettier:
-    name: Run prettier
-    needs: [build-libraries]
-    runs-on: "ledgerhq-device-sdk"
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+      - name: Build
+        id: build
+        run: pnpm turbo run build --affected
 
       - name: Prettier
         id: prettier
-        run: pnpm prettier
-
-  lint:
-    name: Run lint
-    needs: [build-libraries]
-    runs-on: "ledgerhq-device-sdk"
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: pnpm turbo run prettier --affected
 
       - name: Lint
         id: lint
-        run: pnpm lint
-
-  typecheck:
-    name: Run typecheck
-    needs: [build-libraries]
-    runs-on: "ledgerhq-device-sdk"
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: pnpm turbo run lint --affected
 
       - name: Typecheck
         id: typecheck
-        run: pnpm typecheck
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: pnpm turbo run typecheck --affected
 
-  tests:
-    name: Run unit tests
-    needs: [build-libraries]
-    runs-on: "ledgerhq-device-sdk"
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Test
+        id: test
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: pnpm turbo run test --affected
 
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+      - name: Report
+        if: ${{ !cancelled() }}
+        env:
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          PRETTIER_OUTCOME: ${{ steps.prettier.outcome }}
+          LINT_OUTCOME: ${{ steps.lint.outcome }}
+          TYPECHECK_OUTCOME: ${{ steps.typecheck.outcome }}
+          TEST_OUTCOME: ${{ steps.test.outcome }}
+        run: |
+          icon() {
+            case "$1" in
+              success) echo "✅ Passed" ;;
+              failure) echo "❌ Failed" ;;
+              skipped) echo "⏭️ Skipped" ;;
+              *)       echo "➖ ${1:-not run}" ;;
+            esac
+          }
 
-      - name: Tests
-        id: unit-tests
-        run: pnpm test
+          {
+            echo "## Checks summary"
+            echo ""
+            echo "| Step | Result |"
+            echo "| --- | --- |"
+            echo "| Build | $(icon "$BUILD_OUTCOME") |"
+            echo "| Prettier | $(icon "$PRETTIER_OUTCOME") |"
+            echo "| Lint | $(icon "$LINT_OUTCOME") |"
+            echo "| Typecheck | $(icon "$TYPECHECK_OUTCOME") |"
+            echo "| Test | $(icon "$TEST_OUTCOME") |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          failed=0
+          for outcome in "$BUILD_OUTCOME" "$PRETTIER_OUTCOME" "$LINT_OUTCOME" "$TYPECHECK_OUTCOME" "$TEST_OUTCOME"; do
+            if [ "$outcome" = "failure" ]; then
+              failed=1
+            fi
+          done
+
+          if [ "$failed" -eq 1 ]; then
+            echo "One or more checks failed. See the summary above."
+            exit 1
+          fi
+          echo "All checks passed."
 
   health-check:
     name: Run health check
-    # Aggregates the split checks and tests into a single required status so
-    # branch protection only needs to require "Run health check".
-    needs: [build-libraries, prettier, lint, typecheck, tests]
+    # Aggregates the checks into a single required status so branch protection
+    # only needs to require "Run health check".
+    needs: [checks]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -84,109 +84,122 @@ jobs:
           DANGER_GITHUB_API_BASE_URL: "https://api.github.com"
         run: pnpm danger:ci
 
-  build-libraries:
-    name: Build libraries and apps
+  checks:
+    name: Checks (build, prettier, lint, typecheck, test)
+    # Single job running each Turbo task as its own step. Because everything
+    # runs on one runner, build output stays on disk between steps, so there is
+    # no cross-job build-cache upload/download. `--affected` restricts every
+    # task to the packages changed versus the PR base branch.
     needs: [setup]
     runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    env:
+      # Base reference used by `turbo run --affected` to detect changed packages.
+      TURBO_SCM_BASE: origin/${{ github.event.pull_request.base.ref }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
-
-      # Cache the sample app production build so the sample-integration job can
-      # reuse it instead of rebuilding before the Playwright run.
-      - name: Cache sample app build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
-          path: apps/sample/.next
-          key: ${{ runner.os }}-sample-next-${{ github.sha }}
+          # Full history + the base branch are required so Turbo can compute the
+          # merge-base for `--affected`.
+          fetch-depth: 0
 
-      - name: Build apps
-        run: pnpm build
+      - name: Fetch base branch for --affected
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}
 
-  prettier:
-    name: Run prettier
-    needs: [build-libraries]
-    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
 
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+      - name: Build
+        id: build
+        run: pnpm turbo run build --affected
 
       - name: Prettier
         id: prettier
-        run: pnpm prettier
-
-  lint:
-    name: Run lint
-    needs: [build-libraries]
-    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: pnpm turbo run prettier --affected
 
       - name: Lint
         id: lint
-        run: pnpm lint
-
-  typecheck:
-    name: Run typecheck
-    needs: [build-libraries]
-    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: pnpm turbo run lint --affected
 
       - name: Typecheck
         id: typecheck
-        run: pnpm typecheck
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: pnpm turbo run typecheck --affected
 
-  tests:
-    name: Run unit tests
-    needs: [build-libraries]
-    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          fetch-depth: 0
-
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
-
-      - name: Tests
-        id: unit-tests
-        run: pnpm test:coverage
+      - name: Test
+        id: test
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: pnpm turbo run test:coverage --affected
 
       - uses: sonarsource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8
-        if: ${{ steps.unit-tests.conclusion == 'success' && github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
+        if: ${{ steps.test.outcome == 'success' && github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
+      - name: Report
+        if: ${{ !cancelled() }}
+        env:
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          PRETTIER_OUTCOME: ${{ steps.prettier.outcome }}
+          LINT_OUTCOME: ${{ steps.lint.outcome }}
+          TYPECHECK_OUTCOME: ${{ steps.typecheck.outcome }}
+          TEST_OUTCOME: ${{ steps.test.outcome }}
+        run: |
+          icon() {
+            case "$1" in
+              success) echo "✅ Passed" ;;
+              failure) echo "❌ Failed" ;;
+              skipped) echo "⏭️ Skipped" ;;
+              *)       echo "➖ ${1:-not run}" ;;
+            esac
+          }
+
+          {
+            echo "## Checks summary"
+            echo ""
+            echo "| Step | Result |"
+            echo "| --- | --- |"
+            echo "| Build | $(icon "$BUILD_OUTCOME") |"
+            echo "| Prettier | $(icon "$PRETTIER_OUTCOME") |"
+            echo "| Lint | $(icon "$LINT_OUTCOME") |"
+            echo "| Typecheck | $(icon "$TYPECHECK_OUTCOME") |"
+            echo "| Test | $(icon "$TEST_OUTCOME") |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          failed=0
+          for outcome in "$BUILD_OUTCOME" "$PRETTIER_OUTCOME" "$LINT_OUTCOME" "$TYPECHECK_OUTCOME" "$TEST_OUTCOME"; do
+            if [ "$outcome" = "failure" ]; then
+              failed=1
+            fi
+          done
+
+          if [ "$failed" -eq 1 ]; then
+            echo "One or more checks failed. See the summary above."
+            exit 1
+          fi
+          echo "All checks passed."
+
   sample-integration:
     name: Run playwright
-    needs: [build-libraries]
+    needs: [checks]
     runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
-
-      # Reuse the sample app build produced by build-libraries; start-servers.sh
-      # then skips the build and starts the prebuilt app directly.
-      - name: Restore sample app build
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: apps/sample/.next
-          key: ${{ runner.os }}-sample-next-${{ github.sha }}
 
       - name: Install Playwright browsers
         run: pnpm --filter @ledgerhq/device-management-kit-sample exec playwright install --with-deps chromium
 
       - name: Run sample Playwright tests
-        # The Playwright webServer (start-servers.sh) starts both the device mock
-        # server and the sample app, so neither is launched here.
+        # The Playwright webServer (start-servers.sh) runs a production
+        # `next build` and starts both the device mock server and the sample
+        # app, so neither is launched here.
         run: pnpm --filter @ledgerhq/device-management-kit-sample test:playwright
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -199,9 +212,9 @@ jobs:
 
   health-check:
     name: Run health check
-    # Aggregates the split checks and tests into a single required status so
+    # Aggregates the checks and integration jobs into a single required status so
     # branch protection only needs to require "Run health check".
-    needs: [build-libraries, prettier, lint, typecheck, tests, sample-integration]
+    needs: [checks, sample-integration]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-22.04
     steps:
@@ -214,7 +227,7 @@ jobs:
           echo "All required checks passed."
 
   cs-tester:
-    needs: [build-libraries, detect-changes]
+    needs: [checks, detect-changes]
     if: needs.detect-changes.outputs.should-run-ethereum-cs-tester == 'true'
     name: Ethereum Clear Signing Test (${{ matrix.device }} - ${{ matrix.test }})
     runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
@@ -244,7 +257,7 @@ jobs:
           solana-rpc-url: ${{ secrets.SOLANA_LEDGER_RPC_URL }}
 
   solana-cs-tester:
-    needs: [build-libraries, detect-changes]
+    needs: [checks, detect-changes]
     if: needs.detect-changes.outputs.should-run-solana-cs-tester == 'true'
     name: Solana Fixture Test (${{ matrix.device }} - ${{ matrix.test }})
     runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -141,6 +141,38 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
+      # Only run the (heavy) Playwright E2E when the sample app or one of its
+      # dependencies is in the affected set; skip it otherwise.
+      - name: Detect if sample app is affected
+        id: sample-affected
+        if: ${{ !cancelled() }}
+        run: |
+          affected=$(pnpm turbo run build --affected --dry=json 2>/dev/null \
+            | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{const j=JSON.parse(d);console.log((j.packages||[]).includes("@ledgerhq/device-management-kit-sample")?"true":"false")}catch(e){console.log("true")}})')
+          echo "affected=$affected" >> "$GITHUB_OUTPUT"
+          echo "sample app affected: $affected"
+
+      - name: Install Playwright browsers
+        if: ${{ !cancelled() && steps.sample-affected.outputs.affected == 'true' }}
+        run: pnpm --filter @ledgerhq/device-management-kit-sample exec playwright install --with-deps chromium
+
+      - name: Run sample Playwright tests
+        id: playwright
+        # The Playwright webServer (start-servers.sh) runs a production
+        # `next build` and starts both the device mock server and the sample
+        # app, so neither is launched here. Reuses the libs already built above.
+        if: ${{ !cancelled() && steps.sample-affected.outputs.affected == 'true' }}
+        continue-on-error: true
+        run: pnpm --filter @ledgerhq/device-management-kit-sample test:playwright
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: ${{ !cancelled() && steps.playwright.outcome == 'failure' }}
+        with:
+          name: sample-playwright-traces
+          path: apps/sample/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Report
         if: ${{ !cancelled() }}
         env:
@@ -149,6 +181,7 @@ jobs:
           LINT_OUTCOME: ${{ steps.lint.outcome }}
           TYPECHECK_OUTCOME: ${{ steps.typecheck.outcome }}
           TEST_OUTCOME: ${{ steps.test.outcome }}
+          PLAYWRIGHT_OUTCOME: ${{ steps.playwright.outcome }}
         run: |
           icon() {
             case "$1" in
@@ -169,10 +202,11 @@ jobs:
             echo "| Lint | $(icon "$LINT_OUTCOME") |"
             echo "| Typecheck | $(icon "$TYPECHECK_OUTCOME") |"
             echo "| Test | $(icon "$TEST_OUTCOME") |"
+            echo "| Playwright (sample) | $(icon "$PLAYWRIGHT_OUTCOME") |"
           } >> "$GITHUB_STEP_SUMMARY"
 
           failed=0
-          for outcome in "$BUILD_OUTCOME" "$PRETTIER_OUTCOME" "$LINT_OUTCOME" "$TYPECHECK_OUTCOME" "$TEST_OUTCOME"; do
+          for outcome in "$BUILD_OUTCOME" "$PRETTIER_OUTCOME" "$LINT_OUTCOME" "$TYPECHECK_OUTCOME" "$TEST_OUTCOME" "$PLAYWRIGHT_OUTCOME"; do
             if [ "$outcome" = "failure" ]; then
               failed=1
             fi
@@ -184,37 +218,11 @@ jobs:
           fi
           echo "All checks passed."
 
-  sample-integration:
-    name: Run playwright
-    needs: [checks]
-    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
-
-      - name: Install Playwright browsers
-        run: pnpm --filter @ledgerhq/device-management-kit-sample exec playwright install --with-deps chromium
-
-      - name: Run sample Playwright tests
-        # The Playwright webServer (start-servers.sh) runs a production
-        # `next build` and starts both the device mock server and the sample
-        # app, so neither is launched here.
-        run: pnpm --filter @ledgerhq/device-management-kit-sample test:playwright
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: ${{ failure() }}
-        with:
-          name: sample-playwright-traces
-          path: apps/sample/test-results
-          if-no-files-found: ignore
-          retention-days: 7
-
   health-check:
     name: Run health check
-    # Aggregates the checks and integration jobs into a single required status so
-    # branch protection only needs to require "Run health check".
-    needs: [checks, sample-integration]
+    # Aggregates the checks into a single required status so branch protection
+    # only needs to require "Run health check".
+    needs: [checks]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-22.04
     steps:

--- a/package.json
+++ b/package.json
@@ -55,15 +55,14 @@
     "danger:local:fork": "pnpm danger local --dangerfile danger/dangerfile-local-fork.ts --base origin/develop",
     "danger:ci": "pnpm danger ci --dangerfile danger/dangerfile-ci.ts",
     "cli": "pnpm --filter @ledgerhq/ldmk-cli",
-    "tool": "pnpm ldmk-tool",
+    "tool": "node ./packages/tools/ldmk-tool/cli.cjs",
+    "ldmk-tool": "node ./packages/tools/ldmk-tool/cli.cjs",
     "signer-zcash": "pnpm --filter @ledgerhq/device-signer-kit-zcash"
   },
   "devDependencies": {
     "@changesets/changelog-github": "catalog:",
     "@changesets/cli": "catalog:",
     "@changesets/parse": "catalog:",
-    "@ledgerhq/ldmk-cli": "workspace:^",
-    "@ledgerhq/ldmk-tool": "workspace:^",
     "@types/node": "catalog:",
     "@vitest/coverage-istanbul": "catalog:",
     "concurrently": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,12 +395,6 @@ importers:
       '@changesets/parse':
         specifier: 'catalog:'
         version: 0.4.1
-      '@ledgerhq/ldmk-cli':
-        specifier: workspace:^
-        version: link:apps/ldmk-cli
-      '@ledgerhq/ldmk-tool':
-        specifier: workspace:^
-        version: link:packages/tools/ldmk-tool
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -883,7 +877,7 @@ importers:
         version: 0.76.6
       '@react-native/metro-config':
         specifier: 'catalog:'
-        version: 0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))
+        version: 0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@react-native/typescript-config':
         specifier: 'catalog:'
         version: 0.76.6
@@ -16609,7 +16603,7 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
-  '@react-native/metro-config@0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))':
+  '@react-native/metro-config@0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
       '@react-native/js-polyfills': 0.76.6
       '@react-native/metro-babel-transformer': 0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))
@@ -16618,7 +16612,9 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 


### PR DESCRIPTION
### 📝 Description

Speeds up PR / merge-queue CI:

- **Single `checks` job.** `build`, `prettier`, `lint`, `typecheck`, `test` (and Playwright) now run as steps of one job, so build output stays on disk between them. This removes the per-job `**/lib` build-cache upload/download that dominated CI time (cold build compute is only ~3s).
- **`turbo --affected`.** Each task runs only for packages changed vs the base branch.
- **Root workspace deps removed.** Dropped `@ledgerhq/ldmk-cli` / `@ledgerhq/ldmk-tool` from the root `package.json` (root scripts `tool` / `ldmk-tool` now call `node ./packages/tools/ldmk-tool/cli.cjs`) so `--affected` actually scopes core-package changes (e.g. signer-eth: 46 → 4 packages).
- **Playwright gated.** The sample E2E runs only when the sample app is affected.
- **cs-tester de-cached.** The cs-tester composite drops the build-cache and does a cold, scoped `turbo build --filter=@ledgerhq/clear-signing-tester...` (~15 pkgs) instead of a full cached build.
- A final report step summarizes each check and gates the job.

Applies to both `pull_request.yml` and `merge_queue.yml`.

## ⏱️ CI flow: before vs after

**Before** — 6 jobs, each re-running setup + `pnpm install` + `**/lib` build-cache restore/save before its task:

```mermaid
flowchart TD
    S["Setup · 88s"] --> B["Build libraries & apps · 624s<br/>(setup + install + build-cache SAVE + full build)"]
    B --> P["Prettier job · 134s"]
    B --> L["Lint job · 164s"]
    B --> T["Typecheck job · 195s"]
    B --> U["Unit tests job · 223s"]
    B --> W["Playwright job · 233s"]
    P --> H["Health check"]
    L --> H
    T --> H
    U --> H
    W --> H
```

Each check job re-pays ~90–130s of setup + install + build-cache restore, and always builds/tests everything. Wall clock ≈ **1251s (~21 min)**.

**After** — one `checks` job; build output stays on disk (no cache transfer) and `--affected` scopes the work:

```mermaid
flowchart LR
    subgraph C["checks · single job"]
        direction LR
        B["Build --affected<br/>107s"] --> P["Prettier<br/>15s"] --> L["Lint<br/>48s"] --> T["Typecheck<br/>38s"] --> U["Test<br/>54s"] --> W["Playwright<br/>58s · only if sample affected"] --> R["Report"]
    end
    C --> H["Health check"]
```

Setup + install paid once; no `**/lib` upload/download. Wall clock ≈ **460s (~8 min)** for a full run, and less for scoped PRs.

### Per-task timing (representative full run)

| Work | Before (own job) | After (step in `checks`) |
| --- | --- | --- |
| Build | 624s | **107s** |
| Prettier | 134s | **15s** |
| Lint | 164s | **48s** |
| Typecheck | 195s | **38s** |
| Unit tests | 223s | **54s** |
| Playwright | 233s | **58s** |
| **Pipeline wall clock** | **~1251s (~21 min)** | **~460s (~8 min)** — **‑63%** |

_One representative run each (before: a normal full PR run; after: this PR's own run, which builds all packages because it changes the lockfile). `--affected` cuts this further on ordinary PRs — a signer-eth change scopes to just 4 packages._

## 🧪 What's been tested

All verified on real CI (via throwaway PRs based on this branch):

- **`--affected` scoping** — signer-eth change → 4 pkgs, speculos change → 3 pkgs, dmk change → 37 pkgs (dmk is a universal dep). Correct in every case.
- **`ldmk-tool` in the release path** — a snapshot release from this branch ran green: `bump-snapshot`, `canonicalize`, `pack`, and JFrog publish all succeeded (this is the command that would break if the root scripts were wrong).
- **`generate-signer`** — launches from the repo root with the new `ldmk-tool` script (correct cwd), reaches its prompt, no path/module error.
- **Sonar under `--affected`** — a PR with ~47% coverage on new code correctly **failed** the Sonar quality gate (required ≥ 80%), confirming partial (`--affected`) coverage still flows into SonarCloud and the gate enforces it.

## ❓ Context

- **JIRA**: [DSDK-1402](https://ledgerhq.atlassian.net/browse/DSDK-1402)

## ✅ Checklist

- [ ] **Covered by automatic tests** — N/A, CI workflow / root tooling change (validated on CI as above).
- [ ] **Changeset is provided** — Not needed; only `.github/**` and the private root `package.json` change, no published package.
- [ ] **Documentation is up-to-date** — N/A

> Note: this PR touches `pnpm-lock.yaml`, a Turbo global trigger, so its own run builds all packages. `--affected` scoping applies to PRs opened after it lands on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DSDK-1402]: https://ledgerhq.atlassian.net/browse/DSDK-1402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ