### PR TITLE
✨ (signer-eth) [DSDK-1368]: Add ProvideMapEntryCommand for ERC-7730 v2 map support

### DIFF
--- a/.changeset/grumpy-rocks-hear.md
+++ b/.changeset/grumpy-rocks-hear.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": minor
+---
+
+Add `ProvideMapEntryCommand` to send the Ethereum app's `PROVIDE MAP ENTRY` APDU (`0x3A`), part of the ERC-7730 v2 map support (DSDK-1368).

--- a/packages/signer/signer-eth/src/internal/app-binder/command/ProvideMapEntryCommand.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/command/ProvideMapEntryCommand.test.ts
@@ -1,0 +1,101 @@
+import {
+  type ApduResponse,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { EthAppCommandError } from "./utils/ethAppErrors";
+import {
+  ProvideMapEntryCommand,
+  type ProvideMapEntryCommandArgs,
+} from "./ProvideMapEntryCommand";
+
+describe("ProvideMapEntryCommand", () => {
+  describe("name", () => {
+    it("should be 'provideMapEntry'", () => {
+      const command = new ProvideMapEntryCommand({
+        data: new Uint8Array(),
+        isFirstChunk: true,
+      });
+      expect(command.name).toBe("provideMapEntry");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("should return the raw APDU for the first chunk", () => {
+      // GIVEN
+      const args: ProvideMapEntryCommandArgs = {
+        data: Uint8Array.from([0x01, 0x02, 0x03]),
+        isFirstChunk: true,
+      };
+
+      // WHEN
+      const command = new ProvideMapEntryCommand(args);
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.getRawApdu()).toStrictEqual(
+        Uint8Array.from([0xe0, 0x3a, 0x01, 0x00, 0x03, 0x01, 0x02, 0x03]),
+      );
+    });
+
+    it("should return the raw APDU for the subsequent chunk", () => {
+      // GIVEN
+      const args: ProvideMapEntryCommandArgs = {
+        data: Uint8Array.from([0x04, 0x05, 0x06]),
+        isFirstChunk: false,
+      };
+
+      // WHEN
+      const command = new ProvideMapEntryCommand(args);
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.getRawApdu()).toStrictEqual(
+        Uint8Array.from([0xe0, 0x3a, 0x00, 0x00, 0x03, 0x04, 0x05, 0x06]),
+      );
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("should return an error if the response status code is invalid", () => {
+      // GIVEN
+      const response: ApduResponse = {
+        data: Uint8Array.from([]),
+        statusCode: Uint8Array.from([0x6d, 0x00]), // Invalid status code
+      };
+
+      // WHEN
+      const command = new ProvideMapEntryCommand({
+        data: new Uint8Array(0),
+        isFirstChunk: true,
+      });
+      const result = command.parseResponse(response);
+
+      // THEN
+      if (isSuccessCommandResult(result)) {
+        throw new Error("Expected an error");
+      } else {
+        expect(result.error).toBeDefined();
+        expect(result.error).toBeInstanceOf(EthAppCommandError);
+      }
+    });
+
+    it("should return a success result if the response status code is valid", () => {
+      // GIVEN
+      const response: ApduResponse = {
+        data: Uint8Array.from([]),
+        statusCode: Uint8Array.from([0x90, 0x00]), // Success status code
+      };
+
+      // WHEN
+      const command = new ProvideMapEntryCommand({
+        data: new Uint8Array(0),
+        isFirstChunk: true,
+      });
+      const result = command.parseResponse(response);
+
+      // THEN
+      expect(isSuccessCommandResult(result)).toBe(true);
+    });
+  });
+});

--- a/packages/signer/signer-eth/src/internal/app-binder/command/ProvideMapEntryCommand.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/command/ProvideMapEntryCommand.ts
@@ -1,0 +1,60 @@
+// https://github.com/LedgerHQ/app-ethereum/blob/develop/doc/apdu.md#provide-map-entry
+import {
+  type Apdu,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import {
+  ETH_APP_ERRORS,
+  EthAppCommandErrorFactory,
+  type EthErrorCodes,
+} from "./utils/ethAppErrors";
+
+export type ProvideMapEntryCommandArgs = {
+  /**
+   * The MAP_ENTRY TLV data to provide in chunks
+   */
+  readonly data: Uint8Array;
+  /**
+   * If this is the first chunk of the message
+   */
+  readonly isFirstChunk: boolean;
+};
+
+export class ProvideMapEntryCommand
+  implements Command<void, ProvideMapEntryCommandArgs, EthErrorCodes>
+{
+  readonly name = "provideMapEntry";
+  private readonly errorHelper = new CommandErrorHelper<void, EthErrorCodes>(
+    ETH_APP_ERRORS,
+    EthAppCommandErrorFactory,
+  );
+
+  constructor(private readonly args: ProvideMapEntryCommandArgs) {}
+
+  getApdu(): Apdu {
+    const ProvideMapEntryArgs: ApduBuilderArgs = {
+      cla: 0xe0,
+      ins: 0x3a,
+      p1: this.args.isFirstChunk ? 0x01 : 0x00,
+      p2: 0x00,
+    };
+
+    return new ApduBuilder(ProvideMapEntryArgs)
+      .addBufferToData(this.args.data)
+      .build();
+  }
+
+  parseResponse(response: ApduResponse): CommandResult<void, EthErrorCodes> {
+    return Maybe.fromNullable(this.errorHelper.getError(response)).orDefault(
+      CommandResultFactory({ data: undefined }),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `ProvideMapEntryCommand` to `packages/signer/signer-eth`, sending the Ethereum app's `PROVIDE MAP ENTRY` APDU (`CLA 0xE0, INS 0x3A`), confirmed against [app-ethereum's `develop` apdu.md](https://github.com/LedgerHQ/app-ethereum/blob/develop/doc/apdu.md#provide-map-entry).
- Mirrors the existing chunked `Provide*Command` pattern (`ProvideEnumCommand`, `ProvideTransactionFieldDescriptionCommand`): `{ data: Uint8Array; isFirstChunk: boolean }`, `P1` = chunk flag, `P2 = 0x00`.
- First PR of the ERC-7730 v2 track (DSDK-1247 epic). Deliberately scoped to the command class only — no wiring into `ProvideContextTask` / `context-module` yet (new `ClearSignContextType`, dispatch case, exhaustive-switch updates in `BuildBaseContexts`, version gating). That's planned as a follow-on stacked PR.

## Test plan
- [x] `ProvideMapEntryCommand.test.ts`: name, `getApdu` (first chunk + subsequent chunk raw bytes), `parseResponse` (error + success) — 5 tests, all passing
- [x] Full `signer-eth` suite: 73 files / 606 tests passing
- [x] `pnpm eslint` clean
- [x] `pnpm tsc -p tsconfig.prod.json --noEmit` clean
- [x] Changeset added (`@ledgerhq/device-signer-kit-ethereum`: minor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)