### PR TITLE
🧪 (doc) [NO-ISSUE]: Test cold Vercel docs deploy (--force fix)

### DIFF
--- a/apps/docs/content/index.mdx
+++ b/apps/docs/content/index.mdx
@@ -28,3 +28,5 @@ export function Hero() {
 }
 
 <Hero />
+
+{/* vercel cold-build deploy test — DSDK docs (throwaway) */}


### PR DESCRIPTION
**Throwaway — do not merge.** Fresh branch (cold build cache) with a trivial docs edit, to verify the Vercel docs deployment now succeeds on a first/cold build after replacing `--no-cache` with `--force` in the build command. Watching the Vercel deployment check. Close once green.