### PR TITLE
✨ (transport-speculos) [NO-ISSUE]: Sonar test — real speculos change under --affected

### DIFF
--- a/packages/transport/speculos/src/internal/datasource/HttpSpeculosDatasource.ts
+++ b/packages/transport/speculos/src/internal/datasource/HttpSpeculosDatasource.ts
@@ -8,6 +8,11 @@ const TIMEOUT = 2000; // 2 second timeout for availability check
 
 const removeTrailingSlashes = (url: string) => url.replace(/\/+$/, "");
 
+export const ensureHttpScheme = (url: string): string =>
+  url.startsWith("http://") || url.startsWith("https://")
+    ? url
+    : `http://${url}`;
+
 export class HttpSpeculosDatasource implements SpeculosDatasource {
   private readonly baseUrl: string;
   private readonly clientHeader: string;
@@ -17,7 +22,7 @@ export class HttpSpeculosDatasource implements SpeculosDatasource {
     baseUrl: string,
     clientHeader: string = `ldmk-transport-speculos/${PACKAGE.version}`,
   ) {
-    this.baseUrl = removeTrailingSlashes(baseUrl);
+    this.baseUrl = removeTrailingSlashes(ensureHttpScheme(baseUrl));
     this.clientHeader = clientHeader;
     this.http = new DmkNetworkClient({
       headers: {


### PR DESCRIPTION
**Throwaway test PR — do not merge.** Base is the DSDK-1402 branch so the diff is only a real code change in `device-transport-kit-speculos`. Purpose: verify Sonar decorates the PR correctly when the checks job runs `test:coverage --affected` (only speculos + dependents produce coverage).

Note: the speculos package has no unit tests, so the new `ensureHttpScheme` is uncovered — this checks whether Sonar's new-code-coverage flags it under partial (--affected) coverage. Close after inspecting the Sonar decoration.