### PR TITLE
 👷 (mock-server) [NO-ISSUE]: Run deploy-prod on ledgerhq-device-sdk runner

### DIFF
--- a/.github/workflows/mock-server-deploy-prod.yml
+++ b/.github/workflows/mock-server-deploy-prod.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   deploy:
-    runs-on: ledgerhq-shared-small
+    runs-on: ledgerhq-device-sdk
     timeout-minutes: 15
     steps:
       - name: Install ArgoCD CLI


### PR DESCRIPTION
### 📝 Description

`mock-server-deploy-prod.yml` was pinned to `ledgerhq-shared-small`, which isn't available to this repo — the `deploy` job sat in **queued** forever ([example run](https://github.com/LedgerHQ/device-sdk-ts/actions/runs/31010781630)). Switch it to **`ledgerhq-device-sdk`**, the repo's own runner pool (same one `build-prod`/`preview` use, reaches the internal ArgoCD server).

### ❓ Context

- **JIRA**: [INFRAPRJ-13088](https://ledgerhq.atlassian.net/browse/INFRAPRJ-13088)

### ✅ Checklist

- **Tests**: N/A — CI runner label change; verified the job now picks up a runner.
- **Changeset**: N/A — CI only.
- **Impact**: `deploy-prod` workflow only; no app changes.

[INFRAPRJ-13088]: https://ledgerhq.atlassian.net/browse/INFRAPRJ-13088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ