### PR TITLE
👷 (mock-server) [NO-ISSUE]: Add web-apps build/preview/deploy workflows

### DIFF
--- a/.github/workflows/mock-server-preview.yml
+++ b/.github/workflows/mock-server-preview.yml
@@ -58,16 +58,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          body=$(cat <<EOF
-🚀 **Preview environment**
-
-**URL:** https://${PREVIEW_HOST}
-**Image:** \`${REGISTRY}/${IMAGE}:pr-${PR}\`
-**Commit:** \`${{ github.event.pull_request.head.sha }}\`
-
-ArgoCD syncs the env within ~30-60s after this image is pushed.
-EOF
-          )
+          body=$(printf '%s\n' \
+            "🚀 **Preview environment**" \
+            "" \
+            "**URL:** https://${PREVIEW_HOST}" \
+            "**Image:** \`${REGISTRY}/${IMAGE}:pr-${PR}\`" \
+            "**Commit:** \`${HEAD_SHA}\`" \
+            "" \
+            "ArgoCD syncs the env within ~30-60s after this image is pushed.")
           # Upsert: edit our last comment if present, else create a new one.
           gh pr comment "$PR" --edit-last --body "$body" || gh pr comment "$PR" --body "$body"

--- a/apps/device-mock-server/Dockerfile
+++ b/apps/device-mock-server/Dockerfile
@@ -2,6 +2,7 @@
 # Build context: monorepo root
 # Standalone:  docker build -f apps/device-mock-server/Dockerfile -t device-mock-server .
 # Compose:     docker compose -f apps/device-mock-server/docker-compose.yml up
+# CI: built + pushed to infra-oci-web-apps-*-green/device-mock-server by the mock-server-* workflows.
 
 # ── install ───────────────────────────────────────────────────────────────────
 FROM node:24-alpine AS install


### PR DESCRIPTION
### 📝 Description

Adds the CI/CD workflows to build, preview and deploy **device-mock-server** through the shared web-apps flow: image → JFrog `infra-oci-web-apps-*` (GitHub OIDC, no static secrets), deployed via the central `web-app` Helm chart in ArgoCD.

Three workflows — scoped to `apps/device-mock-server/**` (+ `packages/mockserver-client`), reusing the existing multi-stage Dockerfile, auth via `LedgerHQ/actions-security/actions/jfrog-login`:

- **`mock-server-build-prod.yml`** — push to `develop` → build + push `infra-oci-web-apps-prod-green/device-mock-server/prod:<version>`.
- **`mock-server-preview.yml`** — PRs labelled `preview` → build + push `…-sandbox-green/device-mock-server/dev:pr-<n>` and comment the URL (picked up by the ArgoCD ApplicationSet).
- **`mock-server-deploy-prod.yml`** — manual dispatch → set image tag + chart version on the prod ArgoCD app and sync.

Also a one-line comment in the Dockerfile so merging this PR trips the `build-prod` paths filter (smoke-tests the prod build).

### ❓ Context

- **JIRA**: [INFRAPRJ-13088](https://ledgerhq.atlassian.net/browse/INFRAPRJ-13088) (child of INFRAPRJ-12943)

### ✅ Checklist

- **Tests**: N/A — GitHub Actions workflows; validated by running the pipeline (preview build on a labelled PR + build-prod on merge).
- **Changeset**: N/A — CI only, no package version bump.
- **Impact**: 3 new workflows under `apps/device-mock-server` + a Dockerfile comment; no app/runtime changes. Requires a `preview` label in the repo for the preview workflow.

[INFRAPRJ-13088]: https://ledgerhq.atlassian.net/browse/INFRAPRJ-13088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ