### PR TITLE
✨ (os-update) [DSDK-1283]: Adds os update and flash mcu DA integration

### DIFF
--- a/apps/sample/src/components/DeviceActionsView/AllDeviceActions.tsx
+++ b/apps/sample/src/components/DeviceActionsView/AllDeviceActions.tsx
@@ -81,6 +81,14 @@ import {
   type CreateBackupDAIntermediateValue,
   type CreateBackupDAOutput,
   CreateBackupDeviceAction,
+  type FinalFirmware,
+  type FlashMcuDAError,
+  type FlashMcuDAIntermediateValue,
+  FlashMcuDeviceAction,
+  type InstallOsUpdateDAError,
+  type InstallOsUpdateDAIntermediateValue,
+  InstallOsUpdateDeviceAction,
+  type OsUpdate,
   type ResolveOsUpdatePathDAError,
   type ResolveOsUpdatePathDAInput,
   type ResolveOsUpdatePathDAIntermediateValue,
@@ -354,48 +362,6 @@ export const AllDeviceActions: React.FC<{ sessionId: string }> = ({
         GetDeviceMetadataDAIntermediateValue
       >,
       {
-        title: "Resolve OS update path",
-        description: "Resolve the OS update path for the given device",
-        executeDeviceAction: ({ unlockTimeout }) => {
-          const deviceAction = new ResolveOsUpdatePathDeviceAction({
-            input: { unlockTimeout },
-          });
-          return dmk.executeDeviceAction({
-            sessionId,
-            deviceAction,
-          });
-        },
-        initialValues: { unlockTimeout: UNLOCK_TIMEOUT },
-        deviceModelId,
-      } satisfies DeviceActionProps<
-        ResolveOsUpdatePathDAOutput,
-        ResolveOsUpdatePathDAInput,
-        ResolveOsUpdatePathDAError,
-        ResolveOsUpdatePathDAIntermediateValue
-      >,
-      {
-        title: `${SECURE_CHANNEL_ICON} Genuine Check`,
-        description:
-          "Perform all the actions necessary to check the device's genuineness",
-        executeDeviceAction: ({ unlockTimeout }, inspect) => {
-          const deviceAction = new GenuineCheckDeviceAction({
-            input: { unlockTimeout },
-            inspect,
-          });
-          return dmk.executeDeviceAction({
-            sessionId,
-            deviceAction,
-          });
-        },
-        initialValues: { unlockTimeout: UNLOCK_TIMEOUT },
-        deviceModelId,
-      } satisfies DeviceActionProps<
-        GenuineCheckDAOutput,
-        GenuineCheckDAInput,
-        GenuineCheckDAError,
-        GenuineCheckDAIntermediateValue
-      >,
-      {
         title: `${SECURE_CHANNEL_ICON} List Installed App`,
         description:
           "Perform all the actions necessary to list installed apps on the device",
@@ -500,6 +466,48 @@ export const AllDeviceActions: React.FC<{ sessionId: string }> = ({
         UninstallAppDAIntermediateValue
       >,
       {
+        title: `${SECURE_CHANNEL_ICON} Genuine Check`,
+        description:
+          "Perform all the actions necessary to check the device's genuineness",
+        executeDeviceAction: ({ unlockTimeout }, inspect) => {
+          const deviceAction = new GenuineCheckDeviceAction({
+            input: { unlockTimeout },
+            inspect,
+          });
+          return dmk.executeDeviceAction({
+            sessionId,
+            deviceAction,
+          });
+        },
+        initialValues: { unlockTimeout: UNLOCK_TIMEOUT },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        GenuineCheckDAOutput,
+        GenuineCheckDAInput,
+        GenuineCheckDAError,
+        GenuineCheckDAIntermediateValue
+      >,
+      {
+        title: "Resolve OS update path",
+        description: "Resolve the OS update path for the given device",
+        executeDeviceAction: ({ unlockTimeout }) => {
+          const deviceAction = new ResolveOsUpdatePathDeviceAction({
+            input: { unlockTimeout },
+          });
+          return dmk.executeDeviceAction({
+            sessionId,
+            deviceAction,
+          });
+        },
+        initialValues: { unlockTimeout: UNLOCK_TIMEOUT },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        ResolveOsUpdatePathDAOutput,
+        ResolveOsUpdatePathDAInput,
+        ResolveOsUpdatePathDAError,
+        ResolveOsUpdatePathDAIntermediateValue
+      >,
+      {
         title: `${SECURE_CHANNEL_ICON} Create Backup`,
         description:
           "Perform all the actions necessary to backup the device data before an OS update",
@@ -526,12 +534,14 @@ export const AllDeviceActions: React.FC<{ sessionId: string }> = ({
         CreateBackupDAIntermediateValue
       >,
       {
-        title: `${SECURE_CHANNEL_ICON} Clean Device`,
+        title: `${SECURE_CHANNEL_ICON} Install OS Update`,
         description:
-          "Uninstall all installed apps, delete the installed language pack, and remove the custom lock screen to prepare the device for an OS update",
-        executeDeviceAction: ({ unlockTimeout }, inspect) => {
-          const deviceAction = new CleanDeviceDeviceAction({
+          "Install one OS update step (as produced by Resolve OS update path) on the device",
+        executeDeviceAction: ({ osUpdateJson, unlockTimeout }, inspect) => {
+          const osUpdate = JSON.parse(osUpdateJson) as OsUpdate;
+          const deviceAction = new InstallOsUpdateDeviceAction({
             input: {
+              osUpdate,
               unlockTimeout,
             },
             inspect,
@@ -542,14 +552,106 @@ export const AllDeviceActions: React.FC<{ sessionId: string }> = ({
           });
         },
         initialValues: {
+          osUpdateJson: JSON.stringify({
+            osuFirmware: {
+              id: 0,
+              perso: "perso_11",
+              hash: null,
+              notes: null,
+              firmware: "",
+              firmwareKey: "",
+              nextFinalFirmware: 0,
+            },
+            finalFirmware: {
+              id: 0,
+              perso: "perso_11",
+              hash: null,
+              version: "",
+              bytes: null,
+              firmware: null,
+              firmwareKey: null,
+              mcuVersions: [],
+            },
+            shouldFlashMcu: false,
+          } satisfies OsUpdate),
           unlockTimeout: UNLOCK_TIMEOUT,
+        },
+        labelSelector: {
+          osUpdateJson:
+            "OS update (JSON: one entry of the Resolve OS update path output)",
+        },
+        validateValues: ({ osUpdateJson }) => {
+          try {
+            const parsed = JSON.parse(osUpdateJson) as Partial<OsUpdate>;
+            return (
+              parsed.osuFirmware !== undefined &&
+              parsed.finalFirmware !== undefined
+            );
+          } catch {
+            return false;
+          }
         },
         deviceModelId,
       } satisfies DeviceActionProps<
-        CleanDeviceDAOutput,
-        CleanDeviceDAInput,
-        CleanDeviceDAError,
-        CleanDeviceDAIntermediateValue
+        void,
+        {
+          osUpdateJson: string;
+          unlockTimeout: number;
+        },
+        InstallOsUpdateDAError,
+        InstallOsUpdateDAIntermediateValue
+      >,
+      {
+        title: `${SECURE_CHANNEL_ICON} Flash MCU`,
+        description:
+          "Wait for the device to reach bootloader mode, then flash the MCU or bootloader matching the given final firmware",
+        executeDeviceAction: ({ finalFirmwareJson }, inspect) => {
+          const finalFirmware = JSON.parse(finalFirmwareJson) as FinalFirmware;
+          const deviceAction = new FlashMcuDeviceAction({
+            input: {
+              finalFirmware,
+            },
+            inspect,
+          });
+          return dmk.executeDeviceAction({
+            sessionId,
+            deviceAction,
+          });
+        },
+        initialValues: {
+          finalFirmwareJson: JSON.stringify({
+            id: 0,
+            perso: "perso_11",
+            hash: null,
+            version: "",
+            bytes: null,
+            firmware: null,
+            firmwareKey: null,
+            mcuVersions: [],
+          } satisfies FinalFirmware),
+        },
+        labelSelector: {
+          finalFirmwareJson:
+            "Final firmware (JSON: the finalFirmware of a Resolve OS update path entry)",
+        },
+        validateValues: ({ finalFirmwareJson }) => {
+          try {
+            const parsed = JSON.parse(
+              finalFirmwareJson,
+            ) as Partial<FinalFirmware>;
+            return Array.isArray(parsed.mcuVersions);
+          } catch {
+            return false;
+          }
+        },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        void,
+        {
+          finalFirmwareJson: string;
+        },
+        FlashMcuDAError,
+        FlashMcuDAIntermediateValue
       >,
       {
         title: `${SECURE_CHANNEL_ICON} Restore Apps Storage`,
@@ -664,6 +766,32 @@ export const AllDeviceActions: React.FC<{ sessionId: string }> = ({
         },
         RestoreBackupDAError,
         RestoreBackupDAIntermediateValue
+      >,
+      {
+        title: `${SECURE_CHANNEL_ICON} Clean Device`,
+        description:
+          "Uninstall all installed apps, delete the installed language pack, and remove the custom lock screen to prepare the device for an OS update",
+        executeDeviceAction: ({ unlockTimeout }, inspect) => {
+          const deviceAction = new CleanDeviceDeviceAction({
+            input: {
+              unlockTimeout,
+            },
+            inspect,
+          });
+          return dmk.executeDeviceAction({
+            sessionId,
+            deviceAction,
+          });
+        },
+        initialValues: {
+          unlockTimeout: UNLOCK_TIMEOUT,
+        },
+        deviceModelId,
+      } satisfies DeviceActionProps<
+        CleanDeviceDAOutput,
+        CleanDeviceDAInput,
+        CleanDeviceDAError,
+        CleanDeviceDAIntermediateValue
       >,
     ],
     [deviceModelId, dmk, sessionId],

--- a/packages/ledger-wallet/src/index.ts
+++ b/packages/ledger-wallet/src/index.ts
@@ -160,6 +160,13 @@ export type {
   RestoreBackupDAState,
   RestoreBackupSteps,
 } from "./api/device-action/OsUpdate/Restore/RestoreBackup/types";
+export type {
+  BaseFirmware,
+  FinalFirmware,
+  McuFirmware,
+  OsuFirmware,
+  OsUpdate,
+} from "./api/device-action/OsUpdate/Shared/types";
 export { FlashMcuDeviceAction } from "./api/device-action/OsUpdate/Update/FlashMcu/FlashMcuDeviceAction";
 export type {
   FlashMcuDAError,


### PR DESCRIPTION
### 📝 Description

Integrates the OS update device actions into the sample playground so they can be exercised against a real device.

- Adds **Install OS Update** and **Flash MCU** entries in `AllDeviceActions` (JSON inputs for `OsUpdate` / `FinalFirmware`, unlock timeout, progress intermediate values).
- Exports shared OS update types (`OsUpdate`, `FinalFirmware`, `OsuFirmware`, …) from `@ledgerhq/dmk-ledger-wallet` for playground consumption.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1283](https://ledgerhq.atlassian.net/browse/DSDK-1283)

- **Feature**: OS update — sample playground integration for Install OS Update & Flash MCU

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] ~~**Covered by automatic tests** — playground-only wiring~~
- [ ] ~~**Changeset is provided** — no package version bump (sample app + type re-exports only)~~
- [ ] ~~**Documentation is up-to-date**~~
- [x] **Impact of the changes:**
  - Sample app: new **Install OS Update** and **Flash MCU** device actions in the playground
  - Public type exports for shared OS update models
  - QA: from playground, paste an `OsUpdate` JSON into Install OS Update; after reboot, run Flash MCU with final firmware JSON; confirm UI shows steps/progress and errors

[DSDK-1283]: https://ledgerhq.atlassian.net/browse/DSDK-1283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ