### PR TITLE
✨ (signer-zcash) [LIVE-35012]: Add getShieldedAddress

### DIFF
--- a/.changeset/signer-zcash-get-shielded-address.md
+++ b/.changeset/signer-zcash-get-shielded-address.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/device-signer-kit-zcash": minor
+---
+
+Add `getShieldedAddress` to `SignerZcash` for INS_GET_SHIELD_ADDR (0x51).
+
+Sends the transparent derivation path (`44'/coin/account'/change/index`) together with the derived Orchard account path (`32'/coin/account'`) to the device. The device uses the transparent path for account matching and on-device display; the returned unified address contains a single Orchard receiver. Pass `checkOnDevice: true` to have the device display the address for user confirmation.

--- a/apps/docs/content/docs/references/signers/zcash.mdx
+++ b/apps/docs/content/docs/references/signers/zcash.mdx
@@ -3,6 +3,7 @@
 This module provides the implementation of the Ledger zcash signer of the Device Management Kit. It enables interaction with the zcash application on a Ledger device including:
 
 - Retrieving the zcash address using a given derivation path
+- Retrieving a unified shielded address (Orchard receiver) using a given transparent derivation path
 - Retrieving the zcash full viewing key (UFVK or Orchard FVK)
 - Signing a zcash transaction
 - Signing a message displayed on a Ledger device
@@ -20,6 +21,7 @@ This module provides the implementation of the Ledger zcash signer of the Device
    - [Sign Transaction](#use-case-4-sign-transaction)
    - [Sign PCZT Transaction](#use-case-5-sign-pczt-transaction)
    - [Sign Message](#use-case-6-sign-message)
+   - [Get Shielded Address](#use-case-7-get-shielded-address)
 5. [Observable Behavior](#-observable-behavior)
 6. [Example](#-example)
 
@@ -366,6 +368,54 @@ type Signature = {
   r: string;
   s: string;
   v?: number;
+};
+```
+
+- `cancel` A function to cancel the action on the Ledger device.
+
+---
+
+### Use Case 7: Get Shielded Address
+
+This method allows users to retrieve a unified shielded address (single Orchard receiver) based on a transparent derivation path. The device uses the transparent path for account matching and on-device display; the returned unified address begins with `u1`.
+
+```typescript
+const { observable, cancel } = signerZcash.getShieldedAddress(
+  derivationPath,
+  options,
+);
+```
+
+#### **Parameters**
+
+- `derivationPath`
+
+  - **Required**
+  - **Type:** `string` (e.g., `"44'/133'/0'/0/0"`)
+  - Transparent derivation path (BIP-44). The Orchard account path (`32'/coin/account'`) is derived from it automatically.
+
+- `options`
+
+  - Optional
+  - Type: `AddressOptions`
+
+    ```typescript
+    type AddressOptions = {
+      checkOnDevice?: boolean;
+      skipOpenApp?: boolean;
+    };
+    ```
+
+  - `checkOnDevice`: An optional boolean indicating whether user confirmation on the device is required (`true`) or not (`false`).
+  - `skipOpenApp`: An optional boolean indicating whether to skip opening the zcash app automatically (`true`) or not (`false`).
+
+#### **Returns**
+
+- `observable` Emits DeviceActionState updates, including the following details:
+
+```typescript
+type GetShieldedAddressDAOutput = {
+  readonly address: string; // unified address beginning with "u1"
 };
 ```
 

--- a/packages/signer/signer-zcash/README.md
+++ b/packages/signer/signer-zcash/README.md
@@ -3,6 +3,7 @@
 This module provides the implementation of the Ledger Zcash signer of the Device Management Kit. It enables interaction with the Zcash application on a Ledger device including:
 
 - Retrieving a transparent Zcash address for a given derivation path;
+- Retrieving a unified shielded address (Orchard receiver) for a given transparent derivation path;
 - Retrieving a unified or Orchard full viewing key (ZIP-32 account path);
 - Signing a transparent Zcash payment transaction (Ledger Wallet / `hw-app-btc` compatible shape);
 - Signing an Orchard shielded (PCZT) transaction, returning per-action Orchard spend-authorization signatures and per-input transparent signatures;
@@ -23,6 +24,7 @@ This module provides the implementation of the Ledger Zcash signer of the Device
    - [Sign Message](#use-case-5-sign-message)
    - [Get Trusted Input](#use-case-6-get-trusted-input)
    - [Get App Configuration](#use-case-7-get-app-configuration)
+   - [Get Shielded Address](#use-case-8-get-shielded-address)
 5. [Observable Behavior](#observable-behavior)
 6. [Example](#example)
 7. [Development](#development)
@@ -434,6 +436,43 @@ const { observable, cancel } = signerZcash.getTrustedInput(
 ```typescript
 const { observable, cancel } = signerZcash.getAppConfig();
 ```
+
+---
+
+### Use Case 8: Get Shielded Address
+
+Retrieve a unified shielded address (single Orchard receiver) for a transparent derivation path. The device uses the transparent path for account matching and on-device display.
+
+```typescript
+const { observable, cancel } = signerZcash.getShieldedAddress(
+  "44'/133'/0'/0/0",
+  { checkOnDevice: false, skipOpenApp: false },
+);
+```
+
+#### Parameters
+
+- `derivationPath` — **Required** — `string` (e.g. `"44'/133'/0'/0/0"`)
+- `options` — Optional — `AddressOptions`
+
+  ```typescript
+  type AddressOptions = {
+    checkOnDevice?: boolean;
+    skipOpenApp?: boolean;
+  };
+  ```
+
+#### Returns
+
+On success, `output` includes:
+
+```typescript
+type GetShieldedAddressDAOutput = {
+  readonly address: string; // unified address beginning with "u1"
+};
+```
+
+Intermediate value may require `UserInteractionRequired.VerifyAddress` when `checkOnDevice` is true.
 
 ---
 

--- a/packages/signer/signer-zcash/src/api/SignerZcash.ts
+++ b/packages/signer/signer-zcash/src/api/SignerZcash.ts
@@ -1,6 +1,7 @@
 import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
 import { type GetAppConfigDAReturnType } from "@api/app-binder/GetAppConfigDeviceActionTypes";
 import { type GetFullViewingKeyDAReturnType } from "@api/app-binder/GetFullViewingKeyDeviceActionTypes";
+import { type GetShieldedAddressDAReturnType } from "@api/app-binder/GetShieldedAddressDeviceActionTypes";
 import { type GetTrustedInputDAReturnType } from "@api/app-binder/GetTrustedInputActionTypes";
 import { type SignMessageDAReturnType } from "@api/app-binder/SignMessageDeviceActionTypes";
 import { type SignPcztTransactionDAReturnType } from "@api/app-binder/SignPcztTransactionDeviceActionTypes";
@@ -23,6 +24,19 @@ export interface SignerZcash {
     derivationPath: string,
     options?: FullViewingKeyOptions,
   ) => GetFullViewingKeyDAReturnType;
+
+  /**
+   * Returns a unified shielded address (single Orchard receiver) for the given
+   * transparent derivation path. `derivationPath` must be a 5-level BIP44 path
+   * (`44'/coin'/account'/change/index`); the Orchard account path
+   * (`32'/coin'/account'`) is derived from it automatically by the task.
+   * Pass `checkOnDevice: true` to have the address displayed on the device for
+   * user confirmation.
+   */
+  getShieldedAddress: (
+    derivationPath: string,
+    options?: AddressOptions,
+  ) => GetShieldedAddressDAReturnType;
 
   signTransaction: (
     args: LegacyCreateTransactionArg,

--- a/packages/signer/signer-zcash/src/api/app-binder/GetShieldedAddressDeviceActionTypes.ts
+++ b/packages/signer/signer-zcash/src/api/app-binder/GetShieldedAddressDeviceActionTypes.ts
@@ -1,0 +1,35 @@
+import {
+  type CommandErrorResult,
+  type ExecuteDeviceActionReturnType,
+  type OpenAppDAError,
+  type OpenAppDARequiredInteraction,
+  type UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import { type ZcashErrorCodes } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+type GetShieldedAddressDAUserInteractionRequired =
+  | UserInteractionRequired.None
+  | UserInteractionRequired.VerifyAddress;
+
+export type GetShieldedAddressDAOutput = {
+  readonly address: string;
+};
+
+export type GetShieldedAddressDAError =
+  | OpenAppDAError
+  | CommandErrorResult<ZcashErrorCodes>["error"];
+
+type GetShieldedAddressDARequiredInteraction =
+  | OpenAppDARequiredInteraction
+  | GetShieldedAddressDAUserInteractionRequired;
+
+export type GetShieldedAddressDAIntermediateValue = {
+  readonly requiredUserInteraction: GetShieldedAddressDARequiredInteraction;
+};
+
+export type GetShieldedAddressDAReturnType = ExecuteDeviceActionReturnType<
+  GetShieldedAddressDAOutput,
+  GetShieldedAddressDAError,
+  GetShieldedAddressDAIntermediateValue
+>;

--- a/packages/signer/signer-zcash/src/api/index.ts
+++ b/packages/signer/signer-zcash/src/api/index.ts
@@ -15,6 +15,12 @@ export type {
   GetFullViewingKeyDAReturnType,
 } from "@api/app-binder/GetFullViewingKeyDeviceActionTypes";
 export type {
+  GetShieldedAddressDAError,
+  GetShieldedAddressDAIntermediateValue,
+  GetShieldedAddressDAOutput,
+  GetShieldedAddressDAReturnType,
+} from "@api/app-binder/GetShieldedAddressDeviceActionTypes";
+export type {
   GetTrustedInputDAError,
   GetTrustedInputDAIntermediateValue,
   GetTrustedInputDAOutput,

--- a/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.test.ts
+++ b/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.test.ts
@@ -123,6 +123,38 @@ describe("DefaultSignerZcash", () => {
     );
   });
 
+  it("should call getShieldedAddress via device action with derivation path and defaults", () => {
+    const sessionId = "test-session-id" as DeviceSessionId;
+    const derivationPath = "44'/133'/0'/0/0";
+    const executeDeviceAction = vi.fn().mockReturnValue({
+      observable: from([]),
+      cancel: vi.fn(),
+    });
+    const dmk = {
+      executeDeviceAction,
+    } as unknown as DeviceManagementKit;
+    const signer = new DefaultSignerZcash({ dmk, sessionId });
+
+    signer.getShieldedAddress(derivationPath, {});
+
+    expect(executeDeviceAction).toHaveBeenCalledTimes(1);
+    const call = executeDeviceAction.mock.calls[0]![0] as {
+      sessionId: DeviceSessionId;
+      deviceAction: CallTaskInAppDeviceAction<
+        unknown,
+        DmkError,
+        UserInteractionRequired.None
+      >;
+    };
+    expect(call.sessionId).toBe(sessionId);
+    expect(call.deviceAction).toBeInstanceOf(CallTaskInAppDeviceAction);
+    expect(call.deviceAction.input.appName).toBe(APP_NAME);
+    expect(call.deviceAction.input.requiredUserInteraction).toBe(
+      UserInteractionRequired.None,
+    );
+    expect(call.deviceAction.input.skipOpenApp).toBe(false);
+  });
+
   it("should call legacy-compatible signTransaction via device action", () => {
     const dmk = {
       executeDeviceAction: vi.fn(),

--- a/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.ts
+++ b/packages/signer/signer-zcash/src/internal/DefaultSignerZcash.ts
@@ -7,6 +7,7 @@ import { type Container } from "inversify";
 import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
 import { type GetAppConfigDAReturnType } from "@api/app-binder/GetAppConfigDeviceActionTypes";
 import { type GetFullViewingKeyDAReturnType } from "@api/app-binder/GetFullViewingKeyDeviceActionTypes";
+import { type GetShieldedAddressDAReturnType } from "@api/app-binder/GetShieldedAddressDeviceActionTypes";
 import { type GetTrustedInputDAReturnType } from "@api/app-binder/GetTrustedInputActionTypes";
 import { type SignMessageDAReturnType } from "@api/app-binder/SignMessageDeviceActionTypes";
 import { type SignPcztTransactionDAReturnType } from "@api/app-binder/SignPcztTransactionDeviceActionTypes";
@@ -21,6 +22,7 @@ import { makeContainer } from "@internal/di";
 import { addressTypes } from "@internal/use-cases/address/di/addressTypes";
 import { type GetAddressUseCase } from "@internal/use-cases/address/GetAddressUseCase";
 import { type GetFullViewingKeyUseCase } from "@internal/use-cases/address/GetFullViewingKeyUseCase";
+import { type GetShieldedAddressUseCase } from "@internal/use-cases/address/GetShieldedAddressUseCase";
 import { configTypes } from "@internal/use-cases/config/di/configTypes";
 import { type GetAppConfigUseCase } from "@internal/use-cases/config/GetAppConfigUseCase";
 import { messageTypes } from "@internal/use-cases/message/di/messageTypes";
@@ -63,6 +65,15 @@ export class DefaultSignerZcash implements SignerZcash {
   ): GetFullViewingKeyDAReturnType {
     return this._container
       .get<GetFullViewingKeyUseCase>(addressTypes.GetFullViewingKeyUseCase)
+      .execute(derivationPath, options);
+  }
+
+  getShieldedAddress(
+    derivationPath: string,
+    options?: AddressOptions,
+  ): GetShieldedAddressDAReturnType {
+    return this._container
+      .get<GetShieldedAddressUseCase>(addressTypes.GetShieldedAddressUseCase)
       .execute(derivationPath, options);
   }
 

--- a/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.test.ts
@@ -32,6 +32,7 @@ import type { ZcashErrorCodes } from "@internal/app-binder/command/utils/zcashAp
 import { APP_NAME } from "@internal/app-binder/constants";
 import { privateToPrivateTransaction } from "@internal/app-binder/task/__fixtures__/pcztFixtures";
 import { GetFullViewingKeyTask } from "@internal/app-binder/task/GetFullViewingKeyTask";
+import { GetShieldedAddressTask } from "@internal/app-binder/task/GetShieldedAddressTask";
 import { GetTrustedInputTask } from "@internal/app-binder/task/GetTrustedInputTask";
 import { SignPcztTransactionTask } from "@internal/app-binder/task/SignPcztTransactionTask";
 import { SignTransactionTask } from "@internal/app-binder/task/SignTransactionTask";
@@ -55,6 +56,15 @@ type ExecuteDeviceActionTaskCallArgs = {
     unknown,
     DmkError,
     UserInteractionRequired.None | UserInteractionRequired.SignTransaction
+  >;
+};
+
+type ExecuteDeviceActionAddressTaskCallArgs = {
+  sessionId: DeviceSessionId;
+  deviceAction: CallTaskInAppDeviceAction<
+    unknown,
+    DmkError,
+    UserInteractionRequired.None | UserInteractionRequired.VerifyAddress
   >;
 };
 
@@ -199,6 +209,72 @@ describe("ZcashAppBinder", () => {
 
       await args.deviceAction.input.task({} as InternalApi);
       expect(runSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("getShieldedAddress", () => {
+    it("should call dmk.executeDeviceAction with CallTaskInAppDeviceAction and run GetShieldedAddressTask", async () => {
+      const sessionId = "test-session-id";
+      const expectedResult = {
+        observable: from([]),
+        cancel: vi.fn(),
+      };
+      const executeDeviceActionMock = vi.fn().mockReturnValue(expectedResult);
+      const dmkMock = {
+        executeDeviceAction: executeDeviceActionMock,
+      } as unknown as DeviceManagementKit;
+      const binder = new ZcashAppBinder(dmkMock, sessionId);
+      const runSpy = vi
+        .spyOn(GetShieldedAddressTask.prototype, "run")
+        .mockResolvedValue(
+          {} as unknown as Awaited<
+            ReturnType<typeof GetShieldedAddressTask.prototype.run>
+          >,
+        );
+
+      const result = binder.getShieldedAddress({
+        derivationPath: "44'/133'/0'/0/0",
+        checkOnDevice: false,
+        skipOpenApp: false,
+      });
+
+      expect(executeDeviceActionMock).toHaveBeenCalledTimes(1);
+      const args = executeDeviceActionMock.mock
+        .calls[0]![0] as ExecuteDeviceActionAddressTaskCallArgs;
+      expect(args.sessionId).toBe(sessionId);
+      expect(args.deviceAction).toBeInstanceOf(CallTaskInAppDeviceAction);
+      expect(args.deviceAction.input.appName).toBe(APP_NAME);
+      expect(args.deviceAction.input.requiredUserInteraction).toBe(
+        UserInteractionRequired.None,
+      );
+      expect(args.deviceAction.input.skipOpenApp).toBe(false);
+      expect(result).toBe(expectedResult);
+
+      await args.deviceAction.input.task({} as InternalApi);
+      expect(runSpy).toHaveBeenCalledOnce();
+    });
+
+    it("should set VerifyAddress interaction when checkOnDevice is true", () => {
+      const executeDeviceActionMock = vi.fn().mockReturnValue({
+        observable: from([]),
+        cancel: vi.fn(),
+      });
+      const dmkMock = {
+        executeDeviceAction: executeDeviceActionMock,
+      } as unknown as DeviceManagementKit;
+      const binder = new ZcashAppBinder(dmkMock, "session-id");
+
+      binder.getShieldedAddress({
+        derivationPath: "44'/133'/0'/0/0",
+        checkOnDevice: true,
+        skipOpenApp: false,
+      });
+
+      const args = executeDeviceActionMock.mock
+        .calls[0]![0] as ExecuteDeviceActionAddressTaskCallArgs;
+      expect(args.deviceAction.input.requiredUserInteraction).toBe(
+        UserInteractionRequired.VerifyAddress,
+      );
     });
   });
 

--- a/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/ZcashAppBinder.ts
@@ -11,6 +11,7 @@ import { inject, injectable } from "inversify";
 import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceActionTypes";
 import { type GetAppConfigDAReturnType } from "@api/app-binder/GetAppConfigDeviceActionTypes";
 import { type GetFullViewingKeyDAReturnType } from "@api/app-binder/GetFullViewingKeyDeviceActionTypes";
+import { type GetShieldedAddressDAReturnType } from "@api/app-binder/GetShieldedAddressDeviceActionTypes";
 import { type GetTrustedInputDAReturnType } from "@api/app-binder/GetTrustedInputActionTypes";
 import { type SignMessageDAReturnType } from "@api/app-binder/SignMessageDeviceActionTypes";
 import { type SignPcztTransactionDAReturnType } from "@api/app-binder/SignPcztTransactionDeviceActionTypes";
@@ -25,6 +26,7 @@ import { GetAddressCommand } from "./command/GetAddressCommand";
 import { GetAppConfigCommand } from "./command/GetAppConfigCommand";
 import { SignMessageCommand } from "./command/SignMessageCommand";
 import { GetFullViewingKeyTask } from "./task/GetFullViewingKeyTask";
+import { GetShieldedAddressTask } from "./task/GetShieldedAddressTask";
 import { GetTrustedInputTask } from "./task/GetTrustedInputTask";
 import { SignPcztTransactionTask } from "./task/SignPcztTransactionTask";
 import { SignTransactionTask } from "./task/SignTransactionTask";
@@ -60,6 +62,30 @@ export class ZcashAppBinder {
       deviceAction: new SendCommandInAppDeviceAction({
         input: {
           command: new GetAddressCommand(args),
+          appName: APP_NAME,
+          requiredUserInteraction: args.checkOnDevice
+            ? UserInteractionRequired.VerifyAddress
+            : UserInteractionRequired.None,
+          skipOpenApp: args.skipOpenApp,
+        },
+      }),
+    });
+  }
+
+  getShieldedAddress(args: {
+    derivationPath: string;
+    checkOnDevice: boolean;
+    skipOpenApp: boolean;
+  }): GetShieldedAddressDAReturnType {
+    return this.dmk.executeDeviceAction({
+      sessionId: this.sessionId,
+      deviceAction: new CallTaskInAppDeviceAction({
+        input: {
+          task: async (internalApi: InternalApi) =>
+            new GetShieldedAddressTask(internalApi, {
+              derivationPath: args.derivationPath,
+              checkOnDevice: args.checkOnDevice,
+            }).run(),
           appName: APP_NAME,
           requiredUserInteraction: args.checkOnDevice
             ? UserInteractionRequired.VerifyAddress

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetShieldedAddressCommand.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetShieldedAddressCommand.test.ts
@@ -1,0 +1,318 @@
+import {
+  ApduResponse,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { GetShieldedAddressCommand } from "@internal/app-binder/command/GetShieldedAddressCommand";
+import { ZCASH_CLA } from "@internal/app-binder/command/utils/apduHeaderUtils";
+import { type ZcashAppCommandError } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+const GET_SHIELDED_ADDRESS_INS = 0x51;
+
+// 32'/133'/0' + 44'/133'/0'/0/0 — no display
+const GET_SHIELDED_ADDRESS_APDU_NO_DISPLAY = Uint8Array.from([
+  ZCASH_CLA,
+  GET_SHIELDED_ADDRESS_INS,
+  0x00, // P1 (no display)
+  0x00, // P2
+  0x22, // Lc: 1+12+1+20 = 34
+  // Orchard path: 32'/133'/0'
+  0x03,
+  0x80,
+  0x00,
+  0x00,
+  0x20, // 32'
+  0x80,
+  0x00,
+  0x00,
+  0x85, // 133'
+  0x80,
+  0x00,
+  0x00,
+  0x00, // 0'
+  // Transparent path: 44'/133'/0'/0/0
+  0x05,
+  0x80,
+  0x00,
+  0x00,
+  0x2c, // 44'
+  0x80,
+  0x00,
+  0x00,
+  0x85, // 133'
+  0x80,
+  0x00,
+  0x00,
+  0x00, // 0'
+  0x00,
+  0x00,
+  0x00,
+  0x00, // 0
+  0x00,
+  0x00,
+  0x00,
+  0x00, // 0
+]);
+
+// same paths — display on device
+const GET_SHIELDED_ADDRESS_APDU_WITH_DISPLAY = Uint8Array.from([
+  ZCASH_CLA,
+  GET_SHIELDED_ADDRESS_INS,
+  0x01, // P1 (display)
+  0x00,
+  0x22,
+  0x03,
+  0x80,
+  0x00,
+  0x00,
+  0x20,
+  0x80,
+  0x00,
+  0x00,
+  0x85,
+  0x80,
+  0x00,
+  0x00,
+  0x00,
+  0x05,
+  0x80,
+  0x00,
+  0x00,
+  0x2c,
+  0x80,
+  0x00,
+  0x00,
+  0x85,
+  0x80,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+]);
+
+// 32'/133'/1' + 44'/133'/1'/0/0 — account 1, no display
+const GET_SHIELDED_ADDRESS_APDU_ACCOUNT_1 = Uint8Array.from([
+  ZCASH_CLA,
+  GET_SHIELDED_ADDRESS_INS,
+  0x00,
+  0x00,
+  0x22,
+  0x03,
+  0x80,
+  0x00,
+  0x00,
+  0x20,
+  0x80,
+  0x00,
+  0x00,
+  0x85,
+  0x80,
+  0x00,
+  0x00,
+  0x01, // 1'
+  0x05,
+  0x80,
+  0x00,
+  0x00,
+  0x2c,
+  0x80,
+  0x00,
+  0x00,
+  0x85,
+  0x80,
+  0x00,
+  0x00,
+  0x01, // 1'
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+]);
+
+// 32'/133'/0' + 44'/133'/0'/0/5 — proves address index is serialized
+const GET_SHIELDED_ADDRESS_APDU_ADDR_INDEX_5 = Uint8Array.from([
+  ZCASH_CLA,
+  GET_SHIELDED_ADDRESS_INS,
+  0x00,
+  0x00,
+  0x22,
+  0x03,
+  0x80,
+  0x00,
+  0x00,
+  0x20,
+  0x80,
+  0x00,
+  0x00,
+  0x85,
+  0x80,
+  0x00,
+  0x00,
+  0x00,
+  0x05,
+  0x80,
+  0x00,
+  0x00,
+  0x2c,
+  0x80,
+  0x00,
+  0x00,
+  0x85,
+  0x80,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x05, // address index = 5
+]);
+
+function buildSuccessResponse(address: string): ApduResponse {
+  const addressBytes = new TextEncoder().encode(address);
+  const data = new Uint8Array(2 + addressBytes.length);
+
+  // u16 BE length prefix
+  data[0] = (addressBytes.length >> 8) & 0xff;
+  data[1] = addressBytes.length & 0xff;
+
+  // UTF-8 address
+  data.set(addressBytes, 2);
+
+  return new ApduResponse({
+    statusCode: new Uint8Array([0x90, 0x00]),
+    data,
+  });
+}
+
+describe("GetShieldedAddressCommand", () => {
+  const defaultArgs = {
+    transparentDerivationPath: "44'/133'/0'/0/0",
+    orchardDerivationPath: "32'/133'/0'",
+    checkOnDevice: false,
+  };
+
+  describe("name", () => {
+    it("should be 'GetShieldedAddress'", () => {
+      const command = new GetShieldedAddressCommand(defaultArgs);
+      expect(command.name).toBe("GetShieldedAddress");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("should return correct APDU with checkOnDevice false", () => {
+      const command = new GetShieldedAddressCommand(defaultArgs);
+      const apdu = command.getApdu();
+      expect(apdu.getRawApdu()).toStrictEqual(
+        GET_SHIELDED_ADDRESS_APDU_NO_DISPLAY,
+      );
+    });
+
+    it("should return correct APDU with checkOnDevice true", () => {
+      const command = new GetShieldedAddressCommand({
+        ...defaultArgs,
+        checkOnDevice: true,
+      });
+      const apdu = command.getApdu();
+      expect(apdu.getRawApdu()).toStrictEqual(
+        GET_SHIELDED_ADDRESS_APDU_WITH_DISPLAY,
+      );
+    });
+
+    it("should return correct APDU with a 2 custom derivation path", () => {
+      const args = {
+        orchardDerivationPath: "32'/133'/1'",
+        transparentDerivationPath: "44'/133'/1'/0/0",
+        checkOnDevice: false,
+      };
+      const command = new GetShieldedAddressCommand(args);
+      const apdu = command.getApdu();
+      expect(apdu.getRawApdu()).toStrictEqual(
+        GET_SHIELDED_ADDRESS_APDU_ACCOUNT_1,
+      );
+    });
+
+    it("should return correct APDU for 2 derivation paths", () => {
+      const args = {
+        ...defaultArgs,
+        transparentDerivationPath: "44'/133'/0'/0/5",
+      };
+      const command = new GetShieldedAddressCommand(args);
+      const apdu = command.getApdu();
+      expect(apdu.getRawApdu()).toStrictEqual(
+        GET_SHIELDED_ADDRESS_APDU_ADDR_INDEX_5,
+      );
+    });
+  });
+
+  describe("parseResponse", () => {
+    // firmware test vector: test_get_orchard_uaddress_no_confirm in app-zcash/tests/standalone/test_pubkey_cmd.py
+    const expectedAddress =
+      "u1u2h4ce7e2cn3z4nzur95muq2dl4da9x8h8kdp2l80gm9nl9raj8zzpx79ycjnfvar4v5exea5pqr5y9qsnlp0cdunwf9yjjx5c4q7ar9";
+
+    const response = buildSuccessResponse(expectedAddress);
+    it("should return the unified address on success", () => {
+      const command = new GetShieldedAddressCommand(defaultArgs);
+      const res = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(res)).toBe(true);
+      if (isSuccessCommandResult(res)) {
+        expect(res.data.address).toEqual(expectedAddress);
+      }
+    });
+
+    it("should return bad status when user rejected on device", () => {
+      const command = new GetShieldedAddressCommand(defaultArgs);
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x69, 0x85]),
+        data: new Uint8Array(0),
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as ZcashAppCommandError;
+        expect(err.errorCode).toBe("6985");
+      }
+    });
+    it("should return InvalidStatusWordError when response data is empty", () => {
+      const command = new GetShieldedAddressCommand(defaultArgs);
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data: new Uint8Array(0),
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+    });
+    it("should return InvalidStatusWordError when address data is truncated", () => {
+      const command = new GetShieldedAddressCommand(defaultArgs);
+      const data = new Uint8Array([0x00, 0x32, ...new Uint8Array(10)]); // claims 50 bytes, only 10
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x90, 0x00]),
+        data,
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+    });
+  });
+});

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetShieldedAddressCommand.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetShieldedAddressCommand.ts
@@ -1,0 +1,147 @@
+import {
+  type Apdu,
+  APDU_MAX_PAYLOAD,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+import {
+  CommandErrorHelper,
+  DerivationPathUtils,
+} from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import { ZCASH_CLA } from "@internal/app-binder/command/utils/apduHeaderUtils";
+import {
+  ZCASH_APP_ERRORS,
+  ZcashAppCommandErrorFactory,
+  type ZcashErrorCodes,
+} from "@internal/app-binder/command/utils/zcashApplicationErrors";
+
+const GET_SHIELDED_ADDRESS_INS = 0x51;
+
+export type GetShieldedAddressCommandArgs = {
+  readonly transparentDerivationPath: string;
+  readonly orchardDerivationPath: string;
+  readonly checkOnDevice?: boolean;
+};
+
+export type GetShieldedAddressCommandResponse = {
+  readonly address: string;
+};
+
+export class GetShieldedAddressCommand
+  implements
+    Command<
+      GetShieldedAddressCommandResponse,
+      GetShieldedAddressCommandArgs,
+      ZcashErrorCodes
+    >
+{
+  readonly name = "GetShieldedAddress";
+
+  private readonly args: GetShieldedAddressCommandArgs;
+
+  private readonly errorHelper = new CommandErrorHelper<
+    GetShieldedAddressCommandResponse,
+    ZcashErrorCodes
+  >(ZCASH_APP_ERRORS, ZcashAppCommandErrorFactory);
+
+  constructor(args: GetShieldedAddressCommandArgs) {
+    this.args = args;
+  }
+
+  getApdu(): Apdu {
+    const apduArgs: ApduBuilderArgs = {
+      cla: ZCASH_CLA,
+      ins: GET_SHIELDED_ADDRESS_INS,
+      p1: this.args.checkOnDevice ? 0x01 : 0x00,
+      p2: 0x00,
+    };
+
+    const builder = new ApduBuilder(apduArgs);
+
+    const orchardPath = DerivationPathUtils.splitPath(
+      this.args.orchardDerivationPath,
+    );
+    const transparentPath = DerivationPathUtils.splitPath(
+      this.args.transparentDerivationPath,
+    );
+
+    [orchardPath, transparentPath].forEach((path) => {
+      builder.add8BitUIntToData(path.length);
+      path.forEach((element) => {
+        builder.add32BitUIntToData(element);
+      });
+    });
+
+    return builder.build();
+  }
+
+  parseResponse(
+    apduResponse: ApduResponse,
+  ): CommandResult<GetShieldedAddressCommandResponse, ZcashErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      // A unified address with a single Orchard receiver is ~106 bytes, well under
+      // APDU_MAX_PAYLOAD (255). An exactly-full frame means the firmware changed
+      // and now returns a longer payload than expected.
+      if (apduResponse.data.length === APDU_MAX_PAYLOAD) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            "Response requires continuation which is not supported",
+          ),
+        });
+      }
+
+      const parser = new ApduParser(apduResponse);
+
+      const addressLength = parser.extract16BitUInt();
+      if (addressLength === undefined) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Address length is missing"),
+        });
+      }
+
+      if (parser.testMinimalLength(addressLength) === false) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Address is missing"),
+        });
+      }
+
+      const addressBytes = parser.extractFieldByLength(addressLength);
+      if (addressBytes === undefined) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Unable to extract address"),
+        });
+      }
+
+      if (parser.testMinimalLength(1)) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            "Unexpected trailing bytes in response",
+          ),
+        });
+      }
+
+      let address: string;
+      try {
+        address = new TextDecoder("utf-8", { fatal: true }).decode(
+          addressBytes,
+        );
+      } catch {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("Address is not valid UTF-8"),
+        });
+      }
+
+      return CommandResultFactory({ data: { address } });
+    });
+  }
+}

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.test.ts
@@ -80,6 +80,32 @@ describe("GetFullViewingKeyTask", () => {
     expect(readPathsFromApdu(c1)).toEqual(["32'/133'/0'", "44'/133'/0'"]);
   });
 
+  it("should reject a UFVK request when coin type component is empty", async () => {
+    const sendCommand = vi.fn();
+    const api = { sendCommand } as unknown as InternalApi;
+
+    const result = await new GetFullViewingKeyTask(api, {
+      derivationPath: "44'//0'",
+      mode: "ufvk",
+    }).run();
+
+    expect(isSuccessCommandResult(result)).toBe(false);
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it("should reject a UFVK request when account component is empty", async () => {
+    const sendCommand = vi.fn();
+    const api = { sendCommand } as unknown as InternalApi;
+
+    const result = await new GetFullViewingKeyTask(api, {
+      derivationPath: "44'/133'/",
+      mode: "ufvk",
+    }).run();
+
+    expect(isSuccessCommandResult(result)).toBe(false);
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
   it("should reject a UFVK request when the derivation path has fewer than three levels", async () => {
     const sendCommand = vi.fn();
     const api = { sendCommand } as unknown as InternalApi;

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetFullViewingKeyTask.ts
@@ -18,6 +18,7 @@ import {
 } from "@internal/app-binder/command/GetFullViewingKeyCommand";
 import { type ZcashErrorCodes } from "@internal/app-binder/command/utils/zcashApplicationErrors";
 import { concatUint8Arrays } from "@internal/utils/concatUint8Arrays";
+import { deriveOrchardAccountPath } from "@internal/utils/deriveOrchardAccountPath";
 
 export type GetFullViewingKeyTaskArgs = {
   derivationPath: string;
@@ -165,8 +166,15 @@ function deriveUfvkAccountPaths(
     };
   }
   const [, coinType, account] = components;
+  if (!coinType || !account) {
+    return {
+      error: new InvalidStatusWordError(
+        `Zcash UFVK derivation path components are malformed (got "${derivationPath}")`,
+      ),
+    };
+  }
   return {
-    orchardDerivationPath: `32'/${coinType}/${account}`,
+    orchardDerivationPath: deriveOrchardAccountPath(coinType, account),
     transparentDerivationPath: `44'/${coinType}/${account}`,
   };
 }

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetShieldedAddressTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetShieldedAddressTask.test.ts
@@ -1,0 +1,104 @@
+import {
+  CommandResultFactory,
+  type InternalApi,
+  InvalidStatusWordError,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { describe, expect, it, vi } from "vitest";
+
+import { GetShieldedAddressTask } from "./GetShieldedAddressTask";
+
+// firmware test vector: test_get_orchard_uaddress_no_confirm in app-zcash/tests/standalone/test_pubkey_cmd.py
+const EXPECTED_ADDRESS =
+  "u1u2h4ce7e2cn3z4nzur95muq2dl4da9x8h8kdp2l80gm9nl9raj8zzpx79ycjnfvar4v5exea5pqr5y9qsnlp0cdunwf9yjjx5c4q7ar9";
+
+const okResponse = () =>
+  CommandResultFactory({ data: { address: EXPECTED_ADDRESS } });
+
+describe("GetShieldedAddressTask", () => {
+  const defaultArgs = {
+    derivationPath: "44'/133'/0'/0/0",
+    checkOnDevice: false,
+  };
+
+  it("should return the address on success", async () => {
+    const sendCommand = vi.fn().mockResolvedValue(okResponse());
+    const api = { sendCommand } as unknown as InternalApi;
+
+    const result = await new GetShieldedAddressTask(api, defaultArgs).run();
+
+    expect(isSuccessCommandResult(result)).toBe(true);
+    if (isSuccessCommandResult(result)) {
+      expect(result.data.address).toBe(EXPECTED_ADDRESS);
+    }
+  });
+
+  it("should derive orchard path 32'/coin/account from transparent path", async () => {
+    const sendCommand = vi.fn().mockResolvedValue(okResponse());
+    const api = { sendCommand } as unknown as InternalApi;
+
+    await new GetShieldedAddressTask(api, defaultArgs).run();
+
+    const command = sendCommand.mock.calls[0]![0];
+    const apduData = command.getApdu().getRawApdu().slice(5);
+    // first path length byte = 3 (orchard: 32'/133'/0')
+    expect(apduData[0]).toBe(3);
+    // first element of orchard path = 32' = 0x80000020
+    const view = new DataView(apduData.buffer, apduData.byteOffset);
+    expect(view.getUint32(1, false)).toBe(0x80000020);
+  });
+
+  it("should forward command error", async () => {
+    const sendCommand = vi.fn().mockResolvedValue(
+      CommandResultFactory({
+        error: new InvalidStatusWordError("device error"),
+      }),
+    );
+    const api = { sendCommand } as unknown as InternalApi;
+
+    const result = await new GetShieldedAddressTask(api, defaultArgs).run();
+
+    expect(isSuccessCommandResult(result)).toBe(false);
+  });
+
+  it.each([
+    {
+      desc: "derivation path does not have exactly 5 levels",
+      path: "44'/133'/0'",
+    },
+    { desc: "a path component is non-numeric", path: "44'/foo/0'/0/0" },
+    { desc: "coin type component is empty", path: "44'//0'/0/0" },
+    { desc: "coin type is not hardened", path: "44'/133/0'/0/0" },
+    { desc: "account is not hardened", path: "44'/133'/0/0/0" },
+    { desc: "purpose is not 44'", path: "0'/133'/0'/0/0" },
+    { desc: "purpose is not hardened", path: "44/133'/0'/0/0" },
+    { desc: "change is not 0", path: "44'/133'/0'/1/0" },
+  ])("should return error when $desc", async ({ path }) => {
+    const sendCommand = vi.fn();
+    const api = { sendCommand } as unknown as InternalApi;
+
+    const result = await new GetShieldedAddressTask(api, {
+      derivationPath: path,
+    }).run();
+
+    expect(isSuccessCommandResult(result)).toBe(false);
+    expect(sendCommand).not.toHaveBeenCalled();
+  });
+
+  it("should strip m/ prefix and derive correct orchard path", async () => {
+    const sendCommand = vi.fn().mockResolvedValue(okResponse());
+    const api = { sendCommand } as unknown as InternalApi;
+
+    const result = await new GetShieldedAddressTask(api, {
+      derivationPath: "m/44'/133'/0'/0/0",
+    }).run();
+
+    expect(isSuccessCommandResult(result)).toBe(true);
+
+    const command = sendCommand.mock.calls[0]![0];
+    const apduData = command.getApdu().getRawApdu().slice(5);
+    const view = new DataView(apduData.buffer, apduData.byteOffset);
+    // first orchard path element must be 32' = 0x80000020, not 44' = 0x8000002c
+    expect(view.getUint32(1, false)).toBe(0x80000020);
+  });
+});

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetShieldedAddressTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetShieldedAddressTask.ts
@@ -1,0 +1,109 @@
+import {
+  type CommandErrorResult,
+  type DmkResult,
+  DmkResultFactory,
+  type InternalApi,
+  InvalidStatusWordError,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { GetShieldedAddressCommand } from "@internal/app-binder/command/GetShieldedAddressCommand";
+import { type ZcashErrorCodes } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+import { deriveOrchardAccountPath } from "@internal/utils/deriveOrchardAccountPath";
+
+export type GetShieldedAddressTaskArgs = {
+  readonly derivationPath: string;
+  readonly checkOnDevice?: boolean;
+};
+
+export type GetShieldedAddressTaskResult = DmkResult<
+  { readonly address: string },
+  CommandErrorResult<ZcashErrorCodes>["error"]
+>;
+
+function deriveShieldedAddressPaths(
+  derivationPath: string,
+):
+  | { orchardDerivationPath: string; transparentDerivationPath: string }
+  | { error: InvalidStatusWordError } {
+  const normalized = derivationPath.startsWith("m/")
+    ? derivationPath.slice(2)
+    : derivationPath;
+  const components = normalized.split("/");
+  if (components.length !== 5) {
+    return {
+      error: new InvalidStatusWordError(
+        `Shielded address derivation path must have exactly 5 levels purpose/coin/account/change/index (got "${derivationPath}")`,
+      ),
+    };
+  }
+  const isValidBip32Component = (c: string): boolean => /^\d+'?$/.test(c);
+  if (!components.every(isValidBip32Component)) {
+    return {
+      error: new InvalidStatusWordError(
+        `Shielded address derivation path contains non-numeric components (got "${derivationPath}")`,
+      ),
+    };
+  }
+  const [purpose, coin, account, change] = components;
+  if (purpose !== "44'") {
+    return {
+      error: new InvalidStatusWordError(
+        `Shielded address derivation path purpose must be 44' (got "${purpose}")`,
+      ),
+    };
+  }
+  if (!coin?.endsWith("'")) {
+    return {
+      error: new InvalidStatusWordError(
+        `Shielded address derivation path coin type must be hardened (got "${coin}")`,
+      ),
+    };
+  }
+  if (!account?.endsWith("'")) {
+    return {
+      error: new InvalidStatusWordError(
+        `Shielded address derivation path account must be hardened (got "${account}")`,
+      ),
+    };
+  }
+  if (change !== "0") {
+    return {
+      error: new InvalidStatusWordError(
+        `Shielded address derivation path change must be 0 (got "${change}")`,
+      ),
+    };
+  }
+  return {
+    orchardDerivationPath: deriveOrchardAccountPath(coin, account),
+    transparentDerivationPath: normalized,
+  };
+}
+
+export class GetShieldedAddressTask {
+  constructor(
+    private readonly api: InternalApi,
+    private readonly args: GetShieldedAddressTaskArgs,
+  ) {}
+
+  async run(): Promise<GetShieldedAddressTaskResult> {
+    const paths = deriveShieldedAddressPaths(this.args.derivationPath);
+    if ("error" in paths) {
+      return DmkResultFactory({ error: paths.error });
+    }
+
+    const result = await this.api.sendCommand(
+      new GetShieldedAddressCommand({
+        orchardDerivationPath: paths.orchardDerivationPath,
+        transparentDerivationPath: paths.transparentDerivationPath,
+        checkOnDevice: this.args.checkOnDevice,
+      }),
+    );
+
+    if (!isSuccessCommandResult(result)) {
+      return DmkResultFactory({ error: result.error });
+    }
+
+    return DmkResultFactory({ data: { address: result.data.address } });
+  }
+}

--- a/packages/signer/signer-zcash/src/internal/use-cases/address/GetShieldedAddressUseCase.test.ts
+++ b/packages/signer/signer-zcash/src/internal/use-cases/address/GetShieldedAddressUseCase.test.ts
@@ -1,0 +1,73 @@
+import {
+  DeviceActionStatus,
+  type ExecuteDeviceActionReturnType,
+} from "@ledgerhq/device-management-kit";
+import { from } from "rxjs";
+import { vi } from "vitest";
+
+import {
+  type GetShieldedAddressDAError,
+  type GetShieldedAddressDAIntermediateValue,
+  type GetShieldedAddressDAOutput,
+} from "@api/app-binder/GetShieldedAddressDeviceActionTypes";
+import { type ZcashAppBinder } from "@internal/app-binder/ZcashAppBinder";
+
+import { GetShieldedAddressUseCase } from "./GetShieldedAddressUseCase";
+
+describe("GetShieldedAddressUseCase", () => {
+  const derivationPath = "44'/133'/0'/0/0";
+
+  const makeAppBinder = () => {
+    const getShieldedAddress = vi.fn();
+    return {
+      appBinder: { getShieldedAddress } as unknown as ZcashAppBinder,
+      getShieldedAddress,
+    };
+  };
+
+  const expectedResult: ExecuteDeviceActionReturnType<
+    GetShieldedAddressDAOutput,
+    GetShieldedAddressDAError,
+    GetShieldedAddressDAIntermediateValue
+  > = {
+    observable: from([
+      {
+        status: DeviceActionStatus.Completed as const,
+        output: {
+          address:
+            "u17qxnge3fpth2w43cfvz3lezxkevzmh5lpl5j4vlkfclpxdz9rx2fmml98wmwq3268yld6exrhyg29k2xhrnt4rldxva96qe8uwf7qc9",
+        },
+      },
+    ]),
+    cancel: vi.fn(),
+  };
+
+  it("should call getShieldedAddress with default options", () => {
+    const { appBinder, getShieldedAddress } = makeAppBinder();
+    getShieldedAddress.mockReturnValue(expectedResult);
+
+    const useCase = new GetShieldedAddressUseCase(appBinder);
+    const result = useCase.execute(derivationPath);
+
+    expect(getShieldedAddress).toHaveBeenCalledWith({
+      derivationPath,
+      checkOnDevice: false,
+      skipOpenApp: false,
+    });
+    expect(result).toBe(expectedResult);
+  });
+
+  it("should forward checkOnDevice and skipOpenApp from options", () => {
+    const { appBinder, getShieldedAddress } = makeAppBinder();
+    getShieldedAddress.mockReturnValue(expectedResult);
+
+    const useCase = new GetShieldedAddressUseCase(appBinder);
+    useCase.execute(derivationPath, { checkOnDevice: true, skipOpenApp: true });
+
+    expect(getShieldedAddress).toHaveBeenCalledWith({
+      derivationPath,
+      checkOnDevice: true,
+      skipOpenApp: true,
+    });
+  });
+});

--- a/packages/signer/signer-zcash/src/internal/use-cases/address/GetShieldedAddressUseCase.ts
+++ b/packages/signer/signer-zcash/src/internal/use-cases/address/GetShieldedAddressUseCase.ts
@@ -1,0 +1,26 @@
+import { inject, injectable } from "inversify";
+
+import { type GetShieldedAddressDAReturnType } from "@api/app-binder/GetShieldedAddressDeviceActionTypes";
+import { type AddressOptions } from "@api/model/AddressOptions";
+import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
+import { ZcashAppBinder } from "@internal/app-binder/ZcashAppBinder";
+
+@injectable()
+export class GetShieldedAddressUseCase {
+  private readonly _appBinder: ZcashAppBinder;
+
+  constructor(@inject(appBinderTypes.AppBinding) appBinder: ZcashAppBinder) {
+    this._appBinder = appBinder;
+  }
+
+  execute(
+    derivationPath: string,
+    options?: AddressOptions,
+  ): GetShieldedAddressDAReturnType {
+    return this._appBinder.getShieldedAddress({
+      derivationPath,
+      checkOnDevice: options?.checkOnDevice ?? false,
+      skipOpenApp: options?.skipOpenApp ?? false,
+    });
+  }
+}

--- a/packages/signer/signer-zcash/src/internal/use-cases/address/di/addressModule.test.ts
+++ b/packages/signer/signer-zcash/src/internal/use-cases/address/di/addressModule.test.ts
@@ -26,5 +26,11 @@ describe("addressModuleFactory", () => {
         container.isBound(addressTypes.GetFullViewingKeyUseCase),
       ).toBeTruthy();
     });
+
+    it("should bind GetShieldedAddressUseCase", () => {
+      expect(
+        container.isBound(addressTypes.GetShieldedAddressUseCase),
+      ).toBeTruthy();
+    });
   });
 });

--- a/packages/signer/signer-zcash/src/internal/use-cases/address/di/addressModule.ts
+++ b/packages/signer/signer-zcash/src/internal/use-cases/address/di/addressModule.ts
@@ -3,9 +3,11 @@ import { ContainerModule } from "inversify";
 import { addressTypes } from "@internal/use-cases/address/di/addressTypes";
 import { GetAddressUseCase } from "@internal/use-cases/address/GetAddressUseCase";
 import { GetFullViewingKeyUseCase } from "@internal/use-cases/address/GetFullViewingKeyUseCase";
+import { GetShieldedAddressUseCase } from "@internal/use-cases/address/GetShieldedAddressUseCase";
 
 export const addressModuleFactory = () =>
   new ContainerModule(({ bind }) => {
     bind(addressTypes.GetAddressUseCase).to(GetAddressUseCase);
     bind(addressTypes.GetFullViewingKeyUseCase).to(GetFullViewingKeyUseCase);
+    bind(addressTypes.GetShieldedAddressUseCase).to(GetShieldedAddressUseCase);
   });

--- a/packages/signer/signer-zcash/src/internal/use-cases/address/di/addressTypes.ts
+++ b/packages/signer/signer-zcash/src/internal/use-cases/address/di/addressTypes.ts
@@ -1,4 +1,5 @@
 export const addressTypes = {
   GetAddressUseCase: Symbol.for("GetAddressUseCase"),
   GetFullViewingKeyUseCase: Symbol.for("GetFullViewingKeyUseCase"),
+  GetShieldedAddressUseCase: Symbol.for("GetShieldedAddressUseCase"),
 } as const;

--- a/packages/signer/signer-zcash/src/internal/utils/deriveOrchardAccountPath.ts
+++ b/packages/signer/signer-zcash/src/internal/utils/deriveOrchardAccountPath.ts
@@ -1,0 +1,11 @@
+/**
+ * Builds the ZIP-32 Orchard account path from coin type and account components.
+ * Both GetShieldedAddressTask and GetFullViewingKeyTask derive this path
+ * from their respective inputs.
+ */
+export function deriveOrchardAccountPath(
+  coinType: string,
+  account: string,
+): string {
+  return `32'/${coinType}/${account}`;
+}


### PR DESCRIPTION
### 📝 Description

Adds `getShieldedAddress` to `SignerZcash`, wrapping INS_GET_SHIELD_ADDR (0x51) from app-zcash ≥ v3.8.0.

The APDU sends two length-prefixed derivation paths to the device — Orchard (`32'/coin/account'`, 3 hardened levels) and transparent (`44'/coin/account'/change/index`, 5 levels) — and returns a unified address (`u1…`) with a single Orchard receiver. The device can optionally display the address for user confirmation (`checkOnDevice`).

**Usage:**
```ts
const result = signer.getShieldedAddress("44'/133'/0'/0/0", { checkOnDevice: true });
The public API takes a single transparent derivation path; the task layer derives the Orchard account path from it, ensuring account indexes always match.
```
❓ Context

- JIRA or GitHub link: LIVE-35012

✅ Checklist

- [x] Covered by automatic tests — command (getApdu + parseResponse), task (path derivation, command forwarding), and use case layers all have unit tests; 192 tests passing
- [x] Changeset is provided — minor bump for @ledgerhq/device-signer-kit-zcash
- [x] Documentation is up-to-date — README.md and apps/docs/content/docs/references/signers/zcash.mdx updated with usage, parameters, and return type
- [x] Impact of the changes:
  - Adds getShieldedAddress to SignerZcash interface and DefaultSignerZcash — additive only, no existing API changed
  - New files: GetShieldedAddressCommand, GetShieldedAddressTask, GetShieldedAddressUseCase, GetShieldedAddressDeviceActionTypes
  - DI: new symbol and binding in addressTypes / addressModule
  - Requires app-zcash ≥ v3.8.0 (two-path form of 0x51); v3.5.0 single-path form is not used
  - QA should verify: address displayed on device matches host-side derivation, checkOnDevice: false skips device display, 6985 (user rejection) surfaces as typed error