### PR TITLE
✨ (os-update) [NO-ISSUE]: Adds get provider in manager api service

### DIFF
--- a/apps/sample/src/components/DeviceActionsView/AllDeviceActions.tsx
+++ b/apps/sample/src/components/DeviceActionsView/AllDeviceActions.tsx
@@ -490,7 +490,8 @@ export const AllDeviceActions: React.FC<{ sessionId: string }> = ({
       {
         title: "Resolve OS update path",
         description: "Resolve the OS update path for the given device",
-        executeDeviceAction: ({ unlockTimeout }) => {
+        executeDeviceAction: ({ provider, unlockTimeout }) => {
+          dmk.setProvider(provider);
           const deviceAction = new ResolveOsUpdatePathDeviceAction({
             input: { unlockTimeout },
           });
@@ -499,11 +500,11 @@ export const AllDeviceActions: React.FC<{ sessionId: string }> = ({
             deviceAction,
           });
         },
-        initialValues: { unlockTimeout: UNLOCK_TIMEOUT },
+        initialValues: { provider: 1, unlockTimeout: UNLOCK_TIMEOUT },
         deviceModelId,
       } satisfies DeviceActionProps<
         ResolveOsUpdatePathDAOutput,
-        ResolveOsUpdatePathDAInput,
+        ResolveOsUpdatePathDAInput & { provider: number },
         ResolveOsUpdatePathDAError,
         ResolveOsUpdatePathDAIntermediateValue
       >,

--- a/packages/device-management-kit/src/internal/manager-api/service/DefaultManagerApiService.test.ts
+++ b/packages/device-management-kit/src/internal/manager-api/service/DefaultManagerApiService.test.ts
@@ -218,4 +218,15 @@ describe("ManagerApiService", () => {
       expect(dataSource.getMcuList).toHaveBeenCalled();
     });
   });
+
+  describe("getProvider", () => {
+    it("should return the provider", () => {
+      // given
+      dataSource.getProvider.mockReturnValue(1);
+      // when
+      const provider = service.getProvider();
+      // then
+      expect(provider).toEqual(1);
+    });
+  });
 });

--- a/packages/device-management-kit/src/internal/manager-api/service/DefaultManagerApiService.ts
+++ b/packages/device-management-kit/src/internal/manager-api/service/DefaultManagerApiService.ts
@@ -124,4 +124,8 @@ export class DefaultManagerApiService implements ManagerApiService {
       },
     );
   }
+
+  getProvider(): number {
+    return this.dataSource.getProvider();
+  }
 }

--- a/packages/device-management-kit/src/internal/manager-api/service/ManagerApiService.ts
+++ b/packages/device-management-kit/src/internal/manager-api/service/ManagerApiService.ts
@@ -109,4 +109,11 @@ export interface ManagerApiService {
    * @returns An `EitherAsync` containing either an `HttpFetchApiError` or an array of `McuFirmware` objects.
    */
   getMcuList(): EitherAsync<HttpFetchApiError, Array<McuFirmware>>;
+
+  /**
+   * Retrieves the provider for the Manager API.
+   *
+   * @returns The provider for the Manager API.
+   */
+  getProvider(): number;
 }

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/Substeps/ResolveOsUpdatePath.test.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/Substeps/ResolveOsUpdatePath.test.ts
@@ -17,6 +17,8 @@ const leftAsync = (error: unknown) =>
   EitherAsync<unknown, never>(({ throwE }) => Promise.resolve(throwE(error)));
 
 describe("ResolveOsUpdatePath", () => {
+  const DEFAULT_MANAGER_API_PROVIDER = 1;
+
   const apiMock = makeDeviceActionInternalApiMock();
 
   const getOsVersionResponse = {
@@ -117,6 +119,7 @@ describe("ResolveOsUpdatePath", () => {
     getOsuFirmwareVersion: vi.fn(),
     getLatestFirmwareVersion: vi.fn(),
     getNextFirmwareVersion: vi.fn(),
+    getProvider: vi.fn(),
   };
 
   beforeEach(() => {
@@ -136,6 +139,7 @@ describe("ResolveOsUpdatePath", () => {
     managerApiMock.getNextFirmwareVersion.mockReturnValue(
       rightAsync(firstFinalFirmware),
     );
+    managerApiMock.getProvider.mockReturnValue(DEFAULT_MANAGER_API_PROVIDER);
   });
 
   describe("Success", () => {

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/Substeps/ResolveOsUpdatePath.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Resolve/Substeps/ResolveOsUpdatePath.ts
@@ -64,10 +64,12 @@ export const resolveOsUpdatePath =
           const shouldFlashMcu = !finalFirmware.mcuVersions.includes(mcuId);
 
           if (shouldFlashMcu) {
+            const provider = internalApi.getManagerApiService().getProvider();
             mcuId = await liftEither(
               resolveMcuId(
                 mcuList,
-                bestCompatibleMcu(mcuList, finalFirmware)?.name ?? null,
+                bestCompatibleMcu(mcuList, finalFirmware, provider)?.name ??
+                  null,
               ),
             );
           }

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Shared/OsUpdateUtils.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Shared/OsUpdateUtils.ts
@@ -5,7 +5,7 @@ import {
   type McuFirmware,
 } from "@api/device-action/OsUpdate/Shared/types";
 
-const LEDGER_PROVIDER = 1;
+const DEFAULT_MANAGER_API_PROVIDER = 1;
 
 /*
  * List of from_bootloader_versions that are excluded.
@@ -20,12 +20,13 @@ const EXCLUDED_FROM_BOOTLOADER_VERSIONS = new Set([
 export const bestCompatibleMcu = (
   mcuList: McuFirmware[],
   finalFirmware: FinalFirmware,
+  provider: number = DEFAULT_MANAGER_API_PROVIDER,
 ): McuFirmware | null =>
   mcuList
     .filter(
       (mcu) =>
         finalFirmware.mcuVersions.includes(mcu.id) &&
-        mcu.providers.includes(LEDGER_PROVIDER) &&
+        mcu.providers.includes(provider) &&
         !EXCLUDED_FROM_BOOTLOADER_VERSIONS.has(mcu.fromBootloaderVersion),
     )
     .reduce<(McuFirmware & { version: string }) | null>((latestMcu, mcu) => {

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Update/FlashMcu/Substeps/ResolveMcuVersion.test.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Update/FlashMcu/Substeps/ResolveMcuVersion.test.ts
@@ -10,6 +10,7 @@ import { ResolveMcuVersionError } from "@api/device-action/OsUpdate/Update/Flash
 import { resolveMcuVersion } from "@api/device-action/OsUpdate/Update/FlashMcu/Substeps/ResolveMcuVersion";
 
 describe("ResolveMcuVersion", () => {
+  const DEFAULT_MANAGER_API_PROVIDER = 1;
   const apiMock = makeDeviceActionInternalApiMock();
   const { getManagerApiService: getManagerApiServiceMock } = apiMock;
 
@@ -50,11 +51,14 @@ describe("ResolveMcuVersion", () => {
   } satisfies FinalFirmware;
 
   const getMcuListMock = vi.fn();
+  const getProviderMock = vi.fn();
 
   beforeEach(() => {
     vi.resetAllMocks();
+    getProviderMock.mockReturnValue(DEFAULT_MANAGER_API_PROVIDER);
     getManagerApiServiceMock.mockReturnValue({
       getMcuList: getMcuListMock,
+      getProvider: getProviderMock,
     } as unknown as ReturnType<InternalApi["getManagerApiService"]>);
   });
 
@@ -89,12 +93,13 @@ describe("ResolveMcuVersion", () => {
     );
 
     it("Should return the MCU name when the device is already at its starting bootloader version", async () => {
+      getProviderMock.mockReturnValue(12);
       setupMcuList([
         {
           id: 1,
           name: "1.12",
           fromBootloaderVersion: "1.16",
-          providers: [1],
+          providers: [12],
         },
       ]);
 

--- a/packages/ledger-wallet/src/api/device-action/OsUpdate/Update/FlashMcu/Substeps/ResolveMcuVersion.ts
+++ b/packages/ledger-wallet/src/api/device-action/OsUpdate/Update/FlashMcu/Substeps/ResolveMcuVersion.ts
@@ -68,7 +68,8 @@ export const resolveMcuVersion =
     return EitherAsync<ResolveMcuVersionError, string>(
       async ({ fromPromise, throwE }) => {
         const mcuList = await fromPromise(getMcuList(internalApi));
-        const mcu = bestCompatibleMcu(mcuList, finalFirmware);
+        const provider = internalApi.getManagerApiService().getProvider();
+        const mcu = bestCompatibleMcu(mcuList, finalFirmware, provider);
 
         if (!mcu) {
           return throwE(


### PR DESCRIPTION
### 📝 Description

This PR adds the OS update device-action flow in `@ledgerhq/ledger-wallet`, including:

- **Resolve OS update path** — determines whether an OSU and/or MCU flash is required
- **Install OS update** — installs the firmware update over the secure channel
- **Flash MCU** — resolves and flashes the compatible MCU version when needed
- Sample app wiring to exercise these device actions end-to-end

#### Design choice: expose live provider via `ManagerApiService`

MCU selection must respect the **current Manager API provider** (set at build time via `addConfig({ provider })` or at runtime via `dmk.setProvider()`).

We considered several options:

1. **Pass `DmkConfig` into `InternalApi`** — rejected. The DI-bound `DmkConfig` is a build-time constant (`toConstantValue`). After `setProvider()`, `config.provider` would be stale while Manager API requests already use the live value on `HttpManagerApiDataSource`.
2. **Dedicated `DmkConfigService` / extend `ConfigService`** — valid long-term if device actions need full runtime config (URLs, salt, package version). Too heavy for this PR: requires threading config through `ConnectUseCase` → `DeviceSession` → `InternalApi`, and current `ConfigService` only covers package `name`/`version`.
3. **`ManagerApiService.getProvider()`** — chosen. Provider already lives on `ManagerApiDataSource`, is updated by `SetProviderUseCase`, and is already a Manager API request parameter. `InternalApi` already exposes `getManagerApiService()`, so device actions can read the live provider with no session/config plumbing:

```ts
const provider = internalApi.getManagerApiService().getProvider();
const mcu = bestCompatibleMcu(mcuList, finalFirmware, provider);
```

`bestCompatibleMcu` now takes an explicit `provider` (defaulting to `1`) instead of hardcoding Ledger’s provider.

If we later need broader runtime config inside device actions, we can still introduce a proper config service; this PR keeps the change minimal and correctly scoped.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: OS update / Flash MCU device actions + live Manager API provider access for MCU resolution

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [ ] ~~**Documentation is up-to-date** — no README/API doc update for `getProvider()` yet; public DMK `setProvider`/`getProvider` already documented~~
- [x] **Impact of the changes:**
  - New ledger-wallet device actions: Resolve OS update path, Install OS update, Flash MCU
  - `ManagerApiService.getProvider()` delegates to the data source (live provider)
  - MCU compatibility filtering uses the configured provider instead of a hardcoded value
  - Sample app: OS update / Flash MCU device-action UI
  - QA focus: OS update path with/without MCU flash; provider `1` vs custom provider via `setProvider` / `addConfig`

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.