### PR TITLE
🐛 (ldmk-tool) [NO-ISSUE]: Emit a builder test with the generated signer

### DIFF
--- a/packages/tools/ldmk-tool/generate-signer.cjs
+++ b/packages/tools/ldmk-tool/generate-signer.cjs
@@ -488,6 +488,37 @@ export class ${config.taskClassName} {
 `;
 }
 
+/**
+ * Generates a smoke test for the builder.
+ *
+ * `vitest run` exits 1 when a package has no test files, so a generated signer
+ * would fail CI on day one without this. Building the signer also constructs
+ * the DI container, so this covers the container setup. Bindings resolve
+ * lazily, so a missing one only surfaces once its use case is called.
+ */
+function generateBuilderTest(pascalCase) {
+  return `import { type DeviceManagementKit } from "@ledgerhq/device-management-kit";
+
+import { Signer${pascalCase}Builder } from "@api/Signer${pascalCase}Builder";
+import { DefaultSigner${pascalCase} } from "@internal/DefaultSigner${pascalCase}";
+
+describe("Signer${pascalCase}Builder", () => {
+  it("should build a Signer${pascalCase} instance", () => {
+    // ARRANGE
+    const dmk = {} as DeviceManagementKit;
+    const sessionId = "test-session-id";
+    const builder = new Signer${pascalCase}Builder({ dmk, sessionId });
+
+    // ACT
+    const signer = builder.build();
+
+    // ASSERT
+    expect(signer).toBeInstanceOf(DefaultSigner${pascalCase});
+  });
+});
+`;
+}
+
 // ============================================================================
 // Sample App Helper Functions
 // ============================================================================
@@ -1339,6 +1370,11 @@ export class Signer${pascalCase}Builder {
   }
 }
 `,
+    );
+
+    writeFile(
+      `${baseDir}/src/api/Signer${pascalCase}Builder.test.ts`,
+      generateBuilderTest(pascalCase),
     );
 
     // Generate model files (conditional)


### PR DESCRIPTION
### 📝 Description

A freshly generated signer failed its own `test` script. The script is plain `vitest run` like every other signer, and `vitest` exits 1 when it finds no test files — but the generator emits none, so `pnpm test` failed before anyone had written a line of code. I hit this on #1767 and hand-wrote tests there; this fixes it at the source instead.

The generator now emits a smoke test for the builder alongside `Signer<Name>Builder.ts`. That is deliberately the only test generated: it is the smallest one worth keeping, since `builder.build()` also constructs the DI container, so the package entrypoint is covered end to end. Everything else in a fresh scaffold either throws `not implemented` or is a one-line delegation, and generating assertions for those would just produce change-detector tests that the implementer has to delete.

Verified by generating a throwaway `testcoin` signer with all four APIs: `pnpm test` passes with no manual step, and `lint`, `typecheck` and `build` are unaffected (only the pre-existing `CommandResultFactory` warning in the task skeleton).

I also checked what the test actually catches, rather than assuming: making the container constructor throw fails it, while removing a binding does not, because inversify resolves lazily and a missing binding only surfaces when its use case is called. The comment on the template says exactly that, so nobody over-trusts it.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Make `generate-signer` produce a package that passes its own checks.

### ✅ Checklist

- [x] **Covered by automatic tests** — the tool has no test suite; verified manually by generating a throwaway signer with all four APIs and running `test`, `lint`, `typecheck` and `build`. All artifacts removed afterwards.
- [x] **Changeset is provided** — not needed, `@ledgerhq/ldmk-tool` is `private: true` internal tooling.
- [x] **Documentation is up-to-date** — no user-facing docs affected.
- [x] **Impact of the changes:**
  - Newly generated signers ship one passing test and no longer fail `pnpm test` out of the box.
  - No change to existing packages; only the scaffolding tool is touched.

### 🧐 Note for reviewers

The alternative was adding `--passWithNoTests` to the generated `test` script. I went with a real test instead, so the generated package matches the other signers' scripts and does not start life with a suppressed check.

Made with [Cursor](https://cursor.com)