### PR TITLE
🔬 (dmk) [NO-ISSUE]: Verify CI --affected on a DMK change

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -141,6 +141,38 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
+      # Only run the (heavy) Playwright E2E when the sample app or one of its
+      # dependencies is in the affected set; skip it otherwise.
+      - name: Detect if sample app is affected
+        id: sample-affected
+        if: ${{ !cancelled() }}
+        run: |
+          affected=$(pnpm turbo run build --affected --dry=json 2>/dev/null \
+            | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{const j=JSON.parse(d);console.log((j.packages||[]).includes("@ledgerhq/device-management-kit-sample")?"true":"false")}catch(e){console.log("true")}})')
+          echo "affected=$affected" >> "$GITHUB_OUTPUT"
+          echo "sample app affected: $affected"
+
+      - name: Install Playwright browsers
+        if: ${{ !cancelled() && steps.sample-affected.outputs.affected == 'true' }}
+        run: pnpm --filter @ledgerhq/device-management-kit-sample exec playwright install --with-deps chromium
+
+      - name: Run sample Playwright tests
+        id: playwright
+        # The Playwright webServer (start-servers.sh) runs a production
+        # `next build` and starts both the device mock server and the sample
+        # app, so neither is launched here. Reuses the libs already built above.
+        if: ${{ !cancelled() && steps.sample-affected.outputs.affected == 'true' }}
+        continue-on-error: true
+        run: pnpm --filter @ledgerhq/device-management-kit-sample test:playwright
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: ${{ !cancelled() && steps.playwright.outcome == 'failure' }}
+        with:
+          name: sample-playwright-traces
+          path: apps/sample/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Report
         if: ${{ !cancelled() }}
         env:
@@ -149,6 +181,7 @@ jobs:
           LINT_OUTCOME: ${{ steps.lint.outcome }}
           TYPECHECK_OUTCOME: ${{ steps.typecheck.outcome }}
           TEST_OUTCOME: ${{ steps.test.outcome }}
+          PLAYWRIGHT_OUTCOME: ${{ steps.playwright.outcome }}
         run: |
           icon() {
             case "$1" in
@@ -169,10 +202,11 @@ jobs:
             echo "| Lint | $(icon "$LINT_OUTCOME") |"
             echo "| Typecheck | $(icon "$TYPECHECK_OUTCOME") |"
             echo "| Test | $(icon "$TEST_OUTCOME") |"
+            echo "| Playwright (sample) | $(icon "$PLAYWRIGHT_OUTCOME") |"
           } >> "$GITHUB_STEP_SUMMARY"
 
           failed=0
-          for outcome in "$BUILD_OUTCOME" "$PRETTIER_OUTCOME" "$LINT_OUTCOME" "$TYPECHECK_OUTCOME" "$TEST_OUTCOME"; do
+          for outcome in "$BUILD_OUTCOME" "$PRETTIER_OUTCOME" "$LINT_OUTCOME" "$TYPECHECK_OUTCOME" "$TEST_OUTCOME" "$PLAYWRIGHT_OUTCOME"; do
             if [ "$outcome" = "failure" ]; then
               failed=1
             fi
@@ -184,37 +218,11 @@ jobs:
           fi
           echo "All checks passed."
 
-  sample-integration:
-    name: Run playwright
-    needs: [checks]
-    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-
-      - uses: LedgerHQ/device-sdk-ts/.github/actions/setup-with-build-cache-composite@b83ec5020b992dcc53f683830e0abd2e147791ae
-
-      - name: Install Playwright browsers
-        run: pnpm --filter @ledgerhq/device-management-kit-sample exec playwright install --with-deps chromium
-
-      - name: Run sample Playwright tests
-        # The Playwright webServer (start-servers.sh) runs a production
-        # `next build` and starts both the device mock server and the sample
-        # app, so neither is launched here.
-        run: pnpm --filter @ledgerhq/device-management-kit-sample test:playwright
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: ${{ failure() }}
-        with:
-          name: sample-playwright-traces
-          path: apps/sample/test-results
-          if-no-files-found: ignore
-          retention-days: 7
-
   health-check:
     name: Run health check
-    # Aggregates the checks and integration jobs into a single required status so
-    # branch protection only needs to require "Run health check".
-    needs: [checks, sample-integration]
+    # Aggregates the checks into a single required status so branch protection
+    # only needs to require "Run health check".
+    needs: [checks]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-22.04
     steps:

--- a/package.json
+++ b/package.json
@@ -55,15 +55,13 @@
     "danger:local:fork": "pnpm danger local --dangerfile danger/dangerfile-local-fork.ts --base origin/develop",
     "danger:ci": "pnpm danger ci --dangerfile danger/dangerfile-ci.ts",
     "cli": "pnpm --filter @ledgerhq/ldmk-cli",
-    "tool": "pnpm ldmk-tool",
+    "tool": "pnpm --filter @ledgerhq/ldmk-tool exec node cli.cjs",
     "signer-zcash": "pnpm --filter @ledgerhq/device-signer-kit-zcash"
   },
   "devDependencies": {
     "@changesets/changelog-github": "catalog:",
     "@changesets/cli": "catalog:",
     "@changesets/parse": "catalog:",
-    "@ledgerhq/ldmk-cli": "workspace:^",
-    "@ledgerhq/ldmk-tool": "workspace:^",
     "@types/node": "catalog:",
     "@vitest/coverage-istanbul": "catalog:",
     "concurrently": "catalog:",

--- a/packages/device-management-kit/src/index.ts
+++ b/packages/device-management-kit/src/index.ts
@@ -1,3 +1,5 @@
 import "reflect-metadata";
 
 export * from "./api";
+
+// CI verify: DMK change (throwaway, targets chore/dsdk-1402-ci-turbo-affected)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,12 +395,6 @@ importers:
       '@changesets/parse':
         specifier: 'catalog:'
         version: 0.4.1
-      '@ledgerhq/ldmk-cli':
-        specifier: workspace:^
-        version: link:apps/ldmk-cli
-      '@ledgerhq/ldmk-tool':
-        specifier: workspace:^
-        version: link:packages/tools/ldmk-tool
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -883,7 +877,7 @@ importers:
         version: 0.76.6
       '@react-native/metro-config':
         specifier: 'catalog:'
-        version: 0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))
+        version: 0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@react-native/typescript-config':
         specifier: 'catalog:'
         version: 0.76.6
@@ -16609,7 +16603,7 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
-  '@react-native/metro-config@0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))':
+  '@react-native/metro-config@0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
       '@react-native/js-polyfills': 0.76.6
       '@react-native/metro-babel-transformer': 0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))
@@ -16618,7 +16612,9 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 


### PR DESCRIPTION
**Throwaway CI verification — do not merge.** Base is the DSDK-1402 branch so the only diff is a no-op comment in `device-management-kit`. Expect the `checks` job to scope to dmk + its dependents (~37 pkgs; dmk is a universal dep). Confirms the new single-job/--affected CI works for a core-package change. Close after inspecting.