### PR TITLE
🐛 (signer-solana) [DSDK-1406]: Forward cosigners for txc

### DIFF
--- a/.changeset/modern-lemons-dig.md
+++ b/.changeset/modern-lemons-dig.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": patch
+---
+
+`signTransaction` now accepts both `tx.serialize()` (full wire-format) and `tx.serializeMessage()` (raw message bytes). When the full wire-format is provided, co-signer signatures are forwarded to Transaction Check automatically. The `serializedTransactionForTransactionCheck` field has been removed from `SolanaTransactionOptionalConfig`.

--- a/.changeset/slow-rabbits-enjoy.md
+++ b/.changeset/slow-rabbits-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/context-module": patch
+---
+
+Forward cosigners for Solana txc

--- a/apps/docs/content/docs/references/signers/solana.mdx
+++ b/apps/docs/content/docs/references/signers/solana.mdx
@@ -123,7 +123,7 @@ const { observable, cancel } = signerSolana.signTransaction(
   See [Ledger’s guide](https://www.ledger.com/blog/understanding-crypto-addresses-and-derivation-paths) for more information.
 
 - **transaction** `Uint8Array`  
-  The serialized transaction to sign.
+  Serialized transaction bytes. Accepts both raw message bytes (`tx.serializeMessage()`) and the full wire-format transaction (`tx.serialize()`). When the full wire-format is provided, co-signer signatures are forwarded to Transaction Check automatically.
 
 **Optional**
 

--- a/apps/sample/src/components/SignerSolanaView/index.tsx
+++ b/apps/sample/src/components/SignerSolanaView/index.tsx
@@ -292,6 +292,10 @@ export const SignerSolanaView: React.FC<{ sessionId: string }> = ({
           createATAAddress: "",
           createATAMintAddress: "",
         },
+        labelSelector: {
+          transaction:
+            "Transaction, base64(tx.serialize() or tx.serializeMessage())",
+        },
         InputValuesComponent: SignTransactionForm,
         validateValues: ({ transaction }) =>
           isBase64String(transaction) && transaction.length > 0,

--- a/packages/signer/context-module/src/modules/multichain/transaction-check/loaders/SolanaTransactionCheckLoader.test.ts
+++ b/packages/signer/context-module/src/modules/multichain/transaction-check/loaders/SolanaTransactionCheckLoader.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { DeviceModelId } from "@ledgerhq/device-management-kit";
 import bs58 from "bs58";
 import { Left, Right } from "purify-ts";
@@ -126,54 +127,23 @@ describe("SolanaTransactionCheckLoader", () => {
       });
     });
 
-    it("wraps a legacy message with zero-filled signature placeholders before bs58-encoding", async () => {
-      // message[0] = 2 → numRequiredSignatures = 2 (legacy, high bit clear)
-      const message = new Uint8Array([2, 0, 3, 0xaa, 0xbb, 0xcc]);
-      // expected: compact-u16(2) + 2*64 zero bytes + message
-      const expected = new Uint8Array(1 + 2 * 64 + message.length);
-      expected[0] = 2; // compact-u16 encoding of 2
-      expected.set(message, 1 + 2 * 64);
+    it("bs58-encodes transactionBytes and passes it to the data source", async () => {
+      const transactionBytes = new Uint8Array([0xaa, 0xbb, 0xcc, 0xdd]);
 
       await loader.load({
         deviceModelId: DeviceModelId.NANO_X,
         transactionCheck: {
           from: "signer",
-          transactionBytes: message,
+          transactionBytes,
           chain: SolanaTransactionScanChainId.MAINNET,
         },
       });
 
       const sent = dataSourceMock.check.mock.calls[0]![0];
-
       expect(sent.path).toBe(TransactionCheckPaths.SOLANA_TRANSACTION);
       expect(sent.body.tx.from).toBe("signer");
       expect(sent.body.chain).toBe(SolanaTransactionScanChainId.MAINNET);
-      expect(Array.from(bs58.decode(sent.body.tx.raw))).toEqual(
-        Array.from(expected),
-      );
-      expect(sent.body.tx.raw).toBe(bs58.encode(expected));
-    });
-
-    it("wraps a versioned (v0) message with signature placeholders", async () => {
-      // message[0] = 0x80 → versioned prefix; message[1] = 1 → numRequiredSignatures = 1
-      const message = new Uint8Array([0x80, 1, 0, 3, 0xde, 0xad]);
-      // expected: compact-u16(1) + 1*64 zero bytes + message
-      const expected = new Uint8Array(1 + 1 * 64 + message.length);
-      expected[0] = 1; // compact-u16 encoding of 1
-      expected.set(message, 1 + 1 * 64);
-
-      await loader.load({
-        deviceModelId: DeviceModelId.NANO_X,
-        transactionCheck: {
-          from: "signer",
-          transactionBytes: message,
-          chain: SolanaTransactionScanChainId.MAINNET,
-        },
-      });
-
-      const raw = dataSourceMock.check.mock.calls[0]![0].body.tx.raw;
-
-      expect(Array.from(bs58.decode(raw))).toEqual(Array.from(expected));
+      expect(sent.body.tx.raw).toBe(bs58.encode(transactionBytes));
     });
   });
 
@@ -216,28 +186,6 @@ describe("SolanaTransactionCheckLoader", () => {
 
       expect(ctx).toEqual({ type: ClearSignContextType.ERROR, error });
       expect(certificateLoaderMock.loadCertificate).not.toHaveBeenCalled();
-    });
-
-    it("returns an ERROR context when numRequiredSignatures exceeds the 64-signature limit", async () => {
-      // message[0] = 65 → numRequiredSignatures = 65 (legacy, high bit clear), which exceeds SOLANA_MAX_SIGNATURES
-      const message = new Uint8Array([65, 0, 3, 0xaa]);
-
-      const [ctx] = await loader.load({
-        deviceModelId: DeviceModelId.NANO_X,
-        transactionCheck: {
-          from: "signer",
-          transactionBytes: message,
-          chain: SolanaTransactionScanChainId.MAINNET,
-        },
-      });
-
-      expect(ctx).toMatchObject({
-        type: ClearSignContextType.ERROR,
-        error: expect.objectContaining({
-          message: expect.stringContaining("exceeds SOLANA_MAX_SIGNATURES"),
-        }),
-      });
-      expect(dataSourceMock.check).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/signer/context-module/src/modules/multichain/transaction-check/loaders/SolanaTransactionCheckLoader.ts
+++ b/packages/signer/context-module/src/modules/multichain/transaction-check/loaders/SolanaTransactionCheckLoader.ts
@@ -39,13 +39,6 @@ const SUPPORTED_TYPES: ClearSignContextType[] = [
   ClearSignContextType.SOLANA_TRANSACTION_CHECK,
 ];
 
-const SOLANA_SIGNATURE_LENGTH = 64;
-const SOLANA_MAX_SIGNATURES = 64;
-const VERSIONED_MESSAGE_PREFIX_MASK = 0x80;
-const SHORTVEC_CONTINUATION_BIT = 0x80;
-const SHORTVEC_DATA_MASK = 0x7f;
-const SHORTVEC_DATA_BITS = 7;
-
 const solanaTransactionCheckInputCodec = Codec.interface({
   deviceModelId: deviceModelIdCodec,
   transactionCheck: Codec.interface({
@@ -91,21 +84,7 @@ export class SolanaTransactionCheckLoader
   ): Promise<ClearSignContext[]> {
     const { from, transactionBytes, chain } = ctx.transactionCheck;
 
-    let rawTx: string;
-    try {
-      rawTx = this.bs58Encoder.encode(
-        this.wrapMessageAsTransaction(transactionBytes),
-      );
-    } catch (error) {
-      const result: ClearSignContext[] = [
-        {
-          type: ClearSignContextType.ERROR,
-          error: error instanceof Error ? error : new Error(String(error)),
-        },
-      ];
-      this.logger.debug("load result", { data: { result } });
-      return result;
-    }
+    const rawTx = this.bs58Encoder.encode(transactionBytes);
 
     const txCheck = await this.transactionCheckDataSource.check({
       path: TransactionCheckPaths.SOLANA_TRANSACTION,
@@ -136,65 +115,5 @@ export class SolanaTransactionCheckLoader
     const result = [context];
     this.logger.debug("load result", { data: { result } });
     return result;
-  }
-
-  /**
-   * Wrap a serialized Solana Message into a serialized Transaction expected
-   * by the web3checks endpoint, by prepending a compact-u16 signature count
-   * and the matching number of zero-filled signature placeholders.
-   *
-   * Supports legacy and versioned messages: versioned messages start with a
-   * version prefix byte (high bit set), shifting `numRequiredSignatures` by
-   * one position.
-   */
-  private wrapMessageAsTransaction(message: Uint8Array): Uint8Array {
-    const numRequiredSignatures = this.readNumRequiredSignatures(message);
-    const sigCount = this.encodeShortVec(numRequiredSignatures);
-    const placeholdersLength = numRequiredSignatures * SOLANA_SIGNATURE_LENGTH;
-
-    const wrapped = new Uint8Array(
-      sigCount.length + placeholdersLength + message.length,
-    );
-    wrapped.set(sigCount, 0);
-    wrapped.set(message, sigCount.length + placeholdersLength);
-    return wrapped;
-  }
-
-  private readNumRequiredSignatures(message: Uint8Array): number {
-    const firstByte = message[0];
-    if (firstByte === undefined) {
-      throw new Error(
-        "[ContextModule] SolanaTransactionCheckLoader: empty transaction bytes",
-      );
-    }
-    const isVersioned = (firstByte & VERSIONED_MESSAGE_PREFIX_MASK) !== 0;
-    const headerOffset = isVersioned ? 1 : 0;
-    const numRequiredSignatures = message[headerOffset];
-    if (numRequiredSignatures === undefined) {
-      throw new Error(
-        "[ContextModule] SolanaTransactionCheckLoader: malformed message header",
-      );
-    }
-    if (numRequiredSignatures > SOLANA_MAX_SIGNATURES) {
-      throw new Error(
-        `[ContextModule] SolanaTransactionCheckLoader: numRequiredSignatures (${numRequiredSignatures}) exceeds SOLANA_MAX_SIGNATURES (${SOLANA_MAX_SIGNATURES})`,
-      );
-    }
-    return numRequiredSignatures;
-  }
-
-  private encodeShortVec(value: number): Uint8Array {
-    const bytes: number[] = [];
-    let remaining = value;
-    while (true) {
-      const lowBits = remaining & SHORTVEC_DATA_MASK;
-      remaining >>>= SHORTVEC_DATA_BITS;
-      if (remaining === 0) {
-        bytes.push(lowBits);
-        break;
-      }
-      bytes.push(lowBits | SHORTVEC_CONTINUATION_BIT);
-    }
-    return Uint8Array.from(bytes);
   }
 }

--- a/packages/signer/signer-solana/README.md
+++ b/packages/signer/signer-solana/README.md
@@ -118,7 +118,7 @@ const { observable, cancel } = signerSolana.signTransaction(
   See [Ledger’s guide](https://www.ledger.com/blog/understanding-crypto-addresses-and-derivation-paths) for more information.
 
 - **transaction** `Uint8Array`  
-  The serialized transaction to sign.
+  Serialized transaction bytes. Accepts both raw message bytes (`tx.serializeMessage()`) and the full wire-format transaction (`tx.serialize()`). When the full wire-format is provided, co-signer signatures are forwarded to Transaction Check automatically.
 
 **Optional**
 

--- a/packages/signer/signer-solana/src/api/app-binder/SignTransactionDeviceActionTypes.ts
+++ b/packages/signer/signer-solana/src/api/app-binder/SignTransactionDeviceActionTypes.ts
@@ -95,6 +95,11 @@ export type SignTransactionDAInternalState = {
   readonly error: SignTransactionDAError | null;
   readonly signature: Signature | null;
   readonly appConfig: AppConfiguration | null;
+  // Updated by NormalizeTransaction; starts as the raw input and is replaced
+  // with the extracted message bytes once the actor completes. serializedForTxCheck
+  // is only set when the input was tx.serialize().
+  readonly messageBytes: Uint8Array;
+  readonly serializedForTxCheck: Uint8Array | undefined;
   // Set when the generic clear-sign path streamed + FINALIZE-validated the
   // descriptors, so the terminal sign runs the generic PROMPT UI DISPLAY flow
   // instead of the legacy preview.

--- a/packages/signer/signer-solana/src/api/model/Transaction.ts
+++ b/packages/signer/signer-solana/src/api/model/Transaction.ts
@@ -1,1 +1,8 @@
+/**
+ * Serialized Solana transaction bytes. Accepts both raw message bytes
+ * (`tx.serializeMessage()`) and the full wire-format transaction
+ * (`tx.serialize()`). When the full wire-format is provided, co-signer
+ * signatures are forwarded to Transaction Check automatically and the
+ * message bytes are extracted before being sent to the device.
+ */
 export type Transaction = Uint8Array;

--- a/packages/signer/signer-solana/src/internal/DefaultSignerSolana.ts
+++ b/packages/signer/signer-solana/src/internal/DefaultSignerSolana.ts
@@ -56,7 +56,10 @@ export class DefaultSignerSolana implements SignerSolana {
    *   The derivation path used in the transaction (e.g. `"44'/501'/0'/0'"`).
    *
    * - **transaction** `Uint8Array`
-   *   The serialised transaction to sign.
+   *   The serialised transaction to sign. Accepts both raw message bytes
+   *   (`tx.serializeMessage()`) and the full wire-format transaction
+   *   (`tx.serialize()`). When the full wire-format is provided, co-signer
+   *   signatures are forwarded to Transaction Check automatically.
    *
    * **Optional**
    * - **solanaTransactionOptionalConfig** `SolanaTransactionOptionalConfig`

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceAction.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceAction.test.ts
@@ -153,6 +153,10 @@ function run(
 ) {
   const action = new SignTransactionDeviceAction({ input });
   parentSpy = vi.spyOn(action, "extractDependencies").mockReturnValue({
+    normalizeTransaction: vi.fn().mockResolvedValue({
+      messageBytes: exampleTx,
+      serializedForTxCheck: undefined,
+    }),
     getAppConfig: getAppConfigMock,
     transactionCheckOptIn: transactionCheckOptInMock,
     provideTransactionCheck: provideTransactionCheckMock,

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceAction.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceAction.ts
@@ -30,6 +30,10 @@ import {
 import { type SolanaAppErrorCodes } from "@internal/app-binder/command/utils/SolanaApplicationErrors";
 import { APP_NAME } from "@internal/app-binder/constants";
 import {
+  type NormalizedTransactionInput,
+  TransactionInputNormaliser,
+} from "@internal/app-binder/services/TransactionInputNormaliser";
+import {
   isSolanaFeatureSupported,
   type SOLANA_FEATURES,
 } from "@internal/app-binder/SolanaApplicationResolver";
@@ -51,6 +55,7 @@ function resolveSolanaRpcUrl(
 }
 
 export type MachineDependencies = {
+  readonly normalizeTransaction: () => Promise<NormalizedTransactionInput>;
   readonly getAppConfig: () => Promise<
     CommandResult<AppConfiguration, SolanaAppErrorCodes>
   >;
@@ -63,6 +68,7 @@ export type MachineDependencies = {
       transaction: Uint8Array;
       contextModule: ContextModule;
       isBlockhashRefreshNeeded: boolean;
+      serializedForTxCheck?: Uint8Array;
     };
   }) => Promise<void>;
 };
@@ -91,8 +97,12 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
       SignTransactionDAInternalState
     >;
 
-    const { getAppConfig, transactionCheckOptIn, provideTransactionCheck } =
-      this.extractDependencies(internalApi);
+    const {
+      normalizeTransaction,
+      getAppConfig,
+      transactionCheckOptIn,
+      provideTransactionCheck,
+    } = this.extractDependencies(internalApi);
 
     const logger = this.getLoggerFactory(internalApi)(
       "SignTransactionDeviceAction",
@@ -141,6 +151,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
         output: {} as types["output"],
       },
       actors: {
+        normalizeTransaction: fromPromise(normalizeTransaction),
         openAppStateMachine: new OpenAppDeviceAction({
           input: { appName: APP_NAME },
         }).makeStateMachine(internalApi),
@@ -225,7 +236,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
     }).createMachine({
       /** @xstate-layout N4IgpgJg5mDOIC5QGUCWUB2AVATgQw1jwGMAXVAewwBEwA3VYsAQTMowDoBJDVcvADbJSeUmADEAbQAMAXUSgADhVh92CkAA9EARgDsAZg4AOAJzSAbAYAsOgKymdN08YA0IAJ67LxjnbvWxjoW-kGGxgC+Ee5omLgERGxUtAxMrORU3Lz8QiJiUjrySCDKqhkYGtoI+kZmljb2js5unojmRgbS1haG0o5OllEx6Nj4hCTlKYwsSZwA8opgGMyKilNps+IQVGAcqBh0FADWuxSLy6vComAAsiQAFvtgMkVKKmpUlYh6dgBMHL8bJ0LKY7AZOr87O4vAhjHpTCZfkEDHo+nprL8ekMQLFRgkJux1jNyhwFksVooAEpwACuAlIAGF7mBiEcpHINKUPhVilUdL9gn5TCjfr9rNJ+X8WjDzAi9AKDGLwb94RZrNjcfFxrMiel2KTzhTqbA6YzmayCq8Su9yl9qgKLEKRWKJZCkdDEEE-NIffLAX8LPUNSMtYlJvRpnrMgBxMCkCkMqgAM3QWx2ewOx12MHjq0TGBTUBenJt6l5uj9JmsBjhxjhdn0pg91S61gB1kCPT0aosxiRwbiYzDhIjGxJsdzinzhfEYBwOAoOA4igEoiTi4Athwcwnk+hi8Uubby9VK8Zq7X643m78fRwfT7+fCxQ2B3jteHUsT9RPdwX0MappMiybIHm8ZRlqAVQCuYHAWJClj8qYSpQq0LZ6HoHA2D2PpwuCphvqGBLJKO34xnGf6FoB9LARakiFCWEGfCeMHSHBCEWEhKHNt2dj3ghdh9FYgLGHYhFDsRNCkVGnC-nme5QNRZogVIvxWkekFaIgrHsYJnG-Mh1aoTCDQcKYvG9sYaIuJE0Q4iGEk6tJswcAA6mAABGBi0UcsALKQPBphguz7IcJwcAA7p53nmkc-k8GB1pMTyUHaRh-zdHCpjVtInSic2dZGH8gmoi4lmQuJ+JOV+MludFPl+YoAUYLO86Lsuq6kOuOBblFXk+fFGCJRpzGpQgKryhwmXwjleXGd4k3WGCOhWd29g-BYlUfiONUue5-WxY1zVKeImiwHkux4EmYg4AAFNIACU4iao5n6Rnt9WHYNSnDaWo1aQgiqQhwqqmNlxUqrlzaOAi1h6H2KLLZCK1bcOJG7SSPmxsFOCMAyAhgHgOC4sgNKrIuYgQOy6l-SlAMGBYgYg6YjM-NYoLSGC80IMh-yBgYwTwqJ5l2HoqOSbqLlY0sc54wTRMk2Tyg4JTlqMdydoM0zqo9AEHNc82elTd28F1qtnTouL1XvZjsXY7LxD44TxMjKT5Mq5Aqk08lmuM2xOts-rBjc90bFwyEZvgh2KpiXZL1VW9Y4-jLuOO-LLuYEFIWZuFMA43LzskxddzEI8wW-T7J4YmDJjooYir2DY0OdMbjNiuiGIqgRccOQnO028n+dp4XIxZxmYXZinBcK67xcPE89HexrVcGQicJw8qjfWM28FtuZjOBOY1borZwyDn36MD+RQ9OzPmfbMF49ZtuU-D3fGBXGIJdl88anq8eY1q5rzrpvME280J1n+PvUWDgVril+FbROZFZKv1vhnFqc4FxLhXGuTcL8b7pyLtcb+C8OSHlpnaIBtcN4NzATxeGAJMRWF7EqCUBhEH9yTpkZA9xBACAoBFNBuIx6hWfrAXhAh+GCMIbPYh89y5kPAsvMaxUdB+G6I4eEAtpB1m5kEXwDMXDaN7HoHQwQOGXy4ZwHhfCBFCNHpg9qOCup4PEbY6RI9MCf1uPI54iikrKIBqo9RIJGzaN0fQtixgQTw1FBiXRYse7n22pY5BHAsBzg3PsQQwiH7ZwnhwVQmB9hQDJPgcosBvEkIUUvABQTsqYWkBhdENhzxql+DxUEcFqyr26Bibs3cz7vjRlJDG+p44pIwEpHy1N-6aSqCEQUQIGbymMOCMEBVgZgjVNEkELNuixyGURa2ViOATJGdM2KatyGVzGosx0yyehInWQYehCJtkdkZn8YO0Soh2QwBQCAcANDnIls5OpI06ZVAALQWGbLC+8D4kXIrVBY0ZV9OA8DUDki6cz-pVAxM2HQlg2I1hmtIES61Bn2WSSMyWJIyQXDWOCzSkLNZ2EdICasAs-imIMKCAq-g-ABHgv0Wwok0X0v1Iyo0tIaKxTxVC7wFL7z2EEsEUWcNuzQwlMKjewozDNJ0JKll5FJzTnQIqu0OhxSYQbKLLogJ4agleWhYlxKTB1iaYZDsARDk0uGWCsZZrKIATlcpVkVqTw6GFP7FmoIBQrTWToIllg+LmRtaiTmqJlQmuDZwfaMUQJHR4FGsaYonAg1yhCBs2VGapv5feFm-K4lOA3nmjFdUDrFu+uGstAMDJmA4MS8GQRRSKnMgVbKZl4Z9H5KKJEgQO2nOlgQzxH8lYU0gP2qoUc+JjvZhKZC8E4VoX6Iw5EfY4nVmNUkwNJy0n21TvYzAO7EA1jWdQn4GEzD6HlAVOEJgwS3lwvG9hd7jlINqjYyRdiZGvpuYEglok+Iit3lYfoKa0ImzMsBroyF9BxOXWkjJPVslCBGG+hA-gGz3lncLMUBlXUwnhm2Qx0SNrBHMtS0FD7oO90mZckCVH4J-DMgKeUIQwHswKvoLCeyJQbXgvKYj0GaTECYLAeAiG6kLPlJhTEgR5QNxVMxz0oo-AM26PBYI-KzGqZcgAUTajgET+mAQ7OMwKUzzYlqYXDhytZ6q8Lqj+UAA */
       id: "SignTransactionDeviceAction",
-      initial: "InitialState",
+      initial: "NormalizeTransaction",
       context: ({ input }) => ({
         input,
         intermediateValue: {
@@ -236,15 +247,50 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
           error: null,
           signature: null,
           appConfig: null,
+          messageBytes: this.input.transaction,
+          serializedForTxCheck: undefined,
           clearSignPrepared: false,
         },
       }),
       states: {
-        InitialState: {
-          always: [
-            { target: "GetAppConfig", guard: "skipOpenApp" },
-            { target: "OpenAppDeviceAction" },
-          ],
+        NormalizeTransaction: {
+          // Emit the correct first step immediately so the snapshot produced
+          // while the actor runs already reflects where we are headed.
+          entry: assign({
+            intermediateValue: ({ context }) => ({
+              requiredUserInteraction: UserInteractionRequired.None,
+              step: context.input.transactionOptions?.skipOpenApp
+                ? signTransactionDAStateSteps.GET_APP_CONFIG
+                : signTransactionDAStateSteps.OPEN_APP,
+            }),
+          }),
+          invoke: {
+            id: "normalizeTransaction",
+            src: "normalizeTransaction",
+            onDone: [
+              {
+                target: "GetAppConfig",
+                guard: "skipOpenApp",
+                actions: assign({
+                  _internalState: ({ event, context }) => ({
+                    ...context._internalState,
+                    messageBytes: event.output.messageBytes,
+                    serializedForTxCheck: event.output.serializedForTxCheck,
+                  }),
+                }),
+              },
+              {
+                target: "OpenAppDeviceAction",
+                actions: assign({
+                  _internalState: ({ event, context }) => ({
+                    ...context._internalState,
+                    messageBytes: event.output.messageBytes,
+                    serializedForTxCheck: event.output.serializedForTxCheck,
+                  }),
+                }),
+              },
+            ],
+          },
         },
         OpenAppDeviceAction: {
           entry: assign({
@@ -429,10 +475,12 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
               const { rpcUrl, fetchBlockhash } = resolveRefreshSource(context);
               return {
                 derivationPath: context.input.derivationPath,
-                transaction: context.input.transaction,
+                transaction: context._internalState.messageBytes,
                 contextModule: context.input.contextModule,
                 isBlockhashRefreshNeeded:
                   rpcUrl !== undefined || fetchBlockhash !== undefined,
+                serializedForTxCheck:
+                  context._internalState.serializedForTxCheck,
               };
             },
             // Best-effort: a failed scan-descriptor stream never blocks signing.
@@ -468,7 +516,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
             src: "provisionGenericClearSignStateMachine",
             input: ({ context }) => ({
               derivationPath: context.input.derivationPath,
-              transaction: context.input.transaction,
+              transaction: context._internalState.messageBytes,
               contextModule: context.input.contextModule,
             }),
             onSnapshot: {
@@ -532,7 +580,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
               const { rpcUrl, fetchBlockhash } = resolveRefreshSource(context);
               return {
                 derivationPath: context.input.derivationPath,
-                transaction: context.input.transaction,
+                transaction: context._internalState.messageBytes,
                 rpcUrl,
                 fetchBlockhash,
                 userInputType:
@@ -588,7 +636,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
             src: "provisionBasicClearSignStateMachine",
             input: ({ context }) => ({
               derivationPath: context.input.derivationPath,
-              transaction: context.input.transaction,
+              transaction: context._internalState.messageBytes,
               contextModule: context.input.contextModule,
               appConfig: context._internalState.appConfig!,
               rpcUrl: resolveSolanaRpcUrl(context.input),
@@ -615,7 +663,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
               const { rpcUrl, fetchBlockhash } = resolveRefreshSource(context);
               return {
                 derivationPath: context.input.derivationPath,
-                transaction: context.input.transaction,
+                transaction: context._internalState.messageBytes,
                 rpcUrl,
                 fetchBlockhash,
                 userInputType:
@@ -665,6 +713,23 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
   }
 
   extractDependencies(internalApi: InternalApi): MachineDependencies {
+    const normalizeTransaction = async () => {
+      try {
+        return new TransactionInputNormaliser().normalize(
+          this.input.transaction,
+        );
+      } catch (error) {
+        this.getLoggerFactory(internalApi)("NormalizeTransaction").warn(
+          "[normalizeTransaction] format detection failed; treating input as message bytes",
+          { data: { error } },
+        );
+        return {
+          messageBytes: this.input.transaction,
+          serializedForTxCheck: undefined,
+        };
+      }
+    };
+
     const getAppConfig = async () =>
       internalApi.sendCommand(new GetAppConfigurationCommand());
 
@@ -677,6 +742,7 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
         transaction: Uint8Array;
         contextModule: ContextModule;
         isBlockhashRefreshNeeded: boolean;
+        serializedForTxCheck?: Uint8Array;
       };
     }) =>
       new ProvideTransactionCheckTask(internalApi, {
@@ -684,10 +750,13 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
         transactionBytes: arg0.input.transaction,
         contextModule: arg0.input.contextModule,
         isBlockhashRefreshNeeded: arg0.input.isBlockhashRefreshNeeded,
+        serializedTransactionForTransactionCheck:
+          arg0.input.serializedForTxCheck,
         loggerFactory: this.getLoggerFactory(internalApi),
       }).run();
 
     return {
+      normalizeTransaction,
       getAppConfig,
       transactionCheckOptIn,
       provideTransactionCheck,

--- a/packages/signer/signer-solana/src/internal/app-binder/services/DefaultSolanaTransactionSerializer.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/services/DefaultSolanaTransactionSerializer.test.ts
@@ -1,0 +1,200 @@
+import { DefaultSolanaTransactionSerializer } from "./DefaultSolanaTransactionSerializer";
+
+const SIG_LEN = 64;
+
+let serializer: DefaultSolanaTransactionSerializer;
+
+beforeEach(() => {
+  serializer = new DefaultSolanaTransactionSerializer();
+});
+
+function buildSerializedTx(
+  message: Uint8Array,
+  slots: Array<Uint8Array | null>,
+): Uint8Array {
+  const count = slots.length;
+  const tx = new Uint8Array(1 + count * SIG_LEN + message.length);
+  tx[0] = count;
+  for (let i = 0; i < count; i++) {
+    const slot = slots[i];
+    if (slot) tx.set(slot, 1 + i * SIG_LEN);
+  }
+  tx.set(message, 1 + count * SIG_LEN);
+  return tx;
+}
+
+function buildRealSignature(fill: number): Uint8Array {
+  const sig = new Uint8Array(SIG_LEN);
+  sig[0] = fill;
+  sig[1] = fill + 1;
+  return sig;
+}
+
+describe("DefaultSolanaTransactionSerializer", () => {
+  describe("wrapMessageAsTransaction — zero-fill", () => {
+    it("wraps a legacy message with zero-filled signature placeholders", () => {
+      const message = new Uint8Array([2, 0, 3, 0xaa, 0xbb, 0xcc]);
+      const expected = new Uint8Array(1 + 2 * SIG_LEN + message.length);
+      expected[0] = 2;
+      expected.set(message, 1 + 2 * SIG_LEN);
+
+      expect(Array.from(serializer.wrapMessageAsTransaction(message))).toEqual(
+        Array.from(expected),
+      );
+    });
+
+    it("wraps a versioned (v0) message with signature placeholders", () => {
+      const message = new Uint8Array([0x80, 1, 0, 3, 0xde, 0xad]);
+      const expected = new Uint8Array(1 + SIG_LEN + message.length);
+      expected[0] = 1;
+      expected.set(message, 1 + SIG_LEN);
+
+      expect(Array.from(serializer.wrapMessageAsTransaction(message))).toEqual(
+        Array.from(expected),
+      );
+    });
+
+    it("throws when numRequiredSignatures exceeds SOLANA_MAX_SIGNATURES", () => {
+      const message = new Uint8Array([65, 0, 3, 0xaa]);
+      expect(() => serializer.wrapMessageAsTransaction(message)).toThrow(
+        "exceeds SOLANA_MAX_SIGNATURES",
+      );
+    });
+
+    it("throws when message is empty", () => {
+      expect(() =>
+        serializer.wrapMessageAsTransaction(new Uint8Array()),
+      ).toThrow();
+    });
+  });
+
+  describe("wrapMessageAsTransaction — co-signer signature recovery", () => {
+    it("absent field → payload identical to legacy zero-fill", () => {
+      const message = new Uint8Array([2, 0, 3, 0xaa, 0xbb]);
+      const expected = new Uint8Array(1 + 2 * SIG_LEN + message.length);
+      expected[0] = 2;
+      expected.set(message, 1 + 2 * SIG_LEN);
+
+      expect(Array.from(serializer.wrapMessageAsTransaction(message))).toEqual(
+        Array.from(expected),
+      );
+    });
+
+    it("two-signer: real signature in slot 1 appears at the correct offset, slot 0 stays zero", () => {
+      const message = new Uint8Array([2, 0, 3, 0xaa, 0xbb, 0xcc]);
+      const realSig = buildRealSignature(0x42);
+      const serializedTx = buildSerializedTx(message, [null, realSig]);
+
+      const payload = serializer.wrapMessageAsTransaction(
+        message,
+        serializedTx,
+      );
+      const slot0 = payload.slice(1, 1 + SIG_LEN);
+      const slot1 = payload.slice(1 + SIG_LEN, 1 + 2 * SIG_LEN);
+      expect(slot0.every((b) => b === 0)).toBe(true);
+      expect(Array.from(slot1)).toEqual(Array.from(realSig));
+    });
+
+    it("0x01-filled placeholder in slot 0 is normalized to zero", () => {
+      const message = new Uint8Array([1, 0, 3, 0xaa]);
+      const dummySig = new Uint8Array(SIG_LEN).fill(0x01);
+      const serializedTx = buildSerializedTx(message, [dummySig]);
+
+      const payload = serializer.wrapMessageAsTransaction(
+        message,
+        serializedTx,
+      );
+      const slot0 = payload.slice(1, 1 + SIG_LEN);
+      expect(slot0.every((b) => b === 0)).toBe(true);
+    });
+
+    it("all-zero slot is kept as zero (not forwarded as a signature)", () => {
+      const message = new Uint8Array([1, 0, 3, 0xaa]);
+      const zeroSig = new Uint8Array(SIG_LEN);
+      const serializedTx = buildSerializedTx(message, [zeroSig]);
+
+      const payload = serializer.wrapMessageAsTransaction(
+        message,
+        serializedTx,
+      );
+      const slot0 = payload.slice(1, 1 + SIG_LEN);
+      expect(slot0.every((b) => b === 0)).toBe(true);
+    });
+
+    it("versioned (v0) message with a real signature lands at the correct offset", () => {
+      const message = new Uint8Array([0x80, 1, 0, 3, 0xde, 0xad]);
+      const realSig = buildRealSignature(0x99);
+      const serializedTx = buildSerializedTx(message, [realSig]);
+
+      const payload = serializer.wrapMessageAsTransaction(
+        message,
+        serializedTx,
+      );
+      const slot0 = payload.slice(1, 1 + SIG_LEN);
+      expect(Array.from(slot0)).toEqual(Array.from(realSig));
+    });
+
+    it("falls back to zero-fill when signature count disagrees with message header", () => {
+      const message = new Uint8Array([2, 0, 3, 0xaa]);
+      const serializedTx = buildSerializedTx(message, [null]);
+
+      const payload = serializer.wrapMessageAsTransaction(
+        message,
+        serializedTx,
+      );
+      const sigBytes = payload.slice(1, 1 + 2 * SIG_LEN);
+      expect(sigBytes.every((b) => b === 0)).toBe(true);
+    });
+
+    it("falls back to zero-fill when message region length mismatches", () => {
+      const message = new Uint8Array([1, 0, 3, 0xaa]);
+      const wrongMessage = new Uint8Array([1, 0, 3, 0xaa, 0xff]);
+      const serializedTx = buildSerializedTx(wrongMessage, [null]);
+
+      const payload = serializer.wrapMessageAsTransaction(
+        message,
+        serializedTx,
+      );
+      const sigBytes = payload.slice(1, 1 + SIG_LEN);
+      expect(sigBytes.every((b) => b === 0)).toBe(true);
+    });
+
+    it("falls back to zero-fill when message region content mismatches (stale blockhash case)", () => {
+      const message = new Uint8Array([1, 0, 3, 0xaa]);
+      const differentMessage = new Uint8Array([1, 0, 3, 0xbb]);
+      const serializedTx = buildSerializedTx(differentMessage, [null]);
+
+      const payload = serializer.wrapMessageAsTransaction(
+        message,
+        serializedTx,
+      );
+      const sigBytes = payload.slice(1, 1 + SIG_LEN);
+      expect(sigBytes.every((b) => b === 0)).toBe(true);
+    });
+
+    it("falls back to zero-fill when the blob is truncated", () => {
+      const message = new Uint8Array([1, 0, 3, 0xaa]);
+      const truncated = new Uint8Array([1, ...new Array(32).fill(0)]);
+
+      const payload = serializer.wrapMessageAsTransaction(message, truncated);
+      const sigBytes = payload.slice(1, 1 + SIG_LEN);
+      expect(sigBytes.every((b) => b === 0)).toBe(true);
+    });
+
+    it("falls back to zero-fill and does not throw when the compact-u16 header is unterminated", () => {
+      const message = new Uint8Array([1, 0, 3, 0xaa]);
+      const unterminated = new Uint8Array([0x80, 0x80, 0x80, 0x80]);
+
+      expect(() =>
+        serializer.wrapMessageAsTransaction(message, unterminated),
+      ).not.toThrow();
+
+      const payload = serializer.wrapMessageAsTransaction(
+        message,
+        unterminated,
+      );
+      const sigBytes = payload.slice(1, 1 + SIG_LEN);
+      expect(sigBytes.every((b) => b === 0)).toBe(true);
+    });
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/services/DefaultSolanaTransactionSerializer.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/services/DefaultSolanaTransactionSerializer.ts
@@ -1,0 +1,136 @@
+import { type SolanaTransactionSerializer } from "./SolanaTransactionSerializer";
+
+const SOLANA_SIGNATURE_LENGTH = 64;
+const SOLANA_MAX_SIGNATURES = 64;
+const VERSIONED_MESSAGE_PREFIX_MASK = 0x80;
+const SHORTVEC_CONTINUATION_BIT = 0x80;
+const SHORTVEC_DATA_MASK = 0x7f;
+const SHORTVEC_DATA_BITS = 7;
+const PLACEHOLDER_SIGNATURE_FILL = 0x01;
+const SHORTVEC_MAX_SHIFT = 21;
+
+export class DefaultSolanaTransactionSerializer
+  implements SolanaTransactionSerializer
+{
+  wrapMessageAsTransaction(
+    message: Uint8Array,
+    serializedTransactionForTransactionCheck?: Uint8Array,
+  ): Uint8Array {
+    const numRequiredSignatures = this.readNumRequiredSignatures(message);
+    const sigCount = this.encodeShortVec(numRequiredSignatures);
+    const placeholdersLength = numRequiredSignatures * SOLANA_SIGNATURE_LENGTH;
+
+    const wrapped = new Uint8Array(
+      sigCount.length + placeholdersLength + message.length,
+    );
+    wrapped.set(sigCount, 0);
+    wrapped.set(message, sigCount.length + placeholdersLength);
+
+    for (const [index, signature] of this.recoverSignatures(
+      message,
+      numRequiredSignatures,
+      serializedTransactionForTransactionCheck,
+    )) {
+      wrapped.set(signature, sigCount.length + index * SOLANA_SIGNATURE_LENGTH);
+    }
+
+    return wrapped;
+  }
+
+  private recoverSignatures(
+    message: Uint8Array,
+    numRequiredSignatures: number,
+    serialized: Uint8Array | undefined,
+  ): Map<number, Uint8Array> {
+    const none = new Map<number, Uint8Array>();
+    if (!serialized || serialized.length === 0) return none;
+
+    const header = this.decodeShortVec(serialized);
+    if (header === null) return none;
+    const { value: count, byteLength } = header;
+
+    if (count !== numRequiredSignatures) return none;
+
+    const messageOffset = byteLength + count * SOLANA_SIGNATURE_LENGTH;
+    if (serialized.length - messageOffset !== message.length) return none;
+    if (!this.bytesEqual(serialized.subarray(messageOffset), message))
+      return none;
+
+    const recovered = new Map<number, Uint8Array>();
+    for (let i = 0; i < count; i++) {
+      const start = byteLength + i * SOLANA_SIGNATURE_LENGTH;
+      const signature = serialized.subarray(
+        start,
+        start + SOLANA_SIGNATURE_LENGTH,
+      );
+      if (!this.isPlaceholderSignature(signature)) recovered.set(i, signature);
+    }
+    return recovered;
+  }
+
+  private decodeShortVec(
+    bytes: Uint8Array,
+  ): { value: number; byteLength: number } | null {
+    let value = 0;
+    let shift = 0;
+    for (let i = 0; i < bytes.length; i++) {
+      const byte = bytes[i]!;
+      value |= (byte & SHORTVEC_DATA_MASK) << shift;
+      if ((byte & SHORTVEC_CONTINUATION_BIT) === 0) {
+        return { value, byteLength: i + 1 };
+      }
+      shift += SHORTVEC_DATA_BITS;
+      if (shift > SHORTVEC_MAX_SHIFT) return null;
+    }
+    return null;
+  }
+
+  private isPlaceholderSignature(signature: Uint8Array): boolean {
+    const first = signature[0];
+    if (first !== 0x00 && first !== PLACEHOLDER_SIGNATURE_FILL) return false;
+    return signature.every((byte) => byte === first);
+  }
+
+  private bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+    if (a.length !== b.length) return false;
+    return a.every((byte, i) => byte === b[i]);
+  }
+
+  private readNumRequiredSignatures(message: Uint8Array): number {
+    const firstByte = message[0];
+    if (firstByte === undefined) {
+      throw new Error(
+        "[signer-solana] SolanaTransactionSerializer: empty transaction bytes",
+      );
+    }
+    const isVersioned = (firstByte & VERSIONED_MESSAGE_PREFIX_MASK) !== 0;
+    const headerOffset = isVersioned ? 1 : 0;
+    const numRequiredSignatures = message[headerOffset];
+    if (numRequiredSignatures === undefined) {
+      throw new Error(
+        "[signer-solana] SolanaTransactionSerializer: malformed message header",
+      );
+    }
+    if (numRequiredSignatures > SOLANA_MAX_SIGNATURES) {
+      throw new Error(
+        `[signer-solana] SolanaTransactionSerializer: numRequiredSignatures (${numRequiredSignatures}) exceeds SOLANA_MAX_SIGNATURES (${SOLANA_MAX_SIGNATURES})`,
+      );
+    }
+    return numRequiredSignatures;
+  }
+
+  private encodeShortVec(value: number): Uint8Array {
+    const bytes: number[] = [];
+    let remaining = value;
+    while (true) {
+      const lowBits = remaining & SHORTVEC_DATA_MASK;
+      remaining >>>= SHORTVEC_DATA_BITS;
+      if (remaining === 0) {
+        bytes.push(lowBits);
+        break;
+      }
+      bytes.push(lowBits | SHORTVEC_CONTINUATION_BIT);
+    }
+    return Uint8Array.from(bytes);
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/services/SolanaTransactionSerializer.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/services/SolanaTransactionSerializer.ts
@@ -1,0 +1,6 @@
+export interface SolanaTransactionSerializer {
+  wrapMessageAsTransaction(
+    message: Uint8Array,
+    serializedTransactionForTransactionCheck?: Uint8Array,
+  ): Uint8Array;
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/services/TransactionInputNormaliser.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/services/TransactionInputNormaliser.test.ts
@@ -1,0 +1,94 @@
+import { VersionedTransaction } from "@solana/web3.js";
+
+import { TransactionInputNormaliser } from "./TransactionInputNormaliser";
+
+vi.mock("@solana/web3.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@solana/web3.js")>();
+  return {
+    ...actual,
+    VersionedTransaction: {
+      ...actual.VersionedTransaction,
+      deserialize: vi.fn(),
+    },
+  };
+});
+
+const deserializeMock = VersionedTransaction.deserialize as ReturnType<
+  typeof vi.fn
+>;
+
+const SIGNATURE_LENGTH = 64;
+
+function buildWireFormat(sigCount: number, message: Uint8Array): Uint8Array {
+  // compact-u16 for values < 128 is a single byte
+  const wire = new Uint8Array(1 + sigCount * SIGNATURE_LENGTH + message.length);
+  wire[0] = sigCount;
+  wire.set(message, 1 + sigCount * SIGNATURE_LENGTH);
+  return wire;
+}
+
+describe("TransactionInputNormaliser", () => {
+  let normaliser: TransactionInputNormaliser;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    normaliser = new TransactionInputNormaliser();
+  });
+
+  it("passes raw message bytes through unchanged when deserialize throws", () => {
+    deserializeMock.mockImplementation(() => {
+      throw new Error("not a valid wire-format transaction");
+    });
+
+    const message = new Uint8Array([1, 0, 3, 0xf0, 0xca, 0xcc, 0x1a]);
+    const result = normaliser.normalize(message);
+
+    expect(result.messageBytes).toBe(message);
+    expect(result.serializedForTxCheck).toBeUndefined();
+  });
+
+  it("extracts message bytes and sets serializedForTxCheck when deserialize succeeds (1 signer)", () => {
+    deserializeMock.mockReturnValue({});
+
+    const message = new Uint8Array([1, 0, 3, 0xf0, 0xca, 0xcc, 0x1a]);
+    const wire = buildWireFormat(1, message);
+    const result = normaliser.normalize(wire);
+
+    expect(Array.from(result.messageBytes)).toEqual(Array.from(message));
+    expect(result.serializedForTxCheck).toBe(wire);
+  });
+
+  it("extracts message bytes correctly for a 2-signer transaction", () => {
+    deserializeMock.mockReturnValue({});
+
+    const message = new Uint8Array([2, 0, 3, 0xf0, 0xca, 0xcc, 0x1a]);
+    const wire = buildWireFormat(2, message);
+    const result = normaliser.normalize(wire);
+
+    expect(Array.from(result.messageBytes)).toEqual(Array.from(message));
+    expect(result.serializedForTxCheck).toBe(wire);
+  });
+
+  it("messageBytes is a subarray of the original wire buffer (no copy)", () => {
+    deserializeMock.mockReturnValue({});
+
+    const message = new Uint8Array([0xf0, 0xca, 0xcc, 0x1a]);
+    const wire = buildWireFormat(1, message);
+    const result = normaliser.normalize(wire);
+
+    // subarray shares the same underlying ArrayBuffer
+    expect(result.messageBytes.buffer).toBe(wire.buffer);
+  });
+
+  it("falls back to raw bytes when deserialize throws on garbage input", () => {
+    deserializeMock.mockImplementation(() => {
+      throw new Error("malformed");
+    });
+
+    const garbage = new Uint8Array([0xf0, 0xca, 0xcc, 0x1a]);
+    const result = normaliser.normalize(garbage);
+
+    expect(result.messageBytes).toBe(garbage);
+    expect(result.serializedForTxCheck).toBeUndefined();
+  });
+});

--- a/packages/signer/signer-solana/src/internal/app-binder/services/TransactionInputNormaliser.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/services/TransactionInputNormaliser.ts
@@ -1,0 +1,47 @@
+import { VersionedTransaction } from "@solana/web3.js";
+
+const SIGNATURE_LENGTH = 64;
+
+export type NormalizedTransactionInput = {
+  messageBytes: Uint8Array;
+  serializedForTxCheck?: Uint8Array;
+};
+
+/**
+ * Detects whether a transaction input is a full wire-format Solana transaction
+ * (`tx.serialize()`) or raw message bytes (`tx.serializeMessage()`), and
+ * returns the message bytes together with the original blob when it was
+ * full wire-format (used internally to forward co-signer signatures to
+ * Transaction Check without re-serialization).
+ */
+export class TransactionInputNormaliser {
+  normalize(bytes: Uint8Array): NormalizedTransactionInput {
+    try {
+      VersionedTransaction.deserialize(bytes);
+    } catch {
+      return { messageBytes: bytes };
+    }
+
+    // Full wire-format. Extract message bytes directly from the raw bytes so
+    // the slice is byte-identical to what the loader validates against.
+    const { byteLength, value: sigCount } = this.decodeCompactU16(bytes);
+    const messageOffset = byteLength + sigCount * SIGNATURE_LENGTH;
+    const messageBytes = bytes.subarray(messageOffset);
+    return { messageBytes, serializedForTxCheck: bytes };
+  }
+
+  private decodeCompactU16(bytes: Uint8Array): {
+    value: number;
+    byteLength: number;
+  } {
+    let value = 0;
+    let shift = 0;
+    for (let i = 0; i < bytes.length; i++) {
+      const byte = bytes[i]!;
+      value |= (byte & 0x7f) << shift;
+      if ((byte & 0x80) === 0) return { value, byteLength: i + 1 };
+      shift += 7;
+    }
+    return { value, byteLength: bytes.length };
+  }
+}

--- a/packages/signer/signer-solana/src/internal/app-binder/task/ProvideTransactionCheckTask.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/ProvideTransactionCheckTask.test.ts
@@ -14,11 +14,13 @@ import { GetChallengeCommand } from "@internal/app-binder/command/GetChallengeCo
 import { GetPubKeyCommand } from "@internal/app-binder/command/GetPubKeyCommand";
 import { ProvideTransactionCheckCommand } from "@internal/app-binder/command/ProvideTransactionCheckCommand";
 import { BlockhashService } from "@internal/app-binder/services/BlockhashService";
+import { type SolanaTransactionSerializer } from "@internal/app-binder/services/SolanaTransactionSerializer";
 
 import { ProvideTransactionCheckTask } from "./ProvideTransactionCheckTask";
 
 const SIGNER = "So1anaSignerPubKey111111111111111111111111111";
 const TX = new Uint8Array([1, 2, 3]);
+const WRAPPED = new Uint8Array([0x42, 0x43]);
 
 const BLOCKHASH = "a3PD566oU2nE9JHwuC897aaT7ispdqaQ63Si6jzyKAg";
 const payer = new PublicKey("2cHm11EeTGQixAkyaqNRFczpi1XB1n6rK7bSwNiZbCdB");
@@ -47,6 +49,10 @@ function makeTask(
   getContexts: Mock = vi.fn(async () => [txCheckContext]),
   transactionBytes: Uint8Array = TX,
   isBlockhashRefreshNeeded = true,
+  serializedTransactionForTransactionCheck?: Uint8Array,
+  transactionSerializer: SolanaTransactionSerializer = {
+    wrapMessageAsTransaction: vi.fn().mockReturnValue(WRAPPED),
+  },
 ) {
   const api = {
     sendCommand: vi.fn(async (cmd: unknown) => {
@@ -64,10 +70,12 @@ function makeTask(
     transactionBytes,
     contextModule,
     isBlockhashRefreshNeeded,
+    serializedTransactionForTransactionCheck,
+    transactionSerializer,
     loggerFactory: () =>
       ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }) as any,
   });
-  return { task, api, getContexts };
+  return { task, api, getContexts, transactionSerializer };
 }
 
 describe("ProvideTransactionCheckTask", () => {
@@ -87,9 +95,7 @@ describe("ProvideTransactionCheckTask", () => {
         challenge: "deadbeef",
         transactionCheck: {
           from: SIGNER,
-          // Blockhash can't be located in this 3-byte fixture, so the task
-          // falls back to the original bytes (best-effort).
-          transactionBytes: TX,
+          transactionBytes: WRAPPED,
           chain: SolanaTransactionScanChainId.MAINNET,
         },
       }),
@@ -102,36 +108,83 @@ describe("ProvideTransactionCheckTask", () => {
     );
   });
 
-  it("zeroes the blockhash when the sign will refresh it (delayed path)", async () => {
-    // The delayed path previews a blockhash-zeroed message, so the backend must
-    // scan the same bytes — otherwise the verdict can't be matched on-device and
-    // it shows "Transaction Check unavailable".
+  it("zeroes the blockhash before wrapping when the sign will refresh it (delayed path)", async () => {
     const message = buildLegacyMessage();
     const expected = new BlockhashService().zeroBlockhash(message);
     const getContexts = vi.fn(async () => [txCheckContext]);
-    const { task } = makeTask(getContexts, message, true);
+    const serializerMock: SolanaTransactionSerializer = {
+      wrapMessageAsTransaction: vi.fn().mockReturnValue(WRAPPED),
+    };
+    const { task } = makeTask(
+      getContexts,
+      message,
+      true,
+      undefined,
+      serializerMock,
+    );
 
     await task.run();
 
-    const sentBytes = (getContexts.mock.calls[0] as any)[0].transactionCheck
-      .transactionBytes as Uint8Array;
-    expect(sentBytes).toEqual(expected);
-    // The original (non-zeroed) message must not be forwarded as-is.
-    expect(sentBytes).not.toEqual(message);
+    expect(serializerMock.wrapMessageAsTransaction).toHaveBeenCalledWith(
+      expected,
+      undefined,
+    );
   });
 
-  it("keeps the original blockhash when the sign will not refresh it (one-shot path)", async () => {
-    // The one-shot path signs the original message, so the device fingerprints
-    // the real blockhash; zeroing it here would make the verdict unmatchable.
+  it("wraps the original bytes when the sign will not refresh the blockhash (one-shot path)", async () => {
     const message = buildLegacyMessage();
     const getContexts = vi.fn(async () => [txCheckContext]);
-    const { task } = makeTask(getContexts, message, false);
+    const serializerMock: SolanaTransactionSerializer = {
+      wrapMessageAsTransaction: vi.fn().mockReturnValue(WRAPPED),
+    };
+    const { task } = makeTask(
+      getContexts,
+      message,
+      false,
+      undefined,
+      serializerMock,
+    );
 
     await task.run();
 
-    const sentBytes = (getContexts.mock.calls[0] as any)[0].transactionCheck
-      .transactionBytes as Uint8Array;
-    expect(sentBytes).toEqual(message);
+    expect(serializerMock.wrapMessageAsTransaction).toHaveBeenCalledWith(
+      message,
+      undefined,
+    );
+  });
+
+  it("forwards serializedTransactionForTransactionCheck to the serializer", async () => {
+    const blob = new Uint8Array([0xde, 0xad]);
+    const getContexts = vi.fn(async () => [txCheckContext]);
+    const serializerMock: SolanaTransactionSerializer = {
+      wrapMessageAsTransaction: vi.fn().mockReturnValue(WRAPPED),
+    };
+    const { task } = makeTask(getContexts, TX, false, blob, serializerMock);
+
+    await task.run();
+
+    expect(serializerMock.wrapMessageAsTransaction).toHaveBeenCalledWith(
+      TX,
+      blob,
+    );
+  });
+
+  it("zeroes transactionBytes before wrapping when isBlockhashRefreshNeeded and serializedTransactionForTransactionCheck is supplied", async () => {
+    const message = buildLegacyMessage();
+    const blob = new Uint8Array([0xde, 0xad]);
+    const getContexts = vi.fn(async () => [txCheckContext]);
+    const serializerMock: SolanaTransactionSerializer = {
+      wrapMessageAsTransaction: vi.fn().mockReturnValue(WRAPPED),
+    };
+    const { task } = makeTask(getContexts, message, true, blob, serializerMock);
+
+    await task.run();
+
+    const expected = new BlockhashService().zeroBlockhash(message);
+    expect(serializerMock.wrapMessageAsTransaction).toHaveBeenCalledWith(
+      expected,
+      blob,
+    );
   });
 
   it("skips (best-effort) when the public key cannot be read", async () => {

--- a/packages/signer/signer-solana/src/internal/app-binder/task/ProvideTransactionCheckTask.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/ProvideTransactionCheckTask.ts
@@ -13,6 +13,8 @@ import {
 import { GetChallengeCommand } from "@internal/app-binder/command/GetChallengeCommand";
 import { GetPubKeyCommand } from "@internal/app-binder/command/GetPubKeyCommand";
 import { BlockhashService } from "@internal/app-binder/services/BlockhashService";
+import { DefaultSolanaTransactionSerializer } from "@internal/app-binder/services/DefaultSolanaTransactionSerializer";
+import { type SolanaTransactionSerializer } from "@internal/app-binder/services/SolanaTransactionSerializer";
 import { DefaultSolanaMessageNormaliser } from "@internal/app-binder/services/utils/DefaultSolanaMessageNormaliser";
 import { dispatchProvideContext } from "@internal/app-binder/task/context-providers/provideContextRegistry";
 import { type ProvideContextDeps } from "@internal/app-binder/task/context-providers/provideContextTypes";
@@ -31,6 +33,8 @@ export type ProvideTransactionCheckTaskArgs = {
    */
   readonly isBlockhashRefreshNeeded: boolean;
   readonly blockhashService?: BlockhashService;
+  readonly serializedTransactionForTransactionCheck?: Uint8Array;
+  readonly transactionSerializer?: SolanaTransactionSerializer;
 };
 
 /**
@@ -41,6 +45,7 @@ export type ProvideTransactionCheckTaskArgs = {
 export class ProvideTransactionCheckTask {
   private readonly logger: LoggerPublisherService;
   private readonly blockhashService: BlockhashService;
+  private readonly transactionSerializer: SolanaTransactionSerializer;
 
   constructor(
     private readonly api: InternalApi,
@@ -48,6 +53,8 @@ export class ProvideTransactionCheckTask {
   ) {
     this.logger = args.loggerFactory("ProvideTransactionCheckTask");
     this.blockhashService = args.blockhashService ?? new BlockhashService();
+    this.transactionSerializer =
+      args.transactionSerializer ?? new DefaultSolanaTransactionSerializer();
   }
 
   async run(): Promise<void> {
@@ -93,13 +100,19 @@ export class ProvideTransactionCheckTask {
       }
     }
 
+    const wrappedTransactionBytes =
+      this.transactionSerializer.wrapMessageAsTransaction(
+        transactionBytes,
+        this.args.serializedTransactionForTransactionCheck,
+      );
+
     const contexts = await this.args.contextModule.getContexts(
       {
         deviceModelId: this.api.getDeviceSessionState().deviceModelId,
         challenge: challengeResult.data.challenge,
         transactionCheck: {
           from: pubKeyResult.data,
-          transactionBytes,
+          transactionBytes: wrappedTransactionBytes,
           chain: SolanaTransactionScanChainId.MAINNET,
         },
       },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

**Problem**

Multi-signer Solana transactions (Meteora LP, Orca, etc.) arrive at signing time with co-signer signatures already present. The Transaction Check endpoint needs those signatures to verify the full transaction but the signer was stripping them by accepting only raw message bytes (tx.serializeMessage()), so TXC always received a placeholder-only payload and couldn't validate co-signers.

**Summary**

`signTransaction` now auto-detects the input format: when `tx.serialize()` (full wire-format) is passed, co-signer signatures are extracted and forwarded to Transaction Check automatically. When `tx.serializeMessage()` (raw message bytes) is passed, the existing flow is unchanged.

**Changes**

`device-signer-kit-solana`

- `TransactionInputNormaliser`, new stateless service that detects whether the input is a full wire-format transaction or raw message bytes, and extracts message bytes via compact-u16 offset math.
- `SignTransactionDeviceAction`, new best-effort `NormalizeTransaction` initial state that runs the normaliser and stores `messageBytes` + `serializedForTxCheck` in `_internalState`. Errors fall back to raw bytes.
- `DefaultSolanaTransactionSerializer`, new stateless service that wraps raw message bytes into the TXC wire format (compact-u16 sig count + sig slots + message) and recovers real co-signer signatures from the original blob. Falls back to zero-fill on any mismatch, including the blockhash-refresh case.
- `ProvideTransactionCheckTask`, uses `DefaultSolanaTransactionSerializer` to produce the pre-wrapped TXC payload before calling the context module.
- Docs, README, and sample app updated accordingly.

`context-module`
- `SolanaTransactionCheckLoader`, receives an already-wrapped transaction blob from the signer and bs58-encodes it directly.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [DSDK-1406](https://ledgerhq.atlassian.net/browse/DSDK-1406)

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
