### PR TITLE
🐛 (manager-api) [NO-ISSUE]: Handle no available update

### DIFF
--- a/.changeset/moody-cougars-jam.md
+++ b/.changeset/moody-cougars-jam.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Handle no available update when fetching latest firmware from the Manager API

--- a/packages/device-management-kit/src/api/device-action/task/GetFirmwareMetadataTask.test.ts
+++ b/packages/device-management-kit/src/api/device-action/task/GetFirmwareMetadataTask.test.ts
@@ -1,4 +1,4 @@
-import { EitherAsync } from "purify-ts";
+import { EitherAsync, Just, Nothing } from "purify-ts";
 
 import { InvalidStatusWordError } from "@api/command/Errors";
 import { CommandResultFactory } from "@api/command/model/CommandResult";
@@ -38,6 +38,7 @@ describe("GetFirmwareMetadataTask", () => {
   const OSU_VERSION = {
     id: 362,
     perso: "perso_11",
+    notes: "notes",
   } as OsuFirmware;
 
   const NEXT_FIRMWARE_VERSION = {
@@ -51,10 +52,12 @@ describe("GetFirmwareMetadataTask", () => {
     {
       id: 3,
       name: "other_version",
+      fromBootloaderVersion: "1.0",
     },
     {
       id: 1,
       name: "mcu_version",
+      fromBootloaderVersion: "1.0",
     },
   ] as McuFirmware[];
 
@@ -67,7 +70,7 @@ describe("GetFirmwareMetadataTask", () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
 
     apiMock.getManagerApiService.mockReturnValue(
       MANAGER_MOCK as unknown as ManagerApiService,
@@ -79,7 +82,7 @@ describe("GetFirmwareMetadataTask", () => {
       EitherAsync(async () => FIRMWARE_VERSION),
     );
     MANAGER_MOCK.getLatestFirmwareVersion.mockReturnValue(
-      EitherAsync(async () => OSU_VERSION),
+      EitherAsync(async () => Just(OSU_VERSION)),
     );
     MANAGER_MOCK.getNextFirmwareVersion.mockReturnValue(
       EitherAsync(async () => NEXT_FIRMWARE_VERSION),
@@ -88,6 +91,40 @@ describe("GetFirmwareMetadataTask", () => {
   });
 
   it("success with no firmware update available", async () => {
+    // GIVEN
+    apiMock.sendCommand
+      .mockResolvedValueOnce(CommandResultFactory({ data: OS_VERSION }))
+      .mockResolvedValueOnce(CommandResultFactory({ data: CUSTOM_IMAGE_SIZE }));
+    MANAGER_MOCK.getLatestFirmwareVersion.mockReturnValueOnce(
+      EitherAsync(async () => Nothing),
+    );
+
+    // WHEN
+    const result = await new GetFirmwareMetadataTask(apiMock).run();
+
+    // THEN
+    expect(result).toStrictEqual(
+      DmkResultFactory({
+        data: {
+          deviceVersion: DEVICE_VERSION,
+          firmware: FIRMWARE_VERSION,
+          firmwareVersion: {
+            mcu: "mcu_version",
+            bootloader: "bl_version",
+            os: "se_version",
+            metadata: OS_VERSION,
+          },
+          firmwareUpdateContext: {
+            currentFirmware: FIRMWARE_VERSION,
+            availableUpdate: undefined,
+          },
+          customImage: { size: CUSTOM_IMAGE_SIZE },
+        },
+      }),
+    );
+  });
+
+  it("success with no firmware update when latest firmware cannot be fetched", async () => {
     // GIVEN
     apiMock.sendCommand
       .mockResolvedValueOnce(CommandResultFactory({ data: OS_VERSION }))
@@ -209,6 +246,128 @@ describe("GetFirmwareMetadataTask", () => {
               finalFirmware: nextFirmware,
               mcuUpdateRequired: true,
             },
+          },
+          customImage: {},
+        },
+      }),
+    );
+  });
+
+  it("success with a firmware update available when current MCU is unknown", async () => {
+    // GIVEN
+    apiMock.sendCommand
+      .mockResolvedValueOnce(CommandResultFactory({ data: OS_VERSION }))
+      .mockResolvedValueOnce(
+        CommandResultFactory({ error: new InvalidStatusWordError("error") }),
+      );
+    MANAGER_MOCK.getMcuList.mockReturnValueOnce(
+      EitherAsync(async () => [
+        {
+          id: 3,
+          name: "other_version",
+          fromBootloaderVersion: "1.0",
+        },
+      ]),
+    );
+
+    // WHEN
+    const result = await new GetFirmwareMetadataTask(apiMock).run();
+
+    // THEN
+    expect(result).toStrictEqual(
+      DmkResultFactory({
+        data: {
+          deviceVersion: DEVICE_VERSION,
+          firmware: FIRMWARE_VERSION,
+          firmwareVersion: {
+            mcu: "mcu_version",
+            bootloader: "bl_version",
+            os: "se_version",
+            metadata: OS_VERSION,
+          },
+          firmwareUpdateContext: {
+            currentFirmware: FIRMWARE_VERSION,
+            availableUpdate: {
+              osuFirmware: OSU_VERSION,
+              finalFirmware: NEXT_FIRMWARE_VERSION,
+              mcuUpdateRequired: true,
+            },
+          },
+          customImage: {},
+        },
+      }),
+    );
+  });
+
+  it("success with no firmware update when next firmware cannot be fetched", async () => {
+    // GIVEN
+    apiMock.sendCommand
+      .mockResolvedValueOnce(CommandResultFactory({ data: OS_VERSION }))
+      .mockResolvedValueOnce(
+        CommandResultFactory({ error: new InvalidStatusWordError("error") }),
+      );
+    MANAGER_MOCK.getNextFirmwareVersion.mockReturnValueOnce(
+      EitherAsync(async ({ throwE }) => {
+        throwE(new Error("error"));
+      }),
+    );
+
+    // WHEN
+    const result = await new GetFirmwareMetadataTask(apiMock).run();
+
+    // THEN
+    expect(result).toStrictEqual(
+      DmkResultFactory({
+        data: {
+          deviceVersion: DEVICE_VERSION,
+          firmware: FIRMWARE_VERSION,
+          firmwareVersion: {
+            mcu: "mcu_version",
+            bootloader: "bl_version",
+            os: "se_version",
+            metadata: OS_VERSION,
+          },
+          firmwareUpdateContext: {
+            currentFirmware: FIRMWARE_VERSION,
+            availableUpdate: undefined,
+          },
+          customImage: {},
+        },
+      }),
+    );
+  });
+
+  it("success with no firmware update when MCU list cannot be fetched", async () => {
+    // GIVEN
+    apiMock.sendCommand
+      .mockResolvedValueOnce(CommandResultFactory({ data: OS_VERSION }))
+      .mockResolvedValueOnce(
+        CommandResultFactory({ error: new InvalidStatusWordError("error") }),
+      );
+    MANAGER_MOCK.getMcuList.mockReturnValueOnce(
+      EitherAsync(async ({ throwE }) => {
+        throwE(new Error("error"));
+      }),
+    );
+
+    // WHEN
+    const result = await new GetFirmwareMetadataTask(apiMock).run();
+
+    // THEN
+    expect(result).toStrictEqual(
+      DmkResultFactory({
+        data: {
+          deviceVersion: DEVICE_VERSION,
+          firmware: FIRMWARE_VERSION,
+          firmwareVersion: {
+            mcu: "mcu_version",
+            bootloader: "bl_version",
+            os: "se_version",
+            metadata: OS_VERSION,
+          },
+          firmwareUpdateContext: {
+            currentFirmware: FIRMWARE_VERSION,
+            availableUpdate: undefined,
           },
           customImage: {},
         },

--- a/packages/device-management-kit/src/api/device-action/task/GetFirmwareMetadataTask.ts
+++ b/packages/device-management-kit/src/api/device-action/task/GetFirmwareMetadataTask.ts
@@ -14,7 +14,11 @@ import {
 } from "@api/device-session/DeviceSessionState";
 import { type DmkResult, DmkResultFactory } from "@api/model/DmkResult";
 import { type DeviceVersion } from "@internal/manager-api/model/Device";
-import { type FinalFirmware } from "@internal/manager-api/model/Firmware";
+import {
+  type FinalFirmware,
+  type OsuFirmware,
+} from "@internal/manager-api/model/Firmware";
+import { type ManagerApiService } from "@internal/manager-api/service/ManagerApiService";
 
 export type GetFirmwareMetadataTaskResponse = {
   deviceVersion: DeviceVersion;
@@ -67,30 +71,13 @@ export class GetFirmwareMetadataTask {
     }
     const { deviceVersion, currentFirmware } = result.unsafeCoerce();
 
-    // Fetch latest firmware available, if any
-    const maybeUpdate = await manager
-      .getLatestFirmwareVersion(currentFirmware, deviceVersion)
-      .chain((osuFirmware) =>
-        manager.getNextFirmwareVersion(osuFirmware).chain((finalFirmware) =>
-          manager
-            .getMcuList()
-            .map((mcus) => mcus.find((mcu) => mcu.name === firmwareVersion.mcu))
-            .map(
-              (mcu) =>
-                mcu === undefined ||
-                !finalFirmware.mcuVersions.includes(mcu.id),
-            )
-            .map((mcuUpdateRequired) => ({
-              osuFirmware,
-              finalFirmware,
-              mcuUpdateRequired,
-            })),
-        ),
-      );
-    const availableUpdate: FirmwareUpdate | undefined = maybeUpdate.caseOf({
-      Right: (data) => data,
-      Left: (_error) => undefined,
-    });
+    const availableUpdate = await this.getAvailableUpdate(
+      manager,
+      currentFirmware,
+      deviceVersion,
+      firmwareVersion,
+    );
+
     const firmwareUpdateContext = {
       currentFirmware,
       availableUpdate,
@@ -115,5 +102,61 @@ export class GetFirmwareMetadataTask {
         customImage,
       },
     });
+  }
+
+  private async getAvailableUpdate(
+    manager: ManagerApiService,
+    currentFirmware: FinalFirmware,
+    deviceVersion: DeviceVersion,
+    firmwareVersion: FirmwareVersion,
+  ): Promise<FirmwareUpdate | undefined> {
+    // Fetch latest firmware available, if any
+    const maybeOsuFirmwareResult = await manager.getLatestFirmwareVersion(
+      currentFirmware,
+      deviceVersion,
+    );
+    if (maybeOsuFirmwareResult.isLeft()) {
+      return undefined;
+    }
+
+    const maybeOsuFirmware = maybeOsuFirmwareResult.unsafeCoerce();
+    if (maybeOsuFirmware.isNothing()) {
+      return undefined;
+    }
+
+    return this.getFirmwareUpdate(
+      manager,
+      maybeOsuFirmware.unsafeCoerce(),
+      firmwareVersion,
+    );
+  }
+
+  private async getFirmwareUpdate(
+    manager: ManagerApiService,
+    osuFirmware: OsuFirmware,
+    firmwareVersion: FirmwareVersion,
+  ): Promise<FirmwareUpdate | undefined> {
+    const finalFirmwareResult =
+      await manager.getNextFirmwareVersion(osuFirmware);
+    if (finalFirmwareResult.isLeft()) {
+      return undefined;
+    }
+
+    const mcusResult = await manager.getMcuList();
+    if (mcusResult.isLeft()) {
+      return undefined;
+    }
+
+    const finalFirmware = finalFirmwareResult.unsafeCoerce();
+    const mcu = mcusResult
+      .unsafeCoerce()
+      .find((candidate) => candidate.name === firmwareVersion.mcu);
+
+    return {
+      osuFirmware,
+      finalFirmware,
+      mcuUpdateRequired:
+        mcu === undefined || !finalFirmware.mcuVersions.includes(mcu.id),
+    };
   }
 }

--- a/packages/device-management-kit/src/internal/manager-api/data/HttpManagerApiDataSource.test.ts
+++ b/packages/device-management-kit/src/internal/manager-api/data/HttpManagerApiDataSource.test.ts
@@ -1,4 +1,4 @@
-import { Left, Right } from "purify-ts";
+import { Just, Left, Nothing, Right } from "purify-ts";
 
 import {
   BTC_APP,
@@ -443,6 +443,7 @@ describe("HttpManagerApiDataSource", () => {
             se_firmware_osu_version: {
               id: 361,
               perso: "perso_11",
+              notes: "notes",
               firmware: "test",
               firmware_key: "testKey",
               hash: "hash",
@@ -460,16 +461,41 @@ describe("HttpManagerApiDataSource", () => {
 
       // then
       expect(response).toEqual(
-        Right({
-          id: 361,
-          perso: "perso_11",
-          firmware: "test",
-          firmwareKey: "testKey",
-          hash: "hash",
-          nextFinalFirmware: 567,
-        }),
+        Right(
+          Just({
+            id: 361,
+            perso: "perso_11",
+            notes: "notes",
+            firmware: "test",
+            firmwareKey: "testKey",
+            hash: "hash",
+            nextFinalFirmware: 567,
+          }),
+        ),
       );
     });
+
+    it("should return nothing when no latest firmware version is available", async () => {
+      // given
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            result: "null",
+            se_firmware_osu_version: null,
+          }),
+        ),
+      );
+
+      // when
+      const response = await api.getLatestFirmwareVersion({
+        currentFinalFirmwareId: 200,
+        deviceId: 42,
+      });
+
+      // then
+      expect(response).toEqual(Right(Nothing));
+    });
+
     it("should return an error if result is not success", async () => {
       // given
       vi.spyOn(globalThis, "fetch").mockResolvedValue(
@@ -550,6 +576,7 @@ describe("HttpManagerApiDataSource", () => {
           JSON.stringify({
             id: 361,
             perso: "perso_11",
+            notes: "notes",
             firmware: "test",
             firmware_key: "testKey",
             hash: "hash",
@@ -569,6 +596,7 @@ describe("HttpManagerApiDataSource", () => {
         Right({
           id: 361,
           perso: "perso_11",
+          notes: "notes",
           firmware: "test",
           firmwareKey: "testKey",
           hash: "hash",
@@ -752,7 +780,7 @@ describe("HttpManagerApiDataSource", () => {
     afterEach(() => {
       vi.restoreAllMocks();
     });
-    it("should return a the list of MCUs", async () => {
+    it("should return the list of MCUs", async () => {
       // given
       vi.spyOn(globalThis, "fetch").mockResolvedValue(
         new Response(
@@ -764,7 +792,7 @@ describe("HttpManagerApiDataSource", () => {
               description: null,
               providers: [],
               device_versions: [1, 2],
-              from_bootloader_version: "",
+              from_bootloader_version: "1.0",
               from_bootloader_version_id: 2,
               se_firmware_final_versions: [7, 12, 13, 14, 15],
               date_creation: "2018-09-20T13:30:50.156394Z",
@@ -777,7 +805,7 @@ describe("HttpManagerApiDataSource", () => {
               description: null,
               providers: [],
               device_versions: [1, 2],
-              from_bootloader_version: "",
+              from_bootloader_version: "1.0",
               from_bootloader_version_id: 2,
               se_firmware_final_versions: [7, 12, 13, 14, 15],
               date_creation: "2018-09-20T13:30:50.339966Z",
@@ -796,10 +824,12 @@ describe("HttpManagerApiDataSource", () => {
           {
             id: 1,
             name: "1.0",
+            fromBootloaderVersion: "1.0",
           },
           {
             id: 2,
             name: "1.1",
+            fromBootloaderVersion: "1.0",
           },
         ]),
       );

--- a/packages/device-management-kit/src/internal/manager-api/data/HttpManagerApiDataSource.ts
+++ b/packages/device-management-kit/src/internal/manager-api/data/HttpManagerApiDataSource.ts
@@ -1,5 +1,5 @@
 import { inject, injectable } from "inversify";
-import { EitherAsync } from "purify-ts";
+import { EitherAsync, Just, Maybe, Nothing } from "purify-ts";
 
 import { type DmkConfig } from "@api/DmkConfig";
 import { DmkNetworkClient } from "@api/network/DmkNetworkClient";
@@ -169,7 +169,7 @@ export class HttpManagerApiDataSource implements ManagerApiDataSource {
 
   getLatestFirmwareVersion(
     params: GetLatestFirmwareVersionParams,
-  ): EitherAsync<HttpFetchApiError, OsuFirmware> {
+  ): EitherAsync<HttpFetchApiError, Maybe<OsuFirmware>> {
     const livecommonversion = "34.27.0"; // Legacy parameter that should just be a too old
     const { currentFinalFirmwareId, deviceId } = params;
     return EitherAsync(() =>
@@ -330,13 +330,15 @@ export class HttpManagerApiDataSource implements ManagerApiDataSource {
           if (
             typeof mcu !== "object" ||
             typeof mcu.id !== "number" ||
-            typeof mcu.name !== "string"
+            typeof mcu.name !== "string" ||
+            typeof mcu.from_bootloader_version !== "string"
           ) {
             throw new Error(`Incomplete MCU version: ${JSON.stringify(mcu)}`);
           }
           const ret: McuFirmware = {
             id: mcu.id,
             name: mcu.name,
+            fromBootloaderVersion: mcu.from_bootloader_version,
           };
           return ret;
         }),
@@ -402,8 +404,15 @@ export class HttpManagerApiDataSource implements ManagerApiDataSource {
 
   private mapLatestFirmwareDto(
     latestFirmware: LatestFirmwareOsuVersionResponseDto,
-  ): EitherAsync<Error, OsuFirmware> {
-    return EitherAsync<Error, FirmwareOsuVersionDto>(() => {
+  ): EitherAsync<Error, Maybe<OsuFirmware>> {
+    return EitherAsync<Error, FirmwareOsuVersionDto | null>(() => {
+      /**
+       * This is how we know that there is no update available.
+       * See the {@link https://github.com/LedgerHQ/ledger-live/blob/develop/libs/device-core/src/managerApi/repositories/HttpManagerApiRepository.ts#L59-L61 | ledger-live implementation}.
+       */
+      if (latestFirmware.result === "null") {
+        return Promise.resolve(null);
+      }
       if (
         latestFirmware.result !== "success" ||
         !latestFirmware.se_firmware_osu_version
@@ -414,7 +423,14 @@ export class HttpManagerApiDataSource implements ManagerApiDataSource {
       }
       const osuDto = latestFirmware.se_firmware_osu_version;
       return Promise.resolve(osuDto);
-    }).chain((osuDto) => this.mapOsuFirmwareDto(osuDto));
+    }).chain((osuDto) => {
+      if (null === osuDto) {
+        return EitherAsync(() => Promise.resolve(Nothing));
+      }
+      return this.mapOsuFirmwareDto(osuDto).map((osuFirmware) =>
+        Just(osuFirmware),
+      );
+    });
   }
 
   private mapOsuFirmwareDto(
@@ -424,6 +440,7 @@ export class HttpManagerApiDataSource implements ManagerApiDataSource {
       if (
         typeof osuDto !== "object" ||
         typeof osuDto.id !== "number" ||
+        (osuDto.notes !== null && typeof osuDto.notes !== "string") ||
         typeof osuDto.perso !== "string" ||
         typeof osuDto.firmware !== "string" ||
         typeof osuDto.firmware_key !== "string" ||
@@ -436,6 +453,7 @@ export class HttpManagerApiDataSource implements ManagerApiDataSource {
       }
       const ret: OsuFirmware = {
         id: osuDto.id,
+        notes: osuDto.notes,
         perso: osuDto.perso,
         firmware: osuDto.firmware,
         firmwareKey: osuDto.firmware_key,

--- a/packages/device-management-kit/src/internal/manager-api/data/ManagerApiDataSource.ts
+++ b/packages/device-management-kit/src/internal/manager-api/data/ManagerApiDataSource.ts
@@ -1,4 +1,4 @@
-import { type EitherAsync } from "purify-ts";
+import { type EitherAsync, type Maybe } from "purify-ts";
 
 import { type Application } from "@internal/manager-api/model/Application";
 import { type DeviceVersion } from "@internal/manager-api/model/Device";
@@ -95,14 +95,14 @@ export interface ManagerApiDataSource {
   ): EitherAsync<HttpFetchApiError, OsuFirmware>;
 
   /**
-   * Retrieves the latest firmware available for a given current firmware, device ID.
+   * Retrieves the latest firmware available, if any, for a given device.
    *
    * @param params - The parameters for getting the firmware version.
-   * @returns EitherAsync containing the OSU firmware or an HttpFetchApiError.
+   * @returns EitherAsync containing either an `HttpFetchApiError` or a `Maybe<OsuFirmware>` (Nothing when no update is available).
    */
   getLatestFirmwareVersion(
     params: GetLatestFirmwareVersionParams,
-  ): EitherAsync<HttpFetchApiError, OsuFirmware>;
+  ): EitherAsync<HttpFetchApiError, Maybe<OsuFirmware>>;
 
   /**
    * Retrieves the available language packages for a device.

--- a/packages/device-management-kit/src/internal/manager-api/model/Firmware.ts
+++ b/packages/device-management-kit/src/internal/manager-api/model/Firmware.ts
@@ -1,5 +1,6 @@
 export type OsuFirmware = {
   id: number;
+  notes: string | null;
   perso: string;
   firmware: string;
   firmwareKey: string;
@@ -21,4 +22,5 @@ export type FinalFirmware = {
 export type McuFirmware = {
   id: number;
   name: string;
+  fromBootloaderVersion: string;
 };

--- a/packages/device-management-kit/src/internal/manager-api/service/ManagerApiService.ts
+++ b/packages/device-management-kit/src/internal/manager-api/service/ManagerApiService.ts
@@ -1,4 +1,4 @@
-import { type EitherAsync } from "purify-ts";
+import { type EitherAsync, type Maybe } from "purify-ts";
 
 import { type GetOsVersionResponse } from "@api/command/os/GetOsVersionCommand";
 import { type Application } from "@internal/manager-api/model/Application";
@@ -70,7 +70,7 @@ export interface ManagerApiService {
   ): EitherAsync<HttpFetchApiError, OsuFirmware>;
 
   /**
-   * Retrieves the latest firmware available for a given device.
+   * Retrieves the latest firmware available, if any, for a given device.
    *
    * @param currentFirmware - Current firmware obtained from getFirmwareVersion.
    * @param deviceVersion - Response of the GetDeviceVersion HTTP request.
@@ -79,7 +79,7 @@ export interface ManagerApiService {
   getLatestFirmwareVersion(
     currentFirmware: FinalFirmware,
     deviceVersion: DeviceVersion,
-  ): EitherAsync<HttpFetchApiError, OsuFirmware>;
+  ): EitherAsync<HttpFetchApiError, Maybe<OsuFirmware>>;
 
   /**
    * Retrieves the next final firmware following an OSU.


### PR DESCRIPTION
### 📝 Description

This PR fixes the handling of Manager API responses when checking for the latest available firmware update.

Previously, the absence of an available firmware update could be treated the same way as an error response from the Manager API. This made it impossible to reliably differentiate between:

- a valid response where no firmware update is available;
- an actual failure, such as an HTTP/network error or an invalid Manager API response.

The fix introduces an explicit “no available update” case so callers can safely continue when the Manager API successfully reports that no update exists, while still preserving error handling for real failures.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]

- **Feature**: Manager API firmware metadata retrieval

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [ ] ~~**Documentation is up-to-date**~~
- [x] **Impact of the changes:**
  - Firmware metadata retrieval now distinguishes “no available update” from Manager API errors.
  - Device metadata flows can continue normally when the device is already up to date.
  - HTTP/network errors and invalid Manager API responses are still handled as failures.