### PR TITLE
🧪 (transport-web-hid) [NO-ISSUE]: Sonar coverage probe (~50% new code)

### DIFF
--- a/packages/transport/web-hid/src/sonarCoverageProbe.test.ts
+++ b/packages/transport/web-hid/src/sonarCoverageProbe.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { sumUpTo } from "./sonarCoverageProbe";
+
+// Only sumUpTo is exercised; normalizeCsv is intentionally left uncovered so
+// coverage on new code lands around 50%.
+describe("sumUpTo", () => {
+  it("sums integers below n", () => {
+    expect(sumUpTo(5)).toBe(10);
+  });
+
+  it("caps the total at 100", () => {
+    expect(sumUpTo(50)).toBe(100);
+  });
+});

--- a/packages/transport/web-hid/src/sonarCoverageProbe.ts
+++ b/packages/transport/web-hid/src/sonarCoverageProbe.ts
@@ -1,0 +1,37 @@
+/**
+ * Temporary probe to validate Sonar "coverage on new code" under the turbo
+ * --affected CI flow. Two equally sized functions; only `sumUpTo` is tested,
+ * so ~50% of the new lines are covered. Safe to delete.
+ */
+
+export function sumUpTo(n: number): number {
+  let total = 0;
+  for (let i = 0; i < n; i += 1) {
+    total += i;
+  }
+  if (total > 100) {
+    total = 100;
+  }
+  if (total < 0) {
+    total = 0;
+  }
+  const doubled = total * 2;
+  const halved = doubled / 2;
+  return halved;
+}
+
+export function normalizeCsv(input: string): string {
+  const parts = input.split(",");
+  const cleaned: string[] = [];
+  for (const part of parts) {
+    const trimmed = part.trim();
+    if (trimmed.length > 0) {
+      cleaned.push(trimmed);
+    }
+  }
+  if (cleaned.length === 0) {
+    return "empty";
+  }
+  const joined = cleaned.join("|");
+  return joined;
+}


### PR DESCRIPTION
**Throwaway — do not merge.** Adds ~20 coverable new lines in web-hid with a test covering ~47%, to verify Sonar evaluates *coverage on new code* under the turbo --affected flow (previous speculos probe was <20 lines so Sonar skipped the check). Expect the Sonar quality gate to **fail** on new-code coverage if the project threshold is >~47%. Close after inspecting.