### PR TITLE
🐛 (signer-zcash) [LIVE-35258]: Group shielded fields per ZIP-244 digest

### DIFF
--- a/.changeset/lucky-moons-gather.md
+++ b/.changeset/lucky-moons-gather.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-zcash": patch
+---
+
+Regroup the shielded fields of a previous transaction per ZIP-244 digest when streaming it for GET_TRUSTED_INPUT, so the device commits to the right txid, and reject versions this flow does not support instead of streaming them as v5

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.test.ts
@@ -42,6 +42,124 @@ const hexToBytes = (hex: string): Uint8Array =>
   Uint8Array.from(Buffer.from(hex, "hex"));
 const bytesToHex = (bytes: Uint8Array): string =>
   Buffer.from(bytes).toString("hex");
+const concatBytes = (...parts: Uint8Array[]): Uint8Array =>
+  Uint8Array.from(Buffer.concat(parts.map((part) => Buffer.from(part))));
+const byteRun = (marker: number, length: number): Uint8Array =>
+  new Uint8Array(length).fill(marker);
+const runHex = (marker: number, length: number): string =>
+  bytesToHex(byteRun(marker, length));
+
+// Markers for the fields of the synthetic v5 Sapling transaction below. Every
+// field gets its own byte, so a wrong offset or a mixed-up group is readable in
+// the assertion instead of showing up as an opaque hex mismatch. AUTHORIZING
+// fills the proofs and signatures, which the txid does not commit to: it must
+// appear nowhere in the stream.
+const VALUE_BALANCE_MARKER = 0x41;
+const ANCHOR_MARKER = 0x42;
+const AUTHORIZING_MARKER = 0xee;
+const SPEND_CV_MARKER = 0x11;
+const SPEND_NULLIFIER_MARKER = 0x12;
+const SPEND_RK_MARKER = 0x13;
+
+// Sizes the device app reads per field (see `sapling.rs`): a compact output is
+// cmu | ephemeralKey | 52 compact bytes, and a non-compact one is cv | the
+// 16-byte tag of encCiphertext | outCiphertext.
+const SAPLING_SPEND_SIZE = 96;
+const SAPLING_OUTPUTS_COMPACT_SIZE = 116;
+const SAPLING_OUTPUTS_NONCOMPACT_SIZE = 128;
+const SAPLING_MEMO_SIZE = 512;
+const MEMO_CHUNK_SIZE = 128;
+const SAPLING_SPEND_PROOF_AND_SIG_SIZE = 192 + 64;
+const SAPLING_OUTPUT_PROOF_SIZE = 192;
+const SAPLING_BINDING_SIG_SIZE = 64;
+
+const V5_HEADER_HEX = "050000800a27a7265510e7c8"; // version | versionGroupId | branchId
+const V5_LOCK_TIME_HEX = "01020304";
+const V5_EXPIRY_HEX = "05060708";
+// One transparent input and one transparent output, deliberately small so the
+// assertions stay focused on the shielded groups.
+const TRANSPARENT_BODY_HEX =
+  "01" + // tx_in count
+  "51".repeat(32) +
+  "00000000" + // prevout
+  "02" +
+  "5152" + // scriptSig
+  "ffffffff" + // sequence
+  "01" + // tx_out count
+  "40420f0000000000" + // value
+  "02" +
+  "5354"; // scriptPubKey
+
+/** OutputDescriptionV5 on chain: cv | cmu | ephemeralKey | encCiphertext | outCiphertext. */
+const saplingOutputFields = (base: number) => ({
+  cv: byteRun(base + 0x01, 32),
+  cmu: byteRun(base + 0x02, 32),
+  ephemeralKey: byteRun(base + 0x03, 32),
+  encCompact: byteRun(base + 0x04, 52),
+  memo: byteRun(base + 0x05, SAPLING_MEMO_SIZE),
+  encTag: byteRun(base + 0x06, 16),
+  outCiphertext: byteRun(base + 0x07, 80),
+});
+type SaplingOutputFields = ReturnType<typeof saplingOutputFields>;
+
+const serializeSaplingOutput = (output: SaplingOutputFields): Uint8Array =>
+  concatBytes(
+    output.cv,
+    output.cmu,
+    output.ephemeralKey,
+    output.encCompact,
+    output.memo,
+    output.encTag,
+    output.outCiphertext,
+  );
+
+/**
+ * Builds a v5 transaction whose Sapling bundle follows the ZIP-225 on-chain
+ * layout: the descriptions first, then the value balance and the anchor, then
+ * the proofs and signatures that belong to the authorizing data commitment
+ * rather than to the txid.
+ */
+const buildV5TxWithSaplingBundle = (
+  spendCount: number,
+  outputs: SaplingOutputFields[],
+): Uint8Array => {
+  const hasBundle = spendCount > 0 || outputs.length > 0;
+
+  return concatBytes(
+    hexToBytes(V5_HEADER_HEX),
+    hexToBytes(V5_LOCK_TIME_HEX),
+    hexToBytes(V5_EXPIRY_HEX),
+    hexToBytes(TRANSPARENT_BODY_HEX),
+    new Uint8Array([spendCount]),
+    ...Array.from({ length: spendCount }, () =>
+      concatBytes(
+        byteRun(SPEND_CV_MARKER, 32),
+        byteRun(SPEND_NULLIFIER_MARKER, 32),
+        byteRun(SPEND_RK_MARKER, 32),
+      ),
+    ),
+    new Uint8Array([outputs.length]),
+    ...outputs.map(serializeSaplingOutput),
+    hasBundle ? byteRun(VALUE_BALANCE_MARKER, 8) : new Uint8Array(),
+    spendCount > 0 ? byteRun(ANCHOR_MARKER, 32) : new Uint8Array(),
+    byteRun(
+      AUTHORIZING_MARKER,
+      spendCount * SAPLING_SPEND_PROOF_AND_SIG_SIZE +
+        outputs.length * SAPLING_OUTPUT_PROOF_SIZE +
+        (hasBundle ? SAPLING_BINDING_SIG_SIZE : 0),
+    ),
+    new Uint8Array([0x00]), // no Orchard action
+  );
+};
+
+const memoChunksHex = (memo: Uint8Array): string[] =>
+  Array.from({ length: memo.length / MEMO_CHUNK_SIZE }, () =>
+    runHex(memo[0] ?? 0, MEMO_CHUNK_SIZE),
+  );
+const compactHex = (output: SaplingOutputFields): string =>
+  bytesToHex(concatBytes(output.cmu, output.ephemeralKey, output.encCompact));
+const nonCompactHex = (output: SaplingOutputFields): string =>
+  bytesToHex(concatBytes(output.cv, output.encTag, output.outCiphertext));
 
 const makeSuccessResponse = (byte: number) => ({
   statusCode: new Uint8Array([0x90, 0x00]),
@@ -81,6 +199,16 @@ describe("GetTrustedInputTask", () => {
       sendCommand: vi.fn(),
     } as unknown as InternalApi;
   });
+
+  /** Data sent per APDU, the 5-byte APDU header aside. */
+  const sentApduData = (): string[] =>
+    vi
+      .mocked(apiMock.sendCommand)
+      .mock.calls.map(([command]) =>
+        bytesToHex(
+          (command as GetTrustedInputCommand).getApdu().getRawApdu().slice(5),
+        ),
+      );
 
   it("sends the expected trusted-input APDU sequence and returns the last response", async () => {
     const txBytes = hexToBytes(TRANSPARENT_V5_TX_HEX);
@@ -216,6 +344,82 @@ describe("GetTrustedInputTask", () => {
     // carried, so the signed transaction spent an unknown input and the broadcast
     // timed out.
     expect(sentApdus).toEqual(trustedInputApduCallsFromLogs()[1]);
+  });
+
+  it("regroups a v5 Sapling bundle per ZIP-244 digest and leaves the authorizing data out", async () => {
+    vi.mocked(apiMock.sendCommand).mockResolvedValue(
+      CommandResultFactory({ data: makeSuccessResponse(0x01) }),
+    );
+    const outputs = [saplingOutputFields(0x20), saplingOutputFields(0x30)];
+
+    await new GetTrustedInputTask(apiMock, {
+      transaction: buildV5TxWithSaplingBundle(1, outputs),
+      indexLookup: 0,
+    }).run();
+
+    const [firstChunk, ...nextChunks] = sentApduData();
+    expect(firstChunk).toBe(`00000000${V5_HEADER_HEX}01`);
+    expect(nextChunks).toEqual([
+      `${"51".repeat(32)}0000000002`, // prevout | scriptSig length
+      "5152ffffffff", // scriptSig | sequence
+      "01", // tx_out count
+      "40420f0000000000025354", // value | scriptPubKey
+      "010200", // one spend, two outputs, no action
+      runHex(VALUE_BALANCE_MARKER, 8) + runHex(ANCHOR_MARKER, 32),
+      // A spend keeps its on-chain layout, since the app reads cv, nullifier and
+      // rk one by one and routes each to the digest it belongs to.
+      runHex(SPEND_CV_MARKER, 32) +
+        runHex(SPEND_NULLIFIER_MARKER, 32) +
+        runHex(SPEND_RK_MARKER, 32),
+      // Outputs, on the other hand, are regrouped: every compact part, then
+      // every memo, then every non-compact part.
+      compactHex(outputs[0]!),
+      compactHex(outputs[1]!),
+      ...memoChunksHex(outputs[0]!.memo),
+      ...memoChunksHex(outputs[1]!.memo),
+      nonCompactHex(outputs[0]!),
+      nonCompactHex(outputs[1]!),
+      `${V5_LOCK_TIME_HEX}04${V5_EXPIRY_HEX}`,
+    ]);
+
+    // The app reads these three blocks with `hash_reader_exact`, which rejects a
+    // block split across two APDUs — hence the sizes it expects.
+    expect(compactHex(outputs[0]!).length / 2).toBe(
+      SAPLING_OUTPUTS_COMPACT_SIZE,
+    );
+    expect(nonCompactHex(outputs[0]!).length / 2).toBe(
+      SAPLING_OUTPUTS_NONCOMPACT_SIZE,
+    );
+    expect(nextChunks[6]!.length / 2).toBe(SAPLING_SPEND_SIZE);
+
+    // Proofs and signatures are authorizing data, which the txid does not commit
+    // to: not one of their bytes may reach the device.
+    expect(concatBytes(...sentApduData().map(hexToBytes))).not.toContain(
+      AUTHORIZING_MARKER,
+    );
+  });
+
+  it("omits the Sapling anchor when the bundle has outputs but no spend", async () => {
+    vi.mocked(apiMock.sendCommand).mockResolvedValue(
+      CommandResultFactory({ data: makeSuccessResponse(0x01) }),
+    );
+    const output = saplingOutputFields(0x20);
+
+    await new GetTrustedInputTask(apiMock, {
+      transaction: buildV5TxWithSaplingBundle(0, [output]),
+      indexLookup: 0,
+    }).run();
+
+    // ZIP-225 writes the anchor only for a bundle that has spends, and the app
+    // likewise reads the value balance alone before the compact outputs.
+    expect(sentApduData().slice(5)).toEqual([
+      "000100", // no spend, one output, no action
+      runHex(VALUE_BALANCE_MARKER, 8),
+      compactHex(output),
+      ...memoChunksHex(output.memo),
+      nonCompactHex(output),
+      `${V5_LOCK_TIME_HEX}04${V5_EXPIRY_HEX}`,
+    ]);
   });
 
   it("rejects a transaction version the device app does not handle in this flow", async () => {

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.test.ts
@@ -7,6 +7,10 @@ import {
 } from "@ledgerhq/device-management-kit";
 
 import { GetTrustedInputCommand } from "@internal/app-binder/command/GetTrustedInputCommand";
+import {
+  apduRecordStoreFromLogs,
+  splitTransactionArgsFromLogsSecond,
+} from "@internal/app-binder/task/__fixtures__/signTransactionFromLedgerWalletLogs2026-05-12";
 import { signTransactionFromLedgerWalletLogs20260615 } from "@internal/app-binder/task/__fixtures__/signTransactionFromLedgerWalletLogs2026-06-15";
 import {
   getZcashBranchId,
@@ -43,6 +47,31 @@ const makeSuccessResponse = (byte: number) => ({
   statusCode: new Uint8Array([0x90, 0x00]),
   data: new Uint8Array([byte]),
 });
+
+/**
+ * GET_TRUSTED_INPUT APDUs recorded in the 2026-05-12 log, grouped per call (P1=00
+ * starts a new one). They were produced by the pre-DMK implementation, and the
+ * device answered them with the ZIP-244 txids kept in `trustedInputHexesFromLogs`,
+ * which match the chain — so they are the reference framing for a previous
+ * transaction, including the second call whose source carries an Orchard bundle.
+ */
+const trustedInputApduCallsFromLogs = (): string[][] => {
+  const calls: string[][] = [];
+
+  apduRecordStoreFromLogs
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("=> e042"))
+    .map((line) => line.slice(3))
+    .forEach((apdu) => {
+      if (apdu.startsWith("e04200")) {
+        calls.push([]);
+      }
+      calls.at(-1)?.push(apdu);
+    });
+
+  return calls;
+};
 
 describe("GetTrustedInputTask", () => {
   let apiMock: InternalApi;
@@ -160,6 +189,51 @@ describe("GetTrustedInputTask", () => {
     // so the chunker read the count off the locktime byte → "...f04dec4d00" (0 inputs)
     // → the device misparsed the stream and returned 6a80.
     expect(header).toBe("000000000400008085202f89f04dec4d03");
+  });
+
+  it("regroups the shielded fields of a v5 Orchard previous transaction by ZIP-244 digest (regression: wrong txid, then 504 on broadcast)", async () => {
+    vi.mocked(apiMock.sendCommand).mockResolvedValue(
+      CommandResultFactory({ data: makeSuccessResponse(0x01) }),
+    );
+
+    await new GetTrustedInputTask(apiMock, {
+      transaction: hexToBytes(
+        splitTransactionArgsFromLogsSecond.transactionHex,
+      ),
+      indexLookup: 0,
+    }).run();
+
+    const sentApdus = vi
+      .mocked(apiMock.sendCommand)
+      .mock.calls.map(([command]) =>
+        bytesToHex((command as GetTrustedInputCommand).getApdu().getRawApdu()),
+      );
+
+    // On chain an Orchard action keeps its own fields together, while the device
+    // hashes one digest per stream — compact parts, then memos, then non-compact
+    // parts — and rejects any digest block split across two APDUs. Streaming the
+    // raw bytes in their on-chain order made it commit to a txid that no output
+    // carried, so the signed transaction spent an unknown input and the broadcast
+    // timed out.
+    expect(sentApdus).toEqual(trustedInputApduCallsFromLogs()[1]);
+  });
+
+  it("rejects a transaction version the device app does not handle in this flow", async () => {
+    // v6 header (Ironwood): version | nVersionGroupId | branchId | locktime | expiry.
+    // The app turns v6 away with "V6 transaction in legacy path", so the stream
+    // must not be built as if the bundles followed the v5 layout.
+    const v6Header = "060000800a27a726f04dec4d00000000a6233300";
+
+    await expect(
+      new GetTrustedInputTask(apiMock, {
+        transaction: hexToBytes(v6Header),
+        indexLookup: 0,
+      }).run(),
+    ).rejects.toThrow(
+      "Unsupported transaction version 6 while splitting trusted input chunks",
+    );
+
+    expect(apiMock.sendCommand).not.toHaveBeenCalled();
   });
 
   it("throws for malformed transaction input before sending any command", async () => {

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.ts
@@ -322,12 +322,14 @@ const orchardActionDigestParts = (action: Uint8Array): DigestParts => {
   };
 };
 
+// MEMO_SIZE is a whole number of MEMO_CHUNK_SIZE, so slicing each memo on its
+// own yields the same stream as slicing their concatenation, without the copy.
 const pushMemoChunks = (chunks: Uint8Array[], memos: Uint8Array[]): void => {
-  const stream = concatUint8Arrays(...memos);
-
-  for (let offset = 0; offset < stream.length; offset += MEMO_CHUNK_SIZE) {
-    chunks.push(stream.subarray(offset, offset + MEMO_CHUNK_SIZE));
-  }
+  memos.forEach((memo) => {
+    for (let offset = 0; offset < memo.length; offset += MEMO_CHUNK_SIZE) {
+      chunks.push(memo.subarray(offset, offset + MEMO_CHUNK_SIZE));
+    }
+  });
 };
 
 /**

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.ts
@@ -18,8 +18,11 @@ const MAX_APDU_DATA_LENGTH = 0xff;
 const INDEX_LOOKUP_LENGTH = 4;
 const FIRST_CHUNK_MAX_LENGTH = MAX_APDU_DATA_LENGTH - INDEX_LOOKUP_LENGTH;
 const NEXT_CHUNK_MAX_LENGTH = MAX_APDU_DATA_LENGTH;
-const HEADER_V5_SIZE = 4 * 5;
-const HEADER_V4_SIZE = 4 * 3;
+const UINT32_SIZE = 4;
+// version | versionGroupId | consensusBranchId | lockTime | expiryHeight
+const HEADER_V5_SIZE = 5 * UINT32_SIZE;
+// version | versionGroupId | consensusBranchId
+const HEADER_V4_SIZE = 3 * UINT32_SIZE;
 const HASH_SIZE = 32;
 const VALUE_BALANCE_SIZE = 8;
 const FLAGS_SIZE = 1;
@@ -31,11 +34,28 @@ const MEMO_SIZE = 512;
 const ENC_CIPHERTEXT_SIZE =
   ENC_CIPHERTEXT_COMPACT_SIZE + MEMO_SIZE + ENC_CIPHERTEXT_TAG_SIZE;
 const OUT_CIPHERTEXT_SIZE = 80;
-const SAPLING_SPEND_SIZE = 3 * HASH_SIZE;
+// SpendDescriptionV5 on chain: cv | nullifier | rk
+const SAPLING_SPEND_NULLIFIER_OFFSET = HASH_SIZE;
+const SAPLING_SPEND_RK_OFFSET = SAPLING_SPEND_NULLIFIER_OFFSET + HASH_SIZE;
+const SAPLING_SPEND_SIZE = SAPLING_SPEND_RK_OFFSET + HASH_SIZE;
+// OutputDescriptionV5 on chain: cv | cmu | ephemeralKey | encCiphertext | outCiphertext
+const SAPLING_OUTPUT_CMU_OFFSET = HASH_SIZE;
+const SAPLING_OUTPUT_EPHEMERAL_KEY_OFFSET =
+  SAPLING_OUTPUT_CMU_OFFSET + HASH_SIZE;
+const SAPLING_OUTPUT_ENC_OFFSET =
+  SAPLING_OUTPUT_EPHEMERAL_KEY_OFFSET + HASH_SIZE;
 const SAPLING_OUTPUT_SIZE =
-  3 * HASH_SIZE + ENC_CIPHERTEXT_SIZE + OUT_CIPHERTEXT_SIZE;
+  SAPLING_OUTPUT_ENC_OFFSET + ENC_CIPHERTEXT_SIZE + OUT_CIPHERTEXT_SIZE;
+// OrchardAction on chain: cv | nullifier | rk | cmx | ephemeralKey | encCiphertext | outCiphertext
+const ORCHARD_ACTION_NULLIFIER_OFFSET = HASH_SIZE;
+const ORCHARD_ACTION_RK_OFFSET = ORCHARD_ACTION_NULLIFIER_OFFSET + HASH_SIZE;
+const ORCHARD_ACTION_CMX_OFFSET = ORCHARD_ACTION_RK_OFFSET + HASH_SIZE;
+const ORCHARD_ACTION_EPHEMERAL_KEY_OFFSET =
+  ORCHARD_ACTION_CMX_OFFSET + HASH_SIZE;
+const ORCHARD_ACTION_ENC_OFFSET =
+  ORCHARD_ACTION_EPHEMERAL_KEY_OFFSET + HASH_SIZE;
 const ORCHARD_ACTION_SIZE =
-  5 * HASH_SIZE + ENC_CIPHERTEXT_SIZE + OUT_CIPHERTEXT_SIZE;
+  ORCHARD_ACTION_ENC_OFFSET + ENC_CIPHERTEXT_SIZE + OUT_CIPHERTEXT_SIZE;
 const ORCHARD_DIGEST_DATA_SIZE = FLAGS_SIZE + VALUE_BALANCE_SIZE + HASH_SIZE;
 const MEMO_CHUNK_SIZE = 128;
 const SCRIPT_SIG_SEQUENCE_CHUNK_SIZE = 50;
@@ -264,15 +284,17 @@ const readShieldedBundles = (
   };
 };
 
-// OutputDescriptionV5 on chain: cv | cmu | ephemeralKey | encCiphertext | outCiphertext
 const saplingOutputDigestParts = (output: Uint8Array): DigestParts => {
-  const cv = output.subarray(0, HASH_SIZE);
-  const cmuAndEphemeralKey = output.subarray(HASH_SIZE, 3 * HASH_SIZE);
-  const enc = output.subarray(
-    3 * HASH_SIZE,
-    3 * HASH_SIZE + ENC_CIPHERTEXT_SIZE,
+  const cv = output.subarray(0, SAPLING_OUTPUT_CMU_OFFSET);
+  const cmuAndEphemeralKey = output.subarray(
+    SAPLING_OUTPUT_CMU_OFFSET,
+    SAPLING_OUTPUT_ENC_OFFSET,
   );
-  const out = output.subarray(3 * HASH_SIZE + ENC_CIPHERTEXT_SIZE);
+  const enc = output.subarray(
+    SAPLING_OUTPUT_ENC_OFFSET,
+    SAPLING_OUTPUT_ENC_OFFSET + ENC_CIPHERTEXT_SIZE,
+  );
+  const out = output.subarray(SAPLING_OUTPUT_ENC_OFFSET + ENC_CIPHERTEXT_SIZE);
 
   return {
     compact: concatUint8Arrays(
@@ -291,17 +313,25 @@ const saplingOutputDigestParts = (output: Uint8Array): DigestParts => {
   };
 };
 
-// OrchardAction on chain: cv | nullifier | rk | cmx | ephemeralKey | encCiphertext | outCiphertext
 const orchardActionDigestParts = (action: Uint8Array): DigestParts => {
-  const cv = action.subarray(0, HASH_SIZE);
-  const nullifier = action.subarray(HASH_SIZE, 2 * HASH_SIZE);
-  const rk = action.subarray(2 * HASH_SIZE, 3 * HASH_SIZE);
-  const cmxAndEphemeralKey = action.subarray(3 * HASH_SIZE, 5 * HASH_SIZE);
-  const enc = action.subarray(
-    5 * HASH_SIZE,
-    5 * HASH_SIZE + ENC_CIPHERTEXT_SIZE,
+  const cv = action.subarray(0, ORCHARD_ACTION_NULLIFIER_OFFSET);
+  const nullifier = action.subarray(
+    ORCHARD_ACTION_NULLIFIER_OFFSET,
+    ORCHARD_ACTION_RK_OFFSET,
   );
-  const out = action.subarray(5 * HASH_SIZE + ENC_CIPHERTEXT_SIZE);
+  const rk = action.subarray(
+    ORCHARD_ACTION_RK_OFFSET,
+    ORCHARD_ACTION_CMX_OFFSET,
+  );
+  const cmxAndEphemeralKey = action.subarray(
+    ORCHARD_ACTION_CMX_OFFSET,
+    ORCHARD_ACTION_ENC_OFFSET,
+  );
+  const enc = action.subarray(
+    ORCHARD_ACTION_ENC_OFFSET,
+    ORCHARD_ACTION_ENC_OFFSET + ENC_CIPHERTEXT_SIZE,
+  );
+  const out = action.subarray(ORCHARD_ACTION_ENC_OFFSET + ENC_CIPHERTEXT_SIZE);
 
   return {
     compact: concatUint8Arrays(

--- a/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/task/GetTrustedInputTask.ts
@@ -11,6 +11,7 @@ import {
   type GetTrustedInputCommandResponse,
 } from "@internal/app-binder/command/GetTrustedInputCommand";
 import { type ZcashErrorCodes } from "@internal/app-binder/command/utils/zcashApplicationErrors";
+import { createVarint } from "@internal/app-binder/task/utils/legacyTransactionUtils";
 import { concatUint8Arrays } from "@internal/utils/concatUint8Arrays";
 
 const MAX_APDU_DATA_LENGTH = 0xff;
@@ -19,16 +20,28 @@ const FIRST_CHUNK_MAX_LENGTH = MAX_APDU_DATA_LENGTH - INDEX_LOOKUP_LENGTH;
 const NEXT_CHUNK_MAX_LENGTH = MAX_APDU_DATA_LENGTH;
 const HEADER_V5_SIZE = 4 * 5;
 const HEADER_V4_SIZE = 4 * 3;
-const SAPLING_SPEND_SIZE = 32 + 32 + 32;
-const SAPLING_OUTPUT_COMPACT_SIZE = 32 + 32 + 52;
-const SAPLING_OUTPUT_NON_COMPACT_SIZE = 32 + 16 + 80;
-const ORCHARD_ACTION_COMPACT_SIZE = 32 + 32 + 32 + 52;
-const ORCHARD_ACTION_NON_COMPACT_SIZE = 32 + 32 + 16 + 80;
-const ORCHARD_DIGEST_DATA_SIZE = 1 + 8 + 32;
-const MEMO_CHUNK_SIZE = 128;
+const HASH_SIZE = 32;
+const VALUE_BALANCE_SIZE = 8;
+const FLAGS_SIZE = 1;
+const SIGNATURE_SIZE = 64;
+const SAPLING_PROOF_SIZE = 192;
+const ENC_CIPHERTEXT_COMPACT_SIZE = 52;
+const ENC_CIPHERTEXT_TAG_SIZE = 16;
 const MEMO_SIZE = 512;
+const ENC_CIPHERTEXT_SIZE =
+  ENC_CIPHERTEXT_COMPACT_SIZE + MEMO_SIZE + ENC_CIPHERTEXT_TAG_SIZE;
+const OUT_CIPHERTEXT_SIZE = 80;
+const SAPLING_SPEND_SIZE = 3 * HASH_SIZE;
+const SAPLING_OUTPUT_SIZE =
+  3 * HASH_SIZE + ENC_CIPHERTEXT_SIZE + OUT_CIPHERTEXT_SIZE;
+const ORCHARD_ACTION_SIZE =
+  5 * HASH_SIZE + ENC_CIPHERTEXT_SIZE + OUT_CIPHERTEXT_SIZE;
+const ORCHARD_DIGEST_DATA_SIZE = FLAGS_SIZE + VALUE_BALANCE_SIZE + HASH_SIZE;
+const MEMO_CHUNK_SIZE = 128;
 const SCRIPT_SIG_SEQUENCE_CHUNK_SIZE = 50;
 const TX_VERSION_MASK = 0x7fffffff;
+const TX_VERSION_V4 = 4;
+const TX_VERSION_V5 = 5;
 
 type GetTrustedInputTaskArgs = {
   transaction: Uint8Array;
@@ -158,12 +171,229 @@ const splitV5ExtraData = (
   expiry: Uint8Array,
 ): Uint8Array => concatUint8Arrays(locktime, new Uint8Array([0x04]), expiry);
 
+type ShieldedBundles = {
+  saplingSpends: Uint8Array[];
+  saplingOutputs: Uint8Array[];
+  saplingValueBalance: Uint8Array;
+  saplingAnchor: Uint8Array;
+  orchardActions: Uint8Array[];
+  orchardDigestData: Uint8Array;
+};
+
+type DigestParts = {
+  compact: Uint8Array;
+  memo: Uint8Array;
+  nonCompact: Uint8Array;
+};
+
+const createFieldReader = (buffer: Uint8Array, startOffset: number) => {
+  let offset = startOffset;
+
+  return {
+    take: (size: number): Uint8Array => {
+      ensureRange(buffer, offset, offset + size);
+      const bytes = buffer.slice(offset, offset + size);
+      offset += size;
+      return bytes;
+    },
+    skip: (size: number): void => {
+      ensureRange(buffer, offset, offset + size);
+      offset += size;
+    },
+    takeCount: (): number => {
+      const { value, nextOffset } = readCompactSize(buffer, offset);
+      offset = nextOffset;
+      return value;
+    },
+  };
+};
+
+/**
+ * Reads the shielded bundles of a v5 transaction as they are laid out on chain
+ * (ZIP-225): each description keeps its own fields together, and the proofs and
+ * signatures trail the descriptions. Proofs and signatures are skipped, as they
+ * belong to the authorizing data commitment rather than to the txid, but the
+ * Sapling ones still have to be stepped over to reach the Orchard action count.
+ */
+const readShieldedBundles = (
+  transaction: Uint8Array,
+  offset: number,
+): ShieldedBundles => {
+  const reader = createFieldReader(transaction, offset);
+
+  const spendCount = reader.takeCount();
+  const saplingSpends = Array.from({ length: spendCount }, () =>
+    reader.take(SAPLING_SPEND_SIZE),
+  );
+
+  const outputCount = reader.takeCount();
+  const saplingOutputs = Array.from({ length: outputCount }, () =>
+    reader.take(SAPLING_OUTPUT_SIZE),
+  );
+
+  let saplingValueBalance: Uint8Array = new Uint8Array();
+  let saplingAnchor: Uint8Array = new Uint8Array();
+
+  if (spendCount > 0 || outputCount > 0) {
+    saplingValueBalance = reader.take(VALUE_BALANCE_SIZE);
+    if (spendCount > 0) {
+      saplingAnchor = reader.take(HASH_SIZE);
+    }
+    reader.skip(
+      spendCount * (SAPLING_PROOF_SIZE + SIGNATURE_SIZE) +
+        outputCount * SAPLING_PROOF_SIZE +
+        SIGNATURE_SIZE,
+    );
+  }
+
+  const actionCount = reader.takeCount();
+  const orchardActions = Array.from({ length: actionCount }, () =>
+    reader.take(ORCHARD_ACTION_SIZE),
+  );
+
+  return {
+    saplingSpends,
+    saplingOutputs,
+    saplingValueBalance,
+    saplingAnchor,
+    orchardActions,
+    orchardDigestData:
+      actionCount > 0
+        ? reader.take(ORCHARD_DIGEST_DATA_SIZE)
+        : new Uint8Array(),
+  };
+};
+
+// OutputDescriptionV5 on chain: cv | cmu | ephemeralKey | encCiphertext | outCiphertext
+const saplingOutputDigestParts = (output: Uint8Array): DigestParts => {
+  const cv = output.subarray(0, HASH_SIZE);
+  const cmuAndEphemeralKey = output.subarray(HASH_SIZE, 3 * HASH_SIZE);
+  const enc = output.subarray(
+    3 * HASH_SIZE,
+    3 * HASH_SIZE + ENC_CIPHERTEXT_SIZE,
+  );
+  const out = output.subarray(3 * HASH_SIZE + ENC_CIPHERTEXT_SIZE);
+
+  return {
+    compact: concatUint8Arrays(
+      cmuAndEphemeralKey,
+      enc.subarray(0, ENC_CIPHERTEXT_COMPACT_SIZE),
+    ),
+    memo: enc.subarray(
+      ENC_CIPHERTEXT_COMPACT_SIZE,
+      ENC_CIPHERTEXT_COMPACT_SIZE + MEMO_SIZE,
+    ),
+    nonCompact: concatUint8Arrays(
+      cv,
+      enc.subarray(ENC_CIPHERTEXT_COMPACT_SIZE + MEMO_SIZE),
+      out,
+    ),
+  };
+};
+
+// OrchardAction on chain: cv | nullifier | rk | cmx | ephemeralKey | encCiphertext | outCiphertext
+const orchardActionDigestParts = (action: Uint8Array): DigestParts => {
+  const cv = action.subarray(0, HASH_SIZE);
+  const nullifier = action.subarray(HASH_SIZE, 2 * HASH_SIZE);
+  const rk = action.subarray(2 * HASH_SIZE, 3 * HASH_SIZE);
+  const cmxAndEphemeralKey = action.subarray(3 * HASH_SIZE, 5 * HASH_SIZE);
+  const enc = action.subarray(
+    5 * HASH_SIZE,
+    5 * HASH_SIZE + ENC_CIPHERTEXT_SIZE,
+  );
+  const out = action.subarray(5 * HASH_SIZE + ENC_CIPHERTEXT_SIZE);
+
+  return {
+    compact: concatUint8Arrays(
+      nullifier,
+      cmxAndEphemeralKey,
+      enc.subarray(0, ENC_CIPHERTEXT_COMPACT_SIZE),
+    ),
+    memo: enc.subarray(
+      ENC_CIPHERTEXT_COMPACT_SIZE,
+      ENC_CIPHERTEXT_COMPACT_SIZE + MEMO_SIZE,
+    ),
+    nonCompact: concatUint8Arrays(
+      cv,
+      rk,
+      enc.subarray(ENC_CIPHERTEXT_COMPACT_SIZE + MEMO_SIZE),
+      out,
+    ),
+  };
+};
+
+const pushMemoChunks = (chunks: Uint8Array[], memos: Uint8Array[]): void => {
+  const stream = concatUint8Arrays(...memos);
+
+  for (let offset = 0; offset < stream.length; offset += MEMO_CHUNK_SIZE) {
+    chunks.push(stream.subarray(offset, offset + MEMO_CHUNK_SIZE));
+  }
+};
+
+/**
+ * ZIP-244 spreads a shielded description over three digests — compact, memos and
+ * non-compact — and the device app hashes each one from its own stream: it takes
+ * the compact part of every description, then every memo, then every non-compact
+ * part. On chain those fields are interleaved description by description, so they
+ * must be regrouped here; the app hashes as bytes arrive and cannot reorder them.
+ * Sapling spends are the exception and keep their on-chain layout, since the app
+ * reads cv, nullifier and rk individually and routes each to the right digest.
+ */
+const pushShieldedChunks = (
+  chunks: Uint8Array[],
+  bundles: ShieldedBundles,
+): void => {
+  chunks.push(
+    concatUint8Arrays(
+      createVarint(bundles.saplingSpends.length),
+      createVarint(bundles.saplingOutputs.length),
+      createVarint(bundles.orchardActions.length),
+    ),
+  );
+
+  if (bundles.saplingSpends.length > 0 || bundles.saplingOutputs.length > 0) {
+    chunks.push(
+      concatUint8Arrays(bundles.saplingValueBalance, bundles.saplingAnchor),
+    );
+
+    bundles.saplingSpends.forEach((spend) => chunks.push(spend));
+
+    const outputParts = bundles.saplingOutputs.map(saplingOutputDigestParts);
+    outputParts.forEach(({ compact }) => chunks.push(compact));
+    pushMemoChunks(
+      chunks,
+      outputParts.map(({ memo }) => memo),
+    );
+    outputParts.forEach(({ nonCompact }) => chunks.push(nonCompact));
+  }
+
+  if (bundles.orchardActions.length > 0) {
+    const actionParts = bundles.orchardActions.map(orchardActionDigestParts);
+    actionParts.forEach(({ compact }) => chunks.push(compact));
+    pushMemoChunks(
+      chunks,
+      actionParts.map(({ memo }) => memo),
+    );
+    actionParts.forEach(({ nonCompact }) => chunks.push(nonCompact));
+    chunks.push(bundles.orchardDigestData);
+  }
+};
+
 const splitTransactionToTrustedInputChunks = (
   transaction: Uint8Array,
 ): Uint8Array[] => {
   const rawVersion = readUInt32LE(transaction, 0);
   const txVersion = rawVersion & TX_VERSION_MASK;
-  const isTxV4 = txVersion === 4;
+  const isTxV4 = txVersion === TX_VERSION_V4;
+
+  // The device app computes a txid for v4 and v5 only in this flow, and turns
+  // anything newer away with "V6 transaction in legacy path". Naming the version
+  // here beats streaming, say, a v6 as though its bundles followed ZIP-225.
+  if (!isTxV4 && txVersion !== TX_VERSION_V5) {
+    throw new Error(
+      `Unsupported transaction version ${txVersion} while splitting trusted input chunks`,
+    );
+  }
 
   let offset = 0;
   let locktime = new Uint8Array();
@@ -229,120 +459,24 @@ const splitTransactionToTrustedInputChunks = (
     chunks.push(transaction.slice(valueStart, offset));
   }
 
-  const saplingOrchardStart = offset;
-  const saplingSpends = readCompactSize(transaction, offset);
-  offset = saplingSpends.nextOffset;
-  const saplingOutputs = readCompactSize(transaction, offset);
-  offset = saplingOutputs.nextOffset;
-  const orchardActions = readCompactSize(transaction, offset);
-  offset = orchardActions.nextOffset;
-  chunks.push(transaction.slice(saplingOrchardStart, offset));
-
-  if (saplingSpends.value > 0 || saplingOutputs.value > 0) {
-    const saplingHeaderStart = offset;
-    ensureRange(transaction, offset, offset + 8);
-    offset += 8;
-
-    if (saplingSpends.value > 0) {
-      ensureRange(transaction, offset, offset + 32);
-      offset += 32;
-    }
-    chunks.push(transaction.slice(saplingHeaderStart, offset));
-
-    for (
-      let spendIndex = 0;
-      spendIndex < saplingSpends.value;
-      spendIndex += 1
-    ) {
-      const spendStart = offset;
-      ensureRange(transaction, offset, offset + SAPLING_SPEND_SIZE);
-      offset += SAPLING_SPEND_SIZE;
-      chunks.push(transaction.slice(spendStart, offset));
-    }
-
-    for (
-      let outputIndex = 0;
-      outputIndex < saplingOutputs.value;
-      outputIndex += 1
-    ) {
-      const compactStart = offset;
-      ensureRange(transaction, offset, offset + SAPLING_OUTPUT_COMPACT_SIZE);
-      offset += SAPLING_OUTPUT_COMPACT_SIZE;
-      chunks.push(transaction.slice(compactStart, offset));
-    }
-
-    let saplingMemoRemaining = saplingOutputs.value * MEMO_SIZE;
-    while (saplingMemoRemaining > 0) {
-      const memoChunkSize = Math.min(MEMO_CHUNK_SIZE, saplingMemoRemaining);
-      ensureRange(transaction, offset, offset + memoChunkSize);
-      chunks.push(transaction.slice(offset, offset + memoChunkSize));
-      offset += memoChunkSize;
-      saplingMemoRemaining -= memoChunkSize;
-    }
-
-    for (
-      let outputIndex = 0;
-      outputIndex < saplingOutputs.value;
-      outputIndex += 1
-    ) {
-      const nonCompactStart = offset;
-      ensureRange(
-        transaction,
-        offset,
-        offset + SAPLING_OUTPUT_NON_COMPACT_SIZE,
-      );
-      offset += SAPLING_OUTPUT_NON_COMPACT_SIZE;
-      chunks.push(transaction.slice(nonCompactStart, offset));
-    }
-  }
-
-  if (orchardActions.value > 0) {
-    for (
-      let actionIndex = 0;
-      actionIndex < orchardActions.value;
-      actionIndex += 1
-    ) {
-      const compactStart = offset;
-      ensureRange(transaction, offset, offset + ORCHARD_ACTION_COMPACT_SIZE);
-      offset += ORCHARD_ACTION_COMPACT_SIZE;
-      chunks.push(transaction.slice(compactStart, offset));
-    }
-
-    let orchardMemoRemaining = orchardActions.value * MEMO_SIZE;
-    while (orchardMemoRemaining > 0) {
-      const memoChunkSize = Math.min(MEMO_CHUNK_SIZE, orchardMemoRemaining);
-      ensureRange(transaction, offset, offset + memoChunkSize);
-      chunks.push(transaction.slice(offset, offset + memoChunkSize));
-      offset += memoChunkSize;
-      orchardMemoRemaining -= memoChunkSize;
-    }
-
-    for (
-      let actionIndex = 0;
-      actionIndex < orchardActions.value;
-      actionIndex += 1
-    ) {
-      const nonCompactStart = offset;
-      ensureRange(
-        transaction,
-        offset,
-        offset + ORCHARD_ACTION_NON_COMPACT_SIZE,
-      );
-      offset += ORCHARD_ACTION_NON_COMPACT_SIZE;
-      chunks.push(transaction.slice(nonCompactStart, offset));
-    }
-
-    const digestStart = offset;
-    ensureRange(transaction, offset, offset + ORCHARD_DIGEST_DATA_SIZE);
-    offset += ORCHARD_DIGEST_DATA_SIZE;
-    chunks.push(transaction.slice(digestStart, offset));
-  }
-
   if (isTxV4) {
-    chunks.push(transaction.slice(offset));
-  } else {
-    chunks.push(splitV5ExtraData(locktime, expiry));
+    // A v4 previous transaction reaches this point already framed the way the
+    // device expects — three zeroed shielded counts, then locktime, extra data
+    // length and extra data (see `serializeTransaction`), its Sapling fields
+    // travelling in that extra data. Its trailing bytes are forwarded as they
+    // are, the counts keeping the separate chunk the device app was tested with.
+    const spendCount = readCompactSize(transaction, offset);
+    const outputCount = readCompactSize(transaction, spendCount.nextOffset);
+    const actionCount = readCompactSize(transaction, outputCount.nextOffset);
+
+    chunks.push(transaction.slice(offset, actionCount.nextOffset));
+    chunks.push(transaction.slice(actionCount.nextOffset));
+
+    return splitForApduData(chunks);
   }
+
+  pushShieldedChunks(chunks, readShieldedBundles(transaction, offset));
+  chunks.push(splitV5ExtraData(locktime, expiry));
 
   return splitForApduData(chunks);
 };


### PR DESCRIPTION
### 📝 Description

Sending ZAT from an account whose UTXOs come from transactions carrying an Orchard bundle produced a transaction the network could not accept, surfacing as a 504 on broadcast.

The device app hashes one ZIP-244 digest per stream while a trusted input arrives: it consumes the compact part of every shielded description, then every memo, then every non-compact part, and `hash_reader_exact` rejects a digest block split across two APDUs. `GetTrustedInputTask` streamed the previous transaction in its on-chain order instead, where each description keeps its own fields together. The byte count was right (1889 bytes for the reported transaction), only the order was wrong, so the device committed to a txid that no output ever carried. The signed transaction then spent an input that does not exist, and the broadcast timed out.

**Previous behaviour:** for a source transaction with an Orchard bundle, the device returned a txid absent from the chain (`f0e6ff6d…` instead of `218e2834…`), and the resulting transaction was unbroadcastable.

**Fix:** the Sapling and Orchard bundles are read at their real ZIP-225 positions, then re-emitted grouped per ZIP-244 digest, one indivisible block per APDU. The v4 path is untouched, including the chunk boundaries it was validated with on device.

Two details worth flagging for review:

- Correcting Orchard required walking the Sapling bundle correctly too, since the Orchard action count sits after it on chain. No fixture or log available carries a v5 transaction with a non-empty Sapling bundle, so that path is covered by a synthetic vector instead of a real one: every field holds its own marker byte, the expected block sizes are anchored on what the app parser reads (116 / 128 / 96, see `sapling.rs`), and the test asserts that no proof or signature byte reaches the device. It was checked to be discriminating by temporarily injecting a missing binding-signature skip and a shifted group offset, which the pre-existing tests did not catch.
- Transaction versions this flow does not support now fail by name. The app turns v6 away with `V6 transaction in legacy path`, so streaming one as if its bundles followed the v5 layout could only produce a wrong txid.

Verified against the app parser on both `3.0.0` (production) and `3.8.0` (`feat/zcash-integration/ironwood`): the legacy path was renamed and moved there, but the stream format — header, contiguous counters, 148/512/160/41 blocks, digest order, extra-data length check — is identical.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35258
- **Feature**: Zcash transparent send

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - `GetTrustedInputTask` now regroups shielded fields per ZIP-244 digest; the non-regression test replays the Orchard transaction from the 2026-05-12 log and asserts the APDUs match those the device answered with the correct txid — it fails on the previous code.
  - QA focus: sending from a Zcash account funded by transactions with an Orchard bundle (de-shielding), and sending from accounts mixing v4 and v5 sources, which exercise both branches.
  - Manually validated end to end on device, with the signed transaction spending the UTXO Ledger Live selected.

