### PR TITLE
📝 (docs) [NO-ISSUE]: Adapt doc sync for TS/KMP doc split in developer-portal

### DIFF
--- a/.github/workflows/sync_doc.yml
+++ b/.github/workflows/sync_doc.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
     paths:
-      - "apps/docs/pages/docs/*"
+      - "apps/docs/content/docs/*"
 
 jobs:
   sync_doc:
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ github.event.inputs.ref || github.event.ref }}
           path: ldmk
           sparse-checkout: |
-            apps/docs/pages/docs
+            apps/docs/content/docs
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -37,9 +37,9 @@ jobs:
 
       - name: Copy files
         run: |
-          rm -rf portal/content/docs/device-interaction
-          mkdir -p portal/content/docs/device-interaction
-          cp -r ldmk/apps/docs/pages/docs/* portal/content/docs/device-interaction
+          rm -rf portal/content/docs/device-interaction/dmk-ts
+          mkdir -p portal/content/docs/device-interaction/dmk-ts
+          cp -r ldmk/apps/docs/content/docs/* portal/content/docs/device-interaction/dmk-ts
 
 
       - name:  Set branch name in outputs
@@ -53,7 +53,7 @@ jobs:
           cd portal
           # add timestamp to commit message
           git checkout -b ${{ steps.branch-name.outputs.BRANCH_NAME }}
-          git add content/docs/device-interaction
+          git add content/docs/device-interaction/dmk-ts
           git commit -m "doc: add new changes from device management kit to portal"
 
       - name: Create pull request

--- a/apps/docs/content/docs/_meta.js
+++ b/apps/docs/content/docs/_meta.js
@@ -1,9 +1,5 @@
 export default {
-  "---": {
-    title: "Device Interaction",
-    type: "separator",
-  },
-  "getting-started": "Getting started",
+  index: "Overview",
   beginner: "Beginner's guides",
   integration: "Integration Walkthroughs",
   references: "References",

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -1,36 +1,28 @@
----
-title: "Documentation"
-category: overview
----
+# TypeScript DMK
 
-# Documentation
+The TypeScript DMK is a collection of libraries that allow you to interact with Ledger devices using TypeScript.
 
-<iframe
-  width="560"
-  height="315"
-  src="https://www.youtube-nocookie.com/embed/i-Q1ld2lG_4"
-  title="YouTube video player"
-  frameborder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
-></iframe>
+# Platforms
 
-Here you will find all the documentation related to the Device Management Kit and the signers that come along with it.
+The TypeScript DMK is available for the following platforms:
 
-## Glossary
+- Web
+- React Native
+- Node.js
 
-Throughout the documentation we use the following acronyms:
+You just need to import the right transport library for your platform.
 
-- DMK: Device Management Kit
-- DSK: Device Signer Kit
+# Libraries
 
-## Libraries
+Here you can find a summary of all the libraries that compose the TypeScript DMK.
 
-Here you can find a summary of all the libraries that compose the DMK.
+## Device Management Kit (DMK)
 
 | Device Management Kit (DMK) | NPM                                                                                              | Version |
 | --------------------------- | ------------------------------------------------------------------------------------------------ | ------- |
 | Device Management Kit       | [@ledgerhq/device-management-kit](https://www.npmjs.com/package/@ledgerhq/device-management-kit) | 1.7.1   |
+
+## Signers & Trusted App Kit
 
 | Signers & Trusted App Kit | NPM                                                                                                                                                | Version |
 | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
@@ -64,11 +56,3 @@ Here you can find a summary of all the libraries that compose the DMK.
 | DevTools Websocket Common    | [@ledgerhq/device-management-kit-devtools-websocket-common](https://www.npmjs.com/package/@ledgerhq/device-management-kit-devtools-websocket-common)       | 1.0.2   |
 | DevTools Websocket Connector | [@ledgerhq/device-management-kit-devtools-websocket-connector](https://www.npmjs.com/package/@ledgerhq/device-management-kit-devtools-websocket-connector) | 1.1.1   |
 | DevTools Websocket Server    | [@ledgerhq/device-management-kit-devtools-websocket-server](https://www.npmjs.com/package/@ledgerhq/device-management-kit-devtools-websocket-server)       | 1.0.1   |
-
-## Legal notice
-
-The Device Management Kit (DMK) is made available under an open source license and is free to use for development, testing, and integration purposes.
-
-Please note that access to the DMK does not grant you any rights to access Ledger SAS backend services, nor any rights to use tokens, APIs, or infrastructure beyond what is explicitly allowed under the open source license. Access to Ledger SAS backend is strictly prohibited unless explicitly authorized by Ledger SAS.
-
-Use of any token to gain access to Ledger SAS backend without a formal, written legal agreement is forbidden. Unauthorized use or access may lead to legal claims, including but not limited to injunctive relief, damages, or other remedies permitted under applicable law.


### PR DESCRIPTION
## ⚠️ Do NOT merge before developer-portal PR #741

This PR adapts this repo's doc sync automation to match the new doc structure introduced in [LedgerHQ/developer-portal#741](https://github.com/LedgerHQ/developer-portal/pull/741), which splits `device-interaction` docs into `device-interaction/dmk-ts/*` (this repo) and `device-interaction/dmk-kmp/*` (device-sdk-mobile). **Merging this before #741 lands will make `sync_doc.yml` push synced docs into a `dmk-ts/` folder that doesn't exist yet on `main`.**

### What changed

- **`.github/workflows/sync_doc.yml`**
  - Destination changed from wiping/recreating the entire `content/docs/device-interaction` folder in developer-portal to only touching `content/docs/device-interaction/dmk-ts`, so it no longer clobbers the new KMP docs or the shared top-level `getting-started.mdx`.
  - Also fixed the sparse-checkout and trigger paths, which still pointed at `apps/docs/pages/docs` — a location that no longer exists since the docs app migrated to the Next.js app router (`apps/docs/content/docs`). This means the sync has very likely been silently broken/no-op since that migration, independent of the TS/KMP split.
- **`apps/docs/content/docs/getting-started.mdx` → `index.mdx`**: renamed to become the `dmk-ts` section's "Overview" page (matches the page already live in developer-portal). The intro video/glossary/legal notice content now lives on developer-portal's shared top-level `getting-started.mdx` instead of being owned by this repo, so it was dropped from here to avoid duplication. Refreshed the Libraries table to the versions currently in `develop` (this catches an ICP signer entry and version bumps that never made it to developer-portal because of the broken sync above).
- **`apps/docs/content/docs/_meta.js`**: `getting-started` key renamed to `index` / label "Overview", dropped the `---` separator (developer-portal's parent `_meta.js` already provides the section header, so it was redundant) — matches PR review feedback already applied to #741.

### Test plan
- [ ] Confirm `DEVICE_SDK_TS_CI` still has push access after developer-portal restructures `device-interaction`
- [ ] After #741 merges, manually trigger `sync_doc.yml` (`workflow_dispatch`) once and confirm it opens a clean PR touching only `content/docs/device-interaction/dmk-ts` in developer-portal