### PR TITLE
✨ (signer-xrp) [DSDK-1436]: Add GetAppConfig use case and sample integration

### DIFF
--- a/.changeset/free-crews-admire.md
+++ b/.changeset/free-crews-admire.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-xrp": minor
+---
+
+`SignerXrp.getAppConfig` now accepts an optional `AppConfigOptions` (`{ skipOpenApp?: boolean }`), defaulting `skipOpenApp` to `false`.

--- a/apps/docs/content/docs/references/signers/xrp.mdx
+++ b/apps/docs/content/docs/references/signers/xrp.mdx
@@ -51,8 +51,23 @@ The `SignerXrpBuilder.build()` method will return a `SignerXrp` instance that ex
 This method allows users to retrieve the app configuration from the Ledger device.
 
 ```typescript
-const { observable, cancel } = signerXrp.getAppConfig();
+const { observable, cancel } = signerXrp.getAppConfig(options);
 ```
+
+#### **Parameters**
+
+- `options`
+
+  - Optional
+  - Type: `AppConfigOptions`
+
+    ```typescript
+    type AppConfigOptions = {
+      skipOpenApp?: boolean;
+    };
+    ```
+
+  - `skipOpenApp`: An optional boolean indicating whether to skip opening the xrp app automatically (`true`) or not (`false`). Defaults to `false`.
 
 #### **Returns**
 

--- a/apps/sample/playwright/cases/signers/xrp/get-app-config.spec.ts
+++ b/apps/sample/playwright/cases/signers/xrp/get-app-config.spec.ts
@@ -1,0 +1,159 @@
+/* eslint-disable no-restricted-imports */
+import { type DeviceConfig } from "@ledgerhq/device-mockserver-client";
+
+import { expect, test } from "../../../fixtures";
+
+const NANO_X_WITH_XRP: DeviceConfig = {
+  name: "Ledger Nano X",
+  device_type: "nanoX",
+  connectivity_type: "USB",
+  firmware_version: "2.2.3",
+  apps: [
+    { name: "BOLOS", version: "2.2.3" },
+    { name: "XRP", version: "2.4.0" },
+  ],
+  masks: [0x33000000],
+};
+
+// GetAppConfig APDU: CLA e0, INS 06, P1 00, P2 00.
+const GET_APP_CONFIG_PREFIX = "e0060000";
+
+// The XRP app answers 4 bytes `[flags, major, minor, patch]` then `9000`. The
+// flags byte is reserved and skipped by the command, so a non-zero value here
+// also guards against it being mistaken for part of the version.
+const APP_CONFIG_RESPONSE = "0f0204009000";
+const EXPECTED_VERSION = "2.4.0";
+
+// "Condition of use not satisfied (Rejected by user)".
+const REJECTED_RESPONSE = "6985";
+
+// Latest Stax combo carrying an XRP build in coin-apps
+// (`stax/1.10.1/XRP/app_2.6.1.elf`). The declared version is what selects the
+// ELF Speculinho boots, so it doubles as the version the app reports back.
+// If the image ever drops this build, `/acquire` fails — fall back to
+// stax/1.9.1 + XRP 2.5.2, the OS the Tron and Ethereum specs already use.
+const XRP_APP_VERSION = "2.6.1";
+const STAX_WITH_XRP: DeviceConfig = {
+  name: "Ledger Stax",
+  device_type: "stax",
+  connectivity_type: "USB",
+  firmware_version: "1.10.1",
+  apps: [
+    { name: "BOLOS", version: "1.10.1" },
+    { name: "XRP", version: XRP_APP_VERSION },
+  ],
+  masks: [0x33200000],
+};
+
+interface AppConfigOutput {
+  version: string;
+}
+
+test.describe("signer xrp: get app config", () => {
+  // The two tests below never open the XRP app (`skipOpenApp`), so no Speculos
+  // instance is provisioned: the mocked APDU answers the command directly. The
+  // last test is the opposite — it opens the real app and registers no mock.
+  test("returns the app config when skipOpenApp is set", async ({
+    device,
+    mockClient,
+    xrpSigner,
+  }) => {
+    await test.step("Given a connected Nano X answering GetAppConfig", async () => {
+      const dev = await device.addAndConnect(NANO_X_WITH_XRP);
+      await mockClient.addMock(dev.id, {
+        prefix: GET_APP_CONFIG_PREFIX,
+        response: APP_CONFIG_RESPONSE,
+      });
+    });
+
+    await test.step("When Get App Config is executed with skipOpenApp", async () => {
+      await xrpSigner.open();
+      await xrpSigner.getAppConfig({ skipOpenApp: true });
+    });
+
+    await test.step("Then the app version is returned", async () => {
+      const result = await xrpSigner.lastResult<AppConfigOutput>();
+
+      expect(result.status).toBe("completed");
+      expect(result.output).toEqual({ version: EXPECTED_VERSION });
+    });
+  });
+
+  test("surfaces the XRP app error when the device rejects", async ({
+    device,
+    mockClient,
+    xrpSigner,
+  }) => {
+    await test.step("Given a connected Nano X rejecting GetAppConfig", async () => {
+      const dev = await device.addAndConnect(NANO_X_WITH_XRP);
+      await mockClient.addMock(dev.id, {
+        prefix: GET_APP_CONFIG_PREFIX,
+        response: REJECTED_RESPONSE,
+      });
+    });
+
+    await test.step("When Get App Config is executed with skipOpenApp", async () => {
+      await xrpSigner.open();
+      await xrpSigner.getAppConfig({ skipOpenApp: true });
+    });
+
+    await test.step("Then the 6985 status word is surfaced as an XRP app error", async () => {
+      const error = await xrpSigner.lastError();
+
+      expect(error).toContain("XrpAppCommandError");
+      expect(error).toContain("errorCode: '6985'");
+      expect(error).toContain(
+        "Condition of use not satisfied (Rejected by user)",
+      );
+    });
+  });
+
+  test("returns the app config from the real XRP app", async ({
+    device,
+    mockClient,
+    xrpSigner,
+  }) => {
+    // Opening the XRP app provisions a real Speculos instance. The mock server
+    // alone waits up to 120s for the pod to become ready, so the budget here is
+    // larger than that to keep a slow cold start diagnosable instead of an
+    // opaque Playwright timeout.
+    test.setTimeout(180_000);
+
+    let dev!: Awaited<ReturnType<typeof device.addAndConnect>>;
+
+    await test.step("Given a connected Stax with the XRP app and no APDU mock", async () => {
+      // Registering no mock is the load-bearing difference with the tests
+      // above: the Open App APDU falls through to the Speculinho proxy, and
+      // every APDU after it — `e0060000` included — reaches the emulator.
+      dev = await device.addAndConnect(STAX_WITH_XRP);
+    });
+
+    await test.step("When Get App Config is executed without skipOpenApp", async () => {
+      await xrpSigner.open();
+      // skipOpenApp defaults to false, so the device action opens the XRP app
+      // before sending the command. Were it to regress to true, the command
+      // would reach the dashboard instead and fail rather than silently pass.
+      await xrpSigner.getAppConfig();
+    });
+
+    await test.step("Then the version reported by the app is returned", async () => {
+      const result = await xrpSigner.lastResult<AppConfigOutput>({
+        timeout: 150_000,
+      });
+
+      expect(result.status).toBe("completed");
+      // The emulated app reports the version of the ELF that was booted, which
+      // is the one the device config asked for.
+      expect(result.output!.version).toBe(XRP_APP_VERSION);
+    });
+
+    await test.step("And a live Speculos instance was backing the device", async () => {
+      // Proves the version above came from an emulator rather than a mock:
+      // this throws when the device has no active Speculos instance.
+      const instance = await mockClient.getSpeculos(dev.id);
+
+      expect(instance.speculos_url).toMatch(/^https?:\/\//);
+      expect(instance.model.toLowerCase()).toBe("stax");
+    });
+  });
+});

--- a/apps/sample/playwright/fixtures.ts
+++ b/apps/sample/playwright/fixtures.ts
@@ -13,6 +13,7 @@ import { SettingsDriver } from "./utils/drivers/SettingsDriver";
 import { SidebarDriver } from "./utils/drivers/SidebarDriver";
 import { SpeculosDriver } from "./utils/drivers/SpeculosDriver";
 import { TrxSignerDriver } from "./utils/drivers/TrxSignerDriver";
+import { XrpSignerDriver } from "./utils/drivers/XrpSignerDriver";
 import { setupMockServerSession } from "./utils/setup";
 
 type Fixtures = {
@@ -31,6 +32,7 @@ type Fixtures = {
   ethSigner: EthSignerDriver;
   btcSigner: BtcSignerDriver;
   trxSigner: TrxSignerDriver;
+  xrpSigner: XrpSignerDriver;
   /** Build a Speculos driver for a connected device (its app must be opened). */
   speculos: (device: Device) => SpeculosDriver;
 };
@@ -73,6 +75,9 @@ export const test = base.extend<Fixtures>({
   },
   trxSigner: async ({ page }, use) => {
     await use(new TrxSignerDriver(page));
+  },
+  xrpSigner: async ({ page }, use) => {
+    await use(new XrpSignerDriver(page));
   },
   speculos: async ({ mockClient }, use, testInfo) => {
     const drivers: SpeculosDriver[] = [];

--- a/apps/sample/playwright/utils/drivers/ResponsesDriver.ts
+++ b/apps/sample/playwright/utils/drivers/ResponsesDriver.ts
@@ -35,4 +35,20 @@ export class ResponsesDriver {
     const body = last.locator("span", { hasText: '"status"' }).last();
     return JSON.parse(await body.innerText()) as T;
   }
+
+  /**
+   * Wait until the last response contains `until`, then return its raw text.
+   *
+   * Errored device actions are rendered with `util.inspect` rather than as
+   * JSON (see `DeviceActionResponse`), so they carry no `"status"` field and
+   * cannot go through {@link lastJson}.
+   */
+  async lastText(
+    until: string | RegExp,
+    { timeout = 30_000 }: { timeout?: number } = {},
+  ): Promise<string> {
+    const last = this.page.locator(RESPONSE_ITEMS).last();
+    await expect(last).toContainText(until, { timeout });
+    return last.innerText();
+  }
 }

--- a/apps/sample/playwright/utils/drivers/XrpSignerDriver.ts
+++ b/apps/sample/playwright/utils/drivers/XrpSignerDriver.ts
@@ -1,0 +1,86 @@
+import { expect, type Page } from "@playwright/test";
+
+import { ResponsesDriver } from "./ResponsesDriver";
+
+export interface DeviceActionResult<Output> {
+  status: string; // "completed" | "error" | "pending" | ...
+  output?: Output;
+  error?: unknown;
+}
+
+/**
+ * Drives the XRP signer view: navigating to it, executing device actions and
+ * reading back the emitted device-action states.
+ */
+export class XrpSignerDriver {
+  private readonly responses: ResponsesDriver;
+
+  constructor(private readonly page: Page) {
+    this.responses = new ResponsesDriver(page);
+  }
+
+  /** Navigate Signer Kits -> Xrp. */
+  async open(): Promise<void> {
+    await this.page.getByTestId("CTA_route-to-/signers").click();
+    await this.page.waitForURL("http://localhost:3000/signers");
+    await this.page.getByTestId("CTA_command-Xrp").click();
+    await this.page.waitForURL("http://localhost:3000/signers/xrp");
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  /**
+   * Open the Get App Config action and Execute it. With `skipOpenApp` the
+   * command is sent straight to the device, without opening the XRP app first.
+   */
+  async getAppConfig({
+    skipOpenApp = false,
+  }: { skipOpenApp?: boolean } = {}): Promise<void> {
+    await this.page.getByTestId("CTA_command-Get App Config").click();
+    await this.setSwitch("skipOpenApp", skipOpenApp);
+    await this.page.getByTestId("CTA_send-device-action").click();
+  }
+
+  /**
+   * Set a boolean form field to `checked`.
+   *
+   * The `input-switch_*` test id sits on a wrapper around the switch, and
+   * clicking that wrapper does not toggle it — the click has to land on the
+   * inner `role="button"` element. The state is read back from the underlying
+   * checkbox so the toggle is idempotent and a silently ignored click fails
+   * here rather than further down the test.
+   */
+  private async setSwitch(fieldKey: string, checked: boolean): Promise<void> {
+    const field = this.page.getByTestId(`input-switch_${fieldKey}`);
+    const checkbox = field.locator('input[type="checkbox"]');
+    await checkbox.waitFor({ state: "attached" });
+    if ((await checkbox.isChecked()) !== checked) {
+      await field.locator('[role="button"]').click();
+    }
+    await expect(checkbox).toBeChecked({ checked });
+  }
+
+  /**
+   * Wait for the last emitted device-action state to be terminal and return it
+   * parsed.
+   */
+  async lastResult<Output>({
+    timeout = 90_000,
+  }: { timeout?: number } = {}): Promise<DeviceActionResult<Output>> {
+    return this.responses.lastJson<DeviceActionResult<Output>>(
+      /"status": "(completed|error)"/,
+      { timeout },
+    );
+  }
+
+  /**
+   * Wait for the device action to fail and return the rendered error text.
+   *
+   * An errored device action is dumped with `util.inspect`, so it has no JSON
+   * body to parse — the caller asserts on the tag, status word and message.
+   */
+  async lastError({
+    timeout = 90_000,
+  }: { timeout?: number } = {}): Promise<string> {
+    return this.responses.lastText(/_tag: '/, { timeout });
+  }
+}

--- a/apps/sample/src/components/SignerView/index.tsx
+++ b/apps/sample/src/components/SignerView/index.tsx
@@ -59,7 +59,7 @@ const SUPPORTED_SIGNERS = [
   {
     title: "Xrp",
     description: "Access Xrp signer functionality",
-    icon: <CryptoIcon ledgerId="xrp" ticker="XRP" size={size} />,
+    icon: <CryptoIcon ledgerId="ripple" ticker="XRP" size={size} />,
   },
 ];
 

--- a/apps/sample/src/components/SignerXrpView/index.tsx
+++ b/apps/sample/src/components/SignerXrpView/index.tsx
@@ -32,17 +32,21 @@ export const SignerXrpView: React.FC<{ sessionId: string }> = ({
       {
         title: "Get App Config",
         description: "Get the app configuration from the device",
-        executeDeviceAction: () => {
+        executeDeviceAction: ({ skipOpenApp }) => {
           if (!signer) {
             throw new Error("Signer not initialized");
           }
-          return signer.getAppConfig();
+          return signer.getAppConfig({ skipOpenApp });
         },
-        initialValues: {},
+        initialValues: {
+          skipOpenApp: false,
+        },
         deviceModelId,
       } satisfies DeviceActionProps<
         GetAppConfigDAOutput,
-        Record<string, never>,
+        {
+          skipOpenApp?: boolean;
+        },
         GetAppConfigDAError,
         GetAppConfigDAIntermediateValue
       >,

--- a/packages/signer/signer-xrp/src/api/SignerXrp.ts
+++ b/packages/signer/signer-xrp/src/api/SignerXrp.ts
@@ -2,10 +2,11 @@ import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceAct
 import { type GetAppConfigDAReturnType } from "@api/app-binder/GetAppConfigDeviceActionTypes";
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { type AddressOptions } from "@api/model/AddressOptions";
+import { type AppConfigOptions } from "@api/model/AppConfigOptions";
 import { type TransactionOptions } from "@api/model/TransactionOptions";
 
 export interface SignerXrp {
-  getAppConfig: () => GetAppConfigDAReturnType;
+  getAppConfig: (options?: AppConfigOptions) => GetAppConfigDAReturnType;
 
   getAddress: (
     derivationPath: string,

--- a/packages/signer/signer-xrp/src/api/index.ts
+++ b/packages/signer/signer-xrp/src/api/index.ts
@@ -18,6 +18,7 @@ export {
 } from "@api/app-binder/SignTransactionDeviceActionTypes";
 export { type AddressOptions } from "@api/model/AddressOptions";
 export { type AppConfig } from "@api/model/AppConfig";
+export { type AppConfigOptions } from "@api/model/AppConfigOptions";
 export { type Signature } from "@api/model/Signature";
 export { type TransactionOptions } from "@api/model/TransactionOptions";
 export { type SignerXrp } from "@api/SignerXrp";

--- a/packages/signer/signer-xrp/src/api/model/AppConfigOptions.ts
+++ b/packages/signer/signer-xrp/src/api/model/AppConfigOptions.ts
@@ -1,0 +1,3 @@
+export type AppConfigOptions = {
+  skipOpenApp?: boolean;
+};

--- a/packages/signer/signer-xrp/src/internal/DefaultSignerXrp.test.ts
+++ b/packages/signer/signer-xrp/src/internal/DefaultSignerXrp.test.ts
@@ -1,0 +1,92 @@
+import {
+  type DeviceManagementKit,
+  type DeviceSessionId,
+  SendCommandInAppDeviceAction,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+import { from } from "rxjs";
+import { vi } from "vitest";
+
+import { GetAppConfigCommand } from "@internal/app-binder/command/GetAppConfigCommand";
+import { APP_NAME } from "@internal/app-binder/constants";
+
+import { DefaultSignerXrp } from "./DefaultSignerXrp";
+
+type GetAppConfigCallArgs = {
+  sessionId: DeviceSessionId;
+  deviceAction: {
+    input: {
+      command: GetAppConfigCommand;
+      appName: string;
+      requiredUserInteraction: UserInteractionRequired;
+      skipOpenApp: boolean;
+    };
+  };
+};
+
+describe("DefaultSignerXrp", () => {
+  const sessionId = "test-session-id" as DeviceSessionId;
+
+  const setup = () => {
+    const expectedResult = { observable: from([]), cancel: vi.fn() };
+    const executeDeviceAction = vi.fn().mockReturnValue(expectedResult);
+    const dmk = { executeDeviceAction } as unknown as DeviceManagementKit;
+
+    return {
+      executeDeviceAction,
+      expectedResult,
+      signer: new DefaultSignerXrp({ dmk, sessionId }),
+    };
+  };
+
+  it("should be defined", () => {
+    const signer = new DefaultSignerXrp({
+      dmk: {} as DeviceManagementKit,
+      sessionId,
+    });
+
+    expect(signer).toBeDefined();
+  });
+
+  describe("getAppConfig", () => {
+    it("should delegate to the use case and return its result", () => {
+      // GIVEN
+      const { executeDeviceAction, expectedResult, signer } = setup();
+
+      // WHEN
+      const result = signer.getAppConfig();
+
+      // THEN
+      expect(result).toBe(expectedResult);
+      expect(executeDeviceAction).toHaveBeenCalledTimes(1);
+
+      const callArgs = executeDeviceAction.mock
+        .calls[0]![0] as GetAppConfigCallArgs;
+      expect(callArgs.sessionId).toBe(sessionId);
+      expect(callArgs.deviceAction).toBeInstanceOf(
+        SendCommandInAppDeviceAction,
+      );
+      expect(callArgs.deviceAction.input.command).toBeInstanceOf(
+        GetAppConfigCommand,
+      );
+      expect(callArgs.deviceAction.input.appName).toBe(APP_NAME);
+      expect(callArgs.deviceAction.input.requiredUserInteraction).toBe(
+        UserInteractionRequired.None,
+      );
+      expect(callArgs.deviceAction.input.skipOpenApp).toBe(false);
+    });
+
+    it("should forward skipOpenApp", () => {
+      // GIVEN
+      const { executeDeviceAction, signer } = setup();
+
+      // WHEN
+      signer.getAppConfig({ skipOpenApp: true });
+
+      // THEN
+      const callArgs = executeDeviceAction.mock
+        .calls[0]![0] as GetAppConfigCallArgs;
+      expect(callArgs.deviceAction.input.skipOpenApp).toBe(true);
+    });
+  });
+});

--- a/packages/signer/signer-xrp/src/internal/DefaultSignerXrp.ts
+++ b/packages/signer/signer-xrp/src/internal/DefaultSignerXrp.ts
@@ -8,6 +8,7 @@ import { type GetAddressDAReturnType } from "@api/app-binder/GetAddressDeviceAct
 import { type GetAppConfigDAReturnType } from "@api/app-binder/GetAppConfigDeviceActionTypes";
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { type AddressOptions } from "@api/model/AddressOptions";
+import { type AppConfigOptions } from "@api/model/AppConfigOptions";
 import { type TransactionOptions } from "@api/model/TransactionOptions";
 import { type SignerXrp } from "@api/SignerXrp";
 import { makeContainer } from "@internal/di";
@@ -30,10 +31,10 @@ export class DefaultSignerXrp implements SignerXrp {
     this._container = makeContainer({ dmk, sessionId });
   }
 
-  getAppConfig(): GetAppConfigDAReturnType {
+  getAppConfig(options?: AppConfigOptions): GetAppConfigDAReturnType {
     return this._container
       .get<GetAppConfigUseCase>(configTypes.GetAppConfigUseCase)
-      .execute();
+      .execute(options);
   }
 
   getAddress(

--- a/packages/signer/signer-xrp/src/internal/use-cases/config/GetAppConfigUseCase.test.ts
+++ b/packages/signer/signer-xrp/src/internal/use-cases/config/GetAppConfigUseCase.test.ts
@@ -15,33 +15,63 @@ import { type XrpAppBinder } from "@internal/app-binder/XrpAppBinder";
 import { GetAppConfigUseCase } from "./GetAppConfigUseCase";
 
 describe("GetAppConfigUseCase", () => {
-  it("should return the result from appBinder.getAppConfig", () => {
-    // ARRANGE
-    const getAppConfigMock = vi.fn();
+  const expectedResult: ExecuteDeviceActionReturnType<
+    GetAppConfigDAOutput,
+    GetAppConfigDAError,
+    GetAppConfigDAIntermediateValue
+  > = {
+    observable: from([
+      {
+        status: DeviceActionStatus.Completed as const,
+        output: { version: "1.2.3" },
+      },
+    ]),
+    cancel: vi.fn(),
+  };
+
+  const setup = () => {
+    const getAppConfigMock = vi.fn().mockReturnValue(expectedResult);
     const appBinderMock = {
       getAppConfig: getAppConfigMock,
     } as unknown as XrpAppBinder;
-    const expectedResult: ExecuteDeviceActionReturnType<
-      GetAppConfigDAOutput,
-      GetAppConfigDAError,
-      GetAppConfigDAIntermediateValue
-    > = {
-      observable: from([
-        {
-          status: DeviceActionStatus.Completed as const,
-          output: { version: "1.2.3" },
-        },
-      ]),
-      cancel: vi.fn(),
-    };
-    getAppConfigMock.mockReturnValue(expectedResult);
-    const useCase = new GetAppConfigUseCase(appBinderMock);
 
-    // ACT
+    return {
+      getAppConfigMock,
+      useCase: new GetAppConfigUseCase(appBinderMock),
+    };
+  };
+
+  it("should return the result from appBinder.getAppConfig", () => {
+    // GIVEN
+    const { getAppConfigMock, useCase } = setup();
+
+    // WHEN
     const result = useCase.execute();
 
-    // ASSERT
+    // THEN
     expect(getAppConfigMock).toHaveBeenCalledWith({ skipOpenApp: false });
     expect(result).toEqual(expectedResult);
+  });
+
+  it("should default skipOpenApp to false when no option is given", () => {
+    // GIVEN
+    const { getAppConfigMock, useCase } = setup();
+
+    // WHEN
+    useCase.execute({});
+
+    // THEN
+    expect(getAppConfigMock).toHaveBeenCalledWith({ skipOpenApp: false });
+  });
+
+  it("should forward skipOpenApp", () => {
+    // GIVEN
+    const { getAppConfigMock, useCase } = setup();
+
+    // WHEN
+    useCase.execute({ skipOpenApp: true });
+
+    // THEN
+    expect(getAppConfigMock).toHaveBeenCalledWith({ skipOpenApp: true });
   });
 });

--- a/packages/signer/signer-xrp/src/internal/use-cases/config/GetAppConfigUseCase.ts
+++ b/packages/signer/signer-xrp/src/internal/use-cases/config/GetAppConfigUseCase.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from "inversify";
 
 import { type GetAppConfigDAReturnType } from "@api/app-binder/GetAppConfigDeviceActionTypes";
+import { type AppConfigOptions } from "@api/model/AppConfigOptions";
 import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
 import { XrpAppBinder } from "@internal/app-binder/XrpAppBinder";
 
@@ -12,9 +13,9 @@ export class GetAppConfigUseCase {
     this._appBinder = appBinder;
   }
 
-  execute(): GetAppConfigDAReturnType {
+  execute(options?: AppConfigOptions): GetAppConfigDAReturnType {
     return this._appBinder.getAppConfig({
-      skipOpenApp: false,
+      skipOpenApp: options?.skipOpenApp ?? false,
     });
   }
 }


### PR DESCRIPTION
> [!NOTE]
> Stacked on top of #1776 ([DSDK-1435](https://ledgerhq.atlassian.net/browse/DSDK-1435)) — this PR targets `feat/dsdk-1435-xrp-get-app-config`, so review only the last three commits. Retarget to `develop` once #1776 is merged.

### 📝 Description

Wires `getAppConfig` through the full stack so it can be run from the sample app.

`SignerXrp.getAppConfig` now accepts an optional `AppConfigOptions` (`{ skipOpenApp?: boolean }`), threaded through `DefaultSignerXrp` and `GetAppConfigUseCase` down to the app binder and defaulting to `false`:

```typescript
const { observable, cancel } = signerXrp.getAppConfig({ skipOpenApp: true });
```

The sample app's "Get App Config" action exposes the `skipOpenApp` switch accordingly.

Also fixes the XRP icon in the sample's signer list: `CryptoIcon` resolves icons at runtime from `crypto-icons.ledger.com/index.json`, keyed by Ledger currency id, and that index has no `xrp` entry — XRP's id is `ripple` — so the lookup returned null and no icon rendered.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1436](https://ledgerhq.atlassian.net/browse/DSDK-1436)
- **Feature**: XRP signer — get app configuration use case and sample integration

### ✅ Checklist

- [x] **Covered by automatic tests**
  - Unit: `GetAppConfigUseCase.test.ts` (defaults `skipOpenApp` to `false`, forwards an explicit value) and a new `DefaultSignerXrp.test.ts` (delegation, device-action input, `skipOpenApp` forwarding).
  - E2E: new `apps/sample/playwright/cases/signers/xrp/get-app-config.spec.ts` — two mocked-APDU cases (`skipOpenApp` happy path, `6985` rejection) plus one that opens the **real** XRP app on a Speculos emulator (stax `1.10.1` / XRP `2.6.1`) with no mock registered, asserting the reported version and that a live Speculos instance backed the device.
- [x] **Changeset is provided** — `.changeset/free-crews-admire.md`
- [x] **Documentation is up-to-date** — `apps/docs/content/docs/references/signers/xrp.mdx` documents the new `AppConfigOptions` parameter.
- [ ] **Impact of the changes:**
  - `SignerXrp.getAppConfig` gains an optional parameter — backwards compatible, existing no-arg calls keep the previous behaviour.
  - Sample app: `skipOpenApp` switch on the XRP "Get App Config" action, and the XRP list icon now renders.
  - New Playwright driver (`XrpSignerDriver`) and fixture; `ResponsesDriver` gains `lastText` for errored device actions, which render via `util.inspect` and so carry no JSON `status` field.
  - The full Playwright suite passes on CI — 49/49 in 1.1m, the real-Speculos XRP test included ([run 32717244482](https://github.com/LedgerHQ/device-sdk-ts/actions/runs/32717244482/job/97401440139)).


[DSDK-1435]: https://ledgerhq.atlassian.net/browse/DSDK-1435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSDK-1436]: https://ledgerhq.atlassian.net/browse/DSDK-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
