### PR TITLE
✨ (signer-xrp) [DSDK-1435]: Add GetAppConfig command

### DIFF
--- a/.changeset/xrp-get-app-config.md
+++ b/.changeset/xrp-get-app-config.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-xrp": minor
+---
+
+Implement the XRP `getAppConfig` flow. `GetAppConfigCommand` now builds the real `E0 06 00 00` APDU and parses the device response (`[flags, major, minor, patch]`) into `{ version: "major.minor.patch" }`, skipping the RFU flags byte. Adds the XRP application status words (`XRP_APP_ERRORS`, `XrpAppCommandError`) and the XRP APDU header constants, and fixes the app name used to open the application (`XRP`).

--- a/apps/docs/content/docs/references/signers/xrp.mdx
+++ b/apps/docs/content/docs/references/signers/xrp.mdx
@@ -60,12 +60,11 @@ const { observable, cancel } = signerXrp.getAppConfig();
 
 ```typescript
 type GetAppConfigCommandResponse = {
-  // TODO: Define the app configuration response type
-  // Example:
-  // version: string;
-  // flags: number;
+  readonly version: string;
 };
 ```
+
+- `version`: The version of the XRP application installed on the device, formatted as `"major.minor.patch"` (e.g. `"2.5.2"`).
 
 - `cancel` A function to cancel the action on the Ledger device.
 

--- a/packages/signer/signer-xrp/src/api/model/AppConfig.ts
+++ b/packages/signer/signer-xrp/src/api/model/AppConfig.ts
@@ -1,4 +1,3 @@
 export type AppConfig = {
-  // Replace with your app configuration fields
-  version: string;
+  readonly version: string;
 };

--- a/packages/signer/signer-xrp/src/internal/app-binder/XrpAppBinder.test.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/XrpAppBinder.test.ts
@@ -1,0 +1,106 @@
+import {
+  DeviceActionStatus,
+  type DeviceManagementKit,
+  type DeviceSessionId,
+  type ExecuteDeviceActionReturnType,
+  SendCommandInAppDeviceAction,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+import { from } from "rxjs";
+import { vi } from "vitest";
+
+import {
+  type GetAppConfigDAError,
+  type GetAppConfigDAIntermediateValue,
+  type GetAppConfigDAOutput,
+} from "@api/app-binder/GetAppConfigDeviceActionTypes";
+import {
+  GetAppConfigCommand,
+  type GetAppConfigCommandResponse,
+} from "@internal/app-binder/command/GetAppConfigCommand";
+import { type XrpErrorCodes } from "@internal/app-binder/command/utils/xrpApplicationErrors";
+import { APP_NAME } from "@internal/app-binder/constants";
+import { XrpAppBinder } from "@internal/app-binder/XrpAppBinder";
+
+type GetAppConfigSendCommandAction = SendCommandInAppDeviceAction<
+  GetAppConfigCommandResponse,
+  void,
+  XrpErrorCodes,
+  UserInteractionRequired.None
+>;
+
+type ExecuteDeviceActionCallArgs = {
+  sessionId: DeviceSessionId;
+  deviceAction: GetAppConfigSendCommandAction;
+};
+
+describe("XrpAppBinder", () => {
+  it("should be defined", () => {
+    const binder = new XrpAppBinder({} as DeviceManagementKit, "session-id");
+
+    expect(binder).toBeDefined();
+  });
+
+  describe("getAppConfig", () => {
+    it("should execute a SendCommandInAppDeviceAction wrapping GetAppConfigCommand", () => {
+      // GIVEN
+      const sessionId = "test-session-id";
+      const expectedResult: ExecuteDeviceActionReturnType<
+        GetAppConfigDAOutput,
+        GetAppConfigDAError,
+        GetAppConfigDAIntermediateValue
+      > = {
+        observable: from([
+          {
+            status: DeviceActionStatus.Completed as const,
+            output: { version: "1.2.3" },
+          },
+        ]),
+        cancel: vi.fn(),
+      };
+      const executeDeviceAction = vi.fn().mockReturnValue(expectedResult);
+      const dmk = { executeDeviceAction } as unknown as DeviceManagementKit;
+      const binder = new XrpAppBinder(dmk, sessionId);
+
+      // WHEN
+      const result = binder.getAppConfig({ skipOpenApp: false });
+
+      // THEN
+      expect(result).toEqual(expectedResult);
+      expect(executeDeviceAction).toHaveBeenCalledTimes(1);
+
+      const callArgs = executeDeviceAction.mock
+        .calls[0]![0] as ExecuteDeviceActionCallArgs;
+      expect(callArgs.sessionId).toBe(sessionId);
+      expect(callArgs.deviceAction).toBeInstanceOf(
+        SendCommandInAppDeviceAction,
+      );
+      expect(callArgs.deviceAction.input.command).toBeInstanceOf(
+        GetAppConfigCommand,
+      );
+      expect(callArgs.deviceAction.input.appName).toBe(APP_NAME);
+      expect(callArgs.deviceAction.input.requiredUserInteraction).toBe(
+        UserInteractionRequired.None,
+      );
+      expect(callArgs.deviceAction.input.skipOpenApp).toBe(false);
+    });
+
+    it("should forward skipOpenApp", () => {
+      // GIVEN
+      const executeDeviceAction = vi.fn().mockReturnValue({
+        observable: from([]),
+        cancel: vi.fn(),
+      });
+      const dmk = { executeDeviceAction } as unknown as DeviceManagementKit;
+      const binder = new XrpAppBinder(dmk, "test-session-id");
+
+      // WHEN
+      binder.getAppConfig({ skipOpenApp: true });
+
+      // THEN
+      const callArgs = executeDeviceAction.mock
+        .calls[0]![0] as ExecuteDeviceActionCallArgs;
+      expect(callArgs.deviceAction.input.skipOpenApp).toBe(true);
+    });
+  });
+});

--- a/packages/signer/signer-xrp/src/internal/app-binder/command/GetAppConfigCommand.test.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/command/GetAppConfigCommand.test.ts
@@ -1,0 +1,217 @@
+import {
+  ApduResponse,
+  InvalidResponseFormatError,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { GetAppConfigCommand } from "@internal/app-binder/command/GetAppConfigCommand";
+import {
+  INS,
+  P1_DEFAULT,
+  P2_DEFAULT,
+  XRP_CLA,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import { type XrpAppCommandError } from "@internal/app-binder/command/utils/xrpApplicationErrors";
+
+// CLA INS P1 P2 Lc (no data)
+const GET_APP_CONFIG_APDU = Uint8Array.from([
+  XRP_CLA,
+  INS.GET_APP_CONFIGURATION,
+  P1_DEFAULT,
+  P2_DEFAULT,
+  0x00,
+]);
+
+// XRP app response: [flags (RFU), major, minor, patch]
+const buildConfigResponse = (
+  flags: number,
+  major: number,
+  minor: number,
+  patch: number,
+) =>
+  new ApduResponse({
+    statusCode: Uint8Array.from([0x90, 0x00]),
+    data: Uint8Array.from([flags, major, minor, patch]),
+  });
+
+describe("GetAppConfigCommand", () => {
+  let command: GetAppConfigCommand;
+
+  beforeEach(() => {
+    command = new GetAppConfigCommand();
+  });
+
+  describe("name", () => {
+    it("should be 'GetAppConfig'", () => {
+      expect(command.name).toBe("GetAppConfig");
+    });
+  });
+
+  describe("getApdu", () => {
+    it("should return the raw APDU", () => {
+      // WHEN
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.getRawApdu()).toStrictEqual(GET_APP_CONFIG_APDU);
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("should return the app version", () => {
+      // GIVEN
+      const response = buildConfigResponse(0x00, 1, 2, 3);
+
+      // WHEN
+      const result = command.parseResponse(response);
+
+      // THEN
+      if (isSuccessCommandResult(result)) {
+        expect(result.data).toEqual({ version: "1.2.3" });
+      } else {
+        assert.fail("Expected a success");
+      }
+    });
+
+    it("should ignore the RFU flags byte", () => {
+      // GIVEN
+      const response = buildConfigResponse(0xff, 4, 5, 6);
+
+      // WHEN
+      const result = command.parseResponse(response);
+
+      // THEN
+      if (isSuccessCommandResult(result)) {
+        expect(result.data).toEqual({ version: "4.5.6" });
+      } else {
+        assert.fail("Expected a success");
+      }
+    });
+
+    it("should parse a 0.0.0 version", () => {
+      // GIVEN
+      const response = buildConfigResponse(0x00, 0, 0, 0);
+
+      // WHEN
+      const result = command.parseResponse(response);
+
+      // THEN
+      if (isSuccessCommandResult(result)) {
+        expect(result.data).toEqual({ version: "0.0.0" });
+      } else {
+        assert.fail("Expected a success");
+      }
+    });
+
+    it("should return an error if the response is empty", () => {
+      // GIVEN
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x90, 0x00]),
+        data: new Uint8Array(0),
+      });
+
+      // WHEN
+      const result = command.parseResponse(response);
+
+      // THEN
+      if (isSuccessCommandResult(result)) {
+        assert.fail("Expected an error");
+      } else {
+        expect(result.error).toBeInstanceOf(InvalidResponseFormatError);
+        expect(result.error).toEqual(
+          expect.objectContaining({
+            originalError: new Error("Cannot extract config flags"),
+          }),
+        );
+      }
+    });
+
+    it("should return an error if the version is truncated", () => {
+      // GIVEN
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x90, 0x00]),
+        data: Uint8Array.from([0x00, 0x01]),
+      });
+
+      // WHEN
+      const result = command.parseResponse(response);
+
+      // THEN
+      if (isSuccessCommandResult(result)) {
+        assert.fail("Expected an error");
+      } else {
+        expect(result.error).toBeInstanceOf(InvalidResponseFormatError);
+        expect(result.error).toEqual(
+          expect.objectContaining({
+            originalError: new Error("Cannot extract version"),
+          }),
+        );
+      }
+    });
+
+    it("should return an XRP app error if the user rejected", () => {
+      // GIVEN
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x69, 0x85]),
+        data: new Uint8Array(0),
+      });
+
+      // WHEN
+      const result = command.parseResponse(response);
+
+      // THEN
+      if (isSuccessCommandResult(result)) {
+        assert.fail("Expected an error");
+      } else {
+        const error = result.error as XrpAppCommandError;
+        expect(error.errorCode).toBe("6985");
+        expect(error.message).toBe(
+          "Condition of use not satisfied (Rejected by user)",
+        );
+      }
+    });
+
+    it("should return an XRP app error if the instruction is not supported", () => {
+      // GIVEN
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x6d, 0x00]),
+        data: new Uint8Array(0),
+      });
+
+      // WHEN
+      const result = command.parseResponse(response);
+
+      // THEN
+      if (isSuccessCommandResult(result)) {
+        assert.fail("Expected an error");
+      } else {
+        const error = result.error as XrpAppCommandError;
+        expect(error.errorCode).toBe("6d00");
+        expect(error.message).toBe("Incorrect parameter INS");
+      }
+    });
+
+    it("should return an error if the device is locked", () => {
+      // GIVEN
+      const response = new ApduResponse({
+        statusCode: Uint8Array.from([0x55, 0x15]),
+        data: new Uint8Array(0),
+      });
+
+      // WHEN
+      const result = command.parseResponse(response);
+
+      // THEN
+      if (isSuccessCommandResult(result)) {
+        assert.fail("Expected an error");
+      } else {
+        expect(result.error).toEqual(
+          expect.objectContaining({
+            errorCode: "5515",
+            message: "Device is locked.",
+          }),
+        );
+      }
+    });
+  });
+});

--- a/packages/signer/signer-xrp/src/internal/app-binder/command/GetAppConfigCommand.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/command/GetAppConfigCommand.ts
@@ -1,36 +1,84 @@
 import {
   type Apdu,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  ApduParser,
   type ApduResponse,
   type Command,
   type CommandResult,
+  CommandResultFactory,
+  InvalidResponseFormatError,
 } from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
 
-import { type XrpErrorCodes } from "./utils/xrpApplicationErrors";
+import { type AppConfig } from "@api/model/AppConfig";
 
-export type GetAppConfigCommandResponse = {
-  // Replace with your app configuration response fields
-  readonly version: string;
-};
+import { INS, P1_DEFAULT, P2_DEFAULT, XRP_CLA } from "./utils/apduHeaderUtils";
+import {
+  XRP_APP_ERRORS,
+  XrpAppCommandErrorFactory,
+  type XrpErrorCodes,
+} from "./utils/xrpApplicationErrors";
 
+export type GetAppConfigCommandResponse = AppConfig;
+
+/**
+ * Retrieves the configuration of the XRP application.
+ *
+ * The device answers with 4 bytes: `[flags, major, minor, patch]`. The flags
+ * byte is currently reserved for future use by the app and is therefore
+ * skipped.
+ */
 export class GetAppConfigCommand
   implements Command<GetAppConfigCommandResponse, void, XrpErrorCodes>
 {
   readonly name = "GetAppConfig";
 
+  private readonly errorHelper = new CommandErrorHelper<
+    GetAppConfigCommandResponse,
+    XrpErrorCodes
+  >(XRP_APP_ERRORS, XrpAppCommandErrorFactory);
+
   getApdu(): Apdu {
-    // TODO: Implement APDU construction based on your blockchain's protocol
-    // Example structure:
-    // const builder = new ApduBuilder({ cla: 0xe0, ins: 0x02, p1: 0x00, p2: 0x00 });
-    // Add derivation path and other data to builder
-    // return builder.build();
-    throw new Error("GetAppConfigCommand.getApdu() not implemented");
+    const getAppConfigArgs: ApduBuilderArgs = {
+      cla: XRP_CLA,
+      ins: INS.GET_APP_CONFIGURATION,
+      p1: P1_DEFAULT,
+      p2: P2_DEFAULT,
+    };
+
+    return new ApduBuilder(getAppConfigArgs).build();
   }
 
   parseResponse(
-    _apduResponse: ApduResponse,
+    apduResponse: ApduResponse,
   ): CommandResult<GetAppConfigCommandResponse, XrpErrorCodes> {
-    // TODO: Implement response parsing based on your blockchain's protocol
-    // return CommandResultFactory({ data: { ... } });
-    throw new Error("GetAppConfigCommand.parseResponse() not implemented");
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      const parser = new ApduParser(apduResponse);
+
+      const flags = parser.extract8BitUInt();
+      if (flags === undefined) {
+        return CommandResultFactory({
+          error: new InvalidResponseFormatError("Cannot extract config flags"),
+        });
+      }
+
+      const major = parser.extract8BitUInt();
+      const minor = parser.extract8BitUInt();
+      const patch = parser.extract8BitUInt();
+
+      if (major === undefined || minor === undefined || patch === undefined) {
+        return CommandResultFactory({
+          error: new InvalidResponseFormatError("Cannot extract version"),
+        });
+      }
+
+      return CommandResultFactory({
+        data: { version: `${major}.${minor}.${patch}` },
+      });
+    });
   }
 }

--- a/packages/signer/signer-xrp/src/internal/app-binder/command/utils/apduHeaderUtils.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/command/utils/apduHeaderUtils.ts
@@ -1,0 +1,13 @@
+/**
+ * APDU header constants for the XRP application.
+ */
+export const XRP_CLA = 0xe0 as const;
+
+export const INS = {
+  GET_PUBLIC_KEY: 0x02,
+  SIGN: 0x04,
+  GET_APP_CONFIGURATION: 0x06,
+} as const;
+
+export const P1_DEFAULT = 0x00 as const;
+export const P2_DEFAULT = 0x00 as const;

--- a/packages/signer/signer-xrp/src/internal/app-binder/command/utils/xrpApplicationErrors.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/command/utils/xrpApplicationErrors.ts
@@ -1,5 +1,51 @@
-export enum XrpErrorCodes {}
-// Define your error codes here
-// Example:
-// INVALID_DERIVATION_PATH = 0x6a80,
-// TRANSACTION_PARSING_ERROR = 0x6a81,
+import {
+  type CommandErrorArgs,
+  type CommandErrors,
+  DeviceExchangeError,
+} from "@ledgerhq/device-management-kit";
+
+/**
+ * Status words returned by the XRP application.
+ *
+ * Source of truth: `LedgerHQ/app-xrp` (branch `develop`) `src/apdu/entry.c`,
+ * `src/apdu/messages/*.c` and `doc/xrpapp.asc`.
+ *
+ * Note: on a transaction parsing failure the app answers `0x6800 | (exception &
+ * 0x7ff)`, so the whole `6800`-`6fff` range may be returned. Only the anchors
+ * of that range are mapped here; any unmapped status word is surfaced as a
+ * generic device exchange error by the kit.
+ */
+export type XrpErrorCodes =
+  | "6700"
+  | "6800"
+  | "6982"
+  | "6985"
+  | "6a80"
+  | "6a81"
+  | "6b00"
+  | "6d00"
+  | "6e00"
+  | "6f00";
+
+export const XRP_APP_ERRORS: CommandErrors<XrpErrorCodes> = {
+  "6700": { message: "Incorrect length, or transaction too large" },
+  "6800": { message: "Missing critical parameter" },
+  "6982": { message: "Security status not satisfied (Canceled by user)" },
+  "6985": { message: "Condition of use not satisfied (Rejected by user)" },
+  "6a80": { message: "Invalid data" },
+  "6a81": { message: "Invalid derivation path" },
+  "6b00": { message: "Incorrect parameter P1 or P2" },
+  "6d00": { message: "Incorrect parameter INS" },
+  "6e00": { message: "Incorrect parameter CLA" },
+  "6f00": { message: "Technical problem (Internal error, please report)" },
+};
+
+export class XrpAppCommandError extends DeviceExchangeError<XrpErrorCodes> {
+  constructor(args: CommandErrorArgs<XrpErrorCodes>) {
+    super({ tag: "XrpAppCommandError", ...args });
+  }
+}
+
+export const XrpAppCommandErrorFactory = (
+  args: CommandErrorArgs<XrpErrorCodes>,
+) => new XrpAppCommandError(args);

--- a/packages/signer/signer-xrp/src/internal/app-binder/constants.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/constants.ts
@@ -1,1 +1,1 @@
-export const APP_NAME = "Xrp";
+export const APP_NAME = "XRP";

--- a/packages/signer/signer-xrp/src/internal/app-binder/device-action/GetAppConfig/GetAppConfigDeviceAction.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/device-action/GetAppConfig/GetAppConfigDeviceAction.ts
@@ -1,3 +1,0 @@
-// TODO: Implement GetAppConfigDeviceAction if needed
-// This is a placeholder - you may not need a custom device action for getAppConfig
-// if SendCommandInAppDeviceAction is sufficient

--- a/packages/signer/signer-xrp/src/internal/use-cases/config/GetAppConfigUseCase.test.ts
+++ b/packages/signer/signer-xrp/src/internal/use-cases/config/GetAppConfigUseCase.test.ts
@@ -1,0 +1,47 @@
+import {
+  DeviceActionStatus,
+  type ExecuteDeviceActionReturnType,
+} from "@ledgerhq/device-management-kit";
+import { from } from "rxjs";
+import { vi } from "vitest";
+
+import {
+  type GetAppConfigDAError,
+  type GetAppConfigDAIntermediateValue,
+  type GetAppConfigDAOutput,
+} from "@api/app-binder/GetAppConfigDeviceActionTypes";
+import { type XrpAppBinder } from "@internal/app-binder/XrpAppBinder";
+
+import { GetAppConfigUseCase } from "./GetAppConfigUseCase";
+
+describe("GetAppConfigUseCase", () => {
+  it("should return the result from appBinder.getAppConfig", () => {
+    // ARRANGE
+    const getAppConfigMock = vi.fn();
+    const appBinderMock = {
+      getAppConfig: getAppConfigMock,
+    } as unknown as XrpAppBinder;
+    const expectedResult: ExecuteDeviceActionReturnType<
+      GetAppConfigDAOutput,
+      GetAppConfigDAError,
+      GetAppConfigDAIntermediateValue
+    > = {
+      observable: from([
+        {
+          status: DeviceActionStatus.Completed as const,
+          output: { version: "1.2.3" },
+        },
+      ]),
+      cancel: vi.fn(),
+    };
+    getAppConfigMock.mockReturnValue(expectedResult);
+    const useCase = new GetAppConfigUseCase(appBinderMock);
+
+    // ACT
+    const result = useCase.execute();
+
+    // ASSERT
+    expect(getAppConfigMock).toHaveBeenCalledWith({ skipOpenApp: false });
+    expect(result).toEqual(expectedResult);
+  });
+});


### PR DESCRIPTION
### 📝 Description

Implements `GetAppConfigCommand` for the XRP signer.

The command builds the real `E0 06 00 00` APDU and parses the device's 4-byte answer `[flags, major, minor, patch]` into `{ version: "major.minor.patch" }`. The flags byte is RFU per the app spec, so it is skipped rather than decoded into flag bits the way the Ethereum signer does.

Also adds the XRP application status words (`XRP_APP_ERRORS`, `XrpAppCommandError`) and the XRP APDU header constants, and fixes the app name used to open the application (`XRP`).

Command only — the DI / use case / sample wiring lives in the stacked follow-up PR for [DSDK-1436](https://ledgerhq.atlassian.net/browse/DSDK-1436).

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1435](https://ledgerhq.atlassian.net/browse/DSDK-1435)
- **Feature**: XRP signer — get app configuration

### ✅ Checklist

- [x] **Covered by automatic tests** — `GetAppConfigCommand.test.ts` asserts the APDU bytes, the nominal `1.2.3` parse, short-body handling and the mapped error status words; `XrpAppBinder.test.ts` covers the binder input.
- [x] **Changeset is provided** — `.changeset/xrp-get-app-config.md`
- [x] **Documentation is up-to-date** — `apps/docs/content/docs/references/signers/xrp.mdx`
- [ ] **Impact of the changes:**
  - `@ledgerhq/device-signer-kit-xrp` only; no other package is touched.
  - `GetAppConfigCommand` now sends a real APDU instead of the scaffolded stub.
  - The app name used to open the XRP application changed to `XRP`.


[DSDK-1436]: https://ledgerhq.atlassian.net/browse/DSDK-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSDK-1435]: https://ledgerhq.atlassian.net/browse/DSDK-1435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ