### PR TITLE
🐛 (signer-solana) [DSDK-1433]: Fix xState onError error serialization in device actions

### DIFF
--- a/.changeset/eight-yaks-go.md
+++ b/.changeset/eight-yaks-go.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": patch
+---
+
+Fix xState onError error serialization in signer-solana device actions

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/ProvisionBasicClearSignDeviceAction.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/ProvisionBasicClearSignDeviceAction.ts
@@ -254,7 +254,14 @@ export class ProvisionBasicClearSignDeviceAction extends XStateDeviceAction<
               actions: ({ event }) => {
                 logger.error(
                   "[ProvideBasicClearSignContext] Failed to provide transaction context, falling back to blind signing",
-                  { data: { error: event.error } },
+                  {
+                    data: {
+                      error:
+                        event.error instanceof Error
+                          ? event.error.stack
+                          : String(event.error),
+                    },
+                  },
                 );
               },
             },

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/ProvisionGenericClearSignDeviceAction.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/ProvisionGenericClearSignDeviceAction.ts
@@ -171,7 +171,12 @@ export class ProvisionGenericClearSignDeviceAction extends XStateDeviceAction<
                 logger.info(
                   "[ClearSign] build failed; falling back to legacy",
                   {
-                    data: { error: event.error },
+                    data: {
+                      error:
+                        event.error instanceof Error
+                          ? event.error.stack
+                          : String(event.error),
+                    },
                   },
                 ),
             },
@@ -215,7 +220,14 @@ export class ProvisionGenericClearSignDeviceAction extends XStateDeviceAction<
               actions: ({ event }) =>
                 logger.info(
                   "[ClearSign] descriptor streaming failed; falling back to legacy",
-                  { data: { error: event.error } },
+                  {
+                    data: {
+                      error:
+                        event.error instanceof Error
+                          ? event.error.stack
+                          : String(event.error),
+                    },
+                  },
                 ),
             },
           },
@@ -261,7 +273,14 @@ export class ProvisionGenericClearSignDeviceAction extends XStateDeviceAction<
               actions: ({ event }) =>
                 logger.info(
                   "[ClearSign] FINALIZE threw; falling back to legacy",
-                  { data: { error: event.error } },
+                  {
+                    data: {
+                      error:
+                        event.error instanceof Error
+                          ? event.error.stack
+                          : String(event.error),
+                    },
+                  },
                 ),
             },
           },

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/ProvisionTransactionCheckDeviceAction.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/ProvisionTransactionCheckDeviceAction.ts
@@ -151,7 +151,14 @@ export class ProvisionTransactionCheckDeviceAction extends XStateDeviceAction<
               actions: ({ event }) =>
                 logger.info(
                   "[TransactionCheck] opt-in threw; proceeding without transaction-checks",
-                  { data: { error: event.error } },
+                  {
+                    data: {
+                      error:
+                        event.error instanceof Error
+                          ? event.error.stack
+                          : String(event.error),
+                    },
+                  },
                 ),
             },
           },
@@ -201,7 +208,12 @@ export class ProvisionTransactionCheckDeviceAction extends XStateDeviceAction<
               target: "Done",
               actions: ({ event }) =>
                 logger.info("[TransactionCheck] provide threw; proceeding", {
-                  data: { error: event.error },
+                  data: {
+                    error:
+                      event.error instanceof Error
+                        ? event.error.stack
+                        : String(event.error),
+                  },
                 }),
             },
           },

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/SignBasicClearSignDeviceAction.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/SignBasicClearSignDeviceAction.ts
@@ -216,7 +216,14 @@ export class SignBasicClearSignDeviceAction extends XStateDeviceAction<
               actions: ({ event }) =>
                 logger.info(
                   "[SigningOps] blockhash zeroing failed, signing original transaction",
-                  { data: { error: event.error } },
+                  {
+                    data: {
+                      error:
+                        event.error instanceof Error
+                          ? event.error.stack
+                          : String(event.error),
+                    },
+                  },
                 ),
             },
           },
@@ -272,7 +279,14 @@ export class SignBasicClearSignDeviceAction extends XStateDeviceAction<
               actions: ({ event }) =>
                 logger.info(
                   "[SigningOps] preview threw, signing original transaction",
-                  { data: { error: event.error } },
+                  {
+                    data: {
+                      error:
+                        event.error instanceof Error
+                          ? event.error.stack
+                          : String(event.error),
+                    },
+                  },
                 ),
             },
           },

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/SignGenericClearSignDeviceAction.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/SignGenericClearSignDeviceAction.ts
@@ -220,7 +220,14 @@ export class SignGenericClearSignDeviceAction extends XStateDeviceAction<
                 ({ event }) =>
                   logger.info(
                     "[ClearSign] PROMPT UI DISPLAY threw; falling back to legacy",
-                    { data: { error: event.error } },
+                    {
+                      data: {
+                        error:
+                          event.error instanceof Error
+                            ? event.error.stack
+                            : String(event.error),
+                      },
+                    },
                   ),
               ],
             },

--- a/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceAction.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/device-action/SignTransactionDeviceAction.ts
@@ -454,7 +454,14 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
               actions: ({ event }) =>
                 logger.info(
                   "[ClearSign] generic clear-sign threw; falling back to legacy",
-                  { data: { error: event.error } },
+                  {
+                    data: {
+                      error:
+                        event.error instanceof Error
+                          ? event.error.stack
+                          : String(event.error),
+                    },
+                  },
                 ),
             },
           },


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

xState's event.error in onError handlers is a raw JS Error object. Passing it directly to the logger produces {} in the output because Error's properties (message, stack, name) are non-enumerable and invisible to JSON.stringify.


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

<!--- If you are a Ledger employee, please include the relevant ticket number, if applicable (e.g., [JIRA-123] for Jira or #123 for a GitHub issue), [NO-ISSUE] if not.-->

- **JIRA or GitHub link**: [DSDK-1433](https://ledgerhq.atlassian.net/browse/DSDK-1433)

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [ ] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Changeset is provided** <!-- Please provide a changeset -->
- [ ] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[DSDK-1433]: https://ledgerhq.atlassian.net/browse/DSDK-1433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ