### PR TITLE
🐛 (signer-utils): Reject BIP32 index overflow and parseInt truncation

### DIFF
--- a/.changeset/signer-utils-bip32-bounds.md
+++ b/.changeset/signer-utils-bip32-bounds.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/signer-utils": patch
+---
+
+Reject BIP32 path segments that overflow the harden bit or that parseInt would silently truncate

--- a/packages/signer/signer-utils/src/utils/DerivationPathUtils.test.ts
+++ b/packages/signer/signer-utils/src/utils/DerivationPathUtils.test.ts
@@ -73,4 +73,34 @@ describe("DerivationPathUtils", () => {
     // THEN
     expect(result).toThrow(new Error("invalid number provided"));
   });
+
+  it("should reject parseInt prefix truncation", () => {
+    expect(() => DerivationPathUtils.splitPath("44'/60'/0'/0/12abc")).toThrow(
+      new Error("invalid number provided"),
+    );
+    expect(() => DerivationPathUtils.splitPath("44'/60'/0'/0/12abc'")).toThrow(
+      new Error("invalid number provided"),
+    );
+  });
+
+  it("should reject a harden-bit overflow index", () => {
+    expect(() => DerivationPathUtils.splitPath("2147483648")).toThrow(
+      new Error("BIP32 index out of range"),
+    );
+    expect(() => DerivationPathUtils.splitPath("2147483648'")).toThrow(
+      new Error("BIP32 index out of range"),
+    );
+    expect(() =>
+      DerivationPathUtils.splitPath("44'/60'/0'/0/2147483648'"),
+    ).toThrow(new Error("BIP32 index out of range"));
+  });
+
+  it("should accept the maximum valid BIP32 index", () => {
+    expect(DerivationPathUtils.splitPath("2147483647")).toStrictEqual([
+      DerivationPathUtils.MAX_INDEX,
+    ]);
+    expect(DerivationPathUtils.splitPath("2147483647'")).toStrictEqual([
+      DerivationPathUtils.MAX_INDEX + DerivationPathUtils.PADDING,
+    ]);
+  });
 });

--- a/packages/signer/signer-utils/src/utils/DerivationPathUtils.ts
+++ b/packages/signer/signer-utils/src/utils/DerivationPathUtils.ts
@@ -1,18 +1,23 @@
 export class DerivationPathUtils {
   static PADDING = 0x80000000;
+  static MAX_INDEX = 0x7fffffff;
 
   static splitPath(path: string): number[] {
     const result: number[] = [];
     const components = path.split("/");
     components.forEach((element) => {
-      let number = parseInt(element, 10);
-      if (isNaN(number)) {
+      const hardened =
+        element.length > 1 && element[element.length - 1] === "'";
+      const raw = hardened ? element.slice(0, -1) : element;
+      if (!/^\d+$/.test(raw)) {
         throw new Error("invalid number provided");
       }
-      if (element.length > 1 && element[element.length - 1] === "'") {
-        number += this.PADDING;
+      const index = BigInt(raw);
+      if (index > BigInt(this.MAX_INDEX)) {
+        throw new Error("BIP32 index out of range");
       }
-      result.push(number);
+      const number = Number(index);
+      result.push(hardened ? number + this.PADDING : number);
     });
     return result;
   }


### PR DESCRIPTION
### 📝 Description

`DerivationPathUtils.splitPath` is the shared BIP32 parser for the new signer kits (eth, solana, btc, cosmos, and the rest). It used `parseInt` and then added `0x80000000` for a trailing `'`.

That remaps the path the host displays into a different APDU index:

- `parseInt("12abc", 10)` is `12`, so `44'/60'/0'/0/12abc` is sent as account `12`.
- Index `2147483648` is already the harden bit, so an unhardened `2147483648` is encoded as hardened `0`.
- Hardened `2147483648'` becomes `2^32`. `DataView.setUint32` wraps that to `0`. `ApduBuilder.add32BitUIntToData` rejects it, but only after the parser already produced the overflowed number.

Callers then write those numbers as big-endian uint32 on GetAddress / Sign* APDUs.

Fix: require a full decimal segment, cap the index at `0x7fffffff` before applying the harden bit, keep existing valid paths unchanged.

Threat-model: the host or Live App already supplies the derivation path string. It does not hold the seed. The defect is silent remapping (displayed path vs APDU index), not "the caller can pick any valid path."

### ❓ Context

- **JIRA or GitHub link**: no-issue (external)
- **Feature**: fail-closed BIP32 index bounds in `@ledgerhq/signer-utils`

Same class as bitcoinjs/bip32 (`0x7fffffff` cap). Distinct from Ledger Live ledgerjs hw-app BIP32 work. This is the shared util on the Device Management Kit signer stack.

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date** (no public API docs change; `MAX_INDEX` is an internal bound)
- [x] **Impact of the changes:**
  - `splitPath` now rejects non-numeric remnants (`12abc`, `12abc'`) and indexes above `0x7fffffff` (`2147483648`, `2147483648'`)
  - Existing paths such as `44'/60'/0'/0/0` and max valid `2147483647'` are unchanged
  - QA: signer-utils unit tests; no device UX change for well-formed paths

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
