### PR TITLE
🔧 (sample) [NO-ISSUE]: Set default mock server URL to shared instance

### DIFF
--- a/.changeset/loose-parts-kiss.md
+++ b/.changeset/loose-parts-kiss.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit-sample": minor
+---
+
+Default the mock server URL to a shared remote instance instead of `127.0.0.1:9752`, and add a Localhost/Remote/Custom dropdown in Settings to switch between them

--- a/apps/sample/playwright/utils/setup.ts
+++ b/apps/sample/playwright/utils/setup.ts
@@ -1,7 +1,9 @@
 import { MockClient } from "@ledgerhq/device-mockserver-client";
 import { type Page } from "@playwright/test";
 
-const MOCK_SERVER_URL = "http://127.0.0.1:9752";
+const MOCK_SERVER_URL =
+  process.env["MOCK_SERVER_URL"] ||
+  "http://device-mock-server.aws.ldg-ps-default.ldg-tech.com";
 const SETTINGS_STORAGE_KEY = "dmk-sample-settings";
 
 /**

--- a/apps/sample/src/components/SettingsView/MockServerUrlSetting.tsx
+++ b/apps/sample/src/components/SettingsView/MockServerUrlSetting.tsx
@@ -1,17 +1,39 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Flex, Input } from "@ledgerhq/react-ui";
+import { Flex, Input, SelectInput } from "@ledgerhq/react-ui";
 
-import { InputLabel } from "@/components/InputLabel";
+import { InputLabel, SelectInputLabel } from "@/components/InputLabel";
 import { selectMockServerUrl } from "@/state/settings/selectors";
 import { setMockServerUrl } from "@/state/settings/slice";
+import {
+  DEFAULT_MOCK_SERVER_URL_LOCAL,
+  DEFAULT_MOCK_SERVER_URL_REMOTE,
+} from "@/utils/const";
 
 import { ResetSettingCTA } from "./ResetSetting";
 import { SettingBox } from "./SettingBox";
 
+type Option = { label: string; value: string };
+
+const CUSTOM_VALUE = "custom";
+
+const urlOptions: Option[] = [
+  { label: "Localhost", value: DEFAULT_MOCK_SERVER_URL_LOCAL },
+  { label: "Remote", value: DEFAULT_MOCK_SERVER_URL_REMOTE },
+  { label: "Custom", value: CUSTOM_VALUE },
+];
+
+const isPresetUrl = (url: string) =>
+  url === DEFAULT_MOCK_SERVER_URL_LOCAL ||
+  url === DEFAULT_MOCK_SERVER_URL_REMOTE;
+
 export const MockServerUrlSetting: React.FC = () => {
   const mockServerUrl = useSelector(selectMockServerUrl);
   const dispatch = useDispatch();
+
+  // Tracks an explicit "Custom" selection so it sticks even if the typed
+  // value happens to match a preset URL.
+  const [manualCustom, setManualCustom] = useState(false);
 
   const setMockServerUrlFn = useCallback(
     (value: string) => {
@@ -20,19 +42,55 @@ export const MockServerUrlSetting: React.FC = () => {
     [dispatch],
   );
 
+  const resetMockServerUrlFn = useCallback(
+    (value: string) => {
+      setManualCustom(false);
+      setMockServerUrlFn(value);
+    },
+    [setMockServerUrlFn],
+  );
+
+  const isCustom = manualCustom || !isPresetUrl(mockServerUrl);
+  const selectedOption = urlOptions.find((opt) =>
+    isCustom ? opt.value === CUSTOM_VALUE : opt.value === mockServerUrl,
+  );
+
+  const onOptionChange = useCallback(
+    (option: Option | null) => {
+      if (!option) return;
+      if (option.value === CUSTOM_VALUE) {
+        setManualCustom(true);
+      } else {
+        setManualCustom(false);
+        setMockServerUrlFn(option.value);
+      }
+    },
+    [setMockServerUrlFn],
+  );
+
   return (
     <SettingBox>
-      <Flex flex={1} flexDirection="column" alignItems="stretch">
+      <Flex flex={1} flexDirection="column" alignItems="stretch" rowGap={2}>
+        <SelectInput
+          renderLeft={() => <SelectInputLabel>Mock Server</SelectInputLabel>}
+          options={urlOptions}
+          value={selectedOption}
+          onChange={onOptionChange}
+          isMulti={false}
+          isSearchable={false}
+          placeholder="Select mock server"
+        />
         <Input
-          renderLeft={<InputLabel>Mock Server URL</InputLabel>}
+          renderLeft={<InputLabel>URL</InputLabel>}
           value={mockServerUrl}
           onChange={setMockServerUrlFn}
-          placeholder="http://127.0.0.1:4000"
+          placeholder="http://127.0.0.1:9752"
+          disabled={!isCustom}
         />
       </Flex>
       <ResetSettingCTA
         stateSelector={selectMockServerUrl}
-        setStateAction={setMockServerUrlFn}
+        setStateAction={resetMockServerUrlFn}
       />
     </SettingBox>
   );

--- a/apps/sample/src/state/settings/schema.ts
+++ b/apps/sample/src/state/settings/schema.ts
@@ -9,7 +9,11 @@ import {
 } from "@ledgerhq/context-module";
 import { DeviceModelId } from "@ledgerhq/device-management-kit";
 
-import { DEFAULT_SPECULOS_URL, DEFAULT_SPECULOS_VNC_URL } from "@/utils/const";
+import {
+  DEFAULT_MOCK_SERVER_URL_REMOTE,
+  DEFAULT_SPECULOS_URL,
+  DEFAULT_SPECULOS_VNC_URL,
+} from "@/utils/const";
 
 export type CalMode = ContextModuleCalMode;
 export type CalBranch = ContextModuleCalBranch;
@@ -58,7 +62,7 @@ export type SettingsState = {
 export const initialState: SettingsState = {
   // Transport settings
   transportType: getInitialTransportType(),
-  mockServerUrl: "http://device-mock-server.aws.ldg-ps-default.ldg-tech.com/",
+  mockServerUrl: DEFAULT_MOCK_SERVER_URL_REMOTE,
   mockServerSessionToken: "",
   speculosUrl: DEFAULT_SPECULOS_URL,
   speculosVncUrl: DEFAULT_SPECULOS_VNC_URL,

--- a/apps/sample/src/state/settings/schema.ts
+++ b/apps/sample/src/state/settings/schema.ts
@@ -58,7 +58,7 @@ export type SettingsState = {
 export const initialState: SettingsState = {
   // Transport settings
   transportType: getInitialTransportType(),
-  mockServerUrl: "http://127.0.0.1:9752/",
+  mockServerUrl: "http://device-mock-server.aws.ldg-ps-default.ldg-tech.com/",
   mockServerSessionToken: "",
   speculosUrl: DEFAULT_SPECULOS_URL,
   speculosVncUrl: DEFAULT_SPECULOS_VNC_URL,

--- a/apps/sample/src/utils/const.ts
+++ b/apps/sample/src/utils/const.ts
@@ -1,2 +1,6 @@
 export const DEFAULT_SPECULOS_URL = "http://127.0.0.1:5000";
 export const DEFAULT_SPECULOS_VNC_URL = "ws://localhost:3337";
+
+export const DEFAULT_MOCK_SERVER_URL_LOCAL = "http://127.0.0.1:9752/";
+export const DEFAULT_MOCK_SERVER_URL_REMOTE =
+  "http://device-mock-server.aws.ldg-ps-default.ldg-tech.com/";


### PR DESCRIPTION
### 📝 Description

Changes the default device mock server URL used by the sample app and its Playwright e2e tests away from `http://127.0.0.1:9752/` (local-only) to a shared instance: `http://device-mock-server.aws.ldg-ps-default.ldg-tech.com/`. Also adds a dropdown to the sample app's Settings UI so the mock server URL can be switched between the two presets or a custom value.

- `apps/sample/src/utils/const.ts`: adds `DEFAULT_MOCK_SERVER_URL_LOCAL` (`http://127.0.0.1:9752/`) and `DEFAULT_MOCK_SERVER_URL_REMOTE` (the shared instance).
- `apps/sample/src/state/settings/schema.ts`: default `mockServerUrl` in the sample app's initial settings state now points to `DEFAULT_MOCK_SERVER_URL_REMOTE`.
- `apps/sample/src/components/SettingsView/MockServerUrlSetting.tsx`: replaces the plain URL text input with a "Mock Server" dropdown (`Localhost` / `Remote` / `Custom`). Selecting `Localhost` or `Remote` sets the URL to the matching preset and disables the text field; selecting `Custom` keeps the field editable. The chosen value is persisted the same way as before (existing `settingsPersistenceMiddleware` → `localStorage`), so no new persistence plumbing was needed.
- `apps/sample/playwright/utils/setup.ts`: `MOCK_SERVER_URL` now reads from the `MOCK_SERVER_URL` env var first, falling back to the shared instance URL if unset.

Verified locally by building the workspace packages, running the sample app's dev server, and exercising the dropdown in a browser: switching between Localhost/Remote/Custom, typing a custom URL, confirming it persists across a page reload, and confirming Reset correctly restores the default preset selection. Also ran `lint` and `typecheck` on the sample app — 0 errors on both, and no new warnings compared to the base branch.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Point the sample app and e2e tests at a shared mock server by default instead of requiring a locally-running instance on `127.0.0.1:9752`, and let users pick between localhost, the shared remote instance, or a custom URL from the Settings UI.

### ✅ Checklist

- [x] **Covered by automatic tests** — existing Playwright e2e suite exercises the mock server setup path; manually verified the new dropdown UI in a browser (see description). No new automated tests added since this is primarily a default-value and settings-UI change.
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date** — no docs reference the old default URL.
- [x] **Impact of the changes:**
  - Sample app users who previously relied on the built-in `127.0.0.1:9752` default will need to explicitly pick "Localhost" (or "Custom") in Settings if they want to keep using a local mock server.
  - Playwright e2e runs (local or CI) can override via the `MOCK_SERVER_URL` env var; otherwise they will hit the shared instance by default.
  - The Mock Server URL setting is now a dropdown; existing custom URLs saved in `localStorage` continue to work and will show as "Custom".

🤖 Generated with [Claude Code](https://claude.com/claude-code)