### PR TITLE
✨ (os-update) [DSDK-1280]: Adds resolve os update path device action

### DIFF
--- a/.changeset/fair-flies-shout.md
+++ b/.changeset/fair-flies-shout.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/dmk-ledger-wallet": minor
+---
+
+Adds ResolveOsUpdatePathDeviceAction

--- a/apps/sample/src/components/DeviceActionsView/AllDeviceActions.tsx
+++ b/apps/sample/src/components/DeviceActionsView/AllDeviceActions.tsx
@@ -81,6 +81,11 @@ import {
   type CreateBackupDAIntermediateValue,
   type CreateBackupDAOutput,
   CreateBackupDeviceAction,
+  type ResolveOsUpdatePathDAError,
+  type ResolveOsUpdatePathDAInput,
+  type ResolveOsUpdatePathDAIntermediateValue,
+  type ResolveOsUpdatePathDAOutput,
+  ResolveOsUpdatePathDeviceAction,
   type RestoreAppsStorageDAError,
   type RestoreAppsStorageDAIntermediateValue,
   type RestoreAppsStorageDAOutput,
@@ -347,6 +352,26 @@ export const AllDeviceActions: React.FC<{ sessionId: string }> = ({
         GetDeviceMetadataDAInput,
         GetDeviceMetadataDAError,
         GetDeviceMetadataDAIntermediateValue
+      >,
+      {
+        title: "Resolve OS update path",
+        description: "Resolve the OS update path for the given device",
+        executeDeviceAction: ({ unlockTimeout }) => {
+          const deviceAction = new ResolveOsUpdatePathDeviceAction({
+            input: { unlockTimeout },
+          });
+          return dmk.executeDeviceAction({
+            sessionId,
+            deviceAction,
+          });
+        },
+        initialValues: { unlockTimeout: UNLOCK_TIMEOUT },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        ResolveOsUpdatePathDAOutput,
+        ResolveOsUpdatePathDAInput,
+        ResolveOsUpdatePathDAError,
+        ResolveOsUpdatePathDAIntermediateValue
       >,
       {
         title: `${SECURE_CHANNEL_ICON} Genuine Check`,

--- a/packages/ledger-wallet/package.json
+++ b/packages/ledger-wallet/package.json
@@ -42,16 +42,18 @@
     "@ledgerhq/signer-utils": "workspace:^",
     "pako": "^2.1.0",
     "purify-ts": "catalog:",
+    "semver": "catalog:",
     "xstate": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/device-management-kit": "workspace:^",
-    "@ledgerhq/ldmk-tool": "workspace:^",
     "@ledgerhq/eslint-config-dsdk": "workspace:^",
+    "@ledgerhq/ldmk-tool": "workspace:^",
     "@ledgerhq/prettier-config-dsdk": "workspace:^",
     "@ledgerhq/tsconfig-dsdk": "workspace:^",
     "@ledgerhq/vitest-config-dmk": "workspace:^",
     "@types/pako": "^2.0.3",
+    "@types/semver": "catalog:",
     "ts-node": "catalog:"
   },
   "peerDependencies": {

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/ResolveOsUpdatePathDeviceAction.test.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/ResolveOsUpdatePathDeviceAction.test.ts
@@ -1,0 +1,340 @@
+import {
+  DeviceActionStatus,
+  type GetOsVersionResponse,
+  UnknownDAError,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+import { type Either, Left, Right } from "purify-ts";
+import { assign, createMachine } from "xstate";
+
+import { makeDeviceActionInternalApiMock } from "@api/device-action/__test-utils__/makeInternalApi";
+import { testDeviceActionStates } from "@api/device-action/__test-utils__/testDeviceActionStates";
+import { ResolveOsUpdatePathDeviceAction } from "@api/device-action/OsUpdate/Resolve/ResolveOsUpdatePathDeviceAction";
+import {
+  GetOsVersionError,
+  ResolveOsUpdatePathError,
+} from "@api/device-action/OsUpdate/Resolve/ResolveOsUpdatePathDeviceActionErrors";
+import { getOsVersion } from "@api/device-action/OsUpdate/Resolve/Substeps/GetOsVersion";
+import { resolveOsUpdatePath } from "@api/device-action/OsUpdate/Resolve/Substeps/ResolveOsUpdatePath";
+import {
+  type OsUpdate,
+  type ResolveOsUpdatePathDAError,
+  type ResolveOsUpdatePathDAState,
+  ResolveOsUpdatePathSteps,
+} from "@api/device-action/OsUpdate/Resolve/types";
+import { goToDashboard } from "@api/device-action/OsUpdate/Shared/Substeps/GoToDashboard";
+import { waitForAppAndVersion } from "@api/device-action/OsUpdate/Shared/Substeps/WaitForAppAndVersion";
+
+vi.mock("@api/device-action/OsUpdate/Shared/Substeps/WaitForAppAndVersion");
+vi.mock("@api/device-action/OsUpdate/Shared/Substeps/GoToDashboard");
+vi.mock("@api/device-action/OsUpdate/Resolve/Substeps/GetOsVersion");
+vi.mock("@api/device-action/OsUpdate/Resolve/Substeps/ResolveOsUpdatePath");
+
+const pendingState = (
+  step: ResolveOsUpdatePathSteps,
+): ResolveOsUpdatePathDAState => ({
+  status: DeviceActionStatus.Pending,
+  intermediateValue: {
+    requiredUserInteraction: UserInteractionRequired.None,
+    step,
+  },
+});
+
+const completedState = (output: OsUpdate[]): ResolveOsUpdatePathDAState => ({
+  status: DeviceActionStatus.Completed,
+  output,
+});
+
+const errorState = (
+  error: ResolveOsUpdatePathDAError,
+): ResolveOsUpdatePathDAState => ({
+  status: DeviceActionStatus.Error,
+  error,
+});
+
+const createMockActorMachineFromOutput = (
+  output: () => Either<unknown, unknown>,
+) =>
+  createMachine({
+    initial: "ready",
+    states: {
+      ready: {
+        after: { 0: "done" },
+        entry: assign({
+          intermediateValue: () => ({
+            requiredUserInteraction: UserInteractionRequired.None,
+          }),
+        }),
+      },
+      done: { type: "final" },
+    },
+    output,
+  });
+
+const createMockActorMachine = (output: Either<unknown, unknown>) =>
+  createMockActorMachineFromOutput(() => output);
+
+describe("ResolveOsUpdatePathDeviceAction", () => {
+  const getOsVersionResponse = {
+    isBootloader: false,
+    isOsu: false,
+    targetId: 0x33200004,
+    seTargetId: 0x33200004,
+    mcuTargetId: undefined,
+    seVersion: "1.3.0",
+    seFlags: new Uint8Array([0xe6, 0x00, 0x00, 0x00]),
+    mcuSephVersion: "5.24",
+    mcuBootloaderVersion: "0.48",
+    hwVersion: "00",
+    langId: 0,
+    recoverState: undefined,
+    secureElementFlags: {
+      isPinValidated: true,
+      hasMcuSerialNumber: true,
+      hasValidCertificate: true,
+      isCustomAuthorityConnectionAllowed: false,
+      isSecureConnectionAllowed: false,
+      isOnboarded: true,
+      isMcuCodeSigned: true,
+      isInRecoveryMode: false,
+    },
+  } satisfies GetOsVersionResponse;
+
+  const osUpdates = [
+    {
+      osuFirmware: {
+        id: 200,
+        notes: "Update notes",
+        perso: "perso",
+        firmware: "osu",
+        firmwareKey: "osu-key",
+        hash: "osu-hash",
+        nextFinalFirmware: 300,
+      },
+      finalFirmware: {
+        id: 300,
+        version: "1.4.0",
+        perso: "perso",
+        firmware: "final",
+        firmwareKey: "final-key",
+        hash: "final-hash",
+        bytes: 123,
+        mcuVersions: [1],
+      },
+      shouldFlashMcu: false,
+    },
+  ] satisfies OsUpdate[];
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const setupWaitForAppAndVersion = (appName = "BOLOS") =>
+    vi.mocked(waitForAppAndVersion).mockReturnValue(
+      createMockActorMachine(
+        Right({
+          name: appName,
+          version: "1.0.0",
+        }),
+      ) as unknown as ReturnType<typeof waitForAppAndVersion>,
+    );
+
+  const setupWaitForAppAndVersionSequence = (appNames: string[]) => {
+    const remainingAppNames = [...appNames];
+    vi.mocked(waitForAppAndVersion).mockReturnValue(
+      createMockActorMachineFromOutput(() =>
+        Right({
+          name: remainingAppNames.shift() ?? "BOLOS",
+          version: "1.0.0",
+        }),
+      ) as unknown as ReturnType<typeof waitForAppAndVersion>,
+    );
+  };
+
+  const setupGoToDashboard = (
+    output: Either<unknown, unknown> = Right(undefined),
+  ) =>
+    vi
+      .mocked(goToDashboard)
+      .mockReturnValue(
+        createMockActorMachine(output) as unknown as ReturnType<
+          typeof goToDashboard
+        >,
+      );
+
+  const setupGetOsVersion = (
+    result: Either<unknown, GetOsVersionResponse> = Right(getOsVersionResponse),
+  ) =>
+    vi
+      .mocked(getOsVersion)
+      .mockReturnValue(
+        () =>
+          Promise.resolve(result) as ReturnType<
+            ReturnType<typeof getOsVersion>
+          >,
+      );
+
+  const setupResolveOsUpdatePath = (
+    result: Either<unknown, OsUpdate[]> = Right(osUpdates),
+  ) =>
+    vi
+      .mocked(resolveOsUpdatePath)
+      .mockReturnValue(
+        () =>
+          Promise.resolve(result) as ReturnType<
+            ReturnType<typeof resolveOsUpdatePath>
+          >,
+      );
+
+  const makeDeviceAction = () =>
+    new ResolveOsUpdatePathDeviceAction({
+      input: {
+        unlockTimeout: 30_000,
+      },
+    });
+
+  describe("Success", () => {
+    it("Should complete the resolve flow when the device is already on dashboard", () =>
+      new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersion();
+        setupGetOsVersion();
+        setupResolveOsUpdatePath();
+
+        const expectedStates: ResolveOsUpdatePathDAState[] = [
+          pendingState(ResolveOsUpdatePathSteps.WaitForAppAndVersion),
+          pendingState(ResolveOsUpdatePathSteps.WaitForAppAndVersion),
+          pendingState(ResolveOsUpdatePathSteps.GetOsVersion),
+          pendingState(ResolveOsUpdatePathSteps.ResolveOsUpdatePath),
+          completedState(osUpdates),
+        ];
+
+        testDeviceActionStates(
+          makeDeviceAction(),
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          { onDone: resolve, onError: reject },
+        );
+      }));
+
+    it("Should go to dashboard and wait for app and version again when an app is open", () =>
+      new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersionSequence(["Bitcoin", "BOLOS"]);
+        setupGoToDashboard();
+        setupGetOsVersion();
+        setupResolveOsUpdatePath();
+
+        const expectedStates: ResolveOsUpdatePathDAState[] = [
+          pendingState(ResolveOsUpdatePathSteps.WaitForAppAndVersion),
+          pendingState(ResolveOsUpdatePathSteps.WaitForAppAndVersion),
+          pendingState(ResolveOsUpdatePathSteps.GoToDashboard),
+          pendingState(ResolveOsUpdatePathSteps.GoToDashboard),
+          pendingState(ResolveOsUpdatePathSteps.WaitForAppAndVersion),
+          pendingState(ResolveOsUpdatePathSteps.WaitForAppAndVersion),
+          pendingState(ResolveOsUpdatePathSteps.GetOsVersion),
+          pendingState(ResolveOsUpdatePathSteps.ResolveOsUpdatePath),
+          completedState(osUpdates),
+        ];
+
+        testDeviceActionStates(
+          makeDeviceAction(),
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          { onDone: resolve, onError: reject },
+        );
+      }));
+  });
+
+  describe("Error", () => {
+    it("Should go to Error when waitForAppAndVersion returns Left", () =>
+      new Promise<void>((resolve, reject) => {
+        const error = new UnknownDAError("waitForAppAndVersion failed");
+        vi.mocked(waitForAppAndVersion).mockReturnValue(
+          createMockActorMachine(Left(error)) as unknown as ReturnType<
+            typeof waitForAppAndVersion
+          >,
+        );
+
+        const expectedStates: ResolveOsUpdatePathDAState[] = [
+          pendingState(ResolveOsUpdatePathSteps.WaitForAppAndVersion),
+          pendingState(ResolveOsUpdatePathSteps.WaitForAppAndVersion),
+          errorState(error),
+        ];
+
+        testDeviceActionStates(
+          makeDeviceAction(),
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          { onDone: resolve, onError: reject },
+        );
+      }));
+
+    it("Should go to Error when goToDashboard returns Left", () =>
+      new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersion("Bitcoin");
+        const error = new UnknownDAError("goToDashboard failed");
+        setupGoToDashboard(Left(error));
+
+        const expectedStates: ResolveOsUpdatePathDAState[] = [
+          pendingState(ResolveOsUpdatePathSteps.WaitForAppAndVersion),
+          pendingState(ResolveOsUpdatePathSteps.WaitForAppAndVersion),
+          pendingState(ResolveOsUpdatePathSteps.GoToDashboard),
+          pendingState(ResolveOsUpdatePathSteps.GoToDashboard),
+          errorState(error),
+        ];
+
+        testDeviceActionStates(
+          makeDeviceAction(),
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          { onDone: resolve, onError: reject },
+        );
+      }));
+
+    it("Should go to Error when getOsVersion returns Left", () =>
+      new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersion();
+        const error = new GetOsVersionError(new Error("command failed"));
+        setupGetOsVersion(Left(error));
+        setupResolveOsUpdatePath();
+
+        const expectedStates: ResolveOsUpdatePathDAState[] = [
+          pendingState(ResolveOsUpdatePathSteps.WaitForAppAndVersion),
+          pendingState(ResolveOsUpdatePathSteps.WaitForAppAndVersion),
+          pendingState(ResolveOsUpdatePathSteps.GetOsVersion),
+          errorState(error),
+        ];
+
+        testDeviceActionStates(
+          makeDeviceAction(),
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          { onDone: resolve, onError: reject },
+        );
+      }));
+
+    it("Should go to Error when resolveOsUpdatePath returns Left", () =>
+      new Promise<void>((resolve, reject) => {
+        setupWaitForAppAndVersion();
+        setupGetOsVersion();
+        const error = new ResolveOsUpdatePathError(
+          new Error("manager api failed"),
+        );
+        setupResolveOsUpdatePath(Left(error));
+
+        const expectedStates: ResolveOsUpdatePathDAState[] = [
+          pendingState(ResolveOsUpdatePathSteps.WaitForAppAndVersion),
+          pendingState(ResolveOsUpdatePathSteps.WaitForAppAndVersion),
+          pendingState(ResolveOsUpdatePathSteps.GetOsVersion),
+          pendingState(ResolveOsUpdatePathSteps.ResolveOsUpdatePath),
+          errorState(error),
+        ];
+
+        testDeviceActionStates(
+          makeDeviceAction(),
+          expectedStates,
+          makeDeviceActionInternalApiMock(),
+          { onDone: resolve, onError: reject },
+        );
+      }));
+  });
+});

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/ResolveOsUpdatePathDeviceAction.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/ResolveOsUpdatePathDeviceAction.ts
@@ -1,0 +1,317 @@
+import {
+  type DeviceActionStateMachine,
+  type InternalApi,
+  isDashboardName,
+  type StateMachineTypes,
+  UserInteractionRequired,
+  XStateDeviceAction,
+} from "@ledgerhq/device-management-kit";
+import { Left, Right } from "purify-ts";
+import { assign, fromPromise, setup } from "xstate";
+
+import { goToDashboard } from "@api/device-action/OsUpdate/Shared/Substeps/GoToDashboard";
+import { waitForAppAndVersion } from "@api/device-action/OsUpdate/Shared/Substeps/WaitForAppAndVersion";
+
+import { getOsVersion } from "./Substeps/GetOsVersion";
+import { resolveOsUpdatePath } from "./Substeps/ResolveOsUpdatePath";
+import {
+  type ResolveOsUpdatePathDAError,
+  type ResolveOsUpdatePathDAInput,
+  type ResolveOsUpdatePathDAIntermediateValue,
+  type ResolveOsUpdatePathDAInternalState,
+  type ResolveOsUpdatePathDAOutput,
+  ResolveOsUpdatePathSteps,
+} from "./types";
+
+export class ResolveOsUpdatePathDeviceAction extends XStateDeviceAction<
+  ResolveOsUpdatePathDAOutput,
+  ResolveOsUpdatePathDAInput,
+  ResolveOsUpdatePathDAError,
+  ResolveOsUpdatePathDAIntermediateValue,
+  ResolveOsUpdatePathDAInternalState
+> {
+  protected override makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    ResolveOsUpdatePathDAOutput,
+    ResolveOsUpdatePathDAInput,
+    ResolveOsUpdatePathDAError,
+    ResolveOsUpdatePathDAIntermediateValue,
+    ResolveOsUpdatePathDAInternalState
+  > {
+    type types = StateMachineTypes<
+      ResolveOsUpdatePathDAOutput,
+      ResolveOsUpdatePathDAInput,
+      ResolveOsUpdatePathDAError,
+      ResolveOsUpdatePathDAIntermediateValue,
+      ResolveOsUpdatePathDAInternalState
+    >;
+
+    return setup({
+      types: {
+        input: {} as types["input"],
+        output: {} as types["output"],
+        context: {} as types["context"],
+      } as types,
+      actors: {
+        waitForAppAndVersion: waitForAppAndVersion(
+          internalApi,
+          this.input.unlockTimeout,
+        ),
+        goToDashboard: goToDashboard(internalApi, this.input.unlockTimeout),
+        getOsVersion: fromPromise(getOsVersion(internalApi)),
+        resolveOsUpdatePath: fromPromise(resolveOsUpdatePath(internalApi)),
+      },
+      guards: {
+        isDeviceOnDashboard: ({ context }) =>
+          isDashboardName(context._internalState.currentApp),
+        hasError: ({ context }) => context._internalState.error !== null,
+      },
+      actions: {
+        assignErrorFromEvent: assign({
+          _internalState: (_) => ({
+            ..._.context._internalState,
+            error: _.event["error"], // NOTE: should never happen
+          }),
+        }),
+      },
+    }).createMachine({
+      id: "ResolveOsUpdatePathDeviceAction",
+      initial: "WaitForAppAndVersion",
+      context: ({ input }) => ({
+        input: {
+          unlockTimeout: input.unlockTimeout,
+        },
+        intermediateValue: {
+          requiredUserInteraction: UserInteractionRequired.None,
+          step: ResolveOsUpdatePathSteps.Idle,
+        },
+        _internalState: {
+          error: null,
+          currentApp: null,
+          getOsVersionResponse: null,
+          osUpdates: [],
+        },
+      }),
+      states: {
+        WaitForAppAndVersion: {
+          entry: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              step: ResolveOsUpdatePathSteps.WaitForAppAndVersion,
+            }),
+          }),
+          invoke: {
+            src: "waitForAppAndVersion",
+            input: ({ context }) => ({
+              unlockTimeout: context.input.unlockTimeout,
+            }),
+            onSnapshot: {
+              actions: assign({
+                intermediateValue: (_) => ({
+                  ..._.event.snapshot.context.intermediateValue,
+                  step: _.context.intermediateValue.step,
+                }),
+              }),
+            },
+            onDone: {
+              actions: assign({
+                _internalState: (_) => {
+                  return _.event.output.caseOf<ResolveOsUpdatePathDAInternalState>(
+                    {
+                      Left: (error) => ({
+                        ..._.context._internalState,
+                        error,
+                      }),
+                      Right: (output) => ({
+                        ..._.context._internalState,
+                        currentApp: output.name,
+                      }),
+                    },
+                  );
+                },
+              }),
+              target: "CheckIfDeviceIsOnDashboard",
+            },
+            onError: {
+              actions: "assignErrorFromEvent",
+              target: "Error",
+            },
+          },
+        },
+        CheckIfDeviceIsOnDashboard: {
+          always: [
+            {
+              guard: "hasError",
+              target: "Error",
+            },
+            {
+              guard: "isDeviceOnDashboard",
+              target: "GetOsVersion",
+            },
+            {
+              target: "GoToDashboard",
+            },
+          ],
+        },
+        GoToDashboard: {
+          entry: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              step: ResolveOsUpdatePathSteps.GoToDashboard,
+            }),
+          }),
+          invoke: {
+            src: "goToDashboard",
+            input: ({ context }) => ({
+              unlockTimeout: context.input.unlockTimeout,
+            }),
+            onSnapshot: {
+              actions: assign({
+                intermediateValue: (_) => ({
+                  ..._.event.snapshot.context.intermediateValue,
+                  step: _.context.intermediateValue.step,
+                }),
+              }),
+            },
+            onDone: {
+              actions: assign({
+                _internalState: (_) => {
+                  return _.event.output.caseOf<ResolveOsUpdatePathDAInternalState>(
+                    {
+                      Left: (error) => ({
+                        ..._.context._internalState,
+                        error,
+                      }),
+                      Right: () => _.context._internalState,
+                    },
+                  );
+                },
+              }),
+              target: "CheckGoToDashboard",
+            },
+            onError: {
+              actions: "assignErrorFromEvent",
+              target: "Error",
+            },
+          },
+        },
+        CheckGoToDashboard: {
+          always: [
+            {
+              guard: "hasError",
+              target: "Error",
+            },
+            {
+              target: "WaitForAppAndVersion",
+            },
+          ],
+        },
+        GetOsVersion: {
+          entry: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              step: ResolveOsUpdatePathSteps.GetOsVersion,
+            }),
+          }),
+          invoke: {
+            src: "getOsVersion",
+            onDone: {
+              actions: assign({
+                _internalState: (_) => {
+                  return _.event.output.caseOf<ResolveOsUpdatePathDAInternalState>(
+                    {
+                      Left: (error) => ({
+                        ..._.context._internalState,
+                        error,
+                      }),
+                      Right: (getOsVersionResponse) => ({
+                        ..._.context._internalState,
+                        getOsVersionResponse,
+                      }),
+                    },
+                  );
+                },
+              }),
+              target: "CheckGetOsVersion",
+            },
+            onError: {
+              actions: "assignErrorFromEvent",
+              target: "Error",
+            },
+          },
+        },
+        CheckGetOsVersion: {
+          always: [
+            {
+              guard: "hasError",
+              target: "Error",
+            },
+            {
+              target: "ResolveOsUpdatePath",
+            },
+          ],
+        },
+        ResolveOsUpdatePath: {
+          entry: assign({
+            intermediateValue: (_) => ({
+              ..._.context.intermediateValue,
+              step: ResolveOsUpdatePathSteps.ResolveOsUpdatePath,
+            }),
+          }),
+          invoke: {
+            src: "resolveOsUpdatePath",
+            input: ({ context }) => ({
+              getOsVersionResponse:
+                context._internalState.getOsVersionResponse!,
+            }),
+            onDone: {
+              actions: assign({
+                _internalState: (_) => {
+                  return _.event.output.caseOf<ResolveOsUpdatePathDAInternalState>(
+                    {
+                      Left: (error) => ({
+                        ..._.context._internalState,
+                        error,
+                      }),
+                      Right: (osUpdates) => ({
+                        ..._.context._internalState,
+                        osUpdates,
+                      }),
+                    },
+                  );
+                },
+              }),
+              target: "CheckResolveOsUpdatePath",
+            },
+            onError: {
+              actions: "assignErrorFromEvent",
+              target: "Error",
+            },
+          },
+        },
+        CheckResolveOsUpdatePath: {
+          always: [
+            {
+              guard: "hasError",
+              target: "Error",
+            },
+            {
+              target: "Success",
+            },
+          ],
+        },
+        Success: {
+          type: "final",
+        },
+        Error: {
+          type: "final",
+        },
+      },
+      output: ({ context }) =>
+        context._internalState.error !== null
+          ? Left(context._internalState.error)
+          : Right(context._internalState.osUpdates),
+    });
+  }
+}

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/ResolveOsUpdatePathDeviceActionErrors.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/ResolveOsUpdatePathDeviceActionErrors.ts
@@ -1,0 +1,23 @@
+import { type DmkError } from "@ledgerhq/device-management-kit";
+
+export class GetOsVersionError implements DmkError {
+  readonly _tag = "GetOsVersionError";
+  readonly originalError?: unknown;
+
+  constructor(originalError?: unknown) {
+    this.originalError = originalError;
+  }
+}
+
+export class ResolveOsUpdatePathError implements DmkError {
+  readonly _tag = "ResolveOsUpdatePathError";
+  readonly originalError?: unknown;
+
+  constructor(originalError?: unknown) {
+    this.originalError = originalError;
+  }
+}
+
+export type ResolveOsUpdatePathDAErrors =
+  | GetOsVersionError
+  | ResolveOsUpdatePathError;

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/Substeps/GetOsVersion.test.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/Substeps/GetOsVersion.test.ts
@@ -1,0 +1,73 @@
+import {
+  CommandResultFactory,
+  GLOBAL_ERRORS,
+  GlobalCommandError,
+} from "@ledgerhq/device-management-kit";
+
+import { makeDeviceActionInternalApiMock } from "@api/device-action/__test-utils__/makeInternalApi";
+import { GetOsVersionError } from "@api/device-action/OsUpdate/Resolve/ResolveOsUpdatePathDeviceActionErrors";
+import { getOsVersion } from "@api/device-action/OsUpdate/Resolve/Substeps/GetOsVersion";
+
+describe("GetOsVersion", () => {
+  const apiMock = makeDeviceActionInternalApiMock();
+  const { sendCommand: sendCommandMock } = apiMock;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("Success", () => {
+    it("Should return the OS version response", async () => {
+      const osVersion = {
+        isBootloader: false,
+        isOsu: false,
+        targetId: 0x33200004,
+        seTargetId: 0x33200004,
+        mcuTargetId: undefined,
+        seVersion: "1.3.0",
+        seFlags: new Uint8Array([0xe6, 0x00, 0x00, 0x00]),
+        mcuSephVersion: "5.24",
+        mcuBootloaderVersion: "0.48",
+        hwVersion: "00",
+        langId: 0,
+        recoverState: undefined,
+        secureElementFlags: {
+          isPinValidated: true,
+          hasMcuSerialNumber: true,
+          hasValidCertificate: true,
+          isCustomAuthorityConnectionAllowed: false,
+          isSecureConnectionAllowed: false,
+          isOnboarded: true,
+          isMcuCodeSigned: true,
+          isInRecoveryMode: false,
+        },
+      };
+      sendCommandMock.mockResolvedValueOnce(
+        CommandResultFactory({ data: osVersion }),
+      );
+
+      const result = await getOsVersion(apiMock)();
+
+      expect(result.isRight()).toBe(true);
+      expect(result.extract()).toEqual(osVersion);
+    });
+  });
+
+  describe("Error", () => {
+    it("Should return GetOsVersionError", async () => {
+      const error = new GlobalCommandError({
+        errorCode: "6e00",
+        ...GLOBAL_ERRORS["6e00"],
+      });
+      sendCommandMock.mockResolvedValueOnce(CommandResultFactory({ error }));
+
+      const result = await getOsVersion(apiMock)();
+
+      expect(result.isLeft()).toBe(true);
+      result.mapLeft((e) => {
+        expect(e).toBeInstanceOf(GetOsVersionError);
+        expect(e.originalError).toBe(error.originalError);
+      });
+    });
+  });
+});

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/Substeps/GetOsVersion.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/Substeps/GetOsVersion.ts
@@ -1,0 +1,27 @@
+import {
+  GetOsVersionCommand,
+  type GetOsVersionResponse,
+  type InternalApi,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+import { type Either, Left, Right } from "purify-ts/Either";
+
+import { GetOsVersionError } from "@api/device-action/OsUpdate/Resolve/ResolveOsUpdatePathDeviceActionErrors";
+
+type GetOsVersionHandlerResponse = Promise<
+  Either<GetOsVersionError, GetOsVersionResponse>
+>;
+
+type GetOsVersionHandler = () => GetOsVersionHandlerResponse;
+
+export const getOsVersion =
+  (internalApi: InternalApi): GetOsVersionHandler =>
+  async (): GetOsVersionHandlerResponse => {
+    const result = await internalApi.sendCommand(new GetOsVersionCommand());
+
+    if (!isSuccessCommandResult(result)) {
+      return Left(new GetOsVersionError(result.error.originalError));
+    }
+
+    return Right(result.data);
+  };

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/Substeps/ResolveOsUpdatePath.test.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/Substeps/ResolveOsUpdatePath.test.ts
@@ -1,0 +1,354 @@
+import { type GetOsVersionResponse } from "@ledgerhq/device-management-kit";
+import { EitherAsync, Just, Nothing } from "purify-ts";
+
+import { makeDeviceActionInternalApiMock } from "@api/device-action/__test-utils__/makeInternalApi";
+import { ResolveOsUpdatePathError } from "@api/device-action/OsUpdate/Resolve/ResolveOsUpdatePathDeviceActionErrors";
+import { resolveOsUpdatePath } from "@api/device-action/OsUpdate/Resolve/Substeps/ResolveOsUpdatePath";
+import {
+  type FinalFirmware,
+  type McuFirmware,
+  type OsuFirmware,
+} from "@api/device-action/OsUpdate/Resolve/types";
+
+const rightAsync = <T>(value: T) =>
+  EitherAsync<unknown, T>(() => Promise.resolve(value));
+
+const leftAsync = (error: unknown) =>
+  EitherAsync<unknown, never>(({ throwE }) => Promise.resolve(throwE(error)));
+
+describe("ResolveOsUpdatePath", () => {
+  const apiMock = makeDeviceActionInternalApiMock();
+
+  const getOsVersionResponse = {
+    isBootloader: false,
+    isOsu: false,
+    targetId: 0x33200004,
+    seTargetId: 0x33200004,
+    mcuTargetId: undefined,
+    seVersion: "1.3.0",
+    seFlags: new Uint8Array([0xe6, 0x00, 0x00, 0x00]),
+    mcuSephVersion: "1.0.0",
+    mcuBootloaderVersion: "0.48",
+    hwVersion: "00",
+    langId: 0,
+    recoverState: undefined,
+    secureElementFlags: {
+      isPinValidated: true,
+      hasMcuSerialNumber: true,
+      hasValidCertificate: true,
+      isCustomAuthorityConnectionAllowed: false,
+      isSecureConnectionAllowed: false,
+      isOnboarded: true,
+      isMcuCodeSigned: true,
+      isInRecoveryMode: false,
+    },
+  } satisfies GetOsVersionResponse;
+
+  const deviceVersion = {
+    id: 17,
+    target_id: "857735172",
+    name: "Ledger Stax",
+  };
+
+  const currentFirmware = {
+    id: 100,
+    version: "1.3.0",
+    perso: "perso",
+    firmware: null,
+    firmwareKey: null,
+    hash: null,
+    bytes: null,
+    mcuVersions: [1],
+  } satisfies FinalFirmware;
+
+  const firstOsuFirmware = {
+    id: 200,
+    notes: "Update notes",
+    perso: "perso",
+    firmware: "osu",
+    firmwareKey: "osu-key",
+    hash: "osu-hash",
+    nextFinalFirmware: 300,
+  } satisfies OsuFirmware;
+
+  const secondOsuFirmware = {
+    ...firstOsuFirmware,
+    id: 201,
+    nextFinalFirmware: 301,
+  } satisfies OsuFirmware;
+
+  const firstFinalFirmware = {
+    id: 300,
+    version: "1.4.0",
+    perso: "perso",
+    firmware: "final",
+    firmwareKey: "final-key",
+    hash: "final-hash",
+    bytes: 123,
+    mcuVersions: [1],
+  } satisfies FinalFirmware;
+
+  const secondFinalFirmware = {
+    ...firstFinalFirmware,
+    id: 301,
+    version: "1.5.0",
+    mcuVersions: [3],
+  } satisfies FinalFirmware;
+
+  const mcuList = [
+    {
+      id: 1,
+      name: "1.0.0",
+      fromBootloaderVersion: "0.0",
+    },
+    {
+      id: 3,
+      name: "3.0.0",
+      fromBootloaderVersion: "0.0",
+    },
+  ] satisfies McuFirmware[];
+
+  const managerApiMock = {
+    getMcuList: vi.fn(),
+    getDeviceVersion: vi.fn(),
+    getFirmwareVersion: vi.fn(),
+    getOsuFirmwareVersion: vi.fn(),
+    getLatestFirmwareVersion: vi.fn(),
+    getNextFirmwareVersion: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    apiMock.getManagerApiService.mockReturnValue(managerApiMock as never);
+    managerApiMock.getMcuList.mockReturnValue(rightAsync(mcuList));
+    managerApiMock.getDeviceVersion.mockReturnValue(rightAsync(deviceVersion));
+    managerApiMock.getFirmwareVersion.mockReturnValue(
+      rightAsync(currentFirmware),
+    );
+    managerApiMock.getLatestFirmwareVersion.mockReturnValue(
+      rightAsync(Just(firstOsuFirmware)),
+    );
+    managerApiMock.getOsuFirmwareVersion.mockReturnValue(
+      rightAsync(firstOsuFirmware),
+    );
+    managerApiMock.getNextFirmwareVersion.mockReturnValue(
+      rightAsync(firstFinalFirmware),
+    );
+  });
+
+  describe("Success", () => {
+    it("Should return an empty update path when no firmware update is available", async () => {
+      managerApiMock.getLatestFirmwareVersion.mockReturnValueOnce(
+        rightAsync(Nothing),
+      );
+
+      const result = await resolveOsUpdatePath(apiMock)({
+        input: { getOsVersionResponse },
+      });
+
+      expect(result.extract()).toEqual([]);
+      expect(managerApiMock.getDeviceVersion).toHaveBeenCalledWith(
+        getOsVersionResponse,
+      );
+      expect(managerApiMock.getFirmwareVersion).toHaveBeenCalledWith(
+        getOsVersionResponse,
+        deviceVersion,
+      );
+      expect(managerApiMock.getLatestFirmwareVersion).toHaveBeenCalledWith(
+        currentFirmware,
+        deviceVersion,
+      );
+      expect(managerApiMock.getNextFirmwareVersion).not.toHaveBeenCalled();
+    });
+
+    it("Should resolve a single update without MCU flash when the final firmware supports the current MCU", async () => {
+      managerApiMock.getLatestFirmwareVersion
+        .mockReturnValueOnce(rightAsync(Just(firstOsuFirmware)))
+        .mockReturnValueOnce(rightAsync(Nothing));
+
+      const result = await resolveOsUpdatePath(apiMock)({
+        input: { getOsVersionResponse },
+      });
+
+      expect(result.extract()).toEqual([
+        {
+          osuFirmware: firstOsuFirmware,
+          finalFirmware: firstFinalFirmware,
+          shouldFlashMcu: false,
+        },
+      ]);
+    });
+
+    it("Should resolve OSU mode from the OSU firmware endpoint", async () => {
+      managerApiMock.getLatestFirmwareVersion.mockReturnValueOnce(
+        rightAsync(Nothing),
+      );
+
+      const osVersionResponse = {
+        ...getOsVersionResponse,
+        isOsu: true,
+      } satisfies GetOsVersionResponse;
+      const result = await resolveOsUpdatePath(apiMock)({
+        input: { getOsVersionResponse: osVersionResponse },
+      });
+
+      expect(result.extract()).toEqual([
+        {
+          osuFirmware: firstOsuFirmware,
+          finalFirmware: firstFinalFirmware,
+          shouldFlashMcu: false,
+        },
+      ]);
+      expect(managerApiMock.getOsuFirmwareVersion).toHaveBeenCalledWith(
+        osVersionResponse,
+        deviceVersion,
+      );
+      expect(managerApiMock.getFirmwareVersion).not.toHaveBeenCalled();
+    });
+
+    it("Should resolve multiple updates and flag the one requiring an MCU flash", async () => {
+      managerApiMock.getLatestFirmwareVersion
+        .mockReturnValueOnce(rightAsync(Just(firstOsuFirmware)))
+        .mockReturnValueOnce(rightAsync(Just(secondOsuFirmware)))
+        .mockReturnValueOnce(rightAsync(Nothing));
+      managerApiMock.getNextFirmwareVersion
+        .mockReturnValueOnce(rightAsync(firstFinalFirmware))
+        .mockReturnValueOnce(rightAsync(secondFinalFirmware));
+
+      const result = await resolveOsUpdatePath(apiMock)({
+        input: { getOsVersionResponse },
+      });
+
+      expect(result.extract()).toEqual([
+        {
+          osuFirmware: firstOsuFirmware,
+          finalFirmware: firstFinalFirmware,
+          shouldFlashMcu: false,
+        },
+        {
+          osuFirmware: secondOsuFirmware,
+          finalFirmware: secondFinalFirmware,
+          shouldFlashMcu: true,
+        },
+      ]);
+      expect(managerApiMock.getDeviceVersion).toHaveBeenCalledTimes(1);
+      expect(managerApiMock.getLatestFirmwareVersion).toHaveBeenNthCalledWith(
+        2,
+        firstFinalFirmware,
+        deviceVersion,
+      );
+    });
+
+    it("Should resolve the latest compatible MCU when MCU names are not strict semver", async () => {
+      const managerMcuList = [
+        {
+          id: 1,
+          name: "1.0",
+          fromBootloaderVersion: "0.0",
+        },
+        {
+          id: 2,
+          name: "1.1",
+          fromBootloaderVersion: "0.0",
+        },
+        {
+          id: 3,
+          name: "1.2",
+          fromBootloaderVersion: "0.0",
+        },
+      ] satisfies McuFirmware[];
+      const finalFirmwareRequiringMcuFlash = {
+        ...firstFinalFirmware,
+        mcuVersions: [2, 3],
+      } satisfies FinalFirmware;
+      const finalFirmwareSupportingLatestMcu = {
+        ...secondFinalFirmware,
+        mcuVersions: [3],
+      } satisfies FinalFirmware;
+
+      managerApiMock.getMcuList.mockReturnValueOnce(rightAsync(managerMcuList));
+      managerApiMock.getLatestFirmwareVersion
+        .mockReturnValueOnce(rightAsync(Just(firstOsuFirmware)))
+        .mockReturnValueOnce(rightAsync(Just(secondOsuFirmware)))
+        .mockReturnValueOnce(rightAsync(Nothing));
+      managerApiMock.getNextFirmwareVersion
+        .mockReturnValueOnce(rightAsync(finalFirmwareRequiringMcuFlash))
+        .mockReturnValueOnce(rightAsync(finalFirmwareSupportingLatestMcu));
+
+      const result = await resolveOsUpdatePath(apiMock)({
+        input: {
+          getOsVersionResponse: {
+            ...getOsVersionResponse,
+            mcuSephVersion: "1.0",
+          },
+        },
+      });
+
+      expect(result.extract()).toEqual([
+        {
+          osuFirmware: firstOsuFirmware,
+          finalFirmware: finalFirmwareRequiringMcuFlash,
+          shouldFlashMcu: true,
+        },
+        {
+          osuFirmware: secondOsuFirmware,
+          finalFirmware: finalFirmwareSupportingLatestMcu,
+          shouldFlashMcu: false,
+        },
+      ]);
+    });
+  });
+
+  describe("Error", () => {
+    it("Should return ResolveOsUpdatePathError when the MCU list cannot be fetched", async () => {
+      const error = new Error("mcu list failed");
+      managerApiMock.getMcuList.mockReturnValueOnce(leftAsync(error));
+
+      const result = await resolveOsUpdatePath(apiMock)({
+        input: { getOsVersionResponse },
+      });
+
+      expect(result.isLeft()).toBe(true);
+      result.mapLeft((e) => {
+        expect(e).toBeInstanceOf(ResolveOsUpdatePathError);
+        expect(e.originalError).toBe(error);
+      });
+    });
+
+    it("Should return ResolveOsUpdatePathError when the current MCU version is unknown", async () => {
+      const result = await resolveOsUpdatePath(apiMock)({
+        input: {
+          getOsVersionResponse: {
+            ...getOsVersionResponse,
+            mcuSephVersion: "9.9.9",
+          },
+        },
+      });
+
+      expect(result.isLeft()).toBe(true);
+      result.mapLeft((e) => {
+        expect(e).toBeInstanceOf(ResolveOsUpdatePathError);
+        expect(e.originalError).toBe("No MCU firmware found for version 9.9.9");
+      });
+    });
+
+    it("Should return ResolveOsUpdatePathError when no compatible MCU can be resolved for the next firmware", async () => {
+      managerApiMock.getNextFirmwareVersion.mockReturnValueOnce(
+        rightAsync({
+          ...firstFinalFirmware,
+          mcuVersions: [42],
+        }),
+      );
+
+      const result = await resolveOsUpdatePath(apiMock)({
+        input: { getOsVersionResponse },
+      });
+
+      expect(result.isLeft()).toBe(true);
+      result.mapLeft((e) => {
+        expect(e).toBeInstanceOf(ResolveOsUpdatePathError);
+        expect(e.originalError).toBe("No MCU firmware found for version null");
+      });
+    });
+  });
+});

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/Substeps/ResolveOsUpdatePath.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/Substeps/ResolveOsUpdatePath.ts
@@ -1,0 +1,195 @@
+import {
+  type GetOsVersionResponse,
+  type InternalApi,
+} from "@ledgerhq/device-management-kit";
+import { type Either, EitherAsync, Just, Maybe } from "purify-ts";
+import { coerce, compare } from "semver";
+
+import { ResolveOsUpdatePathError } from "@api/device-action/OsUpdate/Resolve/ResolveOsUpdatePathDeviceActionErrors";
+import {
+  type FinalFirmware,
+  type McuFirmware,
+  type OsuFirmware,
+  type OsUpdate,
+} from "@api/device-action/OsUpdate/Resolve/types";
+
+type ResolveOsUpdatePathHandlerInput = {
+  getOsVersionResponse: GetOsVersionResponse;
+};
+
+type ResolveOsUpdatePathHandlerResponse = Promise<
+  Either<ResolveOsUpdatePathError, OsUpdate[]>
+>;
+
+type ResolveOsUpdatePathHandler = ({
+  input,
+}: {
+  input: ResolveOsUpdatePathHandlerInput;
+}) => ResolveOsUpdatePathHandlerResponse;
+
+type DeviceVersion = {
+  id: number;
+};
+
+/**
+ * Limit the number of OS updates to 5 to avoid infinite loops.
+ * In practice, it should never be more than that.
+ */
+const MAX_OS_UPDATES_LIMIT = 5;
+
+export const resolveOsUpdatePath =
+  (internalApi: InternalApi): ResolveOsUpdatePathHandler =>
+  ({ input: { getOsVersionResponse } }): ResolveOsUpdatePathHandlerResponse =>
+    EitherAsync<ResolveOsUpdatePathError, OsUpdate[]>(
+      async ({ liftEither, fromPromise }) => {
+        const mcuList = await fromPromise(getMcuList(internalApi));
+        let mcuId = await liftEither(
+          resolveMcuId(mcuList, getOsVersionResponse.mcuSephVersion),
+        );
+        const deviceVersion = await fromPromise(
+          getDeviceVersion(internalApi, getOsVersionResponse),
+        );
+        let osuFirmware = (
+          await fromPromise(
+            getOsuFirmware(internalApi, getOsVersionResponse, deviceVersion),
+          )
+        ).extractNullable();
+
+        const osUpdates: OsUpdate[] = [];
+
+        while (osuFirmware && osUpdates.length < MAX_OS_UPDATES_LIMIT) {
+          const finalFirmware = await fromPromise(
+            getNextFirmware(internalApi, osuFirmware),
+          );
+          const shouldFlashMcu = !finalFirmware.mcuVersions.includes(mcuId);
+
+          if (shouldFlashMcu) {
+            mcuId = await liftEither(
+              resolveMcuId(
+                mcuList,
+                latestCompatibleMcuName(mcuList, finalFirmware),
+              ),
+            );
+          }
+
+          osUpdates.push({ osuFirmware, finalFirmware, shouldFlashMcu });
+
+          osuFirmware = (
+            await fromPromise(
+              getNextOsuFirmware(internalApi, deviceVersion, finalFirmware),
+            )
+          ).extractNullable();
+        }
+
+        return osUpdates;
+      },
+    ).run();
+
+const toResolveOsUpdatePathError = (error: unknown): ResolveOsUpdatePathError =>
+  new ResolveOsUpdatePathError(error);
+
+const getMcuList = (
+  internalApi: InternalApi,
+): EitherAsync<ResolveOsUpdatePathError, McuFirmware[]> =>
+  internalApi
+    .getManagerApiService()
+    .getMcuList()
+    .map((mcuList) =>
+      mcuList.map((mcu) => ({
+        id: mcu.id,
+        name: mcu.name,
+        fromBootloaderVersion: mcu.fromBootloaderVersion,
+      })),
+    )
+    .mapLeft(toResolveOsUpdatePathError);
+
+const resolveMcuId = (
+  mcuList: McuFirmware[],
+  mcuName: string | null,
+): Either<ResolveOsUpdatePathError, number> =>
+  Maybe.fromNullable(mcuList.find((mcu) => mcu.name === mcuName))
+    .map((mcu) => mcu.id)
+    .toEither(
+      new ResolveOsUpdatePathError(
+        `No MCU firmware found for version ${mcuName}`,
+      ),
+    );
+
+const latestCompatibleMcuName = (
+  mcuList: McuFirmware[],
+  finalFirmware: FinalFirmware,
+): string | null =>
+  mcuList
+    .filter((mcu) => finalFirmware.mcuVersions.includes(mcu.id))
+    .reduce<{ name: string; version: string } | null>((latestMcu, mcu) => {
+      const version = coerce(mcu.name)?.version;
+
+      if (!version) {
+        return latestMcu;
+      }
+
+      if (!latestMcu || compare(version, latestMcu.version) > 0) {
+        return { name: mcu.name, version };
+      }
+
+      return latestMcu;
+    }, null)?.name ?? null;
+
+const getDeviceVersion = (
+  internalApi: InternalApi,
+  getOsVersionResponse: GetOsVersionResponse,
+): EitherAsync<ResolveOsUpdatePathError, DeviceVersion> => {
+  const managerApi = internalApi.getManagerApiService();
+  return managerApi
+    .getDeviceVersion(getOsVersionResponse)
+    .mapLeft(toResolveOsUpdatePathError);
+};
+
+const getOsuFirmware = (
+  internalApi: InternalApi,
+  getOsVersionResponse: GetOsVersionResponse,
+  deviceVersion: DeviceVersion,
+): EitherAsync<ResolveOsUpdatePathError, Maybe<OsuFirmware>> => {
+  const managerApi = internalApi.getManagerApiService();
+  return getOsVersionResponse.isOsu
+    ? managerApi
+        .getOsuFirmwareVersion(getOsVersionResponse, deviceVersion)
+        .map(Just)
+        .mapLeft(toResolveOsUpdatePathError)
+    : managerApi
+        .getFirmwareVersion(getOsVersionResponse, deviceVersion)
+        .chain((firmwareVersion) =>
+          managerApi.getLatestFirmwareVersion(firmwareVersion, deviceVersion),
+        )
+        .mapLeft(toResolveOsUpdatePathError);
+};
+
+const getNextFirmware = (
+  internalApi: InternalApi,
+  osuFirmware: OsuFirmware,
+): EitherAsync<ResolveOsUpdatePathError, FinalFirmware> =>
+  internalApi
+    .getManagerApiService()
+    .getNextFirmwareVersion(osuFirmware)
+    .map((nextFirmware) => ({
+      id: nextFirmware.id,
+      perso: nextFirmware.perso,
+      version: nextFirmware.version,
+      bytes: nextFirmware.bytes,
+      firmware: nextFirmware.firmware,
+      firmwareKey: nextFirmware.firmwareKey,
+      hash: nextFirmware.hash,
+      mcuVersions: nextFirmware.mcuVersions,
+    }))
+    .mapLeft(toResolveOsUpdatePathError);
+
+const getNextOsuFirmware = (
+  internalApi: InternalApi,
+  deviceVersion: DeviceVersion,
+  finalFirmware: FinalFirmware,
+): EitherAsync<ResolveOsUpdatePathError, Maybe<OsuFirmware>> => {
+  const managerApi = internalApi.getManagerApiService();
+  return managerApi
+    .getLatestFirmwareVersion(finalFirmware, deviceVersion)
+    .mapLeft(toResolveOsUpdatePathError);
+};

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/types.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/types.ts
@@ -1,0 +1,100 @@
+import {
+  type DeviceActionState,
+  type GetOsVersionResponse,
+  type GoToDashboardDAError,
+  type GoToDashboardDAIntermediateValue,
+  type GoToDashboardDARequiredInteraction,
+  type UserInteractionRequired,
+  type WaitForAppAndVersionDAError,
+  type WaitForAppAndVersionDAIntermediateValue,
+  type WaitForAppAndVersionDARequiredInteraction,
+} from "@ledgerhq/device-management-kit";
+
+import { type ResolveOsUpdatePathDAErrors } from "./ResolveOsUpdatePathDeviceActionErrors";
+
+export type McuFirmware = {
+  id: number;
+  name: string;
+  fromBootloaderVersion: string;
+};
+
+export type BaseFirmware = {
+  id: number;
+  perso: string;
+  hash: string | null;
+};
+
+export type OsuFirmware = BaseFirmware & {
+  notes: string | null;
+  firmware: string;
+  firmwareKey: string;
+  nextFinalFirmware: number;
+};
+
+export type FinalFirmware = BaseFirmware & {
+  version: string;
+  bytes: number | null;
+  firmware: string | null;
+  firmwareKey: string | null;
+  mcuVersions: number[];
+};
+
+export type OsUpdate = {
+  osuFirmware: OsuFirmware;
+  finalFirmware: FinalFirmware;
+  shouldFlashMcu: boolean;
+};
+
+export type DeviceInfos = {
+  targetId: number;
+  seVersion: string;
+  mcuSephVersion: string;
+  isOsu: boolean;
+};
+
+export type ResolveOsUpdatePathDAInput = {
+  unlockTimeout: number;
+};
+
+export type ResolveOsUpdatePathDAOutput = OsUpdate[];
+
+export type ResolveOsUpdatePathDAError =
+  | WaitForAppAndVersionDAError
+  | GoToDashboardDAError
+  | ResolveOsUpdatePathDAErrors;
+
+export type ResolveOsUpdatePathDAIntermediateValue = (
+  | WaitForAppAndVersionDAIntermediateValue
+  | GoToDashboardDAIntermediateValue
+  | {
+      readonly requiredUserInteraction: ResolveOsUpdatePathDARequiredInteraction;
+    }
+) & {
+  step: ResolveOsUpdatePathSteps;
+};
+
+export type ResolveOsUpdatePathDARequiredInteraction =
+  | WaitForAppAndVersionDARequiredInteraction
+  | GoToDashboardDARequiredInteraction
+  | UserInteractionRequired.None;
+
+export type ResolveOsUpdatePathDAInternalState = {
+  error: ResolveOsUpdatePathDAError | null;
+  currentApp: string | null;
+  getOsVersionResponse: GetOsVersionResponse | null;
+  osUpdates: OsUpdate[];
+};
+
+export type ResolveOsUpdatePathDAState = DeviceActionState<
+  ResolveOsUpdatePathDAOutput,
+  ResolveOsUpdatePathDAError,
+  ResolveOsUpdatePathDAIntermediateValue
+>;
+
+export enum ResolveOsUpdatePathSteps {
+  Idle = "idle",
+  WaitForAppAndVersion = "waitForAppAndVersion",
+  GoToDashboard = "goToDashboard",
+  GetOsVersion = "getOsVersion",
+  ResolveOsUpdatePath = "resolveOsUpdatePath",
+}

--- a/packages/ledger-wallet/src/index.ts
+++ b/packages/ledger-wallet/src/index.ts
@@ -128,6 +128,16 @@ export type {
   CleanDeviceDARequiredInteraction,
   CleanDeviceDAState,
 } from "./api/device-action/OsUpdate/CleanDevice/types";
+export { ResolveOsUpdatePathDeviceAction } from "./api/device-action/OsUpdate/Resolve/ResolveOsUpdatePathDeviceAction";
+export type {
+  ResolveOsUpdatePathDAError,
+  ResolveOsUpdatePathDAInput,
+  ResolveOsUpdatePathDAIntermediateValue,
+  ResolveOsUpdatePathDAOutput,
+  ResolveOsUpdatePathDARequiredInteraction,
+  ResolveOsUpdatePathDAState,
+  ResolveOsUpdatePathSteps,
+} from "./api/device-action/OsUpdate/Resolve/types";
 export { RestoreAppsStorageDeviceAction } from "./api/device-action/OsUpdate/Restore/RestoreAppsStorage/RestoreAppsStorageDeviceAction";
 export type {
   RestoreAppsStorageDAError,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1423,6 +1423,9 @@ importers:
       purify-ts:
         specifier: 'catalog:'
         version: 2.1.0
+      semver:
+        specifier: 'catalog:'
+        version: 7.7.2
       xstate:
         specifier: 'catalog:'
         version: 5.19.2
@@ -1448,6 +1451,9 @@ importers:
       '@types/pako':
         specifier: ^2.0.3
         version: 2.0.4
+      '@types/semver':
+        specifier: 'catalog:'
+        version: 7.7.0
       ts-node:
         specifier: 'catalog:'
         version: 10.9.2(@types/node@24.13.2)(typescript@5.9.2)


### PR DESCRIPTION
### 📝 Description

This pull request introduces the Resolve OS update path device action, which retrieves the current device OS version, resolves the required OSU/final firmware update sequence from the Manager API, and indicates when an MCU flash is required for each update step.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1280](https://ledgerhq.atlassian.net/browse/DSDK-1280?atlOrigin=eyJpIjoiMWFkMDM0NTYwYzA0NDg3M2JhMGQwOGM2NjYxZGUxNWYiLCJwIjoiaiJ9)

- **Feature**: Resolve the firmware update path for Ledger devices before running an OS update flow.

#### Result: 

https://github.com/user-attachments/assets/9dabd524-53de-460c-b363-c4e62d4c4027


### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [ ] ~~**Documentation is up-to-date**~~
- [x] **Impact of the changes:**
  - Adds OS update path resolution to `@ledgerhq/dmk-ledger-wallet`
  - Exposes the new device action from the package public API
  - Adds sample app access to the new action
  - Covers success, dashboard navigation, no-update, OSU resume, multi-step update, MCU flash, and error paths

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.

[DSDK-1280]: https://ledgerhq.atlassian.net/browse/DSDK-1280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ