### PR TITLE
🔧 (device-management-kit) [NO-ISSUE]: Change default mock server URL to hosted instance

### DIFF
--- a/.changeset/easy-rings-bake.md
+++ b/.changeset/easy-rings-bake.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Change the default mock server base URL to the hosted `https://device-mock-server.aws.ldg-ps-default.ldg-tech.com` instead of a local server

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -158,9 +158,8 @@ jobs:
 
       - name: Run sample Playwright tests
         id: playwright
-        # The Playwright webServer (start-servers.sh) runs a production
-        # `next build` and starts both the device mock server and the sample
-        # app, so neither is launched here. Reuses the libs already built above.
+        # The Playwright webServer (start-servers.sh) starts the sample app.
+        # Tests connect to the hosted mock server; no local mock server is needed.
         if: ${{ !cancelled() && steps.sample-affected.outputs.affected == 'true' }}
         continue-on-error: true
         run: pnpm --filter @ledgerhq/device-management-kit-sample test:playwright

--- a/apps/sample/playwright/start-servers.sh
+++ b/apps/sample/playwright/start-servers.sh
@@ -4,23 +4,12 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$SCRIPT_DIR/../../.."
 
-# Each browser context (and each spec) provisions its own mock server session,
-# so no shared session/token is created here.
-
-# Fail fast instead of building. A production build is required (compile-on-demand
-# under `next dev` makes the first request to each route take ~25s+, tripping the
-# Playwright per-test timeout on slower/contended CI runners). The build is
-# expected to already exist: CI restores apps/sample/.next from the build job's
-# cache; locally, run `pnpm sample build` first.
 if [ ! -d "$REPO_ROOT/apps/sample/.next" ]; then
   echo "Error: sample app is not built (apps/sample/.next is missing)." >&2
   echo "Run 'pnpm sample build' before starting the Playwright servers." >&2
   exit 1
 fi
 
-# Track only the processes we start ourselves (space-separated PID list), so
-# servers that were already running (started manually or by CI) are left
-# untouched on cleanup.
 STARTED_PIDS=""
 
 cleanup() {
@@ -30,9 +19,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Start a server only if its port is free; otherwise assume it is already running
-# and reuse it (without registering it for cleanup).
-#   maybe_start <name> <port> <command...>   (command runs from REPO_ROOT)
 maybe_start() {
   name="$1"
   port="$2"
@@ -51,13 +37,10 @@ maybe_start() {
   echo "$name is up!"
 }
 
-maybe_start "device mock server" 9752 pnpm --filter @ledgerhq/device-mock-server serve
 maybe_start "sample app" 3000 pnpm sample start
 
-# Stay in the foreground until Playwright tears the webServer down (which fires
-# the cleanup trap). Block on the servers we started, or idle if both were reused.
 if [ -n "$STARTED_PIDS" ]; then
-  # shellcheck disable=SC2086 # intentional word-splitting of the PID list
+  # shellcheck disable=SC2086
   wait $STARTED_PIDS
 else
   wait

--- a/apps/sample/playwright/utils/setup.ts
+++ b/apps/sample/playwright/utils/setup.ts
@@ -1,25 +1,12 @@
 import { MockClient } from "@ledgerhq/device-mockserver-client";
 import { type Page } from "@playwright/test";
 
-const MOCK_SERVER_URL = "http://127.0.0.1:9752";
+const MOCK_SERVER_URL =
+  process.env["MOCK_SERVER_URL"] ??
+  "https://device-mock-server.aws.ldg-ps-default.ldg-tech.com";
 const SETTINGS_STORAGE_KEY = "dmk-sample-settings";
-
-/**
- * Gating token (a.k.a. origin token) enabling the Web3 Checks / clear-signing
- * context features. Without a valid token the signer falls back to blind
- * signing. Sourced from the test env so CI can provide a real token.
- */
 const GATING_TOKEN = process.env["NEXT_PUBLIC_GATING_TOKEN"];
 
-/**
- * Setup a mock server session and inject the session token (and the gating
- * token, when provided) into the page's localStorage.
- *
- * When `disablePolling` is true (the default), the device-session refresher is
- * turned off (pollingInterval 0) so its periodic GetOsVersion/GetAppAndVersion
- * polling does not pollute the APDU logs. Tests that exercise polling behaviour
- * (e.g. wait-for-app-and-version) can opt out via the `disablePolling` fixture.
- */
 export const setupMockServerSession = async (
   page: Page,
   { disablePolling = true }: { disablePolling?: boolean } = {},
@@ -29,13 +16,12 @@ export const setupMockServerSession = async (
 
   const settings: Record<string, unknown> = {
     transportType: "mockserver",
+    mockServerUrl: MOCK_SERVER_URL,
     mockServerSessionToken: sessionToken,
   };
   if (disablePolling) {
     settings["pollingInterval"] = 0;
   }
-  // Only override the app default when a token is configured, so local runs
-  // without the env var keep the built-in default.
   if (GATING_TOKEN) {
     settings["originToken"] = GATING_TOKEN;
   }

--- a/apps/sample/src/state/settings/schema.ts
+++ b/apps/sample/src/state/settings/schema.ts
@@ -9,7 +9,11 @@ import {
 } from "@ledgerhq/context-module";
 import { DeviceModelId } from "@ledgerhq/device-management-kit";
 
-import { DEFAULT_SPECULOS_URL, DEFAULT_SPECULOS_VNC_URL } from "@/utils/const";
+import {
+  DEFAULT_MOCK_SERVER_URL,
+  DEFAULT_SPECULOS_URL,
+  DEFAULT_SPECULOS_VNC_URL,
+} from "@/utils/const";
 
 export type CalMode = ContextModuleCalMode;
 export type CalBranch = ContextModuleCalBranch;
@@ -58,7 +62,7 @@ export type SettingsState = {
 export const initialState: SettingsState = {
   // Transport settings
   transportType: getInitialTransportType(),
-  mockServerUrl: "http://127.0.0.1:9752/",
+  mockServerUrl: DEFAULT_MOCK_SERVER_URL,
   mockServerSessionToken: "",
   speculosUrl: DEFAULT_SPECULOS_URL,
   speculosVncUrl: DEFAULT_SPECULOS_VNC_URL,

--- a/apps/sample/src/utils/const.ts
+++ b/apps/sample/src/utils/const.ts
@@ -1,2 +1,4 @@
 export const DEFAULT_SPECULOS_URL = "http://127.0.0.1:5000";
 export const DEFAULT_SPECULOS_VNC_URL = "ws://localhost:3337";
+export const DEFAULT_MOCK_SERVER_URL =
+  "https://device-mock-server.aws.ldg-ps-default.ldg-tech.com";

--- a/packages/device-management-kit/src/api/DeviceManagementKitBuilder.test.ts
+++ b/packages/device-management-kit/src/api/DeviceManagementKitBuilder.test.ts
@@ -29,4 +29,11 @@ describe("LedgerDeviceManagementKitBuilder", () => {
     // @ts-expect-error Access private field loggers
     expect(builder.loggers).toContain(logger);
   });
+
+  it("should default mockUrl to the hosted mock server", () => {
+    // @ts-expect-error Access private field config
+    expect(builder.config.mockUrl).toBe(
+      "https://device-mock-server.aws.ldg-ps-default.ldg-tech.com",
+    );
+  });
 });

--- a/packages/device-management-kit/src/di.test.ts
+++ b/packages/device-management-kit/src/di.test.ts
@@ -1,0 +1,17 @@
+import { type DmkConfig } from "@api/DmkConfig";
+import { transportDiTypes } from "@internal/transport/di/transportDiTypes";
+
+import { makeContainer } from "./di";
+
+describe("makeContainer", () => {
+  it("should default mockUrl to the hosted mock server", () => {
+    const container = makeContainer({});
+    const transportConfig = container.get<DmkConfig>(
+      transportDiTypes.DmkConfig,
+    );
+
+    expect(transportConfig.mockUrl).toBe(
+      "https://device-mock-server.aws.ldg-ps-default.ldg-tech.com",
+    );
+  });
+});

--- a/packages/device-management-kit/src/internal/manager-api/model/Const.ts
+++ b/packages/device-management-kit/src/internal/manager-api/model/Const.ts
@@ -1,5 +1,6 @@
 export const DEFAULT_MANAGER_API_BASE_URL =
   "https://manager.api.live.ledger.com/api";
-export const DEFAULT_MOCK_SERVER_BASE_URL = "http://localhost:9752";
+export const DEFAULT_MOCK_SERVER_BASE_URL =
+  "https://device-mock-server.aws.ldg-ps-default.ldg-tech.com";
 export const DEFAULT_PROVIDER = 1;
 export const DEFAULT_FIRMWARE_DISTRIBUTION_SALT = "0";


### PR DESCRIPTION
### 📝 Description

Point the default mock server URL at the hosted mock server instead of a local one, everywhere it is defaulted.

**DMK** — `DEFAULT_MOCK_SERVER_BASE_URL` goes from `http://localhost:9752` to `https://device-mock-server.aws.ldg-ps-default.ldg-tech.com`. This constant is the `mockUrl` fallback in both `makeContainer` (`src/di.ts`) and `DeviceManagementKitBuilder`, so any consumer that builds a DMK without passing an explicit `mockUrl` in its `DmkConfig` now targets the hosted server rather than expecting one to be running locally. Callers that do pass an explicit `mockUrl` are unaffected.

**Sample app** — the initial `mockServerUrl` setting follows the same default (moved next to the other default URLs in `src/utils/const.ts`), so a fresh install works without a local server.

**Playwright e2e** — `setupMockServerSession` provisions its sessions against the hosted server and writes that URL into the app settings, so `start-servers.sh` (and the CI job) no longer start a local mock server. Set `MOCK_SERVER_URL` to point the tests back at a local instance.

| Before | After |
| ------ | ----- |
| `http://localhost:9752` (DMK) | `https://device-mock-server.aws.ldg-ps-default.ldg-tech.com` |
| `http://127.0.0.1:9752/` (sample setting) | `https://device-mock-server.aws.ldg-ps-default.ldg-tech.com` |
| `http://127.0.0.1:9752` (e2e, local server started by CI) | `$MOCK_SERVER_URL` ?? hosted instance |

### ❓ Context

- **JIRA or GitHub link**: NO-ISSUE
- **Feature**: Consumers of the mockserver transport — and the sample app's e2e suite — no longer need to spin up a local mock server to get a working default.

### ✅ Checklist

- [x] **Covered by automatic tests** <!-- New tests assert the hosted default on both fallback paths: DeviceManagementKitBuilder and makeContainer. -->
- [x] **Changeset is provided** <!-- patch bump on @ledgerhq/device-management-kit -->
- [x] **Documentation is up-to-date** <!-- No docs referenced this constant. -->
- [ ] **Impact of the changes:**
  - Default `DmkConfig.mockUrl` now resolves to the hosted mock server, so QA should confirm the mockserver transport works against that host without extra configuration.
  - Playwright runs (CI and local) now depend on the hosted mock server being reachable; a local run can opt out with `MOCK_SERVER_URL=http://127.0.0.1:9752`.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
