### PR TITLE
✨ (contacts-kit) [DSDK-1381]: Register a Ledger account

### DIFF
--- a/.changeset/contacts-register-external-address.md
+++ b/.changeset/contacts-register-external-address.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-contacts-kit": minor
+---
+
+Add `ContactsManager.registerExternalAddress`: the REGISTER IDENTITY operation (register an external address, either in a new contact group or added to an existing one), with the shared Contacts protocol foundation (TLV serializer, chunked framing, error model, validation) and a version-guarded device action that opens the app by default, checks the Contacts version requirements, and supports `skipOpenApp`

--- a/.changeset/contacts-register-ledger-account.md
+++ b/.changeset/contacts-register-ledger-account.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-contacts-kit": minor
+---
+
+Add `ContactsManager.registerLedgerAccount`: the REGISTER LEDGER ACCOUNT operation (register a signer-controlled Ledger account derived on-device from a BIP32 path), reusing the shared Contacts protocol foundation (TLV serializer, chunked framing, error model, validation) with a version-guarded device action that opens the app by default, checks the Contacts version requirements, supports `skipOpenApp`, and returns the device-issued `hmacProof`

--- a/apps/sample/package.json
+++ b/apps/sample/package.json
@@ -22,6 +22,7 @@
     "@ledgerhq/context-module": "workspace:^",
     "@ledgerhq/crypto-icons": "catalog:",
     "@ledgerhq/device-management-kit": "workspace:^",
+    "@ledgerhq/device-contacts-kit": "workspace:^",
     "@ledgerhq/device-management-kit-devtools-core": "workspace:^",
     "@ledgerhq/device-management-kit-devtools-websocket-common": "workspace:^",
     "@ledgerhq/device-management-kit-devtools-websocket-connector": "workspace:^",

--- a/apps/sample/src/app/client-layout.tsx
+++ b/apps/sample/src/app/client-layout.tsx
@@ -20,6 +20,7 @@ import { Sidebar } from "@/components/Sidebar";
 import { useUpdateConnectionsRefresherOptions } from "@/hooks/useUpdateConnectionsRefresherOptions";
 import { useUpdateDeviceSessions } from "@/hooks/useUpdateDeviceSessions";
 import { CalInterceptorProvider } from "@/providers/CalInterceptorProvider";
+import { ContactsProvider } from "@/providers/ContactsProvider";
 import { DmkProvider } from "@/providers/DeviceManagementKitProvider";
 import { LedgerKeyringProtocolProvider } from "@/providers/LedgerKeyringProvider";
 import { SettingsGate } from "@/providers/SettingsGate";
@@ -81,15 +82,20 @@ const ClientRootLayout: React.FC<PropsWithChildren> = ({ children }) => {
                     <SignerZcashProvider>
                       <SignerAleoProvider>
                         <SignerCosmosProvider>
-                          <CalInterceptorProvider>
-                            <GlobalStyle />
-                            <head>
-                              <link rel="shortcut icon" href="../favicon.png" />
-                            </head>
-                            <body>
-                              <RootApp>{children}</RootApp>
-                            </body>
-                          </CalInterceptorProvider>
+                          <ContactsProvider>
+                            <CalInterceptorProvider>
+                              <GlobalStyle />
+                              <head>
+                                <link
+                                  rel="shortcut icon"
+                                  href="../favicon.png"
+                                />
+                              </head>
+                              <body>
+                                <RootApp>{children}</RootApp>
+                              </body>
+                            </CalInterceptorProvider>
+                          </ContactsProvider>
                         </SignerCosmosProvider>
                       </SignerAleoProvider>
                     </SignerZcashProvider>

--- a/apps/sample/src/app/contacts/page.tsx
+++ b/apps/sample/src/app/contacts/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+import React from "react";
+
+import { ContactsView } from "@/components/ContactsView";
+import { SessionIdWrapper } from "@/components/SessionIdWrapper";
+
+const Contacts: React.FC = () => {
+  return <SessionIdWrapper ChildComponent={ContactsView} />;
+};
+
+export default Contacts;

--- a/apps/sample/src/components/ContactsView/index.tsx
+++ b/apps/sample/src/components/ContactsView/index.tsx
@@ -1,0 +1,202 @@
+import React, { useEffect, useMemo } from "react";
+import {
+  type RegisterExternalAddressDAError,
+  type RegisterExternalAddressDAIntermediateValue,
+  type RegisterExternalAddressDAOutput,
+} from "@ledgerhq/device-contacts-kit";
+import { Flex, Tag, Text } from "@ledgerhq/react-ui";
+
+import { DeviceActionsList } from "@/components/DeviceActionsView/DeviceActionsList";
+import { type DeviceActionProps } from "@/components/DeviceActionsView/DeviceActionTester";
+import { useContactsManager } from "@/providers/ContactsProvider";
+import { useDmk } from "@/providers/DeviceManagementKitProvider";
+
+const CONTACTS_STORAGE_KEY = "dmk-sample-contacts";
+
+// Example first-account Ethereum address (no 0x prefix).
+const DEFAULT_IDENTIFIER = "de0b295669a9fd93d5f28d9ec85e40f4cb697bae";
+
+function hexToBytes(hex: string): Uint8Array {
+  const raw = hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex;
+  if (raw.length % 2 !== 0) {
+    throw new Error(`Hex value has an odd length: "${hex}"`);
+  }
+  const bytes = new Uint8Array(raw.length / 2);
+  for (let i = 0; i < raw.length; i += 2) {
+    bytes[i / 2] = parseInt(raw.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+type PersistedContactEntry = {
+  mode: RegisterExternalAddressDAOutput["mode"];
+  contactName: string;
+  scope: string;
+  blockchainFamily: string;
+  chainId?: string;
+  identifierHex: string;
+  groupHandleHex: string;
+  hmacProofHex: string;
+  hmacRestHex: string;
+  registeredAt: string;
+};
+
+function persistProofs(output: RegisterExternalAddressDAOutput): void {
+  if (typeof window === "undefined") return;
+  const entry: PersistedContactEntry = {
+    mode: output.mode,
+    contactName: output.contactName,
+    scope: output.scope,
+    blockchainFamily: output.blockchainFamily,
+    chainId: output.chainId?.toString(),
+    identifierHex: bytesToHex(output.identifier),
+    groupHandleHex: bytesToHex(output.groupHandle),
+    hmacProofHex: bytesToHex(output.hmacProof),
+    hmacRestHex: bytesToHex(output.hmacRest),
+    registeredAt: new Date().toISOString(),
+  };
+  const raw = window.localStorage.getItem(CONTACTS_STORAGE_KEY);
+  const existing: PersistedContactEntry[] = raw
+    ? (JSON.parse(raw) as PersistedContactEntry[])
+    : [];
+  window.localStorage.setItem(
+    CONTACTS_STORAGE_KEY,
+    JSON.stringify([...existing, entry]),
+  );
+}
+
+const RegisterExternalAddressOutputView: React.FC<{
+  output: RegisterExternalAddressDAOutput;
+}> = ({ output }) => {
+  // Persist every returned proof value locally as soon as it is available.
+  useEffect(() => {
+    persistProofs(output);
+  }, [output]);
+
+  const rows: Array<[string, string]> = [
+    ["mode", output.mode],
+    ["contactName", output.contactName],
+    ["scope", output.scope],
+    ["blockchainFamily", output.blockchainFamily],
+    ["chainId", output.chainId?.toString() ?? "—"],
+    ["identifier", bytesToHex(output.identifier)],
+    ["groupHandle", bytesToHex(output.groupHandle)],
+    ["hmacProof", bytesToHex(output.hmacProof)],
+    ["hmacRest", bytesToHex(output.hmacRest)],
+  ];
+
+  return (
+    <Flex flexDirection="column" rowGap={3}>
+      <Flex columnGap={2} alignItems="center">
+        <Tag active type="opacity">
+          Persisted to localStorage
+        </Tag>
+        <Text variant="small" color="neutral.c70">
+          key: {CONTACTS_STORAGE_KEY}
+        </Text>
+      </Flex>
+      {rows.map(([label, value]) => (
+        <Flex key={label} flexDirection="column">
+          <Text variant="tiny" color="neutral.c70">
+            {label}
+          </Text>
+          <Text variant="paragraph" style={{ wordBreak: "break-all" }}>
+            {value}
+          </Text>
+        </Flex>
+      ))}
+    </Flex>
+  );
+};
+
+type RegisterInput = {
+  contactName: string;
+  scope: string;
+  identifier: string;
+  blockchainFamily: string;
+  chainId: string;
+  existingGroupHandle: string;
+  existingHmacProof: string;
+  skipOpenApp: boolean;
+};
+
+export const ContactsView: React.FC<{ sessionId: string }> = ({
+  sessionId,
+}) => {
+  const dmk = useDmk();
+  const contactsManager = useContactsManager();
+
+  const deviceModelId = dmk.getConnectedDevice({ sessionId }).modelId;
+
+  const deviceActions: DeviceActionProps<
+    RegisterExternalAddressDAOutput,
+    RegisterInput,
+    RegisterExternalAddressDAError,
+    RegisterExternalAddressDAIntermediateValue
+  >[] = useMemo(
+    () => [
+      {
+        title: "Register External Address",
+        description:
+          "Register an external address on the device — creating a new contact group, or adding the address to an existing one by providing its group handle and name proof.",
+        executeDeviceAction: ({
+          contactName,
+          scope,
+          identifier,
+          blockchainFamily,
+          chainId,
+          existingGroupHandle,
+          existingHmacProof,
+          skipOpenApp,
+        }) => {
+          if (!contactsManager) {
+            throw new Error("Contacts manager not initialized");
+          }
+          const existingContactGroup =
+            existingGroupHandle.trim().length > 0 &&
+            existingHmacProof.trim().length > 0
+              ? {
+                  groupHandle: hexToBytes(existingGroupHandle.trim()),
+                  hmacProof: hexToBytes(existingHmacProof.trim()),
+                }
+              : undefined;
+
+          return contactsManager.registerExternalAddress({
+            contactName,
+            scope,
+            identifier: hexToBytes(identifier.trim()),
+            blockchainFamily,
+            chainId: chainId.trim().length > 0 ? BigInt(chainId) : undefined,
+            existingContactGroup,
+            skipOpenApp,
+          });
+        },
+        validateValues: ({ contactName, scope, identifier }) =>
+          contactName.trim().length > 0 &&
+          scope.trim().length > 0 &&
+          identifier.trim().length > 0,
+        initialValues: {
+          contactName: "Alice",
+          scope: "Eth main",
+          identifier: DEFAULT_IDENTIFIER,
+          blockchainFamily: "ethereum",
+          chainId: "1",
+          existingGroupHandle: "",
+          existingHmacProof: "",
+          skipOpenApp: false,
+        },
+        OutputComponent: RegisterExternalAddressOutputView,
+        deviceModelId,
+      },
+    ],
+    [contactsManager, deviceModelId],
+  );
+
+  return <DeviceActionsList title="Contacts" deviceActions={deviceActions} />;
+};

--- a/apps/sample/src/components/ContactsView/index.tsx
+++ b/apps/sample/src/components/ContactsView/index.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useMemo } from "react";
 import {
-  type RegisterExternalAddressDAError,
-  type RegisterExternalAddressDAIntermediateValue,
   type RegisterExternalAddressDAOutput,
+  type RegisterLedgerAccountDAOutput,
 } from "@ledgerhq/device-contacts-kit";
 import { Flex, Tag, Text } from "@ledgerhq/react-ui";
 
@@ -34,7 +33,8 @@ function bytesToHex(bytes: Uint8Array): string {
     .join("");
 }
 
-type PersistedContactEntry = {
+type PersistedExternalAddressEntry = {
+  kind: "externalAddress";
   mode: RegisterExternalAddressDAOutput["mode"];
   contactName: string;
   scope: string;
@@ -47,9 +47,35 @@ type PersistedContactEntry = {
   registeredAt: string;
 };
 
-function persistProofs(output: RegisterExternalAddressDAOutput): void {
+type PersistedLedgerAccountEntry = {
+  kind: "ledgerAccount";
+  accountName: string;
+  derivationPath: string;
+  blockchainFamily: string;
+  chainId?: string;
+  hmacProofHex: string;
+  registeredAt: string;
+};
+
+type PersistedContactEntry =
+  | PersistedExternalAddressEntry
+  | PersistedLedgerAccountEntry;
+
+function persistEntry(entry: PersistedContactEntry): void {
   if (typeof window === "undefined") return;
-  const entry: PersistedContactEntry = {
+  const raw = window.localStorage.getItem(CONTACTS_STORAGE_KEY);
+  const existing: PersistedContactEntry[] = raw
+    ? (JSON.parse(raw) as PersistedContactEntry[])
+    : [];
+  window.localStorage.setItem(
+    CONTACTS_STORAGE_KEY,
+    JSON.stringify([...existing, entry]),
+  );
+}
+
+function persistProofs(output: RegisterExternalAddressDAOutput): void {
+  persistEntry({
+    kind: "externalAddress",
     mode: output.mode,
     contactName: output.contactName,
     scope: output.scope,
@@ -60,15 +86,19 @@ function persistProofs(output: RegisterExternalAddressDAOutput): void {
     hmacProofHex: bytesToHex(output.hmacProof),
     hmacRestHex: bytesToHex(output.hmacRest),
     registeredAt: new Date().toISOString(),
-  };
-  const raw = window.localStorage.getItem(CONTACTS_STORAGE_KEY);
-  const existing: PersistedContactEntry[] = raw
-    ? (JSON.parse(raw) as PersistedContactEntry[])
-    : [];
-  window.localStorage.setItem(
-    CONTACTS_STORAGE_KEY,
-    JSON.stringify([...existing, entry]),
-  );
+  });
+}
+
+function persistLedgerAccount(output: RegisterLedgerAccountDAOutput): void {
+  persistEntry({
+    kind: "ledgerAccount",
+    accountName: output.accountName,
+    derivationPath: output.derivationPath,
+    blockchainFamily: output.blockchainFamily,
+    chainId: output.chainId?.toString(),
+    hmacProofHex: bytesToHex(output.hmacProof),
+    registeredAt: new Date().toISOString(),
+  });
 }
 
 const RegisterExternalAddressOutputView: React.FC<{
@@ -91,28 +121,51 @@ const RegisterExternalAddressOutputView: React.FC<{
     ["hmacRest", bytesToHex(output.hmacRest)],
   ];
 
-  return (
-    <Flex flexDirection="column" rowGap={3}>
-      <Flex columnGap={2} alignItems="center">
-        <Tag active type="opacity">
-          Persisted to localStorage
-        </Tag>
-        <Text variant="small" color="neutral.c70">
-          key: {CONTACTS_STORAGE_KEY}
+  return <PersistedProofRows rows={rows} />;
+};
+
+const PersistedProofRows: React.FC<{ rows: Array<[string, string]> }> = ({
+  rows,
+}) => (
+  <Flex flexDirection="column" rowGap={3}>
+    <Flex columnGap={2} alignItems="center">
+      <Tag active type="opacity">
+        Persisted to localStorage
+      </Tag>
+      <Text variant="small" color="neutral.c70">
+        key: {CONTACTS_STORAGE_KEY}
+      </Text>
+    </Flex>
+    {rows.map(([label, value]) => (
+      <Flex key={label} flexDirection="column">
+        <Text variant="tiny" color="neutral.c70">
+          {label}
+        </Text>
+        <Text variant="paragraph" style={{ wordBreak: "break-all" }}>
+          {value}
         </Text>
       </Flex>
-      {rows.map(([label, value]) => (
-        <Flex key={label} flexDirection="column">
-          <Text variant="tiny" color="neutral.c70">
-            {label}
-          </Text>
-          <Text variant="paragraph" style={{ wordBreak: "break-all" }}>
-            {value}
-          </Text>
-        </Flex>
-      ))}
-    </Flex>
-  );
+    ))}
+  </Flex>
+);
+
+const RegisterLedgerAccountOutputView: React.FC<{
+  output: RegisterLedgerAccountDAOutput;
+}> = ({ output }) => {
+  // Persist the returned proof locally as soon as it is available.
+  useEffect(() => {
+    persistLedgerAccount(output);
+  }, [output]);
+
+  const rows: Array<[string, string]> = [
+    ["accountName", output.accountName],
+    ["derivationPath", output.derivationPath],
+    ["blockchainFamily", output.blockchainFamily],
+    ["chainId", output.chainId?.toString() ?? "—"],
+    ["hmacProof", bytesToHex(output.hmacProof)],
+  ];
+
+  return <PersistedProofRows rows={rows} />;
 };
 
 type RegisterInput = {
@@ -126,6 +179,14 @@ type RegisterInput = {
   skipOpenApp: boolean;
 };
 
+type RegisterLedgerAccountInputForm = {
+  accountName: string;
+  derivationPath: string;
+  blockchainFamily: string;
+  chainId: string;
+  skipOpenApp: boolean;
+};
+
 export const ContactsView: React.FC<{ sessionId: string }> = ({
   sessionId,
 }) => {
@@ -134,12 +195,10 @@ export const ContactsView: React.FC<{ sessionId: string }> = ({
 
   const deviceModelId = dmk.getConnectedDevice({ sessionId }).modelId;
 
-  const deviceActions: DeviceActionProps<
-    RegisterExternalAddressDAOutput,
-    RegisterInput,
-    RegisterExternalAddressDAError,
-    RegisterExternalAddressDAIntermediateValue
-  >[] = useMemo(
+  // The Contacts view lists actions with different input/output shapes, so the
+  // list is typed loosely (mirroring the signer sample views).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const deviceActions: DeviceActionProps<any, any, any, any>[] = useMemo(
     () => [
       {
         title: "Register External Address",
@@ -154,7 +213,7 @@ export const ContactsView: React.FC<{ sessionId: string }> = ({
           existingGroupHandle,
           existingHmacProof,
           skipOpenApp,
-        }) => {
+        }: RegisterInput) => {
           if (!contactsManager) {
             throw new Error("Contacts manager not initialized");
           }
@@ -177,7 +236,7 @@ export const ContactsView: React.FC<{ sessionId: string }> = ({
             skipOpenApp,
           });
         },
-        validateValues: ({ contactName, scope, identifier }) =>
+        validateValues: ({ contactName, scope, identifier }: RegisterInput) =>
           contactName.trim().length > 0 &&
           scope.trim().length > 0 &&
           identifier.trim().length > 0,
@@ -192,6 +251,44 @@ export const ContactsView: React.FC<{ sessionId: string }> = ({
           skipOpenApp: false,
         },
         OutputComponent: RegisterExternalAddressOutputView,
+        deviceModelId,
+      },
+      {
+        title: "Register Ledger Account",
+        description:
+          "Register a Ledger (signer-controlled) account on the device. The account is derived on-device from the derivation path; the device returns an HMAC proof to persist.",
+        executeDeviceAction: ({
+          accountName,
+          derivationPath,
+          blockchainFamily,
+          chainId,
+          skipOpenApp,
+        }: RegisterLedgerAccountInputForm) => {
+          if (!contactsManager) {
+            throw new Error("Contacts manager not initialized");
+          }
+
+          return contactsManager.registerLedgerAccount({
+            accountName,
+            derivationPath: derivationPath.trim(),
+            blockchainFamily,
+            chainId: chainId.trim().length > 0 ? BigInt(chainId) : undefined,
+            skipOpenApp,
+          });
+        },
+        validateValues: ({
+          accountName,
+          derivationPath,
+        }: RegisterLedgerAccountInputForm) =>
+          accountName.trim().length > 0 && derivationPath.trim().length > 0,
+        initialValues: {
+          accountName: "Alice",
+          derivationPath: "m/44'/60'/0'/0/0",
+          blockchainFamily: "ethereum",
+          chainId: "1",
+          skipOpenApp: false,
+        },
+        OutputComponent: RegisterLedgerAccountOutputView,
         deviceModelId,
       },
     ],

--- a/apps/sample/src/components/Menu/index.tsx
+++ b/apps/sample/src/components/Menu/index.tsx
@@ -72,6 +72,15 @@ export const Menu: React.FC = () => {
         </MenuTitle>
       </MenuItem>
       <MenuItem>
+        <Icons.User />
+        <MenuTitle
+          data-testid="CTA_route-to-/contacts"
+          onClick={() => router.push("/contacts")}
+        >
+          Contacts
+        </MenuTitle>
+      </MenuItem>
+      <MenuItem>
         <Icons.Apps />
         <MenuTitle
           data-testid="CTA_route-to-/trusted-apps"

--- a/apps/sample/src/providers/ContactsProvider/index.tsx
+++ b/apps/sample/src/providers/ContactsProvider/index.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import React, {
+  createContext,
+  type PropsWithChildren,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import { useSelector } from "react-redux";
+import {
+  type ContactsManager,
+  ContactsManagerBuilder,
+} from "@ledgerhq/device-contacts-kit";
+
+import { useDmk } from "@/providers/DeviceManagementKitProvider";
+import { selectSelectedSessionId } from "@/state/sessions/selectors";
+
+// Contacts v1 is served by the Ethereum embedded app.
+const CONTACTS_APP_NAME = "Ethereum";
+
+type ContactsContextType = {
+  contactsManager: ContactsManager | null;
+};
+
+const initialState: ContactsContextType = {
+  contactsManager: null,
+};
+
+const ContactsContext = createContext<ContactsContextType>(initialState);
+
+export const ContactsProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const dmk = useDmk();
+  const sessionId = useSelector(selectSelectedSessionId);
+
+  const [contactsManager, setContactsManager] =
+    useState<ContactsManager | null>(null);
+
+  useEffect(() => {
+    if (!sessionId || !dmk) {
+      setContactsManager(null);
+      return;
+    }
+
+    setContactsManager(
+      new ContactsManagerBuilder({
+        dmk,
+        sessionId,
+        appName: CONTACTS_APP_NAME,
+      }).build(),
+    );
+  }, [dmk, sessionId]);
+
+  return (
+    <ContactsContext.Provider value={{ contactsManager }}>
+      {children}
+    </ContactsContext.Provider>
+  );
+};
+
+export const useContactsManager = (): ContactsManager | null => {
+  return useContext(ContactsContext).contactsManager;
+};

--- a/packages/device-contacts-kit/README.md
+++ b/packages/device-contacts-kit/README.md
@@ -55,8 +55,34 @@ observable.subscribe((state) => {
 });
 ```
 
-Concrete Contacts operations (Edit Contact Name, Edit Identifier, Edit Scope, Register Ledger
-Account, Edit Ledger Account) are added by their dedicated implementation tickets.
+## Registering a Ledger account
+
+`registerLedgerAccount` runs the device's REGISTER LEDGER ACCOUNT operation. The account is derived
+on-device from `derivationPath`; the op opens the embedded app by default, checks the
+[Contacts version requirements](#version-requirements), then frames the request and returns the
+device-issued `hmacProof` for the host to persist.
+
+```ts
+const { observable } = contactsManager.registerLedgerAccount({
+  accountName: "Alice",
+  derivationPath: "m/44'/60'/0'/0/0",
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+  // skipOpenApp: true, // skip only the open-app step; the version guard still runs
+});
+
+observable.subscribe((state) => {
+  // state.intermediateValue.requiredUserInteraction surfaces open-app confirmation
+  // and the on-device Register Wallet validation.
+  if (state.status === DeviceActionStatus.Completed) {
+    const { hmacProof } = state.output;
+    // persist the echoed input and the hmacProof.
+  }
+});
+```
+
+Concrete Contacts operations (Edit Contact Name, Edit Identifier, Edit Scope, Edit Ledger Account)
+are added by their dedicated implementation tickets.
 
 ## Version requirements
 

--- a/packages/device-contacts-kit/README.md
+++ b/packages/device-contacts-kit/README.md
@@ -27,8 +27,36 @@ const contactsManager = new ContactsManagerBuilder({
 }).build();
 ```
 
-Concrete Contacts operations (Register Identity, Edit Contact Name, Edit Identifier, Edit Scope,
-Register Ledger Account, Edit Ledger Account) are added by their dedicated implementation tickets.
+## Registering an external address
+
+`registerExternalAddress` runs the device's REGISTER IDENTITY operation. It opens the embedded app
+by default, checks the [Contacts version requirements](#version-requirements), then frames the
+request to the device and returns the device-issued proof material for the host to persist.
+
+```ts
+const { observable } = contactsManager.registerExternalAddress({
+  contactName: "Alice",
+  scope: "Eth main",
+  identifier: addressBytes, // 20-byte Ethereum address
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+  // existingContactGroup: { groupHandle, hmacProof }, // to extend an existing contact
+  // skipOpenApp: true, // skip only the open-app step; the version guard still runs
+});
+
+observable.subscribe((state) => {
+  // state.intermediateValue.requiredUserInteraction surfaces open-app confirmation
+  // and the on-device Register Wallet validation.
+  if (state.status === DeviceActionStatus.Completed) {
+    const { mode, groupHandle, hmacProof, hmacRest } = state.output;
+    // persist mode ("newContactGroup" | "existingContactGroup"), the echoed
+    // input, and the proof material.
+  }
+});
+```
+
+Concrete Contacts operations (Edit Contact Name, Edit Identifier, Edit Scope, Register Ledger
+Account, Edit Ledger Account) are added by their dedicated implementation tickets.
 
 ## Version requirements
 

--- a/packages/device-contacts-kit/package.json
+++ b/packages/device-contacts-kit/package.json
@@ -38,6 +38,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@ledgerhq/signer-utils": "workspace:^",
     "inversify": "catalog:",
     "purify-ts": "catalog:",
     "reflect-metadata": "catalog:",

--- a/packages/device-contacts-kit/src/api/ContactsManager.ts
+++ b/packages/device-contacts-kit/src/api/ContactsManager.ts
@@ -1,5 +1,7 @@
 import { type RegisterExternalAddressDAReturnType } from "@api/app-binder/RegisterExternalAddressDeviceActionTypes";
+import { type RegisterLedgerAccountDAReturnType } from "@api/app-binder/RegisterLedgerAccountDeviceActionTypes";
 import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
+import { type RegisterLedgerAccountInput } from "@api/model/RegisterLedgerAccount";
 
 /**
  * Public, stateless Contacts (Address Book) manager.
@@ -21,4 +23,16 @@ export interface ContactsManager {
   registerExternalAddress(
     input: RegisterExternalAddressInput,
   ): RegisterExternalAddressDAReturnType;
+
+  /**
+   * Register a Ledger (signer-controlled) account on the device. The account is
+   * derived on-device from `input.derivationPath`. Opens the embedded app by
+   * default (pass `skipOpenApp: true` to skip only the open-app step; the
+   * version guard still runs), checks the Contacts version requirements, then
+   * runs REGISTER LEDGER ACCOUNT. Returns the device-issued `hmacProof` to
+   * persist.
+   */
+  registerLedgerAccount(
+    input: RegisterLedgerAccountInput,
+  ): RegisterLedgerAccountDAReturnType;
 }

--- a/packages/device-contacts-kit/src/api/ContactsManager.ts
+++ b/packages/device-contacts-kit/src/api/ContactsManager.ts
@@ -1,3 +1,6 @@
+import { type RegisterExternalAddressDAReturnType } from "@api/app-binder/RegisterExternalAddressDeviceActionTypes";
+import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
+
 /**
  * Public, stateless Contacts (Address Book) manager.
  *
@@ -5,11 +8,17 @@
  * operation, and returning the device output (including proof material). It
  * does not store anything, own the address book, or handle persistence; the
  * host is responsible for that.
- *
- * Concrete management operations (Register Identity, Edit Contact Name, Edit
- * Identifier, Edit Scope, Register Ledger Account, Edit Ledger Account) are
- * added by their dedicated implementation tickets. This interface is
- * intentionally empty until then.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface ContactsManager {}
+export interface ContactsManager {
+  /**
+   * Register an external address on the device — either creating a new contact
+   * group or adding the address to an existing one (via
+   * `input.existingContactGroup`). Opens the embedded app by default (pass
+   * `skipOpenApp: true` to skip only the open-app step; the version guard still
+   * runs), checks the Contacts version requirements, then runs REGISTER
+   * IDENTITY. Returns the device-issued group handle and proofs to persist.
+   */
+  registerExternalAddress(
+    input: RegisterExternalAddressInput,
+  ): RegisterExternalAddressDAReturnType;
+}

--- a/packages/device-contacts-kit/src/api/app-binder/RegisterExternalAddressDeviceActionTypes.ts
+++ b/packages/device-contacts-kit/src/api/app-binder/RegisterExternalAddressDeviceActionTypes.ts
@@ -1,0 +1,58 @@
+import {
+  type CommandErrorResult,
+  type DeviceActionState,
+  type ExecuteDeviceActionReturnType,
+  type OpenAppDAError,
+  type OpenAppDARequiredInteraction,
+  type UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import {
+  type RegisterExternalAddressInput,
+  type RegisterExternalAddressOutput,
+} from "@api/model/RegisterExternalAddress";
+import {
+  type ContactsErrorCodes,
+  type ContactsVersionRequirementError,
+} from "@internal/app-binder/model/contactsErrors";
+
+/** Machine input: the public input plus the injected embedded-app name. */
+export type RegisterExternalAddressDAInput = RegisterExternalAddressInput & {
+  readonly appName: string;
+};
+
+export type RegisterExternalAddressDAOutput = RegisterExternalAddressOutput;
+
+export type RegisterExternalAddressDAError =
+  | OpenAppDAError
+  | ContactsVersionRequirementError
+  | CommandErrorResult<ContactsErrorCodes>["error"];
+
+export type RegisterExternalAddressDARequiredInteraction =
+  | OpenAppDARequiredInteraction
+  | UserInteractionRequired.RegisterWallet;
+
+export type RegisterExternalAddressDAIntermediateValue = {
+  readonly requiredUserInteraction: RegisterExternalAddressDARequiredInteraction;
+};
+
+export type RegisterExternalAddressDAState = DeviceActionState<
+  RegisterExternalAddressDAOutput,
+  RegisterExternalAddressDAError,
+  RegisterExternalAddressDAIntermediateValue
+>;
+
+export type RegisterExternalAddressDAInternalState = {
+  readonly error: RegisterExternalAddressDAError | null;
+  readonly proofs: {
+    readonly groupHandle: Uint8Array;
+    readonly hmacProof: Uint8Array;
+    readonly hmacRest: Uint8Array;
+  } | null;
+};
+
+export type RegisterExternalAddressDAReturnType = ExecuteDeviceActionReturnType<
+  RegisterExternalAddressDAOutput,
+  RegisterExternalAddressDAError,
+  RegisterExternalAddressDAIntermediateValue
+>;

--- a/packages/device-contacts-kit/src/api/app-binder/RegisterExternalAddressDeviceActionTypes.ts
+++ b/packages/device-contacts-kit/src/api/app-binder/RegisterExternalAddressDeviceActionTypes.ts
@@ -15,6 +15,7 @@ import {
   type ContactsErrorCodes,
   type ContactsVersionRequirementError,
 } from "@internal/app-binder/model/contactsErrors";
+import { type ContactsValidationError } from "@internal/app-binder/model/contactsValidation";
 
 /** Machine input: the public input plus the injected embedded-app name. */
 export type RegisterExternalAddressDAInput = RegisterExternalAddressInput & {
@@ -25,6 +26,7 @@ export type RegisterExternalAddressDAOutput = RegisterExternalAddressOutput;
 
 export type RegisterExternalAddressDAError =
   | OpenAppDAError
+  | ContactsValidationError
   | ContactsVersionRequirementError
   | CommandErrorResult<ContactsErrorCodes>["error"];
 
@@ -44,6 +46,11 @@ export type RegisterExternalAddressDAState = DeviceActionState<
 
 export type RegisterExternalAddressDAInternalState = {
   readonly error: RegisterExternalAddressDAError | null;
+  /** The running app read freshly by WaitForAppAndVersion, for the version guard. */
+  readonly appAndVersion: {
+    readonly name: string;
+    readonly version: string;
+  } | null;
   readonly proofs: {
     readonly groupHandle: Uint8Array;
     readonly hmacProof: Uint8Array;

--- a/packages/device-contacts-kit/src/api/app-binder/RegisterLedgerAccountDeviceActionTypes.ts
+++ b/packages/device-contacts-kit/src/api/app-binder/RegisterLedgerAccountDeviceActionTypes.ts
@@ -1,0 +1,61 @@
+import {
+  type CommandErrorResult,
+  type DeviceActionState,
+  type ExecuteDeviceActionReturnType,
+  type OpenAppDAError,
+  type OpenAppDARequiredInteraction,
+  type UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import {
+  type RegisterLedgerAccountInput,
+  type RegisterLedgerAccountOutput,
+} from "@api/model/RegisterLedgerAccount";
+import {
+  type ContactsErrorCodes,
+  type ContactsVersionRequirementError,
+} from "@internal/app-binder/model/contactsErrors";
+import { type ContactsValidationError } from "@internal/app-binder/model/contactsValidation";
+
+/** Machine input: the public input plus the injected embedded-app name. */
+export type RegisterLedgerAccountDAInput = RegisterLedgerAccountInput & {
+  readonly appName: string;
+};
+
+export type RegisterLedgerAccountDAOutput = RegisterLedgerAccountOutput;
+
+export type RegisterLedgerAccountDAError =
+  | OpenAppDAError
+  | ContactsValidationError
+  | ContactsVersionRequirementError
+  | CommandErrorResult<ContactsErrorCodes>["error"];
+
+export type RegisterLedgerAccountDARequiredInteraction =
+  | OpenAppDARequiredInteraction
+  | UserInteractionRequired.RegisterWallet;
+
+export type RegisterLedgerAccountDAIntermediateValue = {
+  readonly requiredUserInteraction: RegisterLedgerAccountDARequiredInteraction;
+};
+
+export type RegisterLedgerAccountDAState = DeviceActionState<
+  RegisterLedgerAccountDAOutput,
+  RegisterLedgerAccountDAError,
+  RegisterLedgerAccountDAIntermediateValue
+>;
+
+export type RegisterLedgerAccountDAInternalState = {
+  readonly error: RegisterLedgerAccountDAError | null;
+  /** The running app read freshly by WaitForAppAndVersion, for the version guard. */
+  readonly appAndVersion: {
+    readonly name: string;
+    readonly version: string;
+  } | null;
+  readonly proof: Uint8Array | null;
+};
+
+export type RegisterLedgerAccountDAReturnType = ExecuteDeviceActionReturnType<
+  RegisterLedgerAccountDAOutput,
+  RegisterLedgerAccountDAError,
+  RegisterLedgerAccountDAIntermediateValue
+>;

--- a/packages/device-contacts-kit/src/api/index.ts
+++ b/packages/device-contacts-kit/src/api/index.ts
@@ -1,3 +1,12 @@
+export {
+  type RegisterExternalAddressDAError,
+  type RegisterExternalAddressDAInput,
+  type RegisterExternalAddressDAIntermediateValue,
+  type RegisterExternalAddressDAOutput,
+  type RegisterExternalAddressDARequiredInteraction,
+  type RegisterExternalAddressDAReturnType,
+  type RegisterExternalAddressDAState,
+} from "@api/app-binder/RegisterExternalAddressDeviceActionTypes";
 export { type ContactsManager } from "@api/ContactsManager";
 export { ContactsManagerBuilder } from "@api/ContactsManagerBuilder";
 export {
@@ -12,3 +21,9 @@ export {
   isVersionAtLeast,
   resolveContactsVersionRequirements,
 } from "@api/model/ContactsVersionRequirements";
+export {
+  type ExistingContactGroup,
+  type RegisterExternalAddressInput,
+  type RegisterExternalAddressMode,
+  type RegisterExternalAddressOutput,
+} from "@api/model/RegisterExternalAddress";

--- a/packages/device-contacts-kit/src/api/index.ts
+++ b/packages/device-contacts-kit/src/api/index.ts
@@ -7,6 +7,15 @@ export {
   type RegisterExternalAddressDAReturnType,
   type RegisterExternalAddressDAState,
 } from "@api/app-binder/RegisterExternalAddressDeviceActionTypes";
+export {
+  type RegisterLedgerAccountDAError,
+  type RegisterLedgerAccountDAInput,
+  type RegisterLedgerAccountDAIntermediateValue,
+  type RegisterLedgerAccountDAOutput,
+  type RegisterLedgerAccountDARequiredInteraction,
+  type RegisterLedgerAccountDAReturnType,
+  type RegisterLedgerAccountDAState,
+} from "@api/app-binder/RegisterLedgerAccountDeviceActionTypes";
 export { type ContactsManager } from "@api/ContactsManager";
 export { ContactsManagerBuilder } from "@api/ContactsManagerBuilder";
 export {
@@ -27,3 +36,7 @@ export {
   type RegisterExternalAddressMode,
   type RegisterExternalAddressOutput,
 } from "@api/model/RegisterExternalAddress";
+export {
+  type RegisterLedgerAccountInput,
+  type RegisterLedgerAccountOutput,
+} from "@api/model/RegisterLedgerAccount";

--- a/packages/device-contacts-kit/src/api/model/RegisterExternalAddress.ts
+++ b/packages/device-contacts-kit/src/api/model/RegisterExternalAddress.ts
@@ -1,0 +1,55 @@
+/**
+ * Public input/output types for `ContactsManager.registerExternalAddress`.
+ *
+ * Proof material (`groupHandle`, `hmacProof`, `hmacRest`) is returned as raw
+ * bytes; the host owns persistence and address-book state. `derivationPath` is
+ * intentionally absent — the kit owns a single internal value for external
+ * addresses and does not expose it.
+ */
+
+/** The existing contact group to extend, when adding an address to it. */
+export type ExistingContactGroup = {
+  /** 64-byte group handle returned by the group's first Register Identity. */
+  readonly groupHandle: Uint8Array;
+  /** 32-byte name proof (device `hmac_name`) bound to that group. */
+  readonly hmacProof: Uint8Array;
+};
+
+export type RegisterExternalAddressInput = {
+  readonly contactName: string;
+  readonly scope: string;
+  /** Chain address bytes (20 bytes for Ethereum). */
+  readonly identifier: Uint8Array;
+  /** Blockchain family name, e.g. "ethereum" (v1 supports Ethereum only). */
+  readonly blockchainFamily: string;
+  readonly chainId?: bigint;
+  /**
+   * Set to add the address to an existing contact group. Omit to create a new
+   * contact group.
+   */
+  readonly existingContactGroup?: ExistingContactGroup;
+  /**
+   * When `true`, the open-app step is skipped (the caller guarantees the app is
+   * already open). The app-version guard still runs.
+   */
+  readonly skipOpenApp?: boolean;
+};
+
+export type RegisterExternalAddressMode =
+  | "newContactGroup"
+  | "existingContactGroup";
+
+export type RegisterExternalAddressOutput = {
+  /** Whether a new contact group was created or an existing one was extended. */
+  readonly mode: RegisterExternalAddressMode;
+  /** Echoed input, needed by the host to persist the returned proof material. */
+  readonly contactName: string;
+  readonly scope: string;
+  readonly identifier: Uint8Array;
+  readonly blockchainFamily: string;
+  readonly chainId?: bigint;
+  /** Device-issued proof material. */
+  readonly groupHandle: Uint8Array;
+  readonly hmacProof: Uint8Array;
+  readonly hmacRest: Uint8Array;
+};

--- a/packages/device-contacts-kit/src/api/model/RegisterLedgerAccount.ts
+++ b/packages/device-contacts-kit/src/api/model/RegisterLedgerAccount.ts
@@ -1,0 +1,32 @@
+/**
+ * Public input/output types for `ContactsManager.registerLedgerAccount`.
+ *
+ * A Ledger account is a signer-controlled account derived on the device from
+ * `derivationPath`; unlike an external address there is no explicit identifier
+ * or contact-group branch. The device returns a single 32-byte `hmacProof`
+ * (returned as raw bytes); the host owns persistence and address-book state.
+ */
+
+export type RegisterLedgerAccountInput = {
+  readonly accountName: string;
+  /** BIP32 path of the account to register, e.g. "m/44'/60'/0'/0/0". */
+  readonly derivationPath: string;
+  /** Blockchain family name, e.g. "ethereum" (v1 supports Ethereum only). */
+  readonly blockchainFamily: string;
+  readonly chainId?: bigint;
+  /**
+   * When `true`, the open-app step is skipped (the caller guarantees the app is
+   * already open). The app-version guard still runs.
+   */
+  readonly skipOpenApp?: boolean;
+};
+
+export type RegisterLedgerAccountOutput = {
+  /** Echoed input, needed by the host to persist the returned proof material. */
+  readonly accountName: string;
+  readonly derivationPath: string;
+  readonly blockchainFamily: string;
+  readonly chainId?: bigint;
+  /** Device-issued 32-byte HMAC proof binding this Ledger account. */
+  readonly hmacProof: Uint8Array;
+};

--- a/packages/device-contacts-kit/src/internal/DefaultContactsManager.test.ts
+++ b/packages/device-contacts-kit/src/internal/DefaultContactsManager.test.ts
@@ -1,0 +1,56 @@
+import { type DeviceManagementKit } from "@ledgerhq/device-management-kit";
+
+import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
+
+import { DefaultContactsManager } from "./DefaultContactsManager";
+
+const VALID_INPUT: RegisterExternalAddressInput = {
+  contactName: "Alice",
+  scope: "Eth main",
+  identifier: new Uint8Array(20).fill(0x11),
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+};
+
+describe("DefaultContactsManager", () => {
+  it("registerExternalAddress flows manager -> use-case -> binder -> dmk.executeDeviceAction", () => {
+    const executeDeviceAction = vi.fn().mockReturnValue("DA_RETURN");
+    const dmk = { executeDeviceAction } as unknown as DeviceManagementKit;
+
+    const manager = new DefaultContactsManager({
+      dmk,
+      sessionId: "session-id",
+      appName: "Ethereum",
+    });
+
+    const result = manager.registerExternalAddress(VALID_INPUT);
+
+    expect(executeDeviceAction).toHaveBeenCalledTimes(1);
+    const call = executeDeviceAction.mock.calls[0]![0] as {
+      sessionId: string;
+      deviceAction: unknown;
+    };
+    expect(call.sessionId).toBe("session-id");
+    expect(call.deviceAction).toBeDefined();
+    expect(result).toBe("DA_RETURN");
+  });
+
+  it("propagates validation errors without dispatching a device action", () => {
+    const executeDeviceAction = vi.fn();
+    const dmk = { executeDeviceAction } as unknown as DeviceManagementKit;
+
+    const manager = new DefaultContactsManager({
+      dmk,
+      sessionId: "session-id",
+      appName: "Ethereum",
+    });
+
+    expect(() =>
+      manager.registerExternalAddress({
+        ...VALID_INPUT,
+        contactName: "",
+      }),
+    ).toThrow();
+    expect(executeDeviceAction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/device-contacts-kit/src/internal/DefaultContactsManager.test.ts
+++ b/packages/device-contacts-kit/src/internal/DefaultContactsManager.test.ts
@@ -35,8 +35,10 @@ describe("DefaultContactsManager", () => {
     expect(result).toBe("DA_RETURN");
   });
 
-  it("propagates validation errors without dispatching a device action", () => {
-    const executeDeviceAction = vi.fn();
+  it("does not throw on invalid input — it dispatches the device action, which surfaces the error", () => {
+    // The public API returns a device action; invalid caller input must reach
+    // the observable as a typed error state rather than throwing synchronously.
+    const executeDeviceAction = vi.fn().mockReturnValue("DA_RETURN");
     const dmk = { executeDeviceAction } as unknown as DeviceManagementKit;
 
     const manager = new DefaultContactsManager({
@@ -50,7 +52,7 @@ describe("DefaultContactsManager", () => {
         ...VALID_INPUT,
         contactName: "",
       }),
-    ).toThrow();
-    expect(executeDeviceAction).not.toHaveBeenCalled();
+    ).not.toThrow();
+    expect(executeDeviceAction).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/device-contacts-kit/src/internal/DefaultContactsManager.test.ts
+++ b/packages/device-contacts-kit/src/internal/DefaultContactsManager.test.ts
@@ -1,6 +1,7 @@
 import { type DeviceManagementKit } from "@ledgerhq/device-management-kit";
 
 import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
+import { type RegisterLedgerAccountInput } from "@api/model/RegisterLedgerAccount";
 
 import { DefaultContactsManager } from "./DefaultContactsManager";
 
@@ -8,6 +9,13 @@ const VALID_INPUT: RegisterExternalAddressInput = {
   contactName: "Alice",
   scope: "Eth main",
   identifier: new Uint8Array(20).fill(0x11),
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+};
+
+const VALID_LEDGER_ACCOUNT_INPUT: RegisterLedgerAccountInput = {
+  accountName: "Alice",
+  derivationPath: "m/44'/60'/0'/0/0",
   blockchainFamily: "ethereum",
   chainId: 1n,
 };
@@ -35,7 +43,7 @@ describe("DefaultContactsManager", () => {
     expect(result).toBe("DA_RETURN");
   });
 
-  it("does not throw on invalid input — it dispatches the device action, which surfaces the error", () => {
+  it("registerExternalAddress does not throw on invalid input — it dispatches the device action, which surfaces the error", () => {
     // The public API returns a device action; invalid caller input must reach
     // the observable as a typed error state rather than throwing synchronously.
     const executeDeviceAction = vi.fn().mockReturnValue("DA_RETURN");
@@ -54,5 +62,27 @@ describe("DefaultContactsManager", () => {
       }),
     ).not.toThrow();
     expect(executeDeviceAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("registerLedgerAccount flows manager -> use-case -> binder -> dmk.executeDeviceAction", () => {
+    const executeDeviceAction = vi.fn().mockReturnValue("DA_RETURN");
+    const dmk = { executeDeviceAction } as unknown as DeviceManagementKit;
+
+    const manager = new DefaultContactsManager({
+      dmk,
+      sessionId: "session-id",
+      appName: "Ethereum",
+    });
+
+    const result = manager.registerLedgerAccount(VALID_LEDGER_ACCOUNT_INPUT);
+
+    expect(executeDeviceAction).toHaveBeenCalledTimes(1);
+    const call = executeDeviceAction.mock.calls[0]![0] as {
+      sessionId: string;
+      deviceAction: unknown;
+    };
+    expect(call.sessionId).toBe("session-id");
+    expect(call.deviceAction).toBeDefined();
+    expect(result).toBe("DA_RETURN");
   });
 });

--- a/packages/device-contacts-kit/src/internal/DefaultContactsManager.ts
+++ b/packages/device-contacts-kit/src/internal/DefaultContactsManager.ts
@@ -5,11 +5,14 @@ import {
 import { type Container } from "inversify";
 
 import { type RegisterExternalAddressDAReturnType } from "@api/app-binder/RegisterExternalAddressDeviceActionTypes";
+import { type RegisterLedgerAccountDAReturnType } from "@api/app-binder/RegisterLedgerAccountDeviceActionTypes";
 import { type ContactsManager } from "@api/ContactsManager";
 import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
+import { type RegisterLedgerAccountInput } from "@api/model/RegisterLedgerAccount";
 import { makeContainer } from "@internal/di";
 import { useCaseTypes } from "@internal/use-cases/di/useCaseTypes";
 import { type RegisterExternalAddressUseCase } from "@internal/use-cases/RegisterExternalAddressUseCase";
+import { type RegisterLedgerAccountUseCase } from "@internal/use-cases/RegisterLedgerAccountUseCase";
 
 type DefaultContactsManagerConstructorArgs = {
   dmk: DeviceManagementKit;
@@ -34,6 +37,16 @@ export class DefaultContactsManager implements ContactsManager {
     return this._container
       .get<RegisterExternalAddressUseCase>(
         useCaseTypes.RegisterExternalAddressUseCase,
+      )
+      .execute(input);
+  }
+
+  registerLedgerAccount(
+    input: RegisterLedgerAccountInput,
+  ): RegisterLedgerAccountDAReturnType {
+    return this._container
+      .get<RegisterLedgerAccountUseCase>(
+        useCaseTypes.RegisterLedgerAccountUseCase,
       )
       .execute(input);
   }

--- a/packages/device-contacts-kit/src/internal/DefaultContactsManager.ts
+++ b/packages/device-contacts-kit/src/internal/DefaultContactsManager.ts
@@ -4,8 +4,12 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { type Container } from "inversify";
 
+import { type RegisterExternalAddressDAReturnType } from "@api/app-binder/RegisterExternalAddressDeviceActionTypes";
 import { type ContactsManager } from "@api/ContactsManager";
+import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
 import { makeContainer } from "@internal/di";
+import { useCaseTypes } from "@internal/use-cases/di/useCaseTypes";
+import { type RegisterExternalAddressUseCase } from "@internal/use-cases/RegisterExternalAddressUseCase";
 
 type DefaultContactsManagerConstructorArgs = {
   dmk: DeviceManagementKit;
@@ -24,9 +28,19 @@ export class DefaultContactsManager implements ContactsManager {
     this._container = makeContainer({ dmk, sessionId, appName });
   }
 
+  registerExternalAddress(
+    input: RegisterExternalAddressInput,
+  ): RegisterExternalAddressDAReturnType {
+    return this._container
+      .get<RegisterExternalAddressUseCase>(
+        useCaseTypes.RegisterExternalAddressUseCase,
+      )
+      .execute(input);
+  }
+
   /**
-   * Exposes the DI container so operation methods (added by their dedicated
-   * tickets) can resolve their `UseCase`. Not part of the public API.
+   * Exposes the DI container so future operation methods can resolve their
+   * `UseCase`. Not part of the public API.
    */
   protected get container(): Container {
     return this._container;

--- a/packages/device-contacts-kit/src/internal/app-binder/ContactsAppBinder.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/ContactsAppBinder.ts
@@ -5,8 +5,11 @@ import {
 import { inject, injectable } from "inversify";
 
 import { type RegisterExternalAddressDAReturnType } from "@api/app-binder/RegisterExternalAddressDeviceActionTypes";
+import { type RegisterLedgerAccountDAReturnType } from "@api/app-binder/RegisterLedgerAccountDeviceActionTypes";
 import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
+import { type RegisterLedgerAccountInput } from "@api/model/RegisterLedgerAccount";
 import { RegisterExternalAddressDeviceAction } from "@internal/app-binder/device-action/RegisterExternalAddress/RegisterExternalAddressDeviceAction";
+import { RegisterLedgerAccountDeviceAction } from "@internal/app-binder/device-action/RegisterLedgerAccount/RegisterLedgerAccountDeviceAction";
 import { externalTypes } from "@internal/externalTypes";
 
 /**
@@ -30,6 +33,17 @@ export class ContactsAppBinder {
     return this.dmk.executeDeviceAction({
       sessionId: this.sessionId,
       deviceAction: new RegisterExternalAddressDeviceAction({
+        input: { ...input, appName: this.appName },
+      }),
+    });
+  }
+
+  registerLedgerAccount(
+    input: RegisterLedgerAccountInput,
+  ): RegisterLedgerAccountDAReturnType {
+    return this.dmk.executeDeviceAction({
+      sessionId: this.sessionId,
+      deviceAction: new RegisterLedgerAccountDeviceAction({
         input: { ...input, appName: this.appName },
       }),
     });

--- a/packages/device-contacts-kit/src/internal/app-binder/ContactsAppBinder.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/ContactsAppBinder.ts
@@ -4,13 +4,14 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 
+import { type RegisterExternalAddressDAReturnType } from "@api/app-binder/RegisterExternalAddressDeviceActionTypes";
+import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
+import { RegisterExternalAddressDeviceAction } from "@internal/app-binder/device-action/RegisterExternalAddress/RegisterExternalAddressDeviceAction";
 import { externalTypes } from "@internal/externalTypes";
 
 /**
  * Constructs and executes Contacts `DeviceAction`s using the injected `dmk`,
- * `sessionId`, and `appName`. Operation methods (one per Address Book
- * management command) are added by their dedicated implementation tickets and
- * consume these members.
+ * `sessionId`, and `appName`. Each Address Book operation gets one method here.
  */
 @injectable()
 export class ContactsAppBinder {
@@ -22,4 +23,15 @@ export class ContactsAppBinder {
     @inject(externalTypes.AppName)
     protected readonly appName: string,
   ) {}
+
+  registerExternalAddress(
+    input: RegisterExternalAddressInput,
+  ): RegisterExternalAddressDAReturnType {
+    return this.dmk.executeDeviceAction({
+      sessionId: this.sessionId,
+      deviceAction: new RegisterExternalAddressDeviceAction({
+        input: { ...input, appName: this.appName },
+      }),
+    });
+  }
 }

--- a/packages/device-contacts-kit/src/internal/app-binder/command/RegisterIdentityCommand.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/command/RegisterIdentityCommand.test.ts
@@ -1,0 +1,151 @@
+// RegisterIdentityCommand is a thin chunk-framer: it wraps a pre-framed chunk
+// (2-byte BE length prefix + TLV, assembled by SendRegisterIdentityTask +
+// sendFramedContactsPayload) under B0 10 01 <P2>, and parses the 129-byte
+// register response on the final chunk. TLV byte-parity is asserted in
+// SendRegisterIdentityTask.test.ts.
+import {
+  type ApduResponse,
+  CommandResultStatus,
+} from "@ledgerhq/device-management-kit";
+
+import {
+  CONTACT_SEED_MISMATCH_ERROR_CODE,
+  ContactsCommandError,
+} from "@internal/app-binder/model/contactsErrors";
+
+import { RegisterIdentityCommand } from "./RegisterIdentityCommand";
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    out[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return out;
+}
+
+// Device response: struct_type(0x2d) + group_handle(64) + hmac_name(32) +
+// hmac_rest(32).
+const GROUP_HANDLE = hexToBytes("cc".repeat(64));
+const HMAC_PROOF = hexToBytes("dd".repeat(32));
+const HMAC_REST = hexToBytes("aa".repeat(32));
+const RESPONSE_HEX = "2d" + "cc".repeat(64) + "dd".repeat(32) + "aa".repeat(32);
+
+function makeResponse(hex: string): ApduResponse {
+  return {
+    data: Buffer.from(hexToBytes(hex)),
+    statusCode: Buffer.from([0x90, 0x00]),
+  };
+}
+
+describe("RegisterIdentityCommand", () => {
+  describe("getApdu", () => {
+    it("wraps the framed chunk under B0 10 01 with P2=0x00 for the first/only chunk", () => {
+      const data = Uint8Array.from([0x00, 0x03, 0xaa, 0xbb, 0xcc]);
+
+      const apdu = new RegisterIdentityCommand({ data, p2: 0x00 }).getApdu();
+
+      expect(apdu.getRawApdu()).toStrictEqual(
+        Uint8Array.from([
+          0xb0, 0x10, 0x01, 0x00, 0x05, 0x00, 0x03, 0xaa, 0xbb, 0xcc,
+        ]),
+      );
+    });
+
+    it("uses P2=0x80 for continuation chunks", () => {
+      const data = Uint8Array.from([0xaa, 0xbb]);
+
+      const apdu = new RegisterIdentityCommand({ data, p2: 0x80 }).getApdu();
+
+      expect(apdu.getRawApdu()).toStrictEqual(
+        Uint8Array.from([0xb0, 0x10, 0x01, 0x80, 0x02, 0xaa, 0xbb]),
+      );
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("returns an empty payload for an intermediate chunk (SW=0x9000, no data)", () => {
+      const result = new RegisterIdentityCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      }).parseResponse({
+        data: Buffer.from([]),
+        statusCode: Buffer.from([0x90, 0x00]),
+      });
+
+      expect(result).toStrictEqual({
+        status: CommandResultStatus.Success,
+        data: {},
+      });
+    });
+
+    it("extracts group_handle / hmac_name / hmac_rest from a register response", () => {
+      const command = new RegisterIdentityCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      });
+
+      const result = command.parseResponse(makeResponse(RESPONSE_HEX));
+
+      expect(result).toStrictEqual({
+        status: CommandResultStatus.Success,
+        data: {
+          groupHandle: GROUP_HANDLE,
+          hmacProof: HMAC_PROOF,
+          hmacRest: HMAC_REST,
+        },
+      });
+    });
+
+    it("returns InvalidStatusWordError when struct_type is wrong", () => {
+      const wrongType = "ee" + RESPONSE_HEX.slice(2); // replace 0x2d with 0xee
+      const command = new RegisterIdentityCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      });
+
+      const result = command.parseResponse(makeResponse(wrongType));
+
+      expect(result.status).toBe(CommandResultStatus.Error);
+    });
+
+    it("maps a known SW (0x6985) to a ContactsCommandError", () => {
+      const command = new RegisterIdentityCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      });
+
+      const result = command.parseResponse({
+        data: Buffer.from([]),
+        statusCode: Buffer.from([0x69, 0x85]),
+      });
+
+      expect(result.status).toBe(CommandResultStatus.Error);
+      if (result.status === CommandResultStatus.Error) {
+        expect(result.error).toBeInstanceOf(ContactsCommandError);
+        expect((result.error as ContactsCommandError).errorCode).toBe("6985");
+      }
+    });
+
+    it("maps SW=0x6982 to a seed-mismatch ContactsCommandError", () => {
+      // Reached when extending an existing contact whose group handle was
+      // registered with another seed (once the app verifies before the UI).
+      const command = new RegisterIdentityCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      });
+
+      const result = command.parseResponse({
+        data: Buffer.from([]),
+        statusCode: Buffer.from([0x69, 0x82]),
+      });
+
+      expect(result.status).toBe(CommandResultStatus.Error);
+      if (result.status === CommandResultStatus.Error) {
+        expect(result.error).toBeInstanceOf(ContactsCommandError);
+        expect((result.error as ContactsCommandError).errorCode).toBe(
+          CONTACT_SEED_MISMATCH_ERROR_CODE,
+        );
+      }
+    });
+  });
+});

--- a/packages/device-contacts-kit/src/internal/app-binder/command/RegisterIdentityCommand.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/command/RegisterIdentityCommand.ts
@@ -1,0 +1,157 @@
+// Register Identity (register external address) — sub-command P1=0x01 of the
+// address-book APDU (CLA 0xB0 / INS 0x10). Caller (SendRegisterIdentityTask +
+// sendFramedContactsPayload) assembles the TLV, prepends the 2-byte BE total
+// length and slices into <=255B chunks; this command frames one chunk and, on
+// the final chunk, parses the 129-byte response: struct_type(0x2d) +
+// group_handle(64) + hmac_proof(32) + hmac_rest(32). Intermediate chunks ack
+// with SW=0x9000 and no data.
+// Protocol: Address Book Final Specifications — Register Identity.
+import {
+  type Apdu,
+  ApduBuilder,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import {
+  CONTACTS_APDU_CLA,
+  CONTACTS_APDU_INS,
+  GROUP_HANDLE_BYTES,
+  HMAC_PROOF_BYTES,
+  HMAC_REST_BYTES,
+  SUB_CMD_REGISTER_IDENTITY,
+} from "@internal/app-binder/model/contactsConstants";
+import {
+  CONTACTS_APP_ERRORS,
+  contactsCommandErrorFactory,
+  type ContactsErrorCodes,
+} from "@internal/app-binder/model/contactsErrors";
+
+export type RegisterIdentityCommandArgs = {
+  /** One framed chunk built by sendFramedContactsPayload. */
+  readonly data: Uint8Array;
+  /** 0x00 for the first/only chunk, 0x80 for continuation chunks. */
+  readonly p2: number;
+};
+
+export type RegisterIdentityCommandResponse = {
+  /**
+   * Present only on the final chunk — the device returns struct_type(0x2d) +
+   * group_handle(64) + hmac_proof(32) + hmac_rest(32) there. Intermediate
+   * chunks return SW=0x9000 with no data.
+   *
+   * `hmacProof` is the device's HMAC_PROOF (binds the contact name);
+   * `hmacRest` is the HMAC_REST (binds scope + identifier + family).
+   */
+  readonly groupHandle?: Uint8Array;
+  readonly hmacProof?: Uint8Array;
+  readonly hmacRest?: Uint8Array;
+};
+
+const RESPONSE_STRUCT_TYPE = 0x2d;
+
+/**
+ * Extract `length` bytes as a freshly-owned plain `Uint8Array` (the parser may
+ * hand back a `Buffer` view backed by the response), or `undefined` if the
+ * response is too short.
+ */
+function extractField(
+  parser: ApduParser,
+  length: number,
+): Uint8Array | undefined {
+  const field = parser.extractFieldByLength(length);
+  if (!field || field.length !== length) return undefined;
+  return Uint8Array.from(field);
+}
+
+export class RegisterIdentityCommand
+  implements
+    Command<
+      RegisterIdentityCommandResponse,
+      RegisterIdentityCommandArgs,
+      ContactsErrorCodes
+    >
+{
+  readonly name = "registerIdentity";
+  readonly args: RegisterIdentityCommandArgs;
+  private readonly errorHelper = new CommandErrorHelper<
+    RegisterIdentityCommandResponse,
+    ContactsErrorCodes
+  >(CONTACTS_APP_ERRORS, contactsCommandErrorFactory);
+
+  constructor(args: RegisterIdentityCommandArgs) {
+    this.args = args;
+  }
+
+  getApdu(): Apdu {
+    return new ApduBuilder({
+      cla: CONTACTS_APDU_CLA,
+      ins: CONTACTS_APDU_INS,
+      p1: SUB_CMD_REGISTER_IDENTITY,
+      p2: this.args.p2,
+    })
+      .addBufferToData(this.args.data)
+      .build();
+  }
+
+  parseResponse(
+    response: ApduResponse,
+  ): CommandResult<RegisterIdentityCommandResponse, ContactsErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(response),
+    ).orDefaultLazy(() => {
+      if (response.data.length === 0) {
+        // Intermediate chunk — device acks with SW=0x9000 and no payload.
+        return CommandResultFactory({ data: {} });
+      }
+
+      const parser = new ApduParser(response);
+
+      const structType = parser.extract8BitUInt();
+      if (structType !== RESPONSE_STRUCT_TYPE) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            `Expected struct_type 0x${RESPONSE_STRUCT_TYPE.toString(16)}, got ${
+              structType === undefined
+                ? "undefined"
+                : `0x${structType.toString(16)}`
+            }`,
+          ),
+        });
+      }
+
+      const groupHandle = extractField(parser, GROUP_HANDLE_BYTES);
+      if (!groupHandle) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            "group_handle missing or truncated",
+          ),
+        });
+      }
+
+      const hmacProof = extractField(parser, HMAC_PROOF_BYTES);
+      if (!hmacProof) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("hmac_name missing or truncated"),
+        });
+      }
+
+      const hmacRest = extractField(parser, HMAC_REST_BYTES);
+      if (!hmacRest) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("hmac_rest missing or truncated"),
+        });
+      }
+
+      return CommandResultFactory({
+        data: { groupHandle, hmacProof, hmacRest },
+      });
+    });
+  }
+}

--- a/packages/device-contacts-kit/src/internal/app-binder/command/RegisterLedgerAccountCommand.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/command/RegisterLedgerAccountCommand.test.ts
@@ -1,0 +1,138 @@
+// RegisterLedgerAccountCommand is a thin chunk-framer: it wraps a pre-framed
+// chunk (2-byte BE length prefix + TLV, assembled by
+// SendRegisterLedgerAccountTask + sendFramedContactsPayload) under B0 10 11
+// <P2>, and parses the 33-byte register response (struct_type + hmac_proof) on
+// the final chunk. TLV byte-parity is asserted in
+// SendRegisterLedgerAccountTask.test.ts.
+import {
+  type ApduResponse,
+  CommandResultStatus,
+} from "@ledgerhq/device-management-kit";
+
+import { ContactsCommandError } from "@internal/app-binder/model/contactsErrors";
+
+import { RegisterLedgerAccountCommand } from "./RegisterLedgerAccountCommand";
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    out[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return out;
+}
+
+// Device response: struct_type(0x2f) + hmac_proof(32).
+const HMAC_PROOF = hexToBytes("dd".repeat(32));
+const RESPONSE_HEX = "2f" + "dd".repeat(32);
+
+function makeResponse(hex: string): ApduResponse {
+  return {
+    data: Buffer.from(hexToBytes(hex)),
+    statusCode: Buffer.from([0x90, 0x00]),
+  };
+}
+
+describe("RegisterLedgerAccountCommand", () => {
+  describe("getApdu", () => {
+    it("wraps the framed chunk under B0 10 11 with P2=0x00 for the first/only chunk", () => {
+      const data = Uint8Array.from([0x00, 0x03, 0xaa, 0xbb, 0xcc]);
+
+      const apdu = new RegisterLedgerAccountCommand({
+        data,
+        p2: 0x00,
+      }).getApdu();
+
+      expect(apdu.getRawApdu()).toStrictEqual(
+        Uint8Array.from([
+          0xb0, 0x10, 0x11, 0x00, 0x05, 0x00, 0x03, 0xaa, 0xbb, 0xcc,
+        ]),
+      );
+    });
+
+    it("uses P2=0x80 for continuation chunks", () => {
+      const data = Uint8Array.from([0xaa, 0xbb]);
+
+      const apdu = new RegisterLedgerAccountCommand({
+        data,
+        p2: 0x80,
+      }).getApdu();
+
+      expect(apdu.getRawApdu()).toStrictEqual(
+        Uint8Array.from([0xb0, 0x10, 0x11, 0x80, 0x02, 0xaa, 0xbb]),
+      );
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("returns an empty payload for an intermediate chunk (SW=0x9000, no data)", () => {
+      const result = new RegisterLedgerAccountCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      }).parseResponse({
+        data: Buffer.from([]),
+        statusCode: Buffer.from([0x90, 0x00]),
+      });
+
+      expect(result).toStrictEqual({
+        status: CommandResultStatus.Success,
+        data: {},
+      });
+    });
+
+    it("extracts hmac_proof from a register response", () => {
+      const command = new RegisterLedgerAccountCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      });
+
+      const result = command.parseResponse(makeResponse(RESPONSE_HEX));
+
+      expect(result).toStrictEqual({
+        status: CommandResultStatus.Success,
+        data: { hmacProof: HMAC_PROOF },
+      });
+    });
+
+    it("returns InvalidStatusWordError when struct_type is wrong", () => {
+      const wrongType = "ee" + RESPONSE_HEX.slice(2); // replace 0x2f with 0xee
+      const command = new RegisterLedgerAccountCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      });
+
+      const result = command.parseResponse(makeResponse(wrongType));
+
+      expect(result.status).toBe(CommandResultStatus.Error);
+    });
+
+    it("returns InvalidStatusWordError when hmac_proof is truncated", () => {
+      const truncated = "2f" + "dd".repeat(16); // only 16 of 32 proof bytes
+      const command = new RegisterLedgerAccountCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      });
+
+      const result = command.parseResponse(makeResponse(truncated));
+
+      expect(result.status).toBe(CommandResultStatus.Error);
+    });
+
+    it("maps a known SW (0x6985) to a ContactsCommandError", () => {
+      const command = new RegisterLedgerAccountCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      });
+
+      const result = command.parseResponse({
+        data: Buffer.from([]),
+        statusCode: Buffer.from([0x69, 0x85]),
+      });
+
+      expect(result.status).toBe(CommandResultStatus.Error);
+      if (result.status === CommandResultStatus.Error) {
+        expect(result.error).toBeInstanceOf(ContactsCommandError);
+        expect((result.error as ContactsCommandError).errorCode).toBe("6985");
+      }
+    });
+  });
+});

--- a/packages/device-contacts-kit/src/internal/app-binder/command/RegisterLedgerAccountCommand.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/command/RegisterLedgerAccountCommand.ts
@@ -1,0 +1,133 @@
+// Register Ledger Account (register a signer-controlled account) — sub-command
+// P1=0x11 of the address-book APDU (CLA 0xB0 / INS 0x10). Caller
+// (SendRegisterLedgerAccountTask + sendFramedContactsPayload) assembles the TLV,
+// prepends the 2-byte BE total length and slices into <=255B chunks; this
+// command frames one chunk and, on the final chunk, parses the 33-byte
+// response: struct_type(0x2f) + hmac_proof(32). Intermediate chunks ack with
+// SW=0x9000 and no data.
+// Protocol: Address Book Final Specifications — Register Ledger Account.
+import {
+  type Apdu,
+  ApduBuilder,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import {
+  CONTACTS_APDU_CLA,
+  CONTACTS_APDU_INS,
+  HMAC_PROOF_BYTES,
+  SUB_CMD_REGISTER_LEDGER_ACCOUNT,
+} from "@internal/app-binder/model/contactsConstants";
+import {
+  CONTACTS_APP_ERRORS,
+  contactsCommandErrorFactory,
+  type ContactsErrorCodes,
+} from "@internal/app-binder/model/contactsErrors";
+import { STRUCT_TYPE_REGISTER_LEDGER_ACCOUNT } from "@internal/app-binder/services/contactsTlvSerializer";
+
+export type RegisterLedgerAccountCommandArgs = {
+  /** One framed chunk built by sendFramedContactsPayload. */
+  readonly data: Uint8Array;
+  /** 0x00 for the first/only chunk, 0x80 for continuation chunks. */
+  readonly p2: number;
+};
+
+export type RegisterLedgerAccountCommandResponse = {
+  /**
+   * Present only on the final chunk — the device returns
+   * struct_type(0x2f) + hmac_proof(32) there. Intermediate chunks return
+   * SW=0x9000 with no data.
+   */
+  readonly hmacProof?: Uint8Array;
+};
+
+const RESPONSE_STRUCT_TYPE = STRUCT_TYPE_REGISTER_LEDGER_ACCOUNT;
+
+/**
+ * Extract `length` bytes as a freshly-owned plain `Uint8Array` (the parser may
+ * hand back a `Buffer` view backed by the response), or `undefined` if the
+ * response is too short.
+ */
+function extractField(
+  parser: ApduParser,
+  length: number,
+): Uint8Array | undefined {
+  const field = parser.extractFieldByLength(length);
+  if (!field || field.length !== length) return undefined;
+  return Uint8Array.from(field);
+}
+
+export class RegisterLedgerAccountCommand
+  implements
+    Command<
+      RegisterLedgerAccountCommandResponse,
+      RegisterLedgerAccountCommandArgs,
+      ContactsErrorCodes
+    >
+{
+  readonly name = "registerLedgerAccount";
+  readonly args: RegisterLedgerAccountCommandArgs;
+  private readonly errorHelper = new CommandErrorHelper<
+    RegisterLedgerAccountCommandResponse,
+    ContactsErrorCodes
+  >(CONTACTS_APP_ERRORS, contactsCommandErrorFactory);
+
+  constructor(args: RegisterLedgerAccountCommandArgs) {
+    this.args = args;
+  }
+
+  getApdu(): Apdu {
+    return new ApduBuilder({
+      cla: CONTACTS_APDU_CLA,
+      ins: CONTACTS_APDU_INS,
+      p1: SUB_CMD_REGISTER_LEDGER_ACCOUNT,
+      p2: this.args.p2,
+    })
+      .addBufferToData(this.args.data)
+      .build();
+  }
+
+  parseResponse(
+    response: ApduResponse,
+  ): CommandResult<RegisterLedgerAccountCommandResponse, ContactsErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(response),
+    ).orDefaultLazy(() => {
+      if (response.data.length === 0) {
+        // Intermediate chunk — device acks with SW=0x9000 and no payload.
+        return CommandResultFactory({ data: {} });
+      }
+
+      const parser = new ApduParser(response);
+
+      const structType = parser.extract8BitUInt();
+      if (structType !== RESPONSE_STRUCT_TYPE) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            `Expected struct_type 0x${RESPONSE_STRUCT_TYPE.toString(16)}, got ${
+              structType === undefined
+                ? "undefined"
+                : `0x${structType.toString(16)}`
+            }`,
+          ),
+        });
+      }
+
+      const hmacProof = extractField(parser, HMAC_PROOF_BYTES);
+      if (!hmacProof) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("hmac_proof missing or truncated"),
+        });
+      }
+
+      return CommandResultFactory({ data: { hmacProof } });
+    });
+  }
+}

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterExternalAddress/RegisterExternalAddressDeviceAction.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterExternalAddress/RegisterExternalAddressDeviceAction.test.ts
@@ -18,6 +18,7 @@ import {
 } from "@api/app-binder/RegisterExternalAddressDeviceActionTypes";
 import { makeDeviceActionInternalApiMock } from "@internal/app-binder/device-action/__test-utils__/makeInternalApi";
 import { setupOpenAppDAMock } from "@internal/app-binder/device-action/__test-utils__/setupOpenAppDAMock";
+import { setupWaitForAppAndVersionDAMock } from "@internal/app-binder/device-action/__test-utils__/setupWaitForAppAndVersionDAMock";
 import { testDeviceActionStates } from "@internal/app-binder/device-action/__test-utils__/testDeviceActionStates";
 import {
   ContactsCommandError,
@@ -25,6 +26,7 @@ import {
 } from "@internal/app-binder/model/contactsErrors";
 
 import { RegisterExternalAddressDeviceAction } from "./RegisterExternalAddressDeviceAction";
+import { validateRegisterExternalAddressInput } from "./validateRegisterExternalAddressInput";
 
 vi.mock("@ledgerhq/device-management-kit", async (importOriginal) => {
   const original =
@@ -35,8 +37,13 @@ vi.mock("@ledgerhq/device-management-kit", async (importOriginal) => {
     OpenAppDeviceAction: vi.fn(() => ({
       makeStateMachine: vi.fn(),
     })),
+    WaitForAppAndVersionDeviceAction: vi.fn(() => ({
+      makeStateMachine: vi.fn(),
+    })),
   };
 });
+
+const FRESH_APP = { name: "Ethereum", version: "1.15.0" };
 
 const OK_PROOFS = {
   groupHandle: new Uint8Array(64).fill(0xcc),
@@ -67,6 +74,7 @@ describe("RegisterExternalAddressDeviceAction", () => {
 
   beforeEach(() => {
     apiMock = makeDeviceActionInternalApiMock();
+    setupWaitForAppAndVersionDAMock(FRESH_APP);
     isSupportedMock = vi.fn().mockReturnValue(true);
     registerIdentityMock = vi
       .fn()
@@ -102,6 +110,13 @@ describe("RegisterExternalAddressDeviceAction", () => {
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        // Silent WaitForAppAndVersion read (no interaction).
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
           },
           status: DeviceActionStatus.Pending,
         },
@@ -149,6 +164,13 @@ describe("RegisterExternalAddressDeviceAction", () => {
       });
 
       const expected = [
+        // Silent WaitForAppAndVersion read (no interaction).
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.RegisterWallet,
@@ -186,6 +208,13 @@ describe("RegisterExternalAddressDeviceAction", () => {
       const action = makeAction({ ...BASE_INPUT, skipOpenApp: true });
 
       const expected = [
+        // Silent WaitForAppAndVersion read still runs before the guard.
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
         {
           error: new ContactsVersionRequirementError(),
           status: DeviceActionStatus.Error,
@@ -252,6 +281,13 @@ describe("RegisterExternalAddressDeviceAction", () => {
       const action = makeAction({ ...BASE_INPUT, skipOpenApp: true });
 
       const expected = [
+        // Silent WaitForAppAndVersion read (no interaction).
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
         {
           intermediateValue: {
             requiredUserInteraction: UserInteractionRequired.RegisterWallet,
@@ -272,5 +308,165 @@ describe("RegisterExternalAddressDeviceAction", () => {
         onDone: resolve,
         onError: reject,
       });
+    }));
+
+  it("surfaces invalid input as a typed error state on the skip-open-app path", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const invalidInput = {
+        ...BASE_INPUT,
+        skipOpenApp: true,
+        contactName: "",
+      };
+      const validationError =
+        validateRegisterExternalAddressInput(invalidInput);
+      const action = makeAction(invalidInput);
+
+      const expected = [
+        {
+          error: validationError,
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        RegisterExternalAddressDAOutput,
+        RegisterExternalAddressDAError,
+        RegisterExternalAddressDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+      // Validation fails before the version guard and before any APDU.
+      expect(isSupportedMock).not.toHaveBeenCalled();
+      expect(registerIdentityMock).not.toHaveBeenCalled();
+    }));
+
+  it("validates only after opening the app on the default path", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const invalidInput = {
+        ...BASE_INPUT,
+        skipOpenApp: false,
+        contactName: "",
+      };
+      const validationError =
+        validateRegisterExternalAddressInput(invalidInput);
+      const action = makeAction(invalidInput);
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: validationError,
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        RegisterExternalAddressDAOutput,
+        RegisterExternalAddressDAError,
+        RegisterExternalAddressDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+      expect(registerIdentityMock).not.toHaveBeenCalled();
+    }));
+
+  it("evaluates support from the fresh WaitForAppAndVersion result, not stale session state", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      // Session state (from beforeEach) reports version 1.15.0; the fresh read
+      // reports a different version, which is what the guard must use.
+      const freshApp = { name: "Ethereum", version: "9.9.9" };
+      setupWaitForAppAndVersionDAMock(freshApp);
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: true });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.RegisterWallet,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          output: {
+            mode: "newContactGroup",
+            contactName: "Alice",
+            scope: "Eth main",
+            identifier: BASE_INPUT.identifier,
+            blockchainFamily: "ethereum",
+            chainId: 1n,
+            ...OK_PROOFS,
+          },
+          status: DeviceActionStatus.Completed,
+        },
+      ] as DeviceActionState<
+        RegisterExternalAddressDAOutput,
+        RegisterExternalAddressDAError,
+        RegisterExternalAddressDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: () => {
+          try {
+            expect(isSupportedMock).toHaveBeenCalledWith(freshApp);
+            resolve();
+          } catch (e) {
+            reject(e as Error);
+          }
+        },
+        onError: reject,
+      });
+    }));
+
+  it("surfaces a WaitForAppAndVersion failure as the device action error", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const waitError = new UnknownDAError("could not read app and version");
+      setupWaitForAppAndVersionDAMock({ error: waitError });
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: true });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: waitError,
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        RegisterExternalAddressDAOutput,
+        RegisterExternalAddressDAError,
+        RegisterExternalAddressDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+      // The version guard and the APDU are never reached.
+      expect(isSupportedMock).not.toHaveBeenCalled();
+      expect(registerIdentityMock).not.toHaveBeenCalled();
     }));
 });

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterExternalAddress/RegisterExternalAddressDeviceAction.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterExternalAddress/RegisterExternalAddressDeviceAction.test.ts
@@ -1,0 +1,276 @@
+import {
+  CommandResultFactory,
+  type DeviceActionState,
+  DeviceActionStatus,
+  DeviceModelId,
+  DeviceSessionStateType,
+  DeviceStatus,
+  UnknownDAError,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+import { beforeEach, describe, it, vi } from "vitest";
+
+import {
+  type RegisterExternalAddressDAError,
+  type RegisterExternalAddressDAInput,
+  type RegisterExternalAddressDAIntermediateValue,
+  type RegisterExternalAddressDAOutput,
+} from "@api/app-binder/RegisterExternalAddressDeviceActionTypes";
+import { makeDeviceActionInternalApiMock } from "@internal/app-binder/device-action/__test-utils__/makeInternalApi";
+import { setupOpenAppDAMock } from "@internal/app-binder/device-action/__test-utils__/setupOpenAppDAMock";
+import { testDeviceActionStates } from "@internal/app-binder/device-action/__test-utils__/testDeviceActionStates";
+import {
+  ContactsCommandError,
+  ContactsVersionRequirementError,
+} from "@internal/app-binder/model/contactsErrors";
+
+import { RegisterExternalAddressDeviceAction } from "./RegisterExternalAddressDeviceAction";
+
+vi.mock("@ledgerhq/device-management-kit", async (importOriginal) => {
+  const original =
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    await importOriginal<typeof import("@ledgerhq/device-management-kit")>();
+  return {
+    ...original,
+    OpenAppDeviceAction: vi.fn(() => ({
+      makeStateMachine: vi.fn(),
+    })),
+  };
+});
+
+const OK_PROOFS = {
+  groupHandle: new Uint8Array(64).fill(0xcc),
+  hmacProof: new Uint8Array(32).fill(0xdd),
+  hmacRest: new Uint8Array(32).fill(0xaa),
+};
+
+const BASE_INPUT = {
+  contactName: "Alice",
+  scope: "Eth main",
+  identifier: new Uint8Array(20).fill(0x11),
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+  appName: "Ethereum",
+};
+
+describe("RegisterExternalAddressDeviceAction", () => {
+  let apiMock: ReturnType<typeof makeDeviceActionInternalApiMock>;
+  let isSupportedMock: ReturnType<typeof vi.fn>;
+  let registerIdentityMock: ReturnType<typeof vi.fn>;
+
+  function extractDeps() {
+    return {
+      isSupported: isSupportedMock,
+      registerIdentity: registerIdentityMock,
+    };
+  }
+
+  beforeEach(() => {
+    apiMock = makeDeviceActionInternalApiMock();
+    isSupportedMock = vi.fn().mockReturnValue(true);
+    registerIdentityMock = vi
+      .fn()
+      .mockResolvedValue(CommandResultFactory({ data: OK_PROOFS }));
+    apiMock.getDeviceSessionState.mockReturnValue({
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Ethereum", version: "1.15.0" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: true,
+    });
+  });
+
+  function makeAction(input: RegisterExternalAddressDAInput) {
+    const action = new RegisterExternalAddressDeviceAction({ input });
+    vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+    return action;
+  }
+
+  it("open-app path, new contact group: OpenApp -> VersionGuard -> RegisterIdentity -> Completed", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: false });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.RegisterWallet,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          output: {
+            mode: "newContactGroup",
+            contactName: "Alice",
+            scope: "Eth main",
+            identifier: BASE_INPUT.identifier,
+            blockchainFamily: "ethereum",
+            chainId: 1n,
+            ...OK_PROOFS,
+          },
+          status: DeviceActionStatus.Completed,
+        },
+      ] as DeviceActionState<
+        RegisterExternalAddressDAOutput,
+        RegisterExternalAddressDAError,
+        RegisterExternalAddressDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+    }));
+
+  it("skip-open-app path, existing contact group: VersionGuard -> RegisterIdentity -> Completed", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const existingContactGroup = {
+        groupHandle: new Uint8Array(64).fill(0xcc),
+        hmacProof: new Uint8Array(32).fill(0xdd),
+      };
+      const action = makeAction({
+        ...BASE_INPUT,
+        skipOpenApp: true,
+        existingContactGroup,
+      });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.RegisterWallet,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          output: {
+            mode: "existingContactGroup",
+            contactName: "Alice",
+            scope: "Eth main",
+            identifier: BASE_INPUT.identifier,
+            blockchainFamily: "ethereum",
+            chainId: 1n,
+            ...OK_PROOFS,
+          },
+          status: DeviceActionStatus.Completed,
+        },
+      ] as DeviceActionState<
+        RegisterExternalAddressDAOutput,
+        RegisterExternalAddressDAError,
+        RegisterExternalAddressDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+    }));
+
+  it("version guard rejects on skip-open-app path without opening the app", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      isSupportedMock.mockReturnValue(false);
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: true });
+
+      const expected = [
+        {
+          error: new ContactsVersionRequirementError(),
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        RegisterExternalAddressDAOutput,
+        RegisterExternalAddressDAError,
+        RegisterExternalAddressDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+      expect(registerIdentityMock).not.toHaveBeenCalled();
+    }));
+
+  it("surfaces an open-app failure as the device action error", () =>
+    new Promise<void>((resolve, reject) => {
+      const openAppError = new UnknownDAError("open app failed");
+      setupOpenAppDAMock(openAppError);
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: false });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: openAppError,
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        RegisterExternalAddressDAOutput,
+        RegisterExternalAddressDAError,
+        RegisterExternalAddressDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+      expect(isSupportedMock).not.toHaveBeenCalled();
+    }));
+
+  it("surfaces a Register Identity command error", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const commandError = new ContactsCommandError({
+        errorCode: "6a80",
+        message: "device rejected",
+      });
+      registerIdentityMock.mockResolvedValue(
+        CommandResultFactory({ error: commandError }),
+      );
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: true });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.RegisterWallet,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: commandError,
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        RegisterExternalAddressDAOutput,
+        RegisterExternalAddressDAError,
+        RegisterExternalAddressDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+    }));
+});

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterExternalAddress/RegisterExternalAddressDeviceAction.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterExternalAddress/RegisterExternalAddressDeviceAction.ts
@@ -6,6 +6,7 @@ import {
   type StateMachineTypes,
   UnknownDAError,
   UserInteractionRequired,
+  WaitForAppAndVersionDeviceAction,
   XStateDeviceAction,
 } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
@@ -18,15 +19,20 @@ import {
   type RegisterExternalAddressDAInternalState,
   type RegisterExternalAddressDAOutput,
 } from "@api/app-binder/RegisterExternalAddressDeviceActionTypes";
-import { isContactsSupportedForSession } from "@internal/app-binder/isContactsSupportedForSession";
+import {
+  isContactsSupportedForSession,
+  type RunningApp,
+} from "@internal/app-binder/isContactsSupportedForSession";
 import { ContactsVersionRequirementError } from "@internal/app-binder/model/contactsErrors";
 import {
   type RegisterIdentityProofs,
   SendRegisterIdentityTask,
 } from "@internal/app-binder/task/SendRegisterIdentityTask";
 
+import { validateRegisterExternalAddressInput } from "./validateRegisterExternalAddressInput";
+
 export type RegisterExternalAddressMachineDependencies = {
-  readonly isSupported: () => boolean;
+  readonly isSupported: (app: RunningApp) => boolean;
   readonly registerIdentity: (
     input: RegisterExternalAddressDAInput,
   ) => Promise<Awaited<ReturnType<SendRegisterIdentityTask["run"]>>>;
@@ -70,6 +76,9 @@ export class RegisterExternalAddressDeviceAction extends XStateDeviceAction<
         openAppStateMachine: new OpenAppDeviceAction({
           input: { appName },
         }).makeStateMachine(internalApi),
+        waitForAppAndVersionStateMachine: new WaitForAppAndVersionDeviceAction({
+          input: {},
+        }).makeStateMachine(internalApi),
         registerIdentity: fromPromise(
           ({ input }: { input: RegisterExternalAddressDAInput }) =>
             registerIdentity(input),
@@ -78,9 +87,20 @@ export class RegisterExternalAddressDeviceAction extends XStateDeviceAction<
       guards: {
         skipOpenApp: ({ context }) => context.input.skipOpenApp === true,
         noInternalError: ({ context }) => context._internalState.error === null,
-        contactsSupported: () => isSupported(),
+        contactsSupported: ({ context }) => {
+          const { appAndVersion } = context._internalState;
+          return appAndVersion !== null && isSupported(appAndVersion);
+        },
       },
       actions: {
+        assignValidationError: assign({
+          _internalState: ({ context }) => {
+            const error = validateRegisterExternalAddressInput(context.input);
+            return error
+              ? { ...context._internalState, error }
+              : context._internalState;
+          },
+        }),
         assignVersionError: assign({
           _internalState: ({ context }) => ({
             ...context._internalState,
@@ -108,13 +128,14 @@ export class RegisterExternalAddressDeviceAction extends XStateDeviceAction<
         },
         _internalState: {
           error: null,
+          appAndVersion: null,
           proofs: null,
         },
       }),
       states: {
         InitialState: {
           always: [
-            { target: "VersionGuard", guard: "skipOpenApp" },
+            { target: "ValidateInput", guard: "skipOpenApp" },
             { target: "OpenAppDeviceAction" },
           ],
         },
@@ -143,11 +164,62 @@ export class RegisterExternalAddressDeviceAction extends XStateDeviceAction<
         },
         CheckOpenAppResult: {
           always: [
+            { target: "ValidateInput", guard: "noInternalError" },
+            { target: "Error" },
+          ],
+        },
+        // Input validation runs inside the device action (after the app is
+        // opened) so invalid caller input surfaces as a typed terminal error
+        // state on the observable instead of a synchronous throw. Runs on both
+        // the open-app and skip-open-app paths.
+        ValidateInput: {
+          entry: "assignValidationError",
+          always: [
+            { target: "WaitForAppAndVersion", guard: "noInternalError" },
+            { target: "Error" },
+          ],
+        },
+        // Read the running app + version freshly from the device (rather than
+        // the possibly-stale session state) so the version guard evaluates the
+        // app that is actually running — e.g. when open-app is skipped and the
+        // app was changed outside DMK. Runs on both paths.
+        WaitForAppAndVersion: {
+          // Silent read — no user interaction required for this step.
+          entry: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          }),
+          invoke: {
+            id: "waitForAppAndVersion",
+            src: "waitForAppAndVersionStateMachine",
+            input: () => ({}),
+            onDone: {
+              target: "CheckAppAndVersion",
+              actions: assign({
+                _internalState: ({ event, context }) =>
+                  event.output.caseOf<RegisterExternalAddressDAInternalState>({
+                    Right: (appAndVersion) => ({
+                      ...context._internalState,
+                      appAndVersion: {
+                        name: appAndVersion.name,
+                        version: appAndVersion.version,
+                      },
+                    }),
+                    Left: (error) => ({ ...context._internalState, error }),
+                  }),
+              }),
+            },
+          },
+        },
+        CheckAppAndVersion: {
+          always: [
             { target: "VersionGuard", guard: "noInternalError" },
             { target: "Error" },
           ],
         },
-        // Version guard runs on both the open-app and skip-open-app paths.
+        // Version guard evaluates support from the fresh WaitForAppAndVersion
+        // result. Runs on both the open-app and skip-open-app paths.
         VersionGuard: {
           always: [
             { target: "RegisterIdentity", guard: "contactsSupported" },
@@ -222,15 +294,8 @@ export class RegisterExternalAddressDeviceAction extends XStateDeviceAction<
   extractDependencies(
     internalApi: InternalApi,
   ): RegisterExternalAddressMachineDependencies {
-    const isSupported = () => {
-      const deviceState = internalApi.getDeviceSessionState();
-      const version =
-        "currentApp" in deviceState
-          ? deviceState.currentApp?.version
-          : undefined;
-      if (version === undefined) return false;
-      return isContactsSupportedForSession(internalApi, { version });
-    };
+    const isSupported = (app: RunningApp) =>
+      isContactsSupportedForSession(internalApi, app);
 
     const registerIdentity = (
       input: RegisterExternalAddressDAInput,

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterExternalAddress/RegisterExternalAddressDeviceAction.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterExternalAddress/RegisterExternalAddressDeviceAction.ts
@@ -1,0 +1,251 @@
+import {
+  type DeviceActionStateMachine,
+  type InternalApi,
+  isSuccessCommandResult,
+  OpenAppDeviceAction,
+  type StateMachineTypes,
+  UnknownDAError,
+  UserInteractionRequired,
+  XStateDeviceAction,
+} from "@ledgerhq/device-management-kit";
+import { Left, Right } from "purify-ts";
+import { assign, fromPromise, setup } from "xstate";
+
+import {
+  type RegisterExternalAddressDAError,
+  type RegisterExternalAddressDAInput,
+  type RegisterExternalAddressDAIntermediateValue,
+  type RegisterExternalAddressDAInternalState,
+  type RegisterExternalAddressDAOutput,
+} from "@api/app-binder/RegisterExternalAddressDeviceActionTypes";
+import { isContactsSupportedForSession } from "@internal/app-binder/isContactsSupportedForSession";
+import { ContactsVersionRequirementError } from "@internal/app-binder/model/contactsErrors";
+import {
+  type RegisterIdentityProofs,
+  SendRegisterIdentityTask,
+} from "@internal/app-binder/task/SendRegisterIdentityTask";
+
+export type RegisterExternalAddressMachineDependencies = {
+  readonly isSupported: () => boolean;
+  readonly registerIdentity: (
+    input: RegisterExternalAddressDAInput,
+  ) => Promise<Awaited<ReturnType<SendRegisterIdentityTask["run"]>>>;
+};
+
+export class RegisterExternalAddressDeviceAction extends XStateDeviceAction<
+  RegisterExternalAddressDAOutput,
+  RegisterExternalAddressDAInput,
+  RegisterExternalAddressDAError,
+  RegisterExternalAddressDAIntermediateValue,
+  RegisterExternalAddressDAInternalState
+> {
+  makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    RegisterExternalAddressDAOutput,
+    RegisterExternalAddressDAInput,
+    RegisterExternalAddressDAError,
+    RegisterExternalAddressDAIntermediateValue,
+    RegisterExternalAddressDAInternalState
+  > {
+    type types = StateMachineTypes<
+      RegisterExternalAddressDAOutput,
+      RegisterExternalAddressDAInput,
+      RegisterExternalAddressDAError,
+      RegisterExternalAddressDAIntermediateValue,
+      RegisterExternalAddressDAInternalState
+    >;
+
+    const { isSupported, registerIdentity } =
+      this.extractDependencies(internalApi);
+    const appName = this.input.appName;
+
+    return setup({
+      types: {
+        input: {} as types["input"],
+        context: {} as types["context"],
+        output: {} as types["output"],
+      },
+      actors: {
+        openAppStateMachine: new OpenAppDeviceAction({
+          input: { appName },
+        }).makeStateMachine(internalApi),
+        registerIdentity: fromPromise(
+          ({ input }: { input: RegisterExternalAddressDAInput }) =>
+            registerIdentity(input),
+        ),
+      },
+      guards: {
+        skipOpenApp: ({ context }) => context.input.skipOpenApp === true,
+        noInternalError: ({ context }) => context._internalState.error === null,
+        contactsSupported: () => isSupported(),
+      },
+      actions: {
+        assignVersionError: assign({
+          _internalState: ({ context }) => ({
+            ...context._internalState,
+            error: new ContactsVersionRequirementError(),
+          }),
+        }),
+        assignErrorFromEvent: assign({
+          _internalState: ({ context, event }) => ({
+            ...context._internalState,
+            error: new UnknownDAError(
+              event["error"] instanceof Error
+                ? event["error"].message
+                : String(event["error"]),
+            ),
+          }),
+        }),
+      },
+    }).createMachine({
+      id: "RegisterExternalAddressDeviceAction",
+      initial: "InitialState",
+      context: ({ input }) => ({
+        input,
+        intermediateValue: {
+          requiredUserInteraction: UserInteractionRequired.None,
+        },
+        _internalState: {
+          error: null,
+          proofs: null,
+        },
+      }),
+      states: {
+        InitialState: {
+          always: [
+            { target: "VersionGuard", guard: "skipOpenApp" },
+            { target: "OpenAppDeviceAction" },
+          ],
+        },
+        OpenAppDeviceAction: {
+          invoke: {
+            id: "openAppStateMachine",
+            src: "openAppStateMachine",
+            input: () => ({ appName }),
+            onSnapshot: {
+              actions: assign({
+                intermediateValue: ({ event }) =>
+                  event.snapshot.context.intermediateValue,
+              }),
+            },
+            onDone: {
+              target: "CheckOpenAppResult",
+              actions: assign({
+                _internalState: ({ event, context }) =>
+                  event.output.caseOf<RegisterExternalAddressDAInternalState>({
+                    Right: () => context._internalState,
+                    Left: (error) => ({ ...context._internalState, error }),
+                  }),
+              }),
+            },
+          },
+        },
+        CheckOpenAppResult: {
+          always: [
+            { target: "VersionGuard", guard: "noInternalError" },
+            { target: "Error" },
+          ],
+        },
+        // Version guard runs on both the open-app and skip-open-app paths.
+        VersionGuard: {
+          always: [
+            { target: "RegisterIdentity", guard: "contactsSupported" },
+            { target: "Error", actions: "assignVersionError" },
+          ],
+        },
+        RegisterIdentity: {
+          entry: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.RegisterWallet,
+            },
+          }),
+          exit: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          }),
+          invoke: {
+            id: "registerIdentity",
+            src: "registerIdentity",
+            input: ({ context }) => context.input,
+            onDone: {
+              target: "RegisterIdentityResultCheck",
+              actions: assign({
+                _internalState: ({ event, context }) =>
+                  isSuccessCommandResult(event.output)
+                    ? { ...context._internalState, proofs: event.output.data }
+                    : {
+                        ...context._internalState,
+                        error: event.output.error,
+                      },
+              }),
+            },
+            onError: {
+              target: "Error",
+              actions: "assignErrorFromEvent",
+            },
+          },
+        },
+        RegisterIdentityResultCheck: {
+          always: [
+            { target: "Success", guard: "noInternalError" },
+            { target: "Error" },
+          ],
+        },
+        Success: { type: "final" },
+        Error: { type: "final" },
+      },
+      output: ({ context }) => {
+        const { proofs, error } = context._internalState;
+        if (proofs) {
+          const { input } = context;
+          return Right({
+            mode: input.existingContactGroup
+              ? ("existingContactGroup" as const)
+              : ("newContactGroup" as const),
+            contactName: input.contactName,
+            scope: input.scope,
+            identifier: input.identifier,
+            blockchainFamily: input.blockchainFamily,
+            chainId: input.chainId,
+            groupHandle: proofs.groupHandle,
+            hmacProof: proofs.hmacProof,
+            hmacRest: proofs.hmacRest,
+          });
+        }
+        return Left(error ?? new UnknownDAError("No error in final state"));
+      },
+    });
+  }
+
+  extractDependencies(
+    internalApi: InternalApi,
+  ): RegisterExternalAddressMachineDependencies {
+    const isSupported = () => {
+      const deviceState = internalApi.getDeviceSessionState();
+      const version =
+        "currentApp" in deviceState
+          ? deviceState.currentApp?.version
+          : undefined;
+      if (version === undefined) return false;
+      return isContactsSupportedForSession(internalApi, { version });
+    };
+
+    const registerIdentity = (
+      input: RegisterExternalAddressDAInput,
+    ): Promise<Awaited<ReturnType<SendRegisterIdentityTask["run"]>>> =>
+      new SendRegisterIdentityTask(internalApi, {
+        contactName: input.contactName,
+        scope: input.scope,
+        identifier: input.identifier,
+        blockchainFamily: input.blockchainFamily,
+        chainId: input.chainId,
+        existingContactGroup: input.existingContactGroup,
+      }).run();
+
+    return { isSupported, registerIdentity };
+  }
+}
+
+export type { RegisterIdentityProofs };

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterExternalAddress/validateRegisterExternalAddressInput.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterExternalAddress/validateRegisterExternalAddressInput.test.ts
@@ -1,0 +1,78 @@
+import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
+import { ContactsValidationError } from "@internal/app-binder/model/contactsValidation";
+
+import { validateRegisterExternalAddressInput } from "./validateRegisterExternalAddressInput";
+
+const VALID_INPUT: RegisterExternalAddressInput = {
+  contactName: "Alice",
+  scope: "Eth main",
+  identifier: new Uint8Array(20).fill(0x11),
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+};
+
+describe("validateRegisterExternalAddressInput", () => {
+  it("returns null for valid input", () => {
+    expect(validateRegisterExternalAddressInput(VALID_INPUT)).toBeNull();
+  });
+
+  it("returns null for a valid existing-contact-group input", () => {
+    expect(
+      validateRegisterExternalAddressInput({
+        ...VALID_INPUT,
+        existingContactGroup: {
+          groupHandle: new Uint8Array(64),
+          hmacProof: new Uint8Array(32),
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns a ContactsValidationError for a non-printable contact name", () => {
+    expect(
+      validateRegisterExternalAddressInput({
+        ...VALID_INPUT,
+        contactName: "Amélie",
+      }),
+    ).toBeInstanceOf(ContactsValidationError);
+  });
+
+  it("returns an error for an Ethereum identifier of the wrong length", () => {
+    expect(
+      validateRegisterExternalAddressInput({
+        ...VALID_INPUT,
+        identifier: new Uint8Array(19),
+      }),
+    ).toBeInstanceOf(ContactsValidationError);
+  });
+
+  it("returns an error for an unsupported blockchain family", () => {
+    expect(
+      validateRegisterExternalAddressInput({
+        ...VALID_INPUT,
+        blockchainFamily: "dogecoin",
+      }),
+    ).toBeInstanceOf(ContactsValidationError);
+  });
+
+  it("returns an error when chainId is missing for the Ethereum family", () => {
+    expect(
+      validateRegisterExternalAddressInput({
+        ...VALID_INPUT,
+        chainId: undefined,
+      }),
+    ).toBeInstanceOf(ContactsValidationError);
+  });
+
+  it("returns an error for a wrong-sized existing group handle", () => {
+    expect(
+      validateRegisterExternalAddressInput({
+        ...VALID_INPUT,
+        existingContactGroup: {
+          groupHandle: new Uint8Array(32),
+          hmacProof: new Uint8Array(32),
+        },
+      }),
+    ).toBeInstanceOf(ContactsValidationError);
+  });
+});

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterExternalAddress/validateRegisterExternalAddressInput.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterExternalAddress/validateRegisterExternalAddressInput.ts
@@ -1,0 +1,80 @@
+import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
+import { BLOCKCHAIN_FAMILY_BY_NAME } from "@internal/app-binder/model/contactsConstants";
+import {
+  CONTACT_NAME_BUFFER_LENGTH,
+  ContactsValidationError,
+  ETH_ADDRESS_BYTES,
+  GROUP_HANDLE_SIZE,
+  HMAC_PROOF_LENGTH,
+  SCOPE_BUFFER_LENGTH,
+  validateByteLength,
+  validateChainId,
+  validatePrintableLabel,
+} from "@internal/app-binder/model/contactsValidation";
+
+/**
+ * Validate the caller input for Register External Address. Returns the first
+ * `ContactsValidationError` found, or `null` when the input is valid.
+ *
+ * Non-throwing by design: the device action calls this so an invalid input is
+ * surfaced as a typed terminal error state on the observable, keeping the
+ * public `ContactsManager.registerExternalAddress` free of synchronous throws.
+ */
+export function validateRegisterExternalAddressInput(
+  input: RegisterExternalAddressInput,
+): ContactsValidationError | null {
+  try {
+    validatePrintableLabel(input.contactName, {
+      field: "contactName",
+      bufferLength: CONTACT_NAME_BUFFER_LENGTH,
+    });
+    validatePrintableLabel(input.scope, {
+      field: "scope",
+      bufferLength: SCOPE_BUFFER_LENGTH,
+    });
+
+    const family = input.blockchainFamily.toLowerCase();
+    if (!(family in BLOCKCHAIN_FAMILY_BY_NAME)) {
+      throw new ContactsValidationError(
+        `Unsupported blockchain family: ${input.blockchainFamily}`,
+      );
+    }
+    if (family === "ethereum") {
+      validateByteLength(input.identifier, {
+        field: "identifier",
+        expectedBytes: ETH_ADDRESS_BYTES,
+      });
+      // CHAIN_ID is mandatory for the Ethereum family (multiple networks share
+      // the same address format).
+      if (input.chainId === undefined) {
+        throw new ContactsValidationError(
+          "chainId is required for the Ethereum blockchain family.",
+        );
+      }
+    } else if (input.identifier.length === 0) {
+      throw new ContactsValidationError("identifier must not be empty.");
+    }
+
+    if (input.chainId !== undefined) {
+      validateChainId(input.chainId);
+    }
+
+    if (input.existingContactGroup) {
+      validateByteLength(input.existingContactGroup.groupHandle, {
+        field: "existingContactGroup.groupHandle",
+        expectedBytes: GROUP_HANDLE_SIZE,
+      });
+      validateByteLength(input.existingContactGroup.hmacProof, {
+        field: "existingContactGroup.hmacProof",
+        expectedBytes: HMAC_PROOF_LENGTH,
+      });
+    }
+
+    return null;
+  } catch (error) {
+    if (error instanceof ContactsValidationError) {
+      return error;
+    }
+    throw error;
+  }
+}

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterLedgerAccount/RegisterLedgerAccountDeviceAction.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterLedgerAccount/RegisterLedgerAccountDeviceAction.test.ts
@@ -1,0 +1,442 @@
+import {
+  CommandResultFactory,
+  type DeviceActionState,
+  DeviceActionStatus,
+  DeviceModelId,
+  DeviceSessionStateType,
+  DeviceStatus,
+  UnknownDAError,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+import { beforeEach, describe, it, vi } from "vitest";
+
+import {
+  type RegisterLedgerAccountDAError,
+  type RegisterLedgerAccountDAInput,
+  type RegisterLedgerAccountDAIntermediateValue,
+  type RegisterLedgerAccountDAOutput,
+} from "@api/app-binder/RegisterLedgerAccountDeviceActionTypes";
+import { makeDeviceActionInternalApiMock } from "@internal/app-binder/device-action/__test-utils__/makeInternalApi";
+import { setupOpenAppDAMock } from "@internal/app-binder/device-action/__test-utils__/setupOpenAppDAMock";
+import { setupWaitForAppAndVersionDAMock } from "@internal/app-binder/device-action/__test-utils__/setupWaitForAppAndVersionDAMock";
+import { testDeviceActionStates } from "@internal/app-binder/device-action/__test-utils__/testDeviceActionStates";
+import {
+  ContactsCommandError,
+  ContactsVersionRequirementError,
+} from "@internal/app-binder/model/contactsErrors";
+
+import { RegisterLedgerAccountDeviceAction } from "./RegisterLedgerAccountDeviceAction";
+import { validateRegisterLedgerAccountInput } from "./validateRegisterLedgerAccountInput";
+
+vi.mock("@ledgerhq/device-management-kit", async (importOriginal) => {
+  const original =
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    await importOriginal<typeof import("@ledgerhq/device-management-kit")>();
+  return {
+    ...original,
+    OpenAppDeviceAction: vi.fn(() => ({
+      makeStateMachine: vi.fn(),
+    })),
+    WaitForAppAndVersionDeviceAction: vi.fn(() => ({
+      makeStateMachine: vi.fn(),
+    })),
+  };
+});
+
+const FRESH_APP = { name: "Ethereum", version: "1.15.0" };
+
+const HMAC_PROOF = new Uint8Array(32).fill(0xdd);
+const OK_PROOF = { hmacProof: HMAC_PROOF };
+
+const BASE_INPUT = {
+  accountName: "Alice",
+  derivationPath: "m/44'/60'/0'/0/0",
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+  appName: "Ethereum",
+};
+
+const EXPECTED_OUTPUT = {
+  accountName: "Alice",
+  derivationPath: "m/44'/60'/0'/0/0",
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+  hmacProof: HMAC_PROOF,
+};
+
+describe("RegisterLedgerAccountDeviceAction", () => {
+  let apiMock: ReturnType<typeof makeDeviceActionInternalApiMock>;
+  let isSupportedMock: ReturnType<typeof vi.fn>;
+  let registerLedgerAccountMock: ReturnType<typeof vi.fn>;
+
+  function extractDeps() {
+    return {
+      isSupported: isSupportedMock,
+      registerLedgerAccount: registerLedgerAccountMock,
+    };
+  }
+
+  beforeEach(() => {
+    apiMock = makeDeviceActionInternalApiMock();
+    setupWaitForAppAndVersionDAMock(FRESH_APP);
+    isSupportedMock = vi.fn().mockReturnValue(true);
+    registerLedgerAccountMock = vi
+      .fn()
+      .mockResolvedValue(CommandResultFactory({ data: OK_PROOF }));
+    apiMock.getDeviceSessionState.mockReturnValue({
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Ethereum", version: "1.15.0" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: true,
+    });
+  });
+
+  function makeAction(input: RegisterLedgerAccountDAInput) {
+    const action = new RegisterLedgerAccountDeviceAction({ input });
+    vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+    return action;
+  }
+
+  it("open-app path: OpenApp -> WaitForAppAndVersion -> RegisterLedgerAccount -> Completed", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: false });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        // Silent WaitForAppAndVersion read (no interaction).
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.RegisterWallet,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          output: EXPECTED_OUTPUT,
+          status: DeviceActionStatus.Completed,
+        },
+      ] as DeviceActionState<
+        RegisterLedgerAccountDAOutput,
+        RegisterLedgerAccountDAError,
+        RegisterLedgerAccountDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+    }));
+
+  it("skip-open-app path: WaitForAppAndVersion -> RegisterLedgerAccount -> Completed", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: true });
+
+      const expected = [
+        // Silent WaitForAppAndVersion read (no interaction).
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.RegisterWallet,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          output: EXPECTED_OUTPUT,
+          status: DeviceActionStatus.Completed,
+        },
+      ] as DeviceActionState<
+        RegisterLedgerAccountDAOutput,
+        RegisterLedgerAccountDAError,
+        RegisterLedgerAccountDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+    }));
+
+  it("version guard rejects on skip-open-app path without registering", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      isSupportedMock.mockReturnValue(false);
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: true });
+
+      const expected = [
+        // Silent WaitForAppAndVersion read still runs before the guard.
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: new ContactsVersionRequirementError(),
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        RegisterLedgerAccountDAOutput,
+        RegisterLedgerAccountDAError,
+        RegisterLedgerAccountDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+      expect(registerLedgerAccountMock).not.toHaveBeenCalled();
+    }));
+
+  it("surfaces an open-app failure as the device action error", () =>
+    new Promise<void>((resolve, reject) => {
+      const openAppError = new UnknownDAError("open app failed");
+      setupOpenAppDAMock(openAppError);
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: false });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: openAppError,
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        RegisterLedgerAccountDAOutput,
+        RegisterLedgerAccountDAError,
+        RegisterLedgerAccountDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+      expect(isSupportedMock).not.toHaveBeenCalled();
+    }));
+
+  it("surfaces a Register Ledger Account command error", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const commandError = new ContactsCommandError({
+        errorCode: "6a80",
+        message: "device rejected",
+      });
+      registerLedgerAccountMock.mockResolvedValue(
+        CommandResultFactory({ error: commandError }),
+      );
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: true });
+
+      const expected = [
+        // Silent WaitForAppAndVersion read (no interaction).
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.RegisterWallet,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: commandError,
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        RegisterLedgerAccountDAOutput,
+        RegisterLedgerAccountDAError,
+        RegisterLedgerAccountDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+    }));
+
+  it("surfaces invalid input as a typed error state on the skip-open-app path", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const invalidInput = {
+        ...BASE_INPUT,
+        skipOpenApp: true,
+        accountName: "",
+      };
+      const validationError = validateRegisterLedgerAccountInput(invalidInput);
+      const action = makeAction(invalidInput);
+
+      const expected = [
+        {
+          error: validationError,
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        RegisterLedgerAccountDAOutput,
+        RegisterLedgerAccountDAError,
+        RegisterLedgerAccountDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+      // Validation fails before the version guard and before any APDU.
+      expect(isSupportedMock).not.toHaveBeenCalled();
+      expect(registerLedgerAccountMock).not.toHaveBeenCalled();
+    }));
+
+  it("validates only after opening the app on the default path", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const invalidInput = {
+        ...BASE_INPUT,
+        skipOpenApp: false,
+        accountName: "",
+      };
+      const validationError = validateRegisterLedgerAccountInput(invalidInput);
+      const action = makeAction(invalidInput);
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: validationError,
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        RegisterLedgerAccountDAOutput,
+        RegisterLedgerAccountDAError,
+        RegisterLedgerAccountDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+      expect(registerLedgerAccountMock).not.toHaveBeenCalled();
+    }));
+
+  it("evaluates support from the fresh WaitForAppAndVersion result, not stale session state", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      // Session state (from beforeEach) reports version 1.15.0; the fresh read
+      // reports a different version, which is what the guard must use.
+      const freshApp = { name: "Ethereum", version: "9.9.9" };
+      setupWaitForAppAndVersionDAMock(freshApp);
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: true });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.RegisterWallet,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          output: EXPECTED_OUTPUT,
+          status: DeviceActionStatus.Completed,
+        },
+      ] as DeviceActionState<
+        RegisterLedgerAccountDAOutput,
+        RegisterLedgerAccountDAError,
+        RegisterLedgerAccountDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: () => {
+          try {
+            expect(isSupportedMock).toHaveBeenCalledWith(freshApp);
+            resolve();
+          } catch (e) {
+            reject(e as Error);
+          }
+        },
+        onError: reject,
+      });
+    }));
+
+  it("surfaces a WaitForAppAndVersion failure as the device action error", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const waitError = new UnknownDAError("could not read app and version");
+      setupWaitForAppAndVersionDAMock({ error: waitError });
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: true });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: waitError,
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        RegisterLedgerAccountDAOutput,
+        RegisterLedgerAccountDAError,
+        RegisterLedgerAccountDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+      // The version guard and the APDU are never reached.
+      expect(isSupportedMock).not.toHaveBeenCalled();
+      expect(registerLedgerAccountMock).not.toHaveBeenCalled();
+    }));
+});

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterLedgerAccount/RegisterLedgerAccountDeviceAction.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterLedgerAccount/RegisterLedgerAccountDeviceAction.ts
@@ -1,0 +1,311 @@
+import {
+  type DeviceActionStateMachine,
+  type InternalApi,
+  isSuccessCommandResult,
+  OpenAppDeviceAction,
+  type StateMachineTypes,
+  UnknownDAError,
+  UserInteractionRequired,
+  WaitForAppAndVersionDeviceAction,
+  XStateDeviceAction,
+} from "@ledgerhq/device-management-kit";
+import { Left, Right } from "purify-ts";
+import { assign, fromPromise, setup } from "xstate";
+
+import {
+  type RegisterLedgerAccountDAError,
+  type RegisterLedgerAccountDAInput,
+  type RegisterLedgerAccountDAIntermediateValue,
+  type RegisterLedgerAccountDAInternalState,
+  type RegisterLedgerAccountDAOutput,
+} from "@api/app-binder/RegisterLedgerAccountDeviceActionTypes";
+import {
+  isContactsSupportedForSession,
+  type RunningApp,
+} from "@internal/app-binder/isContactsSupportedForSession";
+import { ContactsVersionRequirementError } from "@internal/app-binder/model/contactsErrors";
+import {
+  type RegisterLedgerAccountProof,
+  SendRegisterLedgerAccountTask,
+} from "@internal/app-binder/task/SendRegisterLedgerAccountTask";
+
+import { validateRegisterLedgerAccountInput } from "./validateRegisterLedgerAccountInput";
+
+export type RegisterLedgerAccountMachineDependencies = {
+  readonly isSupported: (app: RunningApp) => boolean;
+  readonly registerLedgerAccount: (
+    input: RegisterLedgerAccountDAInput,
+  ) => Promise<Awaited<ReturnType<SendRegisterLedgerAccountTask["run"]>>>;
+};
+
+export class RegisterLedgerAccountDeviceAction extends XStateDeviceAction<
+  RegisterLedgerAccountDAOutput,
+  RegisterLedgerAccountDAInput,
+  RegisterLedgerAccountDAError,
+  RegisterLedgerAccountDAIntermediateValue,
+  RegisterLedgerAccountDAInternalState
+> {
+  makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    RegisterLedgerAccountDAOutput,
+    RegisterLedgerAccountDAInput,
+    RegisterLedgerAccountDAError,
+    RegisterLedgerAccountDAIntermediateValue,
+    RegisterLedgerAccountDAInternalState
+  > {
+    type types = StateMachineTypes<
+      RegisterLedgerAccountDAOutput,
+      RegisterLedgerAccountDAInput,
+      RegisterLedgerAccountDAError,
+      RegisterLedgerAccountDAIntermediateValue,
+      RegisterLedgerAccountDAInternalState
+    >;
+
+    const { isSupported, registerLedgerAccount } =
+      this.extractDependencies(internalApi);
+    const appName = this.input.appName;
+
+    return setup({
+      types: {
+        input: {} as types["input"],
+        context: {} as types["context"],
+        output: {} as types["output"],
+      },
+      actors: {
+        openAppStateMachine: new OpenAppDeviceAction({
+          input: { appName },
+        }).makeStateMachine(internalApi),
+        waitForAppAndVersionStateMachine: new WaitForAppAndVersionDeviceAction({
+          input: {},
+        }).makeStateMachine(internalApi),
+        registerLedgerAccount: fromPromise(
+          ({ input }: { input: RegisterLedgerAccountDAInput }) =>
+            registerLedgerAccount(input),
+        ),
+      },
+      guards: {
+        skipOpenApp: ({ context }) => context.input.skipOpenApp === true,
+        noInternalError: ({ context }) => context._internalState.error === null,
+        contactsSupported: ({ context }) => {
+          const { appAndVersion } = context._internalState;
+          return appAndVersion !== null && isSupported(appAndVersion);
+        },
+      },
+      actions: {
+        assignValidationError: assign({
+          _internalState: ({ context }) => {
+            const error = validateRegisterLedgerAccountInput(context.input);
+            return error
+              ? { ...context._internalState, error }
+              : context._internalState;
+          },
+        }),
+        assignVersionError: assign({
+          _internalState: ({ context }) => ({
+            ...context._internalState,
+            error: new ContactsVersionRequirementError(),
+          }),
+        }),
+        assignErrorFromEvent: assign({
+          _internalState: ({ context, event }) => ({
+            ...context._internalState,
+            error: new UnknownDAError(
+              event["error"] instanceof Error
+                ? event["error"].message
+                : String(event["error"]),
+            ),
+          }),
+        }),
+      },
+    }).createMachine({
+      id: "RegisterLedgerAccountDeviceAction",
+      initial: "InitialState",
+      context: ({ input }) => ({
+        input,
+        intermediateValue: {
+          requiredUserInteraction: UserInteractionRequired.None,
+        },
+        _internalState: {
+          error: null,
+          appAndVersion: null,
+          proof: null,
+        },
+      }),
+      states: {
+        InitialState: {
+          always: [
+            { target: "ValidateInput", guard: "skipOpenApp" },
+            { target: "OpenAppDeviceAction" },
+          ],
+        },
+        OpenAppDeviceAction: {
+          invoke: {
+            id: "openAppStateMachine",
+            src: "openAppStateMachine",
+            input: () => ({ appName }),
+            onSnapshot: {
+              actions: assign({
+                intermediateValue: ({ event }) =>
+                  event.snapshot.context.intermediateValue,
+              }),
+            },
+            onDone: {
+              target: "CheckOpenAppResult",
+              actions: assign({
+                _internalState: ({ event, context }) =>
+                  event.output.caseOf<RegisterLedgerAccountDAInternalState>({
+                    Right: () => context._internalState,
+                    Left: (error) => ({ ...context._internalState, error }),
+                  }),
+              }),
+            },
+          },
+        },
+        CheckOpenAppResult: {
+          always: [
+            { target: "ValidateInput", guard: "noInternalError" },
+            { target: "Error" },
+          ],
+        },
+        // Input validation runs inside the device action (after the app is
+        // opened) so invalid caller input surfaces as a typed terminal error
+        // state on the observable instead of a synchronous throw. Runs on both
+        // the open-app and skip-open-app paths.
+        ValidateInput: {
+          entry: "assignValidationError",
+          always: [
+            { target: "WaitForAppAndVersion", guard: "noInternalError" },
+            { target: "Error" },
+          ],
+        },
+        // Read the running app + version freshly from the device (rather than
+        // the possibly-stale session state) so the version guard evaluates the
+        // app that is actually running — e.g. when open-app is skipped and the
+        // app was changed outside DMK. Runs on both paths.
+        WaitForAppAndVersion: {
+          // Silent read — no user interaction required for this step.
+          entry: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          }),
+          invoke: {
+            id: "waitForAppAndVersion",
+            src: "waitForAppAndVersionStateMachine",
+            input: () => ({}),
+            onDone: {
+              target: "CheckAppAndVersion",
+              actions: assign({
+                _internalState: ({ event, context }) =>
+                  event.output.caseOf<RegisterLedgerAccountDAInternalState>({
+                    Right: (appAndVersion) => ({
+                      ...context._internalState,
+                      appAndVersion: {
+                        name: appAndVersion.name,
+                        version: appAndVersion.version,
+                      },
+                    }),
+                    Left: (error) => ({ ...context._internalState, error }),
+                  }),
+              }),
+            },
+          },
+        },
+        CheckAppAndVersion: {
+          always: [
+            { target: "VersionGuard", guard: "noInternalError" },
+            { target: "Error" },
+          ],
+        },
+        // Version guard evaluates support from the fresh WaitForAppAndVersion
+        // result. Runs on both the open-app and skip-open-app paths.
+        VersionGuard: {
+          always: [
+            { target: "RegisterLedgerAccount", guard: "contactsSupported" },
+            { target: "Error", actions: "assignVersionError" },
+          ],
+        },
+        RegisterLedgerAccount: {
+          entry: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.RegisterWallet,
+            },
+          }),
+          exit: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          }),
+          invoke: {
+            id: "registerLedgerAccount",
+            src: "registerLedgerAccount",
+            input: ({ context }) => context.input,
+            onDone: {
+              target: "RegisterLedgerAccountResultCheck",
+              actions: assign({
+                _internalState: ({ event, context }) =>
+                  isSuccessCommandResult(event.output)
+                    ? {
+                        ...context._internalState,
+                        proof: event.output.data.hmacProof,
+                      }
+                    : {
+                        ...context._internalState,
+                        error: event.output.error,
+                      },
+              }),
+            },
+            onError: {
+              target: "Error",
+              actions: "assignErrorFromEvent",
+            },
+          },
+        },
+        RegisterLedgerAccountResultCheck: {
+          always: [
+            { target: "Success", guard: "noInternalError" },
+            { target: "Error" },
+          ],
+        },
+        Success: { type: "final" },
+        Error: { type: "final" },
+      },
+      output: ({ context }) => {
+        const { proof, error } = context._internalState;
+        if (proof) {
+          const { input } = context;
+          return Right({
+            accountName: input.accountName,
+            derivationPath: input.derivationPath,
+            blockchainFamily: input.blockchainFamily,
+            chainId: input.chainId,
+            hmacProof: proof,
+          });
+        }
+        return Left(error ?? new UnknownDAError("No error in final state"));
+      },
+    });
+  }
+
+  extractDependencies(
+    internalApi: InternalApi,
+  ): RegisterLedgerAccountMachineDependencies {
+    const isSupported = (app: RunningApp) =>
+      isContactsSupportedForSession(internalApi, app);
+
+    const registerLedgerAccount = (
+      input: RegisterLedgerAccountDAInput,
+    ): Promise<Awaited<ReturnType<SendRegisterLedgerAccountTask["run"]>>> =>
+      new SendRegisterLedgerAccountTask(internalApi, {
+        accountName: input.accountName,
+        derivationPath: input.derivationPath,
+        blockchainFamily: input.blockchainFamily,
+        chainId: input.chainId,
+      }).run();
+
+    return { isSupported, registerLedgerAccount };
+  }
+}
+
+export type { RegisterLedgerAccountProof };

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterLedgerAccount/validateRegisterLedgerAccountInput.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterLedgerAccount/validateRegisterLedgerAccountInput.test.ts
@@ -1,0 +1,62 @@
+import { type RegisterLedgerAccountInput } from "@api/model/RegisterLedgerAccount";
+import { ContactsValidationError } from "@internal/app-binder/model/contactsValidation";
+
+import { validateRegisterLedgerAccountInput } from "./validateRegisterLedgerAccountInput";
+
+const VALID_INPUT: RegisterLedgerAccountInput = {
+  accountName: "Alice",
+  derivationPath: "m/44'/60'/0'/0/0",
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+};
+
+describe("validateRegisterLedgerAccountInput", () => {
+  it("returns null for valid input", () => {
+    expect(validateRegisterLedgerAccountInput(VALID_INPUT)).toBeNull();
+  });
+
+  it("returns a ContactsValidationError for a non-printable account name", () => {
+    expect(
+      validateRegisterLedgerAccountInput({
+        ...VALID_INPUT,
+        accountName: "Amélie",
+      }),
+    ).toBeInstanceOf(ContactsValidationError);
+  });
+
+  it("returns an error for an empty derivation path", () => {
+    expect(
+      validateRegisterLedgerAccountInput({
+        ...VALID_INPUT,
+        derivationPath: "",
+      }),
+    ).toBeInstanceOf(ContactsValidationError);
+  });
+
+  it("returns an error for a malformed derivation path", () => {
+    expect(
+      validateRegisterLedgerAccountInput({
+        ...VALID_INPUT,
+        derivationPath: "m/44'/foo/0'",
+      }),
+    ).toBeInstanceOf(ContactsValidationError);
+  });
+
+  it("returns an error for an unsupported blockchain family", () => {
+    expect(
+      validateRegisterLedgerAccountInput({
+        ...VALID_INPUT,
+        blockchainFamily: "dogecoin",
+      }),
+    ).toBeInstanceOf(ContactsValidationError);
+  });
+
+  it("returns an error when chainId is missing for the Ethereum family", () => {
+    expect(
+      validateRegisterLedgerAccountInput({
+        ...VALID_INPUT,
+        chainId: undefined,
+      }),
+    ).toBeInstanceOf(ContactsValidationError);
+  });
+});

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterLedgerAccount/validateRegisterLedgerAccountInput.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/RegisterLedgerAccount/validateRegisterLedgerAccountInput.ts
@@ -1,0 +1,54 @@
+import { type RegisterLedgerAccountInput } from "@api/model/RegisterLedgerAccount";
+import { BLOCKCHAIN_FAMILY_BY_NAME } from "@internal/app-binder/model/contactsConstants";
+import {
+  CONTACT_NAME_BUFFER_LENGTH,
+  ContactsValidationError,
+  validateChainId,
+  validateDerivationPath,
+  validatePrintableLabel,
+} from "@internal/app-binder/model/contactsValidation";
+
+/**
+ * Validate the caller input for Register Ledger Account. Returns the first
+ * `ContactsValidationError` found, or `null` when the input is valid.
+ *
+ * Non-throwing by design: the device action calls this so an invalid input is
+ * surfaced as a typed terminal error state on the observable, keeping the
+ * public `ContactsManager.registerLedgerAccount` free of synchronous throws.
+ */
+export function validateRegisterLedgerAccountInput(
+  input: RegisterLedgerAccountInput,
+): ContactsValidationError | null {
+  try {
+    validatePrintableLabel(input.accountName, {
+      field: "accountName",
+      bufferLength: CONTACT_NAME_BUFFER_LENGTH,
+    });
+    validateDerivationPath(input.derivationPath);
+
+    const family = input.blockchainFamily.toLowerCase();
+    if (!(family in BLOCKCHAIN_FAMILY_BY_NAME)) {
+      throw new ContactsValidationError(
+        `Unsupported blockchain family: ${input.blockchainFamily}`,
+      );
+    }
+    if (family === "ethereum" && input.chainId === undefined) {
+      // CHAIN_ID is mandatory for the Ethereum family (multiple networks share
+      // the same account derivation).
+      throw new ContactsValidationError(
+        "chainId is required for the Ethereum blockchain family.",
+      );
+    }
+
+    if (input.chainId !== undefined) {
+      validateChainId(input.chainId);
+    }
+
+    return null;
+  } catch (error) {
+    if (error instanceof ContactsValidationError) {
+      return error;
+    }
+    throw error;
+  }
+}

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/__test-utils__/makeInternalApi.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/__test-utils__/makeInternalApi.ts
@@ -1,0 +1,22 @@
+import { type InternalApi } from "@ledgerhq/device-management-kit";
+import { type Mocked } from "vitest";
+
+export function makeDeviceActionInternalApiMock(): Mocked<InternalApi> {
+  return {
+    sendApdu: vi.fn(),
+    sendCommand: vi.fn().mockResolvedValue(undefined),
+    getDeviceModel: vi.fn(),
+    getDeviceSessionState: vi.fn(),
+    getDeviceSessionStateObservable: vi.fn(),
+    setDeviceSessionState: vi.fn(),
+    getManagerApiService: vi.fn(),
+    getSecureChannelService: vi.fn(),
+    loggerFactory: vi.fn((_tag: string) => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      subscribers: [],
+    })),
+  };
+}

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/__test-utils__/setupOpenAppDAMock.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/__test-utils__/setupOpenAppDAMock.ts
@@ -1,0 +1,33 @@
+import {
+  OpenAppDeviceAction,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+import { Left, Right } from "purify-ts";
+import { type Mock } from "vitest";
+import { assign, createMachine } from "xstate";
+
+export const setupOpenAppDAMock = (error?: unknown) => {
+  (OpenAppDeviceAction as Mock).mockImplementation(() => ({
+    makeStateMachine: vi.fn().mockImplementation(() =>
+      createMachine({
+        initial: "pending",
+        states: {
+          pending: {
+            entry: assign({
+              intermediateValue: {
+                requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+              },
+            }),
+            after: {
+              0: "done",
+            },
+          },
+          done: {
+            type: "final",
+          },
+        },
+        output: () => (error ? Left(error) : Right(undefined)),
+      }),
+    ),
+  }));
+};

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/__test-utils__/setupWaitForAppAndVersionDAMock.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/__test-utils__/setupWaitForAppAndVersionDAMock.ts
@@ -1,0 +1,35 @@
+import { WaitForAppAndVersionDeviceAction } from "@ledgerhq/device-management-kit";
+import { Left, Right } from "purify-ts";
+import { type Mock } from "vitest";
+import { createMachine } from "xstate";
+
+/**
+ * Mock WaitForAppAndVersionDeviceAction to resolve immediately with either a
+ * fresh `{ name, version }` (default) or an error. No user interaction is
+ * emitted (the device is assumed unlocked).
+ */
+export const setupWaitForAppAndVersionDAMock = (
+  result: { name: string; version: string } | { error: unknown } = {
+    name: "Ethereum",
+    version: "1.15.0",
+  },
+) => {
+  (WaitForAppAndVersionDeviceAction as Mock).mockImplementation(() => ({
+    makeStateMachine: vi.fn().mockImplementation(() =>
+      createMachine({
+        initial: "pending",
+        states: {
+          pending: {
+            after: {
+              0: "done",
+            },
+          },
+          done: {
+            type: "final",
+          },
+        },
+        output: () => ("error" in result ? Left(result.error) : Right(result)),
+      }),
+    ),
+  }));
+};

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/__test-utils__/testDeviceActionStates.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/__test-utils__/testDeviceActionStates.ts
@@ -1,0 +1,54 @@
+import {
+  type DeviceAction,
+  type DeviceActionIntermediateValue,
+  type DeviceActionState,
+  type DmkError,
+  type InternalApi,
+} from "@ledgerhq/device-management-kit";
+
+/**
+ * Test that the states emitted by a device action match the expected states.
+ * @param deviceAction The device action to test.
+ * @param expectedStates The expected states.
+ * @param callbacks { onDone, onError } The callbacks to call when the test is done or an error occurs.
+ */
+export function testDeviceActionStates<
+  Output,
+  Input,
+  Error extends DmkError,
+  IntermediateValue extends DeviceActionIntermediateValue,
+>(
+  deviceAction: DeviceAction<Output, Input, Error, IntermediateValue>,
+  expectedStates: Array<DeviceActionState<Output, Error, IntermediateValue>>,
+  internalApi: InternalApi,
+  {
+    onDone,
+    onError,
+  }: {
+    onDone: () => void;
+    onError: (error: Error) => void;
+  },
+) {
+  const observedStates: Array<
+    DeviceActionState<Output, Error, IntermediateValue>
+  > = [];
+
+  const { observable, cancel } = deviceAction._execute(internalApi);
+  observable.subscribe({
+    next: (state) => {
+      observedStates.push(state);
+    },
+    error: (error) => {
+      onError(error);
+    },
+    complete: () => {
+      try {
+        expect(observedStates).toEqual(expectedStates);
+        onDone();
+      } catch (e) {
+        onError(e as Error);
+      }
+    },
+  });
+  return { observable, cancel };
+}

--- a/packages/device-contacts-kit/src/internal/app-binder/isContactsSupportedForSession.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/isContactsSupportedForSession.test.ts
@@ -1,5 +1,4 @@
 import {
-  type AppConfig,
   DeviceModelId,
   DeviceSessionStateType,
   DeviceStatus,
@@ -11,7 +10,10 @@ import {
   resolveContactsVersionRequirements,
 } from "@api/model/ContactsVersionRequirements";
 
-import { isContactsSupportedForSession } from "./isContactsSupportedForSession";
+import {
+  isContactsSupportedForSession,
+  type RunningApp,
+} from "./isContactsSupportedForSession";
 
 const flexSupport = (() => {
   const requirement = resolveContactsVersionRequirements(DeviceModelId.FLEX);
@@ -28,13 +30,11 @@ const MIN_APP_VERSION = (() => {
 const BELOW_ANY_VERSION = "0.0.1";
 
 type ReadyStateOptions = {
-  appName?: string;
   osVersion?: string;
   modelId?: DeviceModelId;
 };
 
 function createReadyState({
-  appName = ETHEREUM_APP_NAME,
   osVersion = MIN_OS_VERSION,
   modelId = DeviceModelId.FLEX,
 }: ReadyStateOptions = {}) {
@@ -42,7 +42,7 @@ function createReadyState({
     sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
     deviceStatus: DeviceStatus.CONNECTED,
     installedApps: [],
-    currentApp: { name: appName, version: "0.0.0" },
+    currentApp: { name: ETHEREUM_APP_NAME, version: "0.0.0" },
     deviceModelId: modelId,
     firmwareVersion: { mcu: "1.0.0", bootloader: "1.0.0", os: osVersion },
     isSecureConnectionAllowed: false,
@@ -55,38 +55,42 @@ function createInternalApi(deviceState: object): InternalApi {
   } as unknown as InternalApi;
 }
 
-function appConfig(version: string): AppConfig {
-  return { version };
+// The running app identity now comes from the caller (a fresh
+// WaitForAppAndVersion result), not the device session state.
+function runningApp(
+  name = ETHEREUM_APP_NAME,
+  version = MIN_APP_VERSION,
+): RunningApp {
+  return { name, version };
 }
 
 describe("isContactsSupportedForSession", () => {
   it("returns true when model, app version and OS version all meet the minimums", () => {
     const api = createInternalApi(createReadyState());
-    expect(isContactsSupportedForSession(api, appConfig(MIN_APP_VERSION))).toBe(
-      true,
-    );
+    expect(isContactsSupportedForSession(api, runningApp())).toBe(true);
   });
 
   it("returns false on an unsupported device model", () => {
     const api = createInternalApi(
       createReadyState({ modelId: DeviceModelId.NANO_X }),
     );
-    expect(isContactsSupportedForSession(api, appConfig(MIN_APP_VERSION))).toBe(
-      false,
-    );
+    expect(isContactsSupportedForSession(api, runningApp())).toBe(false);
   });
 
-  // App-version requirement.
+  // App-version requirement (evaluated from the fresh app version).
   it("returns false when the app version is below the minimum", () => {
     const api = createInternalApi(createReadyState());
     expect(
-      isContactsSupportedForSession(api, appConfig(BELOW_ANY_VERSION)),
+      isContactsSupportedForSession(
+        api,
+        runningApp(ETHEREUM_APP_NAME, BELOW_ANY_VERSION),
+      ),
     ).toBe(false);
   });
 
   it("returns false when the running app is unknown to Contacts", () => {
-    const api = createInternalApi(createReadyState({ appName: "Bitcoin" }));
-    expect(isContactsSupportedForSession(api, appConfig(MIN_APP_VERSION))).toBe(
+    const api = createInternalApi(createReadyState());
+    expect(isContactsSupportedForSession(api, runningApp("Bitcoin"))).toBe(
       false,
     );
   });
@@ -96,9 +100,7 @@ describe("isContactsSupportedForSession", () => {
     const api = createInternalApi(
       createReadyState({ osVersion: BELOW_ANY_VERSION }),
     );
-    expect(isContactsSupportedForSession(api, appConfig(MIN_APP_VERSION))).toBe(
-      false,
-    );
+    expect(isContactsSupportedForSession(api, runningApp())).toBe(false);
   });
 
   it("returns false when the device session has no running app", () => {
@@ -107,8 +109,6 @@ describe("isContactsSupportedForSession", () => {
       deviceStatus: DeviceStatus.CONNECTED,
       deviceModelId: DeviceModelId.FLEX,
     });
-    expect(isContactsSupportedForSession(api, appConfig(MIN_APP_VERSION))).toBe(
-      false,
-    );
+    expect(isContactsSupportedForSession(api, runningApp())).toBe(false);
   });
 });

--- a/packages/device-contacts-kit/src/internal/app-binder/isContactsSupportedForSession.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/isContactsSupportedForSession.ts
@@ -1,5 +1,4 @@
 import {
-  type AppConfig,
   ApplicationChecker,
   type InternalApi,
 } from "@ledgerhq/device-management-kit";
@@ -11,23 +10,32 @@ import {
 
 import { ContactsApplicationResolver } from "./ContactsApplicationResolver";
 
+/** The running app's identity, read freshly from the device. */
+export type RunningApp = {
+  readonly name: string;
+  readonly version: string;
+};
+
 /**
  * Session-aware Contacts support check, for internal consumption by Contacts
- * `DeviceAction`s. Reads the current device session and resolves it against the
- * static requirements table:
+ * `DeviceAction`s. Resolves the given running app against the static
+ * requirements table:
  * - the device model must be supported;
- * - the running app must be known to Contacts and meet its minimum version —
- *   validated with DMK's {@link ApplicationChecker} so the version comes from
- *   the authoritative `GetAppConfiguration` result;
+ * - the running app must be known to Contacts and meet its minimum version;
  * - the device OS must meet its minimum version (a dimension `ApplicationChecker`
  *   does not cover, so it is checked separately here).
  *
+ * The app `name` and `version` are supplied by the caller so they can come from
+ * a fresh `WaitForAppAndVersion` result rather than the (potentially stale)
+ * device session state; the model and OS come from the session state, which
+ * does not change under the caller's feet the way the running app can.
+ *
  * @param internalApi - the DeviceAction's internal API for the current session.
- * @param appConfig - the running app's configuration (must include its version).
+ * @param app - the running app's fresh name and version.
  */
 export function isContactsSupportedForSession(
   internalApi: InternalApi,
-  appConfig: AppConfig,
+  app: RunningApp,
 ): boolean {
   const deviceState = internalApi.getDeviceSessionState();
   const requirement = resolveContactsVersionRequirements(
@@ -35,16 +43,12 @@ export function isContactsSupportedForSession(
   );
   if (!requirement.supported) return false;
 
-  const appName =
-    "currentApp" in deviceState ? deviceState.currentApp?.name : undefined;
-  if (appName === undefined) return false;
-
-  const minAppVersion = requirement.minAppVersion[appName];
+  const minAppVersion = requirement.minAppVersion[app.name];
   if (minAppVersion === undefined) return false;
 
   const appCompatible = new ApplicationChecker(
     deviceState,
-    appConfig,
+    { version: app.version },
     new ContactsApplicationResolver(),
   )
     .withMinVersionInclusive(minAppVersion)

--- a/packages/device-contacts-kit/src/internal/app-binder/model/contactsConstants.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/model/contactsConstants.ts
@@ -1,0 +1,34 @@
+/**
+ * Protocol constants shared by the Contacts (Address Book) operations.
+ *
+ * Wire format and values follow the BOLOS SDK Address Book specification
+ * (ledger-secure-sdk/app_features/address_book). Op-specific sub-command bytes
+ * and response field sizes live here; TLV tags and struct-type bytes live in
+ * {@link ./../services/contactsTlvSerializer}.
+ */
+
+/** APDU class/instruction shared by every Address Book sub-command. */
+export const CONTACTS_APDU_CLA = 0xb0;
+export const CONTACTS_APDU_INS = 0x10;
+
+/** P1 sub-command selector for REGISTER IDENTITY (register external address). */
+export const SUB_CMD_REGISTER_IDENTITY = 0x01;
+
+/** Sizes (bytes) of the fields in the REGISTER IDENTITY final-chunk response. */
+export const GROUP_HANDLE_BYTES = 64;
+export const HMAC_PROOF_BYTES = 32;
+export const HMAC_REST_BYTES = 32;
+
+/**
+ * Blockchain-family byte encoded in the `BLOCKCHAIN_FAMILY` TLV, keyed by a
+ * lowercase family name. v1 ships Ethereum only; the remaining families are
+ * listed for completeness and will be enabled as their chains are supported.
+ */
+export const BLOCKCHAIN_FAMILY_BY_NAME: Readonly<Record<string, number>> = {
+  bitcoin: 0x00,
+  ethereum: 0x01,
+  solana: 0x02,
+  polkadot: 0x03,
+  cosmos: 0x04,
+  cardano: 0x05,
+};

--- a/packages/device-contacts-kit/src/internal/app-binder/model/contactsConstants.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/model/contactsConstants.ts
@@ -14,6 +14,9 @@ export const CONTACTS_APDU_INS = 0x10;
 /** P1 sub-command selector for REGISTER IDENTITY (register external address). */
 export const SUB_CMD_REGISTER_IDENTITY = 0x01;
 
+/** P1 sub-command selector for REGISTER LEDGER ACCOUNT. */
+export const SUB_CMD_REGISTER_LEDGER_ACCOUNT = 0x11;
+
 /** Sizes (bytes) of the fields in the REGISTER IDENTITY final-chunk response. */
 export const GROUP_HANDLE_BYTES = 64;
 export const HMAC_PROOF_BYTES = 32;

--- a/packages/device-contacts-kit/src/internal/app-binder/model/contactsErrors.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/model/contactsErrors.ts
@@ -1,0 +1,74 @@
+import {
+  type CommandErrorArgs,
+  type CommandErrors,
+  DeviceExchangeError,
+  type DmkError,
+} from "@ledgerhq/device-management-kit";
+
+/**
+ * Status word returned by the app's Address Book *edit* operations when the
+ * seed-bound HMAC / group-handle verification fails — i.e. the entry was
+ * registered with a different seed than the one currently on the device.
+ *
+ * The device runs this check *before* showing any UI and returns 0x6982 *only*
+ * for seed-binding failures (user rejection and TLV errors return 0x6a80,
+ * address validation returns 0x6af0), so 0x6982 is an unambiguous "wrong seed"
+ * signal that consumers (e.g. Ledger Wallet) can catch to guide the user.
+ */
+export const CONTACT_SEED_MISMATCH_ERROR_CODE = "6982" as const;
+
+export type ContactsErrorCodes =
+  | "6982"
+  | "6800"
+  | "6983"
+  | "6984"
+  | "6985"
+  | "6a80"
+  | "6a84"
+  | "6a88"
+  | "6af0"
+  | "6b00"
+  | "6f00";
+
+export const CONTACTS_APP_ERRORS: CommandErrors<ContactsErrorCodes> = {
+  [CONTACT_SEED_MISMATCH_ERROR_CODE]: {
+    message:
+      "This address-book entry was registered with a different seed. Connect the Ledger device that registered it to modify this contact.",
+  },
+  "6800": { message: "Internal error (Please report)" },
+  "6983": { message: "Wrong data length" },
+  "6984": {
+    message:
+      "Unsupported address-book operation for this device or app configuration",
+  },
+  "6985": { message: "Condition not satisfied" },
+  "6a80": { message: "Invalid contact data, or operation refused on device" },
+  "6a84": { message: "Insufficient memory: the device address book is full" },
+  "6a88": { message: "Contact data not found" },
+  "6af0": { message: "Invalid value for this contact entry" },
+  "6b00": { message: "The app rejected the contact data" },
+  "6f00": { message: "Technical problem (Internal error, please report)" },
+};
+
+export class ContactsCommandError extends DeviceExchangeError<ContactsErrorCodes> {
+  constructor(args: CommandErrorArgs<ContactsErrorCodes>) {
+    super({ tag: "ContactsCommandError", ...args });
+  }
+}
+
+export const contactsCommandErrorFactory = (
+  args: CommandErrorArgs<ContactsErrorCodes>,
+) => new ContactsCommandError(args);
+
+/**
+ * Raised by a Contacts `DeviceAction` when the connected device model, app
+ * version, or OS version does not meet the Contacts requirements — i.e. the
+ * DSDK-1376 support check fails before any APDU is sent.
+ */
+export class ContactsVersionRequirementError implements DmkError {
+  readonly _tag = "ContactsVersionRequirementError";
+  readonly originalError?: unknown;
+  constructor(
+    readonly message = "The connected device or app does not meet the Contacts version requirements.",
+  ) {}
+}

--- a/packages/device-contacts-kit/src/internal/app-binder/model/contactsValidation.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/model/contactsValidation.test.ts
@@ -1,0 +1,91 @@
+import {
+  CONTACT_NAME_BUFFER_LENGTH,
+  ContactsValidationError,
+  validateByteLength,
+  validateChainId,
+  validateDerivationPath,
+  validatePrintableLabel,
+} from "./contactsValidation";
+
+// A representative BIP32 path (used by Ledger-Account ops, not external
+// addresses). Kept here to exercise the shared validator.
+const SAMPLE_DERIVATION_PATH = "44'/60'/0'/0/0";
+
+describe("contactsValidation", () => {
+  describe("validatePrintableLabel", () => {
+    const opts = { field: "name", bufferLength: CONTACT_NAME_BUFFER_LENGTH };
+
+    it("accepts a printable ASCII label within the buffer", () => {
+      expect(() => validatePrintableLabel("Alice", opts)).not.toThrow();
+    });
+
+    it("rejects an empty label", () => {
+      expect(() => validatePrintableLabel("", opts)).toThrow(
+        ContactsValidationError,
+      );
+    });
+
+    it("rejects a label exceeding bufferLength - 1 bytes", () => {
+      expect(() =>
+        validatePrintableLabel("x".repeat(CONTACT_NAME_BUFFER_LENGTH), opts),
+      ).toThrow(ContactsValidationError);
+    });
+
+    it("rejects non-ASCII / accented characters (byte-level isprint)", () => {
+      expect(() => validatePrintableLabel("Amélie", opts)).toThrow(
+        ContactsValidationError,
+      );
+    });
+  });
+
+  describe("validateByteLength", () => {
+    it("accepts an exact-length buffer", () => {
+      expect(() =>
+        validateByteLength(new Uint8Array(20), {
+          field: "identifier",
+          expectedBytes: 20,
+        }),
+      ).not.toThrow();
+    });
+
+    it("rejects a wrong-length buffer", () => {
+      expect(() =>
+        validateByteLength(new Uint8Array(19), {
+          field: "identifier",
+          expectedBytes: 20,
+        }),
+      ).toThrow(ContactsValidationError);
+    });
+  });
+
+  describe("validateChainId", () => {
+    it("accepts a positive integer and bigint", () => {
+      expect(() => validateChainId(1)).not.toThrow();
+      expect(() => validateChainId(56n)).not.toThrow();
+    });
+
+    it("rejects zero, negative, and non-integer", () => {
+      expect(() => validateChainId(0)).toThrow(ContactsValidationError);
+      expect(() => validateChainId(-1)).toThrow(ContactsValidationError);
+      expect(() => validateChainId(1.5)).toThrow(ContactsValidationError);
+    });
+  });
+
+  describe("validateDerivationPath", () => {
+    it("accepts a representative BIP32 path", () => {
+      expect(() =>
+        validateDerivationPath(SAMPLE_DERIVATION_PATH),
+      ).not.toThrow();
+    });
+
+    it("accepts m-prefixed and hardened paths", () => {
+      expect(() => validateDerivationPath("m/44'/60'/0'/0/0")).not.toThrow();
+    });
+
+    it("rejects a non-numeric segment", () => {
+      expect(() => validateDerivationPath("44'/x/0")).toThrow(
+        ContactsValidationError,
+      );
+    });
+  });
+});

--- a/packages/device-contacts-kit/src/internal/app-binder/model/contactsValidation.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/model/contactsValidation.ts
@@ -7,6 +7,7 @@
  * pure equality checks against the upstream `#define`s. The byte-level
  * `0x20..0x7E` printable check exactly matches firmware `is_printable_string`.
  */
+import { type DmkError } from "@ledgerhq/device-management-kit";
 
 // ---- SDK-mirrored constants -------------------------------------------------
 // Source of truth: ledger-secure-sdk/app_features/address_book/include/
@@ -20,7 +21,15 @@ export const ETH_ADDRESS_BYTES = 20; // protocol convention, no header
 
 // ---- error type -------------------------------------------------------------
 
-export class ContactsValidationError extends Error {
+/**
+ * Raised when caller input fails a pre-APDU check. Implements `DmkError` (and
+ * stays an `Error` subclass) so a Contacts device action can surface it as a
+ * typed terminal error state on the observable rather than throwing out of the
+ * public, device-action-returning API.
+ */
+export class ContactsValidationError extends Error implements DmkError {
+  readonly _tag = "ContactsValidationError";
+  readonly originalError?: unknown;
   constructor(message: string) {
     super(message);
     this.name = "ContactsValidationError";

--- a/packages/device-contacts-kit/src/internal/app-binder/model/contactsValidation.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/model/contactsValidation.ts
@@ -1,0 +1,175 @@
+/**
+ * Pre-APDU input validators for the Contacts operations.
+ *
+ * Buffer-length constants mirror the Ledger secure SDK `#define` values
+ * *including* the trailing NUL terminator (so a 32-printable-char name lives in
+ * a 33-byte buffer). Validators subtract 1 internally so the constants remain
+ * pure equality checks against the upstream `#define`s. The byte-level
+ * `0x20..0x7E` printable check exactly matches firmware `is_printable_string`.
+ */
+
+// ---- SDK-mirrored constants -------------------------------------------------
+// Source of truth: ledger-secure-sdk/app_features/address_book/include/
+
+export const CONTACT_NAME_BUFFER_LENGTH = 33; // identity.h:49 (incl. NUL)
+export const SCOPE_BUFFER_LENGTH = 33; // identity.h:50 (incl. NUL)
+export const GROUP_HANDLE_SIZE = 64; // identity.h:47
+export const HMAC_PROOF_LENGTH = 32; // CX_SHA256_SIZE
+export const MAX_BIP32_DEPTH = 10; // bip32.h:15 (MAX_BIP32_PATH)
+export const ETH_ADDRESS_BYTES = 20; // protocol convention, no header
+
+// ---- error type -------------------------------------------------------------
+
+export class ContactsValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ContactsValidationError";
+  }
+}
+
+// ---- printable-string validation -------------------------------------------
+
+const PRINTABLE_MIN = 0x20;
+const PRINTABLE_MAX = 0x7e;
+
+const utf8Encoder = new TextEncoder();
+
+/**
+ * Mirror of firmware `is_printable_string` + length cap. `bufferLength` is the
+ * firmware's fixed buffer size *including* the trailing NUL, so the maximum
+ * payload byte length is `bufferLength - 1`.
+ */
+export function validatePrintableLabel(
+  value: string,
+  options: { field: string; bufferLength: number },
+): void {
+  const { field, bufferLength } = options;
+  if (!value) {
+    throw new ContactsValidationError(
+      `${field} must not be empty (firmware rejects empty strings).`,
+    );
+  }
+  const encoded = utf8Encoder.encode(value);
+  const maxBytes = bufferLength - 1;
+  if (encoded.length > maxBytes) {
+    throw new ContactsValidationError(
+      `${field} ${JSON.stringify(value)} is too long: ${encoded.length} bytes ` +
+        `encoded (max ${maxBytes}). The device buffer is ${bufferLength} bytes ` +
+        `including the trailing NUL.`,
+    );
+  }
+  const badPositions: number[] = [];
+  for (let i = 0; i < encoded.length; i++) {
+    const byte = encoded[i]!;
+    if (byte < PRINTABLE_MIN || byte > PRINTABLE_MAX) {
+      badPositions.push(i);
+    }
+  }
+  if (badPositions.length > 0) {
+    const offendingBytes = Array.from(
+      new Set(badPositions.map((i) => encoded[i]!)),
+    ).sort((a, b) => a - b);
+    const offendingHex = offendingBytes
+      .map((b) => `0x${b.toString(16).padStart(2, "0")}`)
+      .join(", ");
+    throw new ContactsValidationError(
+      `${field} ${JSON.stringify(value)} contains ${badPositions.length} ` +
+        `non-ASCII byte(s) at position(s) [${badPositions.join(", ")}]: ` +
+        `${offendingHex}. The device buffer is byte-level isprint() — only ` +
+        `0x20-0x7E are accepted, no UTF-8 / accents / emoji.`,
+    );
+  }
+}
+
+// ---- byte-buffer validation ------------------------------------------------
+
+/** Assert a byte buffer is exactly `expectedBytes` long and non-empty. */
+export function validateByteLength(
+  value: Uint8Array,
+  options: { field: string; expectedBytes: number },
+): void {
+  const { field, expectedBytes } = options;
+  if (value.length !== expectedBytes) {
+    throw new ContactsValidationError(
+      `${field} is ${value.length} bytes, expected ${expectedBytes}.`,
+    );
+  }
+}
+
+// ---- BIP32 path validation -------------------------------------------------
+
+/**
+ * Sanity-check a BIP32 path before serialization. Firmware enforces depth <=
+ * MAX_BIP32_DEPTH and rejects malformed segments. Accepts `m/44'/60'/0'/0/0`
+ * style; segments may end in `'` (hardened).
+ */
+export function validateDerivationPath(path: string): void {
+  if (!path) {
+    throw new ContactsValidationError(
+      `derivationPath must not be empty (e.g. "m/44'/60'/0'/0/0").`,
+    );
+  }
+  const parts = path.split("/");
+  const segments =
+    parts[0] === "m" || parts[0] === "M" ? parts.slice(1) : parts;
+  if (segments.length === 0) {
+    throw new ContactsValidationError(
+      `derivationPath ${JSON.stringify(path)} has no segments past 'm'.`,
+    );
+  }
+  if (segments.length > MAX_BIP32_DEPTH) {
+    throw new ContactsValidationError(
+      `derivationPath ${JSON.stringify(path)} has ${segments.length} segments ` +
+        `(max ${MAX_BIP32_DEPTH}). Firmware rejects deeper paths.`,
+    );
+  }
+  for (const segment of segments) {
+    const token = segment.endsWith("'") ? segment.slice(0, -1) : segment;
+    if (!token || !/^\d+$/.test(token)) {
+      throw new ContactsValidationError(
+        `derivationPath ${JSON.stringify(path)} segment ${JSON.stringify(segment)} ` +
+          `is not numeric. Use plain integers, optionally suffixed with ' for hardened.`,
+      );
+    }
+    const n = Number(token);
+    if (!Number.isSafeInteger(n) || n >= 0x80000000) {
+      throw new ContactsValidationError(
+        `derivationPath ${JSON.stringify(path)} segment ${JSON.stringify(segment)} ` +
+          `>= 2^31. Use the ' suffix for hardening rather than overflowing.`,
+      );
+    }
+  }
+}
+
+// ---- chain id validation ---------------------------------------------------
+
+/**
+ * Firmware encodes chain_id as uint64. JS `number` is fine up to 2^53; accept
+ * `bigint` for the high range so callers don't silently truncate.
+ */
+export function validateChainId(value: number | bigint): void {
+  const isNumber = typeof value === "number";
+  const isBigInt = typeof value === "bigint";
+  if (!isNumber && !isBigInt) {
+    throw new ContactsValidationError(
+      `chainId must be number or bigint, got ${typeof value}.`,
+    );
+  }
+  if (isNumber && !Number.isInteger(value)) {
+    throw new ContactsValidationError(
+      `chainId must be an integer, got ${value}.`,
+    );
+  }
+  const v = typeof value === "bigint" ? value : BigInt(value);
+  if (v <= 0n) {
+    throw new ContactsValidationError(
+      `chainId must be positive, got ${value}.`,
+    );
+  }
+  const UINT64_MAX = (1n << 64n) - 1n;
+  if (v > UINT64_MAX) {
+    throw new ContactsValidationError(
+      `chainId ${value} exceeds uint64 range (max ${UINT64_MAX}).`,
+    );
+  }
+}

--- a/packages/device-contacts-kit/src/internal/app-binder/services/contactsTlvSerializer.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/services/contactsTlvSerializer.test.ts
@@ -1,0 +1,98 @@
+import { ByteArrayBuilder } from "@ledgerhq/device-management-kit";
+
+import {
+  CONTACTS_TLV_TAG,
+  encodeTlvAscii,
+  encodeTlvBuffer,
+  encodeTlvChainId,
+  encodeTlvUInt8,
+  packDerivationPath,
+} from "./contactsTlvSerializer";
+
+describe("contactsTlvSerializer", () => {
+  describe("DERIVATION_PATH tag", () => {
+    // Pins the ETH-app 1.23 / BOLOS SDK protocol change (commit 963d72b7):
+    // the address-book derivation-path tag moved from 0x21 to 0x69. Sending the
+    // old tag makes the on-device TLV parser reject with 0x6A80.
+    it("is 0x69 (not the pre-1.23 value 0x21)", () => {
+      expect(CONTACTS_TLV_TAG.DERIVATION_PATH).toBe(0x69);
+    });
+
+    it("encodes a packed path under tag 0x69", () => {
+      const builder = new ByteArrayBuilder();
+      const path = packDerivationPath([0x8000002c, 0x8000003c, 0x80000000]);
+
+      encodeTlvBuffer(builder, CONTACTS_TLV_TAG.DERIVATION_PATH, path);
+
+      expect(builder.build()).toStrictEqual(
+        Uint8Array.from([
+          0x69, // DERIVATION_PATH tag
+          0x0d, // length: 1 count byte + 3 * 4-byte segments
+          0x03, // segment count
+          0x80,
+          0x00,
+          0x00,
+          0x2c, // 44'
+          0x80,
+          0x00,
+          0x00,
+          0x3c, // 60'
+          0x80,
+          0x00,
+          0x00,
+          0x00, // 0'
+        ]),
+      );
+    });
+  });
+
+  describe("primitive encoders", () => {
+    it("encodes a single-byte TLV (tag < 0x80, length 1)", () => {
+      const builder = new ByteArrayBuilder();
+      encodeTlvUInt8(builder, CONTACTS_TLV_TAG.STRUCT_TYPE, 0x2d);
+      expect(builder.build()).toStrictEqual(
+        Uint8Array.from([0x01, 0x01, 0x2d]),
+      );
+    });
+
+    it("uses the 2-byte long-tag form for tags >= 0x80", () => {
+      const builder = new ByteArrayBuilder();
+      encodeTlvAscii(builder, CONTACTS_TLV_TAG.CONTACT_NAME, "AB");
+      // 0x81 0xf0 prefix for tag 0xf0, length 2, ASCII "AB".
+      expect(builder.build()).toStrictEqual(
+        Uint8Array.from([0x81, 0xf0, 0x02, 0x41, 0x42]),
+      );
+    });
+
+    it("encodes chainId as minimal big-endian bytes", () => {
+      const builder = new ByteArrayBuilder();
+      encodeTlvChainId(builder, CONTACTS_TLV_TAG.CHAIN_ID, 1n);
+      expect(builder.build()).toStrictEqual(
+        Uint8Array.from([0x23, 0x01, 0x01]),
+      );
+
+      const builder2 = new ByteArrayBuilder();
+      encodeTlvChainId(builder2, CONTACTS_TLV_TAG.CHAIN_ID, 56);
+      expect(builder2.build()).toStrictEqual(
+        Uint8Array.from([0x23, 0x01, 0x38]),
+      );
+    });
+
+    it("emits DER long-form length for payloads >= 0x80 bytes", () => {
+      const builder = new ByteArrayBuilder();
+      const value = new Uint8Array(200).fill(0xab);
+      encodeTlvBuffer(builder, CONTACTS_TLV_TAG.ACCOUNT_IDENTIFIER, value);
+      const out = builder.build();
+      // tag 0xf2 → 0x81 0xf2, then long-form length 0x81 0xc8 (200).
+      expect(Array.from(out.slice(0, 4))).toEqual([0x81, 0xf2, 0x81, 0xc8]);
+      expect(out.length).toBe(4 + 200);
+    });
+
+    it("rejects a non-positive chainId", () => {
+      const builder = new ByteArrayBuilder();
+      expect(() =>
+        encodeTlvChainId(builder, CONTACTS_TLV_TAG.CHAIN_ID, 0),
+      ).toThrow();
+    });
+  });
+});

--- a/packages/device-contacts-kit/src/internal/app-binder/services/contactsTlvSerializer.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/services/contactsTlvSerializer.test.ts
@@ -55,12 +55,12 @@ describe("contactsTlvSerializer", () => {
       );
     });
 
-    it("uses the 2-byte long-tag form for tags >= 0x80", () => {
+    it("encodes tags >= 0x80 as a single raw byte", () => {
       const builder = new ByteArrayBuilder();
       encodeTlvAscii(builder, CONTACTS_TLV_TAG.CONTACT_NAME, "AB");
-      // 0x81 0xf0 prefix for tag 0xf0, length 2, ASCII "AB".
+      // Raw tag 0xf0 (no BER multi-byte prefix), length 2, ASCII "AB".
       expect(builder.build()).toStrictEqual(
-        Uint8Array.from([0x81, 0xf0, 0x02, 0x41, 0x42]),
+        Uint8Array.from([0xf0, 0x02, 0x41, 0x42]),
       );
     });
 
@@ -83,9 +83,9 @@ describe("contactsTlvSerializer", () => {
       const value = new Uint8Array(200).fill(0xab);
       encodeTlvBuffer(builder, CONTACTS_TLV_TAG.ACCOUNT_IDENTIFIER, value);
       const out = builder.build();
-      // tag 0xf2 → 0x81 0xf2, then long-form length 0x81 0xc8 (200).
-      expect(Array.from(out.slice(0, 4))).toEqual([0x81, 0xf2, 0x81, 0xc8]);
-      expect(out.length).toBe(4 + 200);
+      // raw tag 0xf2, then long-form length 0x81 0xc8 (200).
+      expect(Array.from(out.slice(0, 3))).toEqual([0xf2, 0x81, 0xc8]);
+      expect(out.length).toBe(3 + 200);
     });
 
     it("rejects a non-positive chainId", () => {

--- a/packages/device-contacts-kit/src/internal/app-binder/services/contactsTlvSerializer.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/services/contactsTlvSerializer.ts
@@ -1,10 +1,9 @@
-// DER-style TLV encoding for the Contacts feature.
-// Tags >= 0x80 use the 2-byte form (0x81 0xTT); lengths >= 0x80 use long form.
+// TLV encoding for the Contacts feature.
+// Tags are always encoded as their raw one-byte value per the Address Book
+// specification; lengths >= 0x80 use DER long form.
 // Wire format per the BOLOS SDK address-book spec
 // (ledger-secure-sdk/app_features/address_book/doc/address_book_spec.md §4.2).
 import { ByteArrayBuilder } from "@ledgerhq/device-management-kit";
-
-const LONG_TAG_PREFIX_HIGH_BYTE = 0x81 << 8;
 
 export const CONTACTS_TLV_TAG = {
   STRUCT_TYPE: 0x01,
@@ -37,13 +36,8 @@ export const STRUCT_TYPE_PROVIDE_LEDGER_ACCOUNT_CONTACT = 0x34;
 export const STRUCT_VERSION_VALUE = 0x01;
 
 function writeTag(builder: ByteArrayBuilder, tag: number): void {
-  if (tag < 0x80) {
-    builder.add8BitUIntToData(tag);
-  } else if (tag <= 0xff) {
-    builder.add16BitUIntToData(LONG_TAG_PREFIX_HIGH_BYTE + tag);
-  } else {
-    throw new Error(`TLV tag ${tag} exceeds supported single-byte range`);
-  }
+  // Address Book tags are always a single raw byte — no BER multi-byte form.
+  builder.add8BitUIntToData(tag);
 }
 
 function writeDerLength(builder: ByteArrayBuilder, length: number): void {

--- a/packages/device-contacts-kit/src/internal/app-binder/services/contactsTlvSerializer.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/services/contactsTlvSerializer.ts
@@ -1,0 +1,125 @@
+// DER-style TLV encoding for the Contacts feature.
+// Tags >= 0x80 use the 2-byte form (0x81 0xTT); lengths >= 0x80 use long form.
+// Wire format per the BOLOS SDK address-book spec
+// (ledger-secure-sdk/app_features/address_book/doc/address_book_spec.md §4.2).
+import { ByteArrayBuilder } from "@ledgerhq/device-management-kit";
+
+const LONG_TAG_PREFIX_HIGH_BYTE = 0x81 << 8;
+
+export const CONTACTS_TLV_TAG = {
+  STRUCT_TYPE: 0x01,
+  STRUCT_VERSION: 0x02,
+  // Ledger-Account operations only; external-address ops carry no path.
+  // TODO(Ledger Account ticket): spec tag registry lists 0x69 but the per-op
+  // payload tables list 0x21 — confirm before the Ledger-Account op ships.
+  DERIVATION_PATH: 0x69,
+  CHAIN_ID: 0x23,
+  HMAC_PROOF: 0x29,
+  BLOCKCHAIN_FAMILY: 0x51,
+  CONTACT_NAME: 0xf0,
+  SCOPE: 0xf1,
+  ACCOUNT_IDENTIFIER: 0xf2,
+  PREVIOUS_CONTACT_NAME: 0xf3,
+  PREVIOUS_IDENTIFIER: 0xf4,
+  PREVIOUS_SCOPE: 0xf5,
+  GROUP_HANDLE: 0xf6,
+  HMAC_REST: 0xf7,
+} as const;
+
+export const STRUCT_TYPE_REGISTER_IDENTITY = 0x2d;
+export const STRUCT_TYPE_EDIT_CONTACT_NAME = 0x2e;
+export const STRUCT_TYPE_REGISTER_LEDGER_ACCOUNT = 0x2f;
+export const STRUCT_TYPE_EDIT_LEDGER_ACCOUNT = 0x30;
+export const STRUCT_TYPE_EDIT_IDENTIFIER = 0x31;
+export const STRUCT_TYPE_EDIT_SCOPE = 0x32;
+export const STRUCT_TYPE_PROVIDE_CONTACT = 0x33;
+export const STRUCT_TYPE_PROVIDE_LEDGER_ACCOUNT_CONTACT = 0x34;
+export const STRUCT_VERSION_VALUE = 0x01;
+
+function writeTag(builder: ByteArrayBuilder, tag: number): void {
+  if (tag < 0x80) {
+    builder.add8BitUIntToData(tag);
+  } else if (tag <= 0xff) {
+    builder.add16BitUIntToData(LONG_TAG_PREFIX_HIGH_BYTE + tag);
+  } else {
+    throw new Error(`TLV tag ${tag} exceeds supported single-byte range`);
+  }
+}
+
+function writeDerLength(builder: ByteArrayBuilder, length: number): void {
+  if (length < 0x80) {
+    builder.add8BitUIntToData(length);
+  } else if (length <= 0xff) {
+    builder.add8BitUIntToData(0x81);
+    builder.add8BitUIntToData(length);
+  } else if (length <= 0xffff) {
+    builder.add8BitUIntToData(0x82);
+    builder.add16BitUIntToData(length);
+  } else {
+    throw new Error(`TLV length ${length} exceeds supported range`);
+  }
+}
+
+function chainIdToMinimalBytes(chainId: number | bigint): Uint8Array {
+  const big = typeof chainId === "bigint" ? chainId : BigInt(chainId);
+  if (big <= 0n) {
+    throw new Error(`chainId must be positive, got ${chainId}`);
+  }
+  if (big > 0xffffffffffffffffn) {
+    throw new Error(`chainId ${chainId} exceeds uint64 range`);
+  }
+  const bytes: number[] = [];
+  let n = big;
+  while (n > 0n) {
+    bytes.unshift(Number(n & 0xffn));
+    n >>= 8n;
+  }
+  return Uint8Array.from(bytes);
+}
+
+export function encodeTlvUInt8(
+  builder: ByteArrayBuilder,
+  tag: number,
+  value: number,
+): void {
+  writeTag(builder, tag);
+  builder.add8BitUIntToData(1);
+  builder.add8BitUIntToData(value);
+}
+
+export function encodeTlvAscii(
+  builder: ByteArrayBuilder,
+  tag: number,
+  value: string,
+): void {
+  writeTag(builder, tag);
+  const bytes = new TextEncoder().encode(value);
+  writeDerLength(builder, bytes.length);
+  builder.addBufferToData(bytes);
+}
+
+export function encodeTlvBuffer(
+  builder: ByteArrayBuilder,
+  tag: number,
+  value: Uint8Array,
+): void {
+  writeTag(builder, tag);
+  writeDerLength(builder, value.length);
+  builder.addBufferToData(value);
+}
+
+export function encodeTlvChainId(
+  builder: ByteArrayBuilder,
+  tag: number,
+  chainId: number | bigint,
+): void {
+  encodeTlvBuffer(builder, tag, chainIdToMinimalBytes(chainId));
+}
+
+/** Pack BIP32 segments as `count(1) || segment(4 BE)*count`. */
+export function packDerivationPath(segments: number[]): Uint8Array {
+  const builder = new ByteArrayBuilder();
+  builder.add8BitUIntToData(segments.length);
+  segments.forEach((segment) => builder.add32BitUIntToData(segment));
+  return builder.build();
+}

--- a/packages/device-contacts-kit/src/internal/app-binder/services/sendFramedContactsPayload.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/services/sendFramedContactsPayload.test.ts
@@ -1,0 +1,108 @@
+import {
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  type InternalApi,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+
+import { sendFramedContactsPayload } from "./sendFramedContactsPayload";
+
+function makeApiMock(): InternalApi & {
+  sendCommand: ReturnType<typeof vi.fn>;
+} {
+  return {
+    sendCommand: vi.fn(),
+  } as unknown as InternalApi & { sendCommand: ReturnType<typeof vi.fn> };
+}
+
+function makePayload(byteCount: number, fillByte = 0x42): Uint8Array {
+  return new Uint8Array(byteCount).fill(fillByte);
+}
+
+const makeCommandFactory = () =>
+  vi.fn(
+    (chunk: Uint8Array, p2: number) =>
+      ({
+        name: "test",
+        args: { chunk, p2 },
+        getApdu: vi.fn(),
+        parseResponse: vi.fn(),
+      }) as unknown as Command<unknown, unknown, unknown>,
+  );
+
+describe("sendFramedContactsPayload", () => {
+  it("single-chunk: prepends BE length, uses P2=0x00, returns command result", async () => {
+    const api = makeApiMock();
+    const finalResult = CommandResultFactory({ data: { ok: true } });
+    api.sendCommand.mockResolvedValueOnce(finalResult);
+    const makeCommand = makeCommandFactory();
+
+    const result = await sendFramedContactsPayload(api, {
+      payload: makePayload(100),
+      p1: 0x01,
+      makeCommand,
+    });
+
+    expect(makeCommand).toHaveBeenCalledTimes(1);
+    const [chunk, p2] = makeCommand.mock.calls[0]!;
+    expect(p2).toBe(0x00);
+    // 2-byte BE length prefix = 100 → 0x00, 0x64.
+    expect(chunk[0]).toBe(0x00);
+    expect(chunk[1]).toBe(0x64);
+    expect(chunk.length).toBe(102);
+    expect(result).toBe(finalResult);
+  });
+
+  it("multi-chunk: splits into <=255B pieces, P2 0x00 then 0x80, prefix on first only", async () => {
+    const api = makeApiMock();
+    const intermediateOk = CommandResultFactory({ data: {} });
+    const finalResult = CommandResultFactory({ data: { ok: true } });
+    api.sendCommand
+      .mockResolvedValueOnce(intermediateOk)
+      .mockResolvedValueOnce(intermediateOk)
+      .mockResolvedValueOnce(finalResult);
+    const makeCommand = makeCommandFactory();
+
+    // 600 bytes payload → 602 with frame prefix → 3 chunks (255 + 255 + 92).
+    const result = await sendFramedContactsPayload(api, {
+      payload: makePayload(600, 0x55),
+      p1: 0x01,
+      makeCommand,
+    });
+
+    expect(makeCommand).toHaveBeenCalledTimes(3);
+    const [chunk0, p20] = makeCommand.mock.calls[0]!;
+    const [chunk1, p21] = makeCommand.mock.calls[1]!;
+    const [chunk2, p22] = makeCommand.mock.calls[2]!;
+    expect([p20, p21, p22]).toEqual([0x00, 0x80, 0x80]);
+    expect([chunk0.length, chunk1.length, chunk2.length]).toEqual([
+      255, 255, 92,
+    ]);
+    // Frame prefix (600 = 0x0258) only on the first chunk.
+    expect(chunk0[0]).toBe(0x02);
+    expect(chunk0[1]).toBe(0x58);
+    // Continuation chunks begin with raw payload bytes.
+    expect(chunk1[0]).toBe(0x55);
+    expect(result).toBe(finalResult);
+  });
+
+  it("short-circuits on intermediate-chunk error without dispatching remaining chunks", async () => {
+    const api = makeApiMock();
+    const errorResult: CommandResult<unknown> = CommandResultFactory({
+      error: new InvalidStatusWordError("kaboom"),
+    });
+    api.sendCommand.mockResolvedValueOnce(errorResult);
+    const makeCommand = makeCommandFactory();
+
+    const result = await sendFramedContactsPayload(api, {
+      payload: makePayload(600),
+      p1: 0x01,
+      makeCommand,
+    });
+
+    expect(api.sendCommand).toHaveBeenCalledTimes(1);
+    expect(makeCommand).toHaveBeenCalledTimes(1);
+    expect(result).toBe(errorResult);
+  });
+});

--- a/packages/device-contacts-kit/src/internal/app-binder/services/sendFramedContactsPayload.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/services/sendFramedContactsPayload.ts
@@ -1,0 +1,121 @@
+// Chunked-framing transport for the Contacts ops. Since the BOLOS SDK
+// "use uniform chunked transport for all sub-commands" change, every
+// address-book sub-command frames its TLV this way.
+//
+// First chunk is dispatched with P2=0x00 and carries the 2-byte BE
+// total-payload-length prefix. Subsequent chunks use P2=0x80. The
+// caller-supplied `makeCommand` builds a Command per chunk; the helper
+// returns the final chunk's CommandResult unchanged so the caller can
+// parse the device's structured response off the last exchange.
+// Protocol: ledger-secure-sdk/app_features/address_book/doc/address_book_spec.md §3
+import {
+  type Command,
+  type CommandResult,
+  type InternalApi,
+  isSuccessDmkResult,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+
+const MAX_CHUNK_BYTES = 255;
+const P2_FIRST = 0x00;
+const P2_NEXT = 0x80;
+
+export type SendFramedContactsPayloadArgs<Response> = {
+  /** TLV payload bytes (without any header or length framing). */
+  readonly payload: Uint8Array;
+  /** Sub-command byte (e.g. 0x01 for REGISTER IDENTITY). */
+  readonly p1: number;
+  /** Per-chunk Command factory. The helper passes the chunk bytes and the P2 byte. */
+  readonly makeCommand: (
+    chunk: Uint8Array,
+    p2: number,
+  ) => Command<Response, unknown, unknown>;
+  /** Optional per-chunk diagnostic logging (one `debug` entry per outgoing chunk). */
+  readonly logger?: LoggerPublisherService;
+  readonly commandTag?: string;
+};
+
+export async function sendFramedContactsPayload<Response>(
+  api: InternalApi,
+  {
+    payload,
+    makeCommand,
+    logger,
+    commandTag,
+  }: SendFramedContactsPayloadArgs<Response>,
+): Promise<CommandResult<Response>> {
+  const framed = prependFrameLength(payload);
+  const chunks = sliceChunks(framed, MAX_CHUNK_BYTES);
+  const tag = commandTag ?? "framed-contacts";
+
+  // Intermediate chunks: dispatch and short-circuit on error.
+  for (let i = 0; i < chunks.length - 1; i++) {
+    const p2 = i === 0 ? P2_FIRST : P2_NEXT;
+    const chunk = chunks[i]!;
+    logChunk(logger, tag, i, chunks.length, p2, chunk.length, framed.length);
+    const result = (await api.sendCommand(
+      makeCommand(chunk, p2),
+    )) as CommandResult<Response>;
+    if (!isSuccessDmkResult(result)) {
+      return result;
+    }
+  }
+
+  const lastIndex = chunks.length - 1;
+  const lastP2 = lastIndex === 0 ? P2_FIRST : P2_NEXT;
+  const lastChunk = chunks[lastIndex]!;
+  logChunk(
+    logger,
+    tag,
+    lastIndex,
+    chunks.length,
+    lastP2,
+    lastChunk.length,
+    framed.length,
+  );
+  return (await api.sendCommand(
+    makeCommand(lastChunk, lastP2),
+  )) as CommandResult<Response>;
+}
+
+function logChunk(
+  logger: LoggerPublisherService | undefined,
+  tag: string,
+  index: number,
+  total: number,
+  p2: number,
+  chunkLen: number,
+  framedLen: number,
+): void {
+  if (!logger) return;
+  logger.debug(`[chunk ${index + 1}/${total}] sending`, {
+    tag,
+    data: {
+      chunkIndex: index,
+      chunkCount: total,
+      p2: `0x${p2.toString(16).padStart(2, "0")}`,
+      chunkLen,
+      framedPayloadLen: framedLen,
+      isFirst: index === 0,
+      isLast: index === total - 1,
+    },
+  });
+}
+
+function prependFrameLength(payload: Uint8Array): Uint8Array {
+  const total = payload.length;
+  const framed = new Uint8Array(total + 2);
+  framed[0] = (total >> 8) & 0xff;
+  framed[1] = total & 0xff;
+  framed.set(payload, 2);
+  return framed;
+}
+
+function sliceChunks(buffer: Uint8Array, max: number): Uint8Array[] {
+  if (buffer.length === 0) return [buffer];
+  const out: Uint8Array[] = [];
+  for (let offset = 0; offset < buffer.length; offset += max) {
+    out.push(buffer.slice(offset, Math.min(offset + max, buffer.length)));
+  }
+  return out;
+}

--- a/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterIdentityTask.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterIdentityTask.test.ts
@@ -1,0 +1,155 @@
+// Validates that the TLV serializer + tag ordering + chunk framing produce the
+// expected wire bytes for op 1 (Register Identity). The framed chunk = 2-byte
+// BE total length + TLV, with DERIVATION_PATH under tag 0x69 (SDK 963d72b7).
+import {
+  CommandResultFactory,
+  type InternalApi,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+
+import { RegisterIdentityCommand } from "@internal/app-binder/command/RegisterIdentityCommand";
+
+import { SendRegisterIdentityTask } from "./SendRegisterIdentityTask";
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    out[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return out;
+}
+
+// Framed chunk = "00 <Lc>" (2-byte BE total TLV length) + TLV. External-address
+// Register Identity carries no DERIVATION_PATH: the tag order is STRUCT_TYPE,
+// STRUCT_VERSION, CONTACT_NAME, SCOPE, ACCOUNT_IDENTIFIER, CHAIN_ID,
+// BLOCKCHAIN_FAMILY, then optional GROUP_HANDLE + HMAC_PROOF.
+const FRESH_FRAMED_CHUNK = hexToBytes(
+  "003601012d02010181f005416c69636581f108457468206d61696e81f21400000000000000000000000000000000deadbeef230101510101",
+);
+
+const EXTENSION_FRAMED_CHUNK = hexToBytes(
+  "009c01012d02010181f005416c69636581f108417262206d61696e81f2144444444444444444444444444444444444444444" +
+    "2302a4b1510101" +
+    "81f640cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" +
+    "2920dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+);
+
+const OK_PROOFS = {
+  groupHandle: hexToBytes("cc".repeat(64)),
+  hmacProof: hexToBytes("dd".repeat(32)),
+  hmacRest: hexToBytes("aa".repeat(32)),
+};
+
+function makeApiMock(): InternalApi & {
+  sendCommand: ReturnType<typeof vi.fn>;
+} {
+  return { sendCommand: vi.fn() } as unknown as InternalApi & {
+    sendCommand: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("SendRegisterIdentityTask", () => {
+  it("assembles a fresh-register framed chunk and dispatches RegisterIdentityCommand", async () => {
+    const api = makeApiMock();
+    api.sendCommand.mockResolvedValueOnce(
+      CommandResultFactory({ data: OK_PROOFS }),
+    );
+
+    const result = await new SendRegisterIdentityTask(api, {
+      contactName: "Alice",
+      scope: "Eth main",
+      identifier: hexToBytes("00000000000000000000000000000000deadbeef"),
+      blockchainFamily: "ethereum",
+      chainId: 1n,
+    }).run();
+
+    expect(api.sendCommand.mock.calls).toHaveLength(1);
+    expect(api.sendCommand.mock.calls[0]![0]).toStrictEqual(
+      new RegisterIdentityCommand({ data: FRESH_FRAMED_CHUNK, p2: 0x00 }),
+    );
+    expect(result).toStrictEqual(CommandResultFactory({ data: OK_PROOFS }));
+  });
+
+  it("appends GROUP_HANDLE + HMAC_PROOF on extension and frames the extension payload", async () => {
+    const api = makeApiMock();
+    api.sendCommand.mockResolvedValueOnce(
+      CommandResultFactory({ data: OK_PROOFS }),
+    );
+
+    await new SendRegisterIdentityTask(api, {
+      contactName: "Alice",
+      scope: "Arb main",
+      identifier: hexToBytes("44".repeat(20)),
+      blockchainFamily: "ethereum",
+      chainId: 42161n,
+      existingContactGroup: {
+        groupHandle: hexToBytes("cc".repeat(64)),
+        hmacProof: hexToBytes("dd".repeat(32)),
+      },
+    }).run();
+
+    expect(api.sendCommand.mock.calls).toHaveLength(1);
+    expect(api.sendCommand.mock.calls[0]![0]).toStrictEqual(
+      new RegisterIdentityCommand({ data: EXTENSION_FRAMED_CHUNK, p2: 0x00 }),
+    );
+  });
+
+  it("omits the CHAIN_ID TLV when chainId is not provided", async () => {
+    const api = makeApiMock();
+    api.sendCommand.mockResolvedValueOnce(
+      CommandResultFactory({ data: OK_PROOFS }),
+    );
+
+    await new SendRegisterIdentityTask(api, {
+      contactName: "Alice",
+      scope: "Eth main",
+      identifier: hexToBytes("00000000000000000000000000000000deadbeef"),
+      blockchainFamily: "ethereum",
+    }).run();
+
+    const command = api.sendCommand.mock
+      .calls[0]![0] as RegisterIdentityCommand;
+    // No `23 01 ..` CHAIN_ID TLV; BLOCKCHAIN_FAMILY 51 01 01 follows the path.
+    const framedHex = Buffer.from(command.args.data).toString("hex");
+    expect(framedHex).not.toContain("230101");
+    expect(framedHex.endsWith("510101")).toBe(true);
+  });
+
+  it("propagates command-level errors", async () => {
+    const api = makeApiMock();
+    api.sendCommand.mockResolvedValueOnce(
+      CommandResultFactory({
+        error: new InvalidStatusWordError("user cancelled"),
+      }),
+    );
+
+    const result = await new SendRegisterIdentityTask(api, {
+      contactName: "Alice",
+      scope: "Eth main",
+      identifier: hexToBytes("00000000000000000000000000000000deadbeef"),
+      blockchainFamily: "ethereum",
+      chainId: 1n,
+    }).run();
+
+    expect(result).toStrictEqual(
+      CommandResultFactory({
+        error: new InvalidStatusWordError("user cancelled"),
+      }),
+    );
+  });
+
+  it("throws on an unsupported blockchain family", async () => {
+    const api = makeApiMock();
+
+    await expect(
+      new SendRegisterIdentityTask(api, {
+        contactName: "Alice",
+        scope: "Eth main",
+        identifier: hexToBytes("00000000000000000000000000000000deadbeef"),
+        blockchainFamily: "dogecoin",
+        chainId: 1n,
+      }).run(),
+    ).rejects.toThrow(/Unsupported blockchain family/);
+    expect(api.sendCommand).not.toHaveBeenCalled();
+  });
+});

--- a/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterIdentityTask.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterIdentityTask.test.ts
@@ -24,13 +24,13 @@ function hexToBytes(hex: string): Uint8Array {
 // STRUCT_VERSION, CONTACT_NAME, SCOPE, ACCOUNT_IDENTIFIER, CHAIN_ID,
 // BLOCKCHAIN_FAMILY, then optional GROUP_HANDLE + HMAC_PROOF.
 const FRESH_FRAMED_CHUNK = hexToBytes(
-  "003601012d02010181f005416c69636581f108457468206d61696e81f21400000000000000000000000000000000deadbeef230101510101",
+  "003301012d020101f005416c696365f108457468206d61696ef21400000000000000000000000000000000deadbeef230101510101",
 );
 
 const EXTENSION_FRAMED_CHUNK = hexToBytes(
-  "009c01012d02010181f005416c69636581f108417262206d61696e81f2144444444444444444444444444444444444444444" +
+  "009801012d020101f005416c696365f108417262206d61696ef2144444444444444444444444444444444444444444" +
     "2302a4b1510101" +
-    "81f640cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" +
+    "f640cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" +
     "2920dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
 );
 

--- a/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterIdentityTask.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterIdentityTask.ts
@@ -1,0 +1,144 @@
+// Builds the TLV payload for op 1 (Register Identity / Register External
+// Address) and dispatches it via the chunked-framing scheme shared with the
+// other address-book ops (2-byte BE total length + <=255B chunks). The device
+// returns the 129-byte register response on the final chunk.
+//
+// Reference: Address Book Final Specifications — Register Identity. Tag order:
+//   STRUCT_TYPE, STRUCT_VERSION, CONTACT_NAME, SCOPE, ACCOUNT_IDENTIFIER,
+//   CHAIN_ID (Ethereum only), BLOCKCHAIN_FAMILY, then optional GROUP_HANDLE +
+//   HMAC_PROOF when extending an existing group. External-address operations
+//   carry no DERIVATION_PATH (that tag is Ledger-Account only).
+import {
+  ByteArrayBuilder,
+  type CommandResult,
+  DmkResultFactory,
+  type InternalApi,
+  InvalidStatusWordError,
+  isSuccessCommandResult,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+
+import { type ExistingContactGroup } from "@api/model/RegisterExternalAddress";
+import { RegisterIdentityCommand } from "@internal/app-binder/command/RegisterIdentityCommand";
+import {
+  BLOCKCHAIN_FAMILY_BY_NAME,
+  SUB_CMD_REGISTER_IDENTITY,
+} from "@internal/app-binder/model/contactsConstants";
+import { type ContactsErrorCodes } from "@internal/app-binder/model/contactsErrors";
+import {
+  CONTACTS_TLV_TAG,
+  encodeTlvAscii,
+  encodeTlvBuffer,
+  encodeTlvChainId,
+  encodeTlvUInt8,
+  STRUCT_TYPE_REGISTER_IDENTITY,
+  STRUCT_VERSION_VALUE,
+} from "@internal/app-binder/services/contactsTlvSerializer";
+import { sendFramedContactsPayload } from "@internal/app-binder/services/sendFramedContactsPayload";
+
+export type RegisterIdentityProofs = {
+  readonly groupHandle: Uint8Array;
+  readonly hmacProof: Uint8Array;
+  readonly hmacRest: Uint8Array;
+};
+
+export type SendRegisterIdentityTaskArgs = {
+  readonly contactName: string;
+  readonly scope: string;
+  readonly identifier: Uint8Array;
+  readonly blockchainFamily: string;
+  readonly chainId?: bigint;
+  readonly existingContactGroup?: ExistingContactGroup;
+  readonly logger?: LoggerPublisherService;
+};
+
+export class SendRegisterIdentityTask {
+  constructor(
+    private readonly api: InternalApi,
+    private readonly args: SendRegisterIdentityTaskArgs,
+  ) {}
+
+  async run(): Promise<
+    CommandResult<RegisterIdentityProofs, ContactsErrorCodes>
+  > {
+    const payload = this.buildPayload(this.args);
+
+    const result = (await sendFramedContactsPayload(this.api, {
+      payload,
+      p1: SUB_CMD_REGISTER_IDENTITY,
+      makeCommand: (chunk, p2) =>
+        new RegisterIdentityCommand({ data: chunk, p2 }),
+      logger: this.args.logger,
+      commandTag: "SendRegisterIdentityTask",
+    })) as CommandResult<
+      {
+        readonly groupHandle?: Uint8Array;
+        readonly hmacProof?: Uint8Array;
+        readonly hmacRest?: Uint8Array;
+      },
+      ContactsErrorCodes
+    >;
+
+    if (!isSuccessCommandResult(result)) {
+      return result;
+    }
+
+    const { groupHandle, hmacProof, hmacRest } = result.data;
+    if (!groupHandle || !hmacProof || !hmacRest) {
+      return DmkResultFactory({
+        error: new InvalidStatusWordError(
+          "RegisterIdentity final-chunk response was incomplete",
+        ),
+      });
+    }
+    return DmkResultFactory({ data: { groupHandle, hmacProof, hmacRest } });
+  }
+
+  private buildPayload(args: SendRegisterIdentityTaskArgs): Uint8Array {
+    const family =
+      BLOCKCHAIN_FAMILY_BY_NAME[args.blockchainFamily.toLowerCase()];
+    if (family === undefined) {
+      throw new Error(
+        `Unsupported blockchain family: ${args.blockchainFamily}`,
+      );
+    }
+
+    const builder = new ByteArrayBuilder();
+    encodeTlvUInt8(
+      builder,
+      CONTACTS_TLV_TAG.STRUCT_TYPE,
+      STRUCT_TYPE_REGISTER_IDENTITY,
+    );
+    encodeTlvUInt8(
+      builder,
+      CONTACTS_TLV_TAG.STRUCT_VERSION,
+      STRUCT_VERSION_VALUE,
+    );
+    encodeTlvAscii(builder, CONTACTS_TLV_TAG.CONTACT_NAME, args.contactName);
+    encodeTlvAscii(builder, CONTACTS_TLV_TAG.SCOPE, args.scope);
+    encodeTlvBuffer(
+      builder,
+      CONTACTS_TLV_TAG.ACCOUNT_IDENTIFIER,
+      args.identifier,
+    );
+    if (args.chainId !== undefined) {
+      encodeTlvChainId(builder, CONTACTS_TLV_TAG.CHAIN_ID, args.chainId);
+    }
+    encodeTlvUInt8(builder, CONTACTS_TLV_TAG.BLOCKCHAIN_FAMILY, family);
+
+    if (args.existingContactGroup) {
+      encodeTlvBuffer(
+        builder,
+        CONTACTS_TLV_TAG.GROUP_HANDLE,
+        args.existingContactGroup.groupHandle,
+      );
+      encodeTlvBuffer(
+        builder,
+        CONTACTS_TLV_TAG.HMAC_PROOF,
+        args.existingContactGroup.hmacProof,
+      );
+    }
+
+    return builder.build();
+  }
+}

--- a/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterLedgerAccountTask.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterLedgerAccountTask.test.ts
@@ -1,0 +1,163 @@
+// Validates that the TLV serializer + tag ordering + chunk framing produce the
+// expected wire bytes for op 0x11 (Register Ledger Account). The framed chunk =
+// 2-byte BE total length + TLV, with DERIVATION_PATH under tag 0x69. Tag order:
+// STRUCT_TYPE, STRUCT_VERSION, CONTACT_NAME, DERIVATION_PATH, CHAIN_ID
+// (Ethereum only), BLOCKCHAIN_FAMILY.
+import {
+  CommandResultFactory,
+  type InternalApi,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+
+import { RegisterLedgerAccountCommand } from "@internal/app-binder/command/RegisterLedgerAccountCommand";
+
+import { SendRegisterLedgerAccountTask } from "./SendRegisterLedgerAccountTask";
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    out[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return out;
+}
+
+// name="Alice", path="m/44'/60'/0'/0/0", chainId=1, family=ethereum(0x01).
+const FRAMED_CHUNK_WITH_CHAIN = hexToBytes(
+  "002a01012f020101f005416c6963656915058000002c8000003c800000000000000000000000230101510101",
+);
+// Same input without chainId — the 23 01 01 CHAIN_ID TLV is dropped.
+const FRAMED_CHUNK_NO_CHAIN = hexToBytes(
+  "002701012f020101f005416c6963656915058000002c8000003c800000000000000000000000510101",
+);
+
+const OK_PROOF = { hmacProof: hexToBytes("dd".repeat(32)) };
+
+function makeApiMock(): InternalApi & {
+  sendCommand: ReturnType<typeof vi.fn>;
+} {
+  return { sendCommand: vi.fn() } as unknown as InternalApi & {
+    sendCommand: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("SendRegisterLedgerAccountTask", () => {
+  it("assembles the framed chunk and dispatches RegisterLedgerAccountCommand", async () => {
+    const api = makeApiMock();
+    api.sendCommand.mockResolvedValueOnce(
+      CommandResultFactory({ data: OK_PROOF }),
+    );
+
+    const result = await new SendRegisterLedgerAccountTask(api, {
+      accountName: "Alice",
+      derivationPath: "m/44'/60'/0'/0/0",
+      blockchainFamily: "ethereum",
+      chainId: 1n,
+    }).run();
+
+    expect(api.sendCommand.mock.calls).toHaveLength(1);
+    expect(api.sendCommand.mock.calls[0]![0]).toStrictEqual(
+      new RegisterLedgerAccountCommand({
+        data: FRAMED_CHUNK_WITH_CHAIN,
+        p2: 0x00,
+      }),
+    );
+    expect(result).toStrictEqual(CommandResultFactory({ data: OK_PROOF }));
+  });
+
+  it("accepts a path without the leading master 'm' segment", async () => {
+    const api = makeApiMock();
+    api.sendCommand.mockResolvedValueOnce(
+      CommandResultFactory({ data: OK_PROOF }),
+    );
+
+    await new SendRegisterLedgerAccountTask(api, {
+      accountName: "Alice",
+      derivationPath: "44'/60'/0'/0/0",
+      blockchainFamily: "ethereum",
+      chainId: 1n,
+    }).run();
+
+    expect(api.sendCommand.mock.calls[0]![0]).toStrictEqual(
+      new RegisterLedgerAccountCommand({
+        data: FRAMED_CHUNK_WITH_CHAIN,
+        p2: 0x00,
+      }),
+    );
+  });
+
+  it("omits the CHAIN_ID TLV when chainId is not provided", async () => {
+    const api = makeApiMock();
+    api.sendCommand.mockResolvedValueOnce(
+      CommandResultFactory({ data: OK_PROOF }),
+    );
+
+    await new SendRegisterLedgerAccountTask(api, {
+      accountName: "Alice",
+      derivationPath: "m/44'/60'/0'/0/0",
+      blockchainFamily: "ethereum",
+    }).run();
+
+    expect(api.sendCommand.mock.calls[0]![0]).toStrictEqual(
+      new RegisterLedgerAccountCommand({
+        data: FRAMED_CHUNK_NO_CHAIN,
+        p2: 0x00,
+      }),
+    );
+  });
+
+  it("returns an InvalidStatusWordError when the final chunk carries no hmac_proof", async () => {
+    const api = makeApiMock();
+    api.sendCommand.mockResolvedValueOnce(CommandResultFactory({ data: {} }));
+
+    const result = await new SendRegisterLedgerAccountTask(api, {
+      accountName: "Alice",
+      derivationPath: "m/44'/60'/0'/0/0",
+      blockchainFamily: "ethereum",
+      chainId: 1n,
+    }).run();
+
+    expect(result).toStrictEqual(
+      CommandResultFactory({
+        error: new InvalidStatusWordError(
+          "RegisterLedgerAccount final-chunk response did not carry hmac_proof",
+        ),
+      }),
+    );
+  });
+
+  it("propagates command-level errors", async () => {
+    const api = makeApiMock();
+    api.sendCommand.mockResolvedValueOnce(
+      CommandResultFactory({
+        error: new InvalidStatusWordError("user cancelled"),
+      }),
+    );
+
+    const result = await new SendRegisterLedgerAccountTask(api, {
+      accountName: "Alice",
+      derivationPath: "m/44'/60'/0'/0/0",
+      blockchainFamily: "ethereum",
+      chainId: 1n,
+    }).run();
+
+    expect(result).toStrictEqual(
+      CommandResultFactory({
+        error: new InvalidStatusWordError("user cancelled"),
+      }),
+    );
+  });
+
+  it("throws on an unsupported blockchain family", async () => {
+    const api = makeApiMock();
+
+    await expect(
+      new SendRegisterLedgerAccountTask(api, {
+        accountName: "Alice",
+        derivationPath: "m/44'/60'/0'/0/0",
+        blockchainFamily: "dogecoin",
+        chainId: 1n,
+      }).run(),
+    ).rejects.toThrow(/Unsupported blockchain family/);
+    expect(api.sendCommand).not.toHaveBeenCalled();
+  });
+});

--- a/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterLedgerAccountTask.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterLedgerAccountTask.ts
@@ -1,0 +1,133 @@
+// Builds the TLV payload for op 0x11 (Register Ledger Account) and dispatches
+// it via the chunked-framing scheme shared with the other address-book ops
+// (2-byte BE total length + <=255B chunks). The device returns the 33-byte
+// register response (struct_type + hmac_proof) on the final chunk.
+//
+// Reference: Address Book Final Specifications — Register Ledger Account. Tag
+// order: STRUCT_TYPE, STRUCT_VERSION, CONTACT_NAME (account name),
+// DERIVATION_PATH, CHAIN_ID (Ethereum only), BLOCKCHAIN_FAMILY. Unlike Register
+// Identity there is no SCOPE / ACCOUNT_IDENTIFIER and no existing-group
+// appendix — the account is derived on-device from DERIVATION_PATH.
+import {
+  ByteArrayBuilder,
+  type CommandResult,
+  DmkResultFactory,
+  type InternalApi,
+  InvalidStatusWordError,
+  isSuccessCommandResult,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+import { DerivationPathUtils } from "@ledgerhq/signer-utils";
+
+import { RegisterLedgerAccountCommand } from "@internal/app-binder/command/RegisterLedgerAccountCommand";
+import {
+  BLOCKCHAIN_FAMILY_BY_NAME,
+  SUB_CMD_REGISTER_LEDGER_ACCOUNT,
+} from "@internal/app-binder/model/contactsConstants";
+import { type ContactsErrorCodes } from "@internal/app-binder/model/contactsErrors";
+import {
+  CONTACTS_TLV_TAG,
+  encodeTlvAscii,
+  encodeTlvBuffer,
+  encodeTlvChainId,
+  encodeTlvUInt8,
+  packDerivationPath,
+  STRUCT_TYPE_REGISTER_LEDGER_ACCOUNT,
+  STRUCT_VERSION_VALUE,
+} from "@internal/app-binder/services/contactsTlvSerializer";
+import { sendFramedContactsPayload } from "@internal/app-binder/services/sendFramedContactsPayload";
+
+export type RegisterLedgerAccountProof = {
+  readonly hmacProof: Uint8Array;
+};
+
+export type SendRegisterLedgerAccountTaskArgs = {
+  readonly accountName: string;
+  readonly derivationPath: string;
+  readonly blockchainFamily: string;
+  readonly chainId?: bigint;
+  readonly logger?: LoggerPublisherService;
+};
+
+/** Drop an optional leading `m`/`M` segment so splitPath gets numeric parts. */
+function stripMasterPrefix(path: string): string {
+  const parts = path.split("/");
+  if (parts[0] === "m" || parts[0] === "M") {
+    return parts.slice(1).join("/");
+  }
+  return path;
+}
+
+export class SendRegisterLedgerAccountTask {
+  constructor(
+    private readonly api: InternalApi,
+    private readonly args: SendRegisterLedgerAccountTaskArgs,
+  ) {}
+
+  async run(): Promise<
+    CommandResult<RegisterLedgerAccountProof, ContactsErrorCodes>
+  > {
+    const payload = this.buildPayload(this.args);
+
+    const result = (await sendFramedContactsPayload(this.api, {
+      payload,
+      p1: SUB_CMD_REGISTER_LEDGER_ACCOUNT,
+      makeCommand: (chunk, p2) =>
+        new RegisterLedgerAccountCommand({ data: chunk, p2 }),
+      logger: this.args.logger,
+      commandTag: "SendRegisterLedgerAccountTask",
+    })) as CommandResult<
+      { readonly hmacProof?: Uint8Array },
+      ContactsErrorCodes
+    >;
+
+    if (!isSuccessCommandResult(result)) {
+      return result;
+    }
+
+    const { hmacProof } = result.data;
+    if (!hmacProof) {
+      return DmkResultFactory({
+        error: new InvalidStatusWordError(
+          "RegisterLedgerAccount final-chunk response did not carry hmac_proof",
+        ),
+      });
+    }
+    return DmkResultFactory({ data: { hmacProof } });
+  }
+
+  private buildPayload(args: SendRegisterLedgerAccountTaskArgs): Uint8Array {
+    const family =
+      BLOCKCHAIN_FAMILY_BY_NAME[args.blockchainFamily.toLowerCase()];
+    if (family === undefined) {
+      throw new Error(
+        `Unsupported blockchain family: ${args.blockchainFamily}`,
+      );
+    }
+
+    const segments = DerivationPathUtils.splitPath(
+      stripMasterPrefix(args.derivationPath),
+    );
+    const pathBytes = packDerivationPath(segments);
+
+    const builder = new ByteArrayBuilder();
+    encodeTlvUInt8(
+      builder,
+      CONTACTS_TLV_TAG.STRUCT_TYPE,
+      STRUCT_TYPE_REGISTER_LEDGER_ACCOUNT,
+    );
+    encodeTlvUInt8(
+      builder,
+      CONTACTS_TLV_TAG.STRUCT_VERSION,
+      STRUCT_VERSION_VALUE,
+    );
+    encodeTlvAscii(builder, CONTACTS_TLV_TAG.CONTACT_NAME, args.accountName);
+    encodeTlvBuffer(builder, CONTACTS_TLV_TAG.DERIVATION_PATH, pathBytes);
+    if (args.chainId !== undefined) {
+      encodeTlvChainId(builder, CONTACTS_TLV_TAG.CHAIN_ID, args.chainId);
+    }
+    encodeTlvUInt8(builder, CONTACTS_TLV_TAG.BLOCKCHAIN_FAMILY, family);
+
+    return builder.build();
+  }
+}

--- a/packages/device-contacts-kit/src/internal/di.test.ts
+++ b/packages/device-contacts-kit/src/internal/di.test.ts
@@ -4,6 +4,8 @@ import { ContactsAppBinder } from "@internal/app-binder/ContactsAppBinder";
 import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
 import { makeContainer } from "@internal/di";
 import { externalTypes } from "@internal/externalTypes";
+import { useCaseTypes } from "@internal/use-cases/di/useCaseTypes";
+import { RegisterExternalAddressUseCase } from "@internal/use-cases/RegisterExternalAddressUseCase";
 
 describe("makeContainer", () => {
   const dmk = {} as DeviceManagementKit;
@@ -22,5 +24,11 @@ describe("makeContainer", () => {
     expect(container.get(appBinderTypes.AppBinder)).toBeInstanceOf(
       ContactsAppBinder,
     );
+  });
+
+  it("binds the RegisterExternalAddressUseCase", () => {
+    expect(
+      container.get(useCaseTypes.RegisterExternalAddressUseCase),
+    ).toBeInstanceOf(RegisterExternalAddressUseCase);
   });
 });

--- a/packages/device-contacts-kit/src/internal/di.test.ts
+++ b/packages/device-contacts-kit/src/internal/di.test.ts
@@ -6,6 +6,7 @@ import { makeContainer } from "@internal/di";
 import { externalTypes } from "@internal/externalTypes";
 import { useCaseTypes } from "@internal/use-cases/di/useCaseTypes";
 import { RegisterExternalAddressUseCase } from "@internal/use-cases/RegisterExternalAddressUseCase";
+import { RegisterLedgerAccountUseCase } from "@internal/use-cases/RegisterLedgerAccountUseCase";
 
 describe("makeContainer", () => {
   const dmk = {} as DeviceManagementKit;
@@ -30,5 +31,11 @@ describe("makeContainer", () => {
     expect(
       container.get(useCaseTypes.RegisterExternalAddressUseCase),
     ).toBeInstanceOf(RegisterExternalAddressUseCase);
+  });
+
+  it("binds the RegisterLedgerAccountUseCase", () => {
+    expect(
+      container.get(useCaseTypes.RegisterLedgerAccountUseCase),
+    ).toBeInstanceOf(RegisterLedgerAccountUseCase);
   });
 });

--- a/packages/device-contacts-kit/src/internal/di.ts
+++ b/packages/device-contacts-kit/src/internal/di.ts
@@ -6,6 +6,7 @@ import { Container } from "inversify";
 
 import { appBinderModuleFactory } from "@internal/app-binder/di/appBinderModule";
 import { externalTypes } from "@internal/externalTypes";
+import { useCaseModuleFactory } from "@internal/use-cases/di/useCaseModule";
 
 type MakeContainerProps = {
   dmk: DeviceManagementKit;
@@ -27,6 +28,7 @@ export const makeContainer = ({
   container.bind<string>(externalTypes.AppName).toConstantValue(appName);
 
   container.loadSync(appBinderModuleFactory());
+  container.loadSync(useCaseModuleFactory());
 
   return container;
 };

--- a/packages/device-contacts-kit/src/internal/use-cases/RegisterExternalAddressUseCase.test.ts
+++ b/packages/device-contacts-kit/src/internal/use-cases/RegisterExternalAddressUseCase.test.ts
@@ -1,6 +1,5 @@
 import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
 import { type ContactsAppBinder } from "@internal/app-binder/ContactsAppBinder";
-import { ContactsValidationError } from "@internal/app-binder/model/contactsValidation";
 
 import { RegisterExternalAddressUseCase } from "./RegisterExternalAddressUseCase";
 
@@ -22,7 +21,7 @@ const VALID_INPUT: RegisterExternalAddressInput = {
 };
 
 describe("RegisterExternalAddressUseCase", () => {
-  it("validates input and delegates to the app binder", () => {
+  it("delegates to the app binder", () => {
     const { useCase, registerExternalAddress } = makeUseCase();
 
     const result = useCase.execute(VALID_INPUT);
@@ -31,68 +30,13 @@ describe("RegisterExternalAddressUseCase", () => {
     expect(result).toBe("DA_RETURN");
   });
 
-  it("accepts an existing contact group with correctly sized proofs", () => {
+  it("does not validate — invalid input is forwarded, not thrown", () => {
+    // Validation now lives in the device action and surfaces as a typed DA
+    // error state; the use case must never throw for bad input.
     const { useCase, registerExternalAddress } = makeUseCase();
 
-    useCase.execute({
-      ...VALID_INPUT,
-      existingContactGroup: {
-        groupHandle: new Uint8Array(64),
-        hmacProof: new Uint8Array(32),
-      },
-    });
-
-    expect(registerExternalAddress).toHaveBeenCalledTimes(1);
-  });
-
-  it("rejects a non-printable contact name before dispatching", () => {
-    const { useCase, registerExternalAddress } = makeUseCase();
-
-    expect(() =>
-      useCase.execute({ ...VALID_INPUT, contactName: "Amélie" }),
-    ).toThrow(ContactsValidationError);
-    expect(registerExternalAddress).not.toHaveBeenCalled();
-  });
-
-  it("rejects an Ethereum identifier of the wrong length", () => {
-    const { useCase, registerExternalAddress } = makeUseCase();
-
-    expect(() =>
-      useCase.execute({ ...VALID_INPUT, identifier: new Uint8Array(19) }),
-    ).toThrow(ContactsValidationError);
-    expect(registerExternalAddress).not.toHaveBeenCalled();
-  });
-
-  it("rejects an unsupported blockchain family", () => {
-    const { useCase, registerExternalAddress } = makeUseCase();
-
-    expect(() =>
-      useCase.execute({ ...VALID_INPUT, blockchainFamily: "dogecoin" }),
-    ).toThrow(ContactsValidationError);
-    expect(registerExternalAddress).not.toHaveBeenCalled();
-  });
-
-  it("requires chainId for the Ethereum family", () => {
-    const { useCase, registerExternalAddress } = makeUseCase();
-
-    expect(() =>
-      useCase.execute({ ...VALID_INPUT, chainId: undefined }),
-    ).toThrow(ContactsValidationError);
-    expect(registerExternalAddress).not.toHaveBeenCalled();
-  });
-
-  it("rejects a wrong-sized existing group handle", () => {
-    const { useCase, registerExternalAddress } = makeUseCase();
-
-    expect(() =>
-      useCase.execute({
-        ...VALID_INPUT,
-        existingContactGroup: {
-          groupHandle: new Uint8Array(32),
-          hmacProof: new Uint8Array(32),
-        },
-      }),
-    ).toThrow(ContactsValidationError);
-    expect(registerExternalAddress).not.toHaveBeenCalled();
+    const invalidInput = { ...VALID_INPUT, contactName: "" };
+    expect(() => useCase.execute(invalidInput)).not.toThrow();
+    expect(registerExternalAddress).toHaveBeenCalledWith(invalidInput);
   });
 });

--- a/packages/device-contacts-kit/src/internal/use-cases/RegisterExternalAddressUseCase.test.ts
+++ b/packages/device-contacts-kit/src/internal/use-cases/RegisterExternalAddressUseCase.test.ts
@@ -1,0 +1,98 @@
+import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
+import { type ContactsAppBinder } from "@internal/app-binder/ContactsAppBinder";
+import { ContactsValidationError } from "@internal/app-binder/model/contactsValidation";
+
+import { RegisterExternalAddressUseCase } from "./RegisterExternalAddressUseCase";
+
+function makeUseCase() {
+  const registerExternalAddress = vi.fn().mockReturnValue("DA_RETURN");
+  const appBinder = { registerExternalAddress } as unknown as ContactsAppBinder;
+  return {
+    useCase: new RegisterExternalAddressUseCase(appBinder),
+    registerExternalAddress,
+  };
+}
+
+const VALID_INPUT: RegisterExternalAddressInput = {
+  contactName: "Alice",
+  scope: "Eth main",
+  identifier: new Uint8Array(20).fill(0x11),
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+};
+
+describe("RegisterExternalAddressUseCase", () => {
+  it("validates input and delegates to the app binder", () => {
+    const { useCase, registerExternalAddress } = makeUseCase();
+
+    const result = useCase.execute(VALID_INPUT);
+
+    expect(registerExternalAddress).toHaveBeenCalledWith(VALID_INPUT);
+    expect(result).toBe("DA_RETURN");
+  });
+
+  it("accepts an existing contact group with correctly sized proofs", () => {
+    const { useCase, registerExternalAddress } = makeUseCase();
+
+    useCase.execute({
+      ...VALID_INPUT,
+      existingContactGroup: {
+        groupHandle: new Uint8Array(64),
+        hmacProof: new Uint8Array(32),
+      },
+    });
+
+    expect(registerExternalAddress).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a non-printable contact name before dispatching", () => {
+    const { useCase, registerExternalAddress } = makeUseCase();
+
+    expect(() =>
+      useCase.execute({ ...VALID_INPUT, contactName: "Amélie" }),
+    ).toThrow(ContactsValidationError);
+    expect(registerExternalAddress).not.toHaveBeenCalled();
+  });
+
+  it("rejects an Ethereum identifier of the wrong length", () => {
+    const { useCase, registerExternalAddress } = makeUseCase();
+
+    expect(() =>
+      useCase.execute({ ...VALID_INPUT, identifier: new Uint8Array(19) }),
+    ).toThrow(ContactsValidationError);
+    expect(registerExternalAddress).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unsupported blockchain family", () => {
+    const { useCase, registerExternalAddress } = makeUseCase();
+
+    expect(() =>
+      useCase.execute({ ...VALID_INPUT, blockchainFamily: "dogecoin" }),
+    ).toThrow(ContactsValidationError);
+    expect(registerExternalAddress).not.toHaveBeenCalled();
+  });
+
+  it("requires chainId for the Ethereum family", () => {
+    const { useCase, registerExternalAddress } = makeUseCase();
+
+    expect(() =>
+      useCase.execute({ ...VALID_INPUT, chainId: undefined }),
+    ).toThrow(ContactsValidationError);
+    expect(registerExternalAddress).not.toHaveBeenCalled();
+  });
+
+  it("rejects a wrong-sized existing group handle", () => {
+    const { useCase, registerExternalAddress } = makeUseCase();
+
+    expect(() =>
+      useCase.execute({
+        ...VALID_INPUT,
+        existingContactGroup: {
+          groupHandle: new Uint8Array(32),
+          hmacProof: new Uint8Array(32),
+        },
+      }),
+    ).toThrow(ContactsValidationError);
+    expect(registerExternalAddress).not.toHaveBeenCalled();
+  });
+});

--- a/packages/device-contacts-kit/src/internal/use-cases/RegisterExternalAddressUseCase.ts
+++ b/packages/device-contacts-kit/src/internal/use-cases/RegisterExternalAddressUseCase.ts
@@ -1,0 +1,83 @@
+import { inject, injectable } from "inversify";
+
+import { type RegisterExternalAddressDAReturnType } from "@api/app-binder/RegisterExternalAddressDeviceActionTypes";
+import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
+import { ContactsAppBinder } from "@internal/app-binder/ContactsAppBinder";
+import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
+import { BLOCKCHAIN_FAMILY_BY_NAME } from "@internal/app-binder/model/contactsConstants";
+import {
+  CONTACT_NAME_BUFFER_LENGTH,
+  ContactsValidationError,
+  ETH_ADDRESS_BYTES,
+  GROUP_HANDLE_SIZE,
+  HMAC_PROOF_LENGTH,
+  SCOPE_BUFFER_LENGTH,
+  validateByteLength,
+  validateChainId,
+  validatePrintableLabel,
+} from "@internal/app-binder/model/contactsValidation";
+
+/**
+ * Validates the caller input, then delegates to `ContactsAppBinder`, which uses
+ * its injected `dmk`, `sessionId`, and `appName` to construct and execute the
+ * `RegisterExternalAddressDeviceAction`.
+ */
+@injectable()
+export class RegisterExternalAddressUseCase {
+  constructor(
+    @inject(appBinderTypes.AppBinder)
+    private readonly appBinder: ContactsAppBinder,
+  ) {}
+
+  execute(
+    input: RegisterExternalAddressInput,
+  ): RegisterExternalAddressDAReturnType {
+    validatePrintableLabel(input.contactName, {
+      field: "contactName",
+      bufferLength: CONTACT_NAME_BUFFER_LENGTH,
+    });
+    validatePrintableLabel(input.scope, {
+      field: "scope",
+      bufferLength: SCOPE_BUFFER_LENGTH,
+    });
+
+    const family = input.blockchainFamily.toLowerCase();
+    if (!(family in BLOCKCHAIN_FAMILY_BY_NAME)) {
+      throw new ContactsValidationError(
+        `Unsupported blockchain family: ${input.blockchainFamily}`,
+      );
+    }
+    if (family === "ethereum") {
+      validateByteLength(input.identifier, {
+        field: "identifier",
+        expectedBytes: ETH_ADDRESS_BYTES,
+      });
+      // CHAIN_ID is mandatory for the Ethereum family (multiple networks share
+      // the same address format).
+      if (input.chainId === undefined) {
+        throw new ContactsValidationError(
+          "chainId is required for the Ethereum blockchain family.",
+        );
+      }
+    } else if (input.identifier.length === 0) {
+      throw new ContactsValidationError("identifier must not be empty.");
+    }
+
+    if (input.chainId !== undefined) {
+      validateChainId(input.chainId);
+    }
+
+    if (input.existingContactGroup) {
+      validateByteLength(input.existingContactGroup.groupHandle, {
+        field: "existingContactGroup.groupHandle",
+        expectedBytes: GROUP_HANDLE_SIZE,
+      });
+      validateByteLength(input.existingContactGroup.hmacProof, {
+        field: "existingContactGroup.hmacProof",
+        expectedBytes: HMAC_PROOF_LENGTH,
+      });
+    }
+
+    return this.appBinder.registerExternalAddress(input);
+  }
+}

--- a/packages/device-contacts-kit/src/internal/use-cases/RegisterExternalAddressUseCase.ts
+++ b/packages/device-contacts-kit/src/internal/use-cases/RegisterExternalAddressUseCase.ts
@@ -4,23 +4,14 @@ import { type RegisterExternalAddressDAReturnType } from "@api/app-binder/Regist
 import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
 import { ContactsAppBinder } from "@internal/app-binder/ContactsAppBinder";
 import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
-import { BLOCKCHAIN_FAMILY_BY_NAME } from "@internal/app-binder/model/contactsConstants";
-import {
-  CONTACT_NAME_BUFFER_LENGTH,
-  ContactsValidationError,
-  ETH_ADDRESS_BYTES,
-  GROUP_HANDLE_SIZE,
-  HMAC_PROOF_LENGTH,
-  SCOPE_BUFFER_LENGTH,
-  validateByteLength,
-  validateChainId,
-  validatePrintableLabel,
-} from "@internal/app-binder/model/contactsValidation";
 
 /**
- * Validates the caller input, then delegates to `ContactsAppBinder`, which uses
- * its injected `dmk`, `sessionId`, and `appName` to construct and execute the
- * `RegisterExternalAddressDeviceAction`.
+ * Delegates to `ContactsAppBinder`, which uses its injected `dmk`, `sessionId`,
+ * and `appName` to construct and execute the `RegisterExternalAddressDeviceAction`.
+ *
+ * Caller-input validation is intentionally NOT done here: the public API returns
+ * a device action, so validation lives inside the device action and surfaces as
+ * a typed terminal error state on the observable rather than a synchronous throw.
  */
 @injectable()
 export class RegisterExternalAddressUseCase {
@@ -32,52 +23,6 @@ export class RegisterExternalAddressUseCase {
   execute(
     input: RegisterExternalAddressInput,
   ): RegisterExternalAddressDAReturnType {
-    validatePrintableLabel(input.contactName, {
-      field: "contactName",
-      bufferLength: CONTACT_NAME_BUFFER_LENGTH,
-    });
-    validatePrintableLabel(input.scope, {
-      field: "scope",
-      bufferLength: SCOPE_BUFFER_LENGTH,
-    });
-
-    const family = input.blockchainFamily.toLowerCase();
-    if (!(family in BLOCKCHAIN_FAMILY_BY_NAME)) {
-      throw new ContactsValidationError(
-        `Unsupported blockchain family: ${input.blockchainFamily}`,
-      );
-    }
-    if (family === "ethereum") {
-      validateByteLength(input.identifier, {
-        field: "identifier",
-        expectedBytes: ETH_ADDRESS_BYTES,
-      });
-      // CHAIN_ID is mandatory for the Ethereum family (multiple networks share
-      // the same address format).
-      if (input.chainId === undefined) {
-        throw new ContactsValidationError(
-          "chainId is required for the Ethereum blockchain family.",
-        );
-      }
-    } else if (input.identifier.length === 0) {
-      throw new ContactsValidationError("identifier must not be empty.");
-    }
-
-    if (input.chainId !== undefined) {
-      validateChainId(input.chainId);
-    }
-
-    if (input.existingContactGroup) {
-      validateByteLength(input.existingContactGroup.groupHandle, {
-        field: "existingContactGroup.groupHandle",
-        expectedBytes: GROUP_HANDLE_SIZE,
-      });
-      validateByteLength(input.existingContactGroup.hmacProof, {
-        field: "existingContactGroup.hmacProof",
-        expectedBytes: HMAC_PROOF_LENGTH,
-      });
-    }
-
     return this.appBinder.registerExternalAddress(input);
   }
 }

--- a/packages/device-contacts-kit/src/internal/use-cases/RegisterLedgerAccountUseCase.test.ts
+++ b/packages/device-contacts-kit/src/internal/use-cases/RegisterLedgerAccountUseCase.test.ts
@@ -1,0 +1,41 @@
+import { type RegisterLedgerAccountInput } from "@api/model/RegisterLedgerAccount";
+import { type ContactsAppBinder } from "@internal/app-binder/ContactsAppBinder";
+
+import { RegisterLedgerAccountUseCase } from "./RegisterLedgerAccountUseCase";
+
+function makeUseCase() {
+  const registerLedgerAccount = vi.fn().mockReturnValue("DA_RETURN");
+  const appBinder = { registerLedgerAccount } as unknown as ContactsAppBinder;
+  return {
+    useCase: new RegisterLedgerAccountUseCase(appBinder),
+    registerLedgerAccount,
+  };
+}
+
+const VALID_INPUT: RegisterLedgerAccountInput = {
+  accountName: "Alice",
+  derivationPath: "m/44'/60'/0'/0/0",
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+};
+
+describe("RegisterLedgerAccountUseCase", () => {
+  it("delegates to the app binder", () => {
+    const { useCase, registerLedgerAccount } = makeUseCase();
+
+    const result = useCase.execute(VALID_INPUT);
+
+    expect(registerLedgerAccount).toHaveBeenCalledWith(VALID_INPUT);
+    expect(result).toBe("DA_RETURN");
+  });
+
+  it("does not validate — invalid input is forwarded, not thrown", () => {
+    // Validation now lives in the device action and surfaces as a typed DA
+    // error state; the use case must never throw for bad input.
+    const { useCase, registerLedgerAccount } = makeUseCase();
+
+    const invalidInput = { ...VALID_INPUT, accountName: "" };
+    expect(() => useCase.execute(invalidInput)).not.toThrow();
+    expect(registerLedgerAccount).toHaveBeenCalledWith(invalidInput);
+  });
+});

--- a/packages/device-contacts-kit/src/internal/use-cases/RegisterLedgerAccountUseCase.ts
+++ b/packages/device-contacts-kit/src/internal/use-cases/RegisterLedgerAccountUseCase.ts
@@ -1,0 +1,28 @@
+import { inject, injectable } from "inversify";
+
+import { type RegisterLedgerAccountDAReturnType } from "@api/app-binder/RegisterLedgerAccountDeviceActionTypes";
+import { type RegisterLedgerAccountInput } from "@api/model/RegisterLedgerAccount";
+import { ContactsAppBinder } from "@internal/app-binder/ContactsAppBinder";
+import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
+
+/**
+ * Delegates to `ContactsAppBinder`, which uses its injected `dmk`, `sessionId`,
+ * and `appName` to construct and execute the `RegisterLedgerAccountDeviceAction`.
+ *
+ * Caller-input validation is intentionally NOT done here: the public API returns
+ * a device action, so validation lives inside the device action and surfaces as
+ * a typed terminal error state on the observable rather than a synchronous throw.
+ */
+@injectable()
+export class RegisterLedgerAccountUseCase {
+  constructor(
+    @inject(appBinderTypes.AppBinder)
+    private readonly appBinder: ContactsAppBinder,
+  ) {}
+
+  execute(
+    input: RegisterLedgerAccountInput,
+  ): RegisterLedgerAccountDAReturnType {
+    return this.appBinder.registerLedgerAccount(input);
+  }
+}

--- a/packages/device-contacts-kit/src/internal/use-cases/di/useCaseModule.ts
+++ b/packages/device-contacts-kit/src/internal/use-cases/di/useCaseModule.ts
@@ -1,0 +1,12 @@
+import { ContainerModule } from "inversify";
+
+import { RegisterExternalAddressUseCase } from "@internal/use-cases/RegisterExternalAddressUseCase";
+
+import { useCaseTypes } from "./useCaseTypes";
+
+export const useCaseModuleFactory = () =>
+  new ContainerModule(({ bind }) => {
+    bind(useCaseTypes.RegisterExternalAddressUseCase).to(
+      RegisterExternalAddressUseCase,
+    );
+  });

--- a/packages/device-contacts-kit/src/internal/use-cases/di/useCaseModule.ts
+++ b/packages/device-contacts-kit/src/internal/use-cases/di/useCaseModule.ts
@@ -1,6 +1,7 @@
 import { ContainerModule } from "inversify";
 
 import { RegisterExternalAddressUseCase } from "@internal/use-cases/RegisterExternalAddressUseCase";
+import { RegisterLedgerAccountUseCase } from "@internal/use-cases/RegisterLedgerAccountUseCase";
 
 import { useCaseTypes } from "./useCaseTypes";
 
@@ -8,5 +9,8 @@ export const useCaseModuleFactory = () =>
   new ContainerModule(({ bind }) => {
     bind(useCaseTypes.RegisterExternalAddressUseCase).to(
       RegisterExternalAddressUseCase,
+    );
+    bind(useCaseTypes.RegisterLedgerAccountUseCase).to(
+      RegisterLedgerAccountUseCase,
     );
   });

--- a/packages/device-contacts-kit/src/internal/use-cases/di/useCaseTypes.ts
+++ b/packages/device-contacts-kit/src/internal/use-cases/di/useCaseTypes.ts
@@ -1,3 +1,4 @@
 export const useCaseTypes = {
   RegisterExternalAddressUseCase: Symbol.for("RegisterExternalAddressUseCase"),
+  RegisterLedgerAccountUseCase: Symbol.for("RegisterLedgerAccountUseCase"),
 } as const;

--- a/packages/device-contacts-kit/src/internal/use-cases/di/useCaseTypes.ts
+++ b/packages/device-contacts-kit/src/internal/use-cases/di/useCaseTypes.ts
@@ -1,0 +1,3 @@
+export const useCaseTypes = {
+  RegisterExternalAddressUseCase: Symbol.for("RegisterExternalAddressUseCase"),
+} as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1121,6 +1121,9 @@ importers:
 
   packages/device-contacts-kit:
     dependencies:
+      '@ledgerhq/signer-utils':
+        specifier: workspace:^
+        version: link:../signer/signer-utils
       inversify:
         specifier: 'catalog:'
         version: 7.5.1(reflect-metadata@0.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -926,6 +926,9 @@ importers:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 1.4.0(react-dom@18.3.1(react@18.3.1))(react-native@0.76.6(@babel/core@7.28.3)(@babel/preset-env@7.26.9(@babel/core@7.28.3))(@react-native-community/cli-server-api@15.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@types/react@18.3.12)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.28.3)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+      '@ledgerhq/device-contacts-kit':
+        specifier: workspace:^
+        version: link:../../packages/device-contacts-kit
       '@ledgerhq/device-management-kit':
         specifier: workspace:^
         version: link:../../packages/device-management-kit


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Implements DSDK-1381: Register a Ledger account contact, the second operation of @ledgerhq/device-contacts-kit (Address Book). It adds the full vertical slice for the firmware REGISTER LEDGER ACCOUNT command, reusing the shared Contacts protocol foundation (TLV, framing, errors, validation) introduced by DSDK-1377.

Unlike Register Identity, a Ledger account is derived on-device from a BIP32 path (no explicit address/scope), and the device returns a single 32-byte hmacProof.

Public API
```ts
const contactsManager = new ContactsManagerBuilder({ dmk, sessionId, appName: "Ethereum" }).build();

const { observable } = contactsManager.registerLedgerAccount({
  accountName: "Alice",
  derivationPath: "m/44'/60'/0'/0/0",
  blockchainFamily: "ethereum",
  chainId: 1n,          // mandatory for Ethereum
  // skipOpenApp: true, // skip only the open-app step; the version guard still runs
});
// on completion → { …echoed input, hmacProof }
```

The device action opens the coin app by default, reads the running app + version freshly (WaitForAppAndVersion) before checking the Contacts version requirements, then runs REGISTER LEDGER ACCOUNT. Caller-input validation runs inside the device action and surfaces as a typed terminal error state the public API never throws.

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [DSDK-1381]

- **Feature**: Feature: Address Book / Contacts kit. Stacked on DSDK-1377 (shares the Contacts protocol foundation); review/merge after it.

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [X] **Covered by automatic tests**
- [X] **Changeset is provided**
- [X] **Documentation is up-to-date**
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
