### PR TITLE
🔥 (device-mock-server) [DSDK-1403]: Remove unused bin in package json

### DIFF
--- a/apps/device-mock-server/package.json
+++ b/apps/device-mock-server/package.json
@@ -9,9 +9,6 @@
   },
   "main": "lib/cjs/index.js",
   "types": "lib/types/index.d.ts",
-  "bin": {
-    "device-mock-server": "./lib/cjs/main.js"
-  },
   "exports": {
     ".": {
       "types": "./lib/types/index.d.ts",


### PR DESCRIPTION
### 📝 Description

Removes the unused `bin` from `apps/device-mock-server/package.json`:

```json
"bin": { "device-mock-server": "./lib/cjs/main.js" }
```

It's dead: the package is `private` (never published to npm), and every launch path bypasses it — Docker runs `node server.js` from its own esbuild bundle, sample/Playwright uses `pnpm --filter @ledgerhq/device-mock-server serve` (`tsx src/main.ts`), and the `start` script uses `node lib/cjs/main.js`. Its only effect was a recurring, harmless warning on every `pnpm install`:

```
WARN Failed to create bin at .../device-mock-server/lib/cjs/main.js
     ENOENT: no such file or directory
```
(pnpm links the bin before the package is built, so the target doesn't exist yet). Removing it silences the warning with **zero functional impact** — verified `pnpm install` no longer emits it, and the lockfile is unchanged.

### ❓ Context

- **JIRA**: [DSDK-1403](https://ledgerhq.atlassian.net/browse/DSDK-1403)

### ✅ Checklist

- [ ] **Covered by automatic tests** — N/A, removes an unused package.json field; existing mock-server start paths unchanged.
- [ ] **Changeset is provided** — Not needed; `device-mock-server` is a private, unpublished package.
- [ ] **Documentation is up-to-date** — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DSDK-1403]: https://ledgerhq.atlassian.net/browse/DSDK-1403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ