### PR TITLE
✨ (signer-xrp) [DSDK-1437]: Add GetAddress command

### DIFF
--- a/.changeset/xrp-get-address-command.md
+++ b/.changeset/xrp-get-address-command.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-xrp": minor
+---
+
+Implement the XRP `GetAddressCommand`. It builds the `E0 02` APDU with P1 selecting display-and-confirm and P2 carrying the secp256k1 curve selector OR-ed with the return-chain-code flag, followed by the derivation path as a count byte and big-endian 32-bit elements. The response is parsed by its length prefixes into `{ publicKey, address, chainCode? }`, with the public key hex encoded and the address passed through as the ASCII the app returns. Adds the `Address` API model and a shared `validateDerivationPath` helper enforcing the app's 10-element limit.

--- a/packages/signer/signer-xrp/src/api/app-binder/GetAddressCommandTypes.ts
+++ b/packages/signer/signer-xrp/src/api/app-binder/GetAddressCommandTypes.ts
@@ -1,0 +1,11 @@
+import { type Address } from "@api/model/Address";
+
+export type GetAddressCommandArgs = {
+  readonly derivationPath: string;
+  /** Display the address on the device and wait for the user to confirm it. */
+  readonly checkOnDevice?: boolean;
+  /** Ask the app to append the BIP32 chain code to its answer. */
+  readonly returnChainCode?: boolean;
+};
+
+export type GetAddressCommandResponse = Address;

--- a/packages/signer/signer-xrp/src/api/app-binder/GetAddressDeviceActionTypes.ts
+++ b/packages/signer/signer-xrp/src/api/app-binder/GetAddressDeviceActionTypes.ts
@@ -7,7 +7,7 @@ import {
   type UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
 
-import { type GetAddressCommandResponse } from "@internal/app-binder/command/GetAddressCommand";
+import { type GetAddressCommandResponse } from "@api/app-binder/GetAddressCommandTypes";
 import { type XrpErrorCodes } from "@internal/app-binder/command/utils/xrpApplicationErrors";
 
 type GetAddressDAUserInteractionRequired =

--- a/packages/signer/signer-xrp/src/api/index.ts
+++ b/packages/signer/signer-xrp/src/api/index.ts
@@ -1,4 +1,8 @@
 export {
+  type GetAddressCommandArgs,
+  type GetAddressCommandResponse,
+} from "@api/app-binder/GetAddressCommandTypes";
+export {
   type GetAddressDAError,
   type GetAddressDAIntermediateValue,
   type GetAddressDAOutput,
@@ -16,6 +20,7 @@ export {
   type SignTransactionDAOutput,
   type SignTransactionDAReturnType,
 } from "@api/app-binder/SignTransactionDeviceActionTypes";
+export { type Address } from "@api/model/Address";
 export { type AddressOptions } from "@api/model/AddressOptions";
 export { type AppConfig } from "@api/model/AppConfig";
 export { type AppConfigOptions } from "@api/model/AppConfigOptions";

--- a/packages/signer/signer-xrp/src/api/model/Address.ts
+++ b/packages/signer/signer-xrp/src/api/model/Address.ts
@@ -1,0 +1,16 @@
+export type Address = {
+  /**
+   * The public key the application returned, hex encoded. Its width is not
+   * fixed: app-xrp compresses it to 33 bytes, while the APDU spec describes an
+   * uncompressed 65 byte key. The app length-prefixes it and it is parsed by
+   * that prefix, so callers should not assume either size.
+   */
+  readonly publicKey: string;
+  /**
+   * The XRP address. The application returns it as ASCII and it is passed
+   * through as-is — unlike the Ethereum signer, there is no `0x` prefix.
+   */
+  readonly address: string;
+  /** BIP32 chain code, hex encoded. Only set when it was requested. */
+  readonly chainCode?: string;
+};

--- a/packages/signer/signer-xrp/src/internal/app-binder/command/GetAddressCommand.test.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/command/GetAddressCommand.test.ts
@@ -1,0 +1,377 @@
+import {
+  ApduResponse,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { GetAddressCommand } from "@internal/app-binder/command/GetAddressCommand";
+import {
+  INS,
+  XRP_CLA,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import { DerivationPathTooLongError } from "@internal/app-binder/command/utils/validateDerivationPath";
+import { type XrpAppCommandError } from "@internal/app-binder/command/utils/xrpApplicationErrors";
+
+const DERIVATION_PATH = "44'/144'/0'/0/0";
+
+// The path above, encoded the way the legacy hw-app-xrp client emits it: a
+// count byte then each element as a big-endian u32, hardened elements OR-ed
+// with 0x80000000.
+const ENCODED_PATH = [
+  0x05, 0x80, 0x00, 0x00, 0x2c, 0x80, 0x00, 0x00, 0x90, 0x80, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+];
+
+const buildExpectedApdu = (p1: number, p2: number) =>
+  Uint8Array.from([
+    XRP_CLA,
+    INS.GET_PUBLIC_KEY,
+    p1,
+    p2,
+    ENCODED_PATH.length,
+    ...ENCODED_PATH,
+  ]);
+
+// Uncompressed secp256k1 public key: 0x04 then two 32-byte coordinates.
+const PUBLIC_KEY = Uint8Array.from([
+  0x04,
+  ...Array.from({ length: 64 }, (_, i) => (i + 1) & 0xff),
+]);
+const PUBLIC_KEY_HEX =
+  "04" +
+  Array.from({ length: 64 }, (_, i) =>
+    ((i + 1) & 0xff).toString(16).padStart(2, "0"),
+  ).join("");
+
+const ADDRESS = "rDsbeomae4FXwgQTJp9Rs64Qg9vDiTCdBv";
+const ADDRESS_BYTES = Array.from(ADDRESS, (c) => c.charCodeAt(0));
+
+const CHAIN_CODE = Uint8Array.from(
+  Array.from({ length: 32 }, (_, i) => (0xa0 + i) & 0xff),
+);
+const CHAIN_CODE_HEX = Array.from(CHAIN_CODE, (b) =>
+  b.toString(16).padStart(2, "0"),
+).join("");
+
+const success = (data: number[]) =>
+  new ApduResponse({
+    statusCode: Uint8Array.from([0x90, 0x00]),
+    data: Uint8Array.from(data),
+  });
+
+const nominalBody = ({ withChainCode = false } = {}) => [
+  PUBLIC_KEY.length,
+  ...PUBLIC_KEY,
+  ADDRESS_BYTES.length,
+  ...ADDRESS_BYTES,
+  ...(withChainCode ? Array.from(CHAIN_CODE) : []),
+];
+
+describe("GetAddressCommand", () => {
+  describe("name", () => {
+    it("should be 'GetAddress'", () => {
+      expect(
+        new GetAddressCommand({ derivationPath: DERIVATION_PATH }).name,
+      ).toBe("GetAddress");
+    });
+  });
+
+  describe("getApdu", () => {
+    // 2 display x 2 chain code, the curve selector being always secp256k1.
+    const matrix: {
+      checkOnDevice: boolean;
+      returnChainCode: boolean;
+      p1: number;
+      p2: number;
+    }[] = [
+      {
+        checkOnDevice: false,
+        returnChainCode: false,
+        p1: 0x00,
+        p2: 0x40,
+      },
+      {
+        checkOnDevice: false,
+        returnChainCode: true,
+        p1: 0x00,
+        p2: 0x41,
+      },
+      {
+        checkOnDevice: true,
+        returnChainCode: false,
+        p1: 0x01,
+        p2: 0x40,
+      },
+      {
+        checkOnDevice: true,
+        returnChainCode: true,
+        p1: 0x01,
+        p2: 0x41,
+      },
+    ];
+
+    it.each(matrix)(
+      "should build P1=$p1 P2=$p2 for checkOnDevice=$checkOnDevice returnChainCode=$returnChainCode",
+      ({ checkOnDevice, returnChainCode, p1, p2 }) => {
+        // GIVEN
+        const command = new GetAddressCommand({
+          derivationPath: DERIVATION_PATH,
+          checkOnDevice,
+          returnChainCode,
+        });
+
+        // WHEN
+        const apdu = command.getApdu();
+
+        // THEN
+        expect(apdu.getRawApdu()).toStrictEqual(buildExpectedApdu(p1, p2));
+      },
+    );
+
+    it("should default to no display and no chain code", () => {
+      // GIVEN
+      const command = new GetAddressCommand({
+        derivationPath: DERIVATION_PATH,
+      });
+
+      // WHEN
+      const apdu = command.getApdu();
+
+      // THEN
+      expect(apdu.getRawApdu()).toStrictEqual(buildExpectedApdu(0x00, 0x40));
+    });
+
+    it("should accept a 10 element derivation path", () => {
+      // GIVEN
+      const command = new GetAddressCommand({
+        derivationPath: "44'/144'/0'/0/0/0/0/0/0/0",
+      });
+
+      // WHEN / THEN
+      expect(() => command.getApdu()).not.toThrow();
+    });
+
+    it("should reject a derivation path longer than 10 elements", () => {
+      // GIVEN
+      const command = new GetAddressCommand({
+        derivationPath: "44'/144'/0'/0/0/0/0/0/0/0/0",
+      });
+
+      // WHEN / THEN
+      expect(() => command.getApdu()).toThrow(DerivationPathTooLongError);
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("should parse the public key and the ASCII address", () => {
+      // GIVEN
+      const command = new GetAddressCommand({
+        derivationPath: DERIVATION_PATH,
+      });
+
+      // WHEN
+      const result = command.parseResponse(success(nominalBody()));
+
+      // THEN
+      if (!isSuccessCommandResult(result)) {
+        assert.fail("Expected a success");
+      }
+      expect(result.data.publicKey).toBe(PUBLIC_KEY_HEX);
+      expect(result.data.publicKey).toHaveLength(130); // 65 bytes
+      // Passed through as-is: no `0x` prefix, unlike the Ethereum signer.
+      expect(result.data.address).toBe(ADDRESS);
+      expect(result.data.chainCode).toBeUndefined();
+    });
+
+    it("should parse a compressed public key, as the app actually sends", () => {
+      // GIVEN the 33 byte key the app compresses its answer down to, which is
+      // shorter than the 65 bytes the APDU spec describes — the length prefix
+      // is what decides, never a constant.
+      const compressedKey = [
+        0x02,
+        ...Array.from({ length: 32 }, (_, i) => (i + 1) & 0xff),
+      ];
+      const command = new GetAddressCommand({
+        derivationPath: DERIVATION_PATH,
+      });
+
+      // WHEN
+      const result = command.parseResponse(
+        success([
+          compressedKey.length,
+          ...compressedKey,
+          ADDRESS_BYTES.length,
+          ...ADDRESS_BYTES,
+        ]),
+      );
+
+      // THEN
+      if (!isSuccessCommandResult(result)) {
+        assert.fail("Expected a success");
+      }
+      expect(result.data.publicKey).toHaveLength(66); // 33 bytes
+      expect(result.data.address).toBe(ADDRESS);
+    });
+
+    it("should parse the chain code when it was requested", () => {
+      // GIVEN
+      const command = new GetAddressCommand({
+        derivationPath: DERIVATION_PATH,
+        returnChainCode: true,
+      });
+
+      // WHEN
+      const result = command.parseResponse(
+        success(nominalBody({ withChainCode: true })),
+      );
+
+      // THEN
+      if (!isSuccessCommandResult(result)) {
+        assert.fail("Expected a success");
+      }
+      expect(result.data.chainCode).toBe(CHAIN_CODE_HEX);
+    });
+
+    it("should ignore trailing chain code bytes when it was not requested", () => {
+      // GIVEN
+      const command = new GetAddressCommand({
+        derivationPath: DERIVATION_PATH,
+      });
+
+      // WHEN
+      const result = command.parseResponse(
+        success(nominalBody({ withChainCode: true })),
+      );
+
+      // THEN
+      if (!isSuccessCommandResult(result)) {
+        assert.fail("Expected a success");
+      }
+      expect(result.data.address).toBe(ADDRESS);
+      expect(result.data.chainCode).toBeUndefined();
+    });
+
+    describe("truncated responses", () => {
+      const cases: { name: string; data: number[]; message: string }[] = [
+        {
+          name: "public key length is missing",
+          data: [],
+          message: "Cannot extract public key length",
+        },
+        {
+          name: "public key is truncated",
+          data: [PUBLIC_KEY.length, ...Array.from(PUBLIC_KEY).slice(0, 10)],
+          message: "Cannot extract public key",
+        },
+        {
+          name: "address length is missing",
+          data: [PUBLIC_KEY.length, ...PUBLIC_KEY],
+          message: "Cannot extract address length",
+        },
+        {
+          name: "address is truncated",
+          data: [
+            PUBLIC_KEY.length,
+            ...PUBLIC_KEY,
+            ADDRESS_BYTES.length,
+            ...ADDRESS_BYTES.slice(0, 5),
+          ],
+          message: "Cannot extract address",
+        },
+      ];
+
+      it.each(cases)("should fail when the $name", ({ data, message }) => {
+        // GIVEN
+        const command = new GetAddressCommand({
+          derivationPath: DERIVATION_PATH,
+        });
+
+        // WHEN
+        const result = command.parseResponse(success(data));
+
+        // THEN
+        if (isSuccessCommandResult(result)) {
+          assert.fail("Expected an error");
+        }
+        expect(result.error).toEqual(
+          expect.objectContaining({
+            _tag: "InvalidResponseFormatError",
+            originalError: new Error(message),
+          }),
+        );
+      });
+
+      it("should fail when the chain code is truncated", () => {
+        // GIVEN
+        const command = new GetAddressCommand({
+          derivationPath: DERIVATION_PATH,
+          returnChainCode: true,
+        });
+
+        // WHEN
+        const result = command.parseResponse(
+          success([...nominalBody(), ...Array.from(CHAIN_CODE).slice(0, 16)]),
+        );
+
+        // THEN
+        if (isSuccessCommandResult(result)) {
+          assert.fail("Expected an error");
+        }
+        expect(result.error).toEqual(
+          expect.objectContaining({
+            _tag: "InvalidResponseFormatError",
+            originalError: new Error("Cannot extract chain code"),
+          }),
+        );
+      });
+    });
+
+    it("should map an XRP app status word to an XRP app error", () => {
+      // GIVEN
+      const command = new GetAddressCommand({
+        derivationPath: DERIVATION_PATH,
+        checkOnDevice: true,
+      });
+
+      // WHEN
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x69, 0x85]),
+          data: new Uint8Array(0),
+        }),
+      );
+
+      // THEN
+      if (isSuccessCommandResult(result)) {
+        assert.fail("Expected an error");
+      }
+      const error = result.error as XrpAppCommandError;
+      expect(error.errorCode).toBe("6985");
+      expect(error.message).toBe(
+        "Condition of use not satisfied (Rejected by user)",
+      );
+    });
+
+    it("should map an invalid derivation path status word", () => {
+      // GIVEN
+      const command = new GetAddressCommand({
+        derivationPath: DERIVATION_PATH,
+      });
+
+      // WHEN
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x6a, 0x81]),
+          data: new Uint8Array(0),
+        }),
+      );
+
+      // THEN
+      if (isSuccessCommandResult(result)) {
+        assert.fail("Expected an error");
+      }
+      const error = result.error as XrpAppCommandError;
+      expect(error.errorCode).toBe("6a81");
+      expect(error.message).toBe("Invalid derivation path");
+    });
+  });
+});

--- a/packages/signer/signer-xrp/src/internal/app-binder/command/GetAddressCommand.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/command/GetAddressCommand.ts
@@ -1,22 +1,51 @@
 import {
   type Apdu,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  ApduParser,
   type ApduResponse,
   type Command,
   type CommandResult,
+  CommandResultFactory,
+  InvalidResponseFormatError,
 } from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
 
-import { type XrpErrorCodes } from "./utils/xrpApplicationErrors";
+import {
+  type GetAddressCommandArgs,
+  type GetAddressCommandResponse,
+} from "@api/app-binder/GetAddressCommandTypes";
 
-export type GetAddressCommandArgs = {
-  readonly derivationPath: string;
-  readonly checkOnDevice?: boolean;
-};
+import {
+  INS,
+  P1_DEFAULT,
+  P1_DISPLAY,
+  P2_RETURN_CHAIN_CODE,
+  P2_SECP256K1,
+  XRP_CLA,
+} from "./utils/apduHeaderUtils";
+import { validateDerivationPath } from "./utils/validateDerivationPath";
+import {
+  XRP_APP_ERRORS,
+  XrpAppCommandErrorFactory,
+  type XrpErrorCodes,
+} from "./utils/xrpApplicationErrors";
 
-export type GetAddressCommandResponse = {
-  readonly publicKey: Uint8Array;
-  readonly chainCode?: Uint8Array;
-};
+const CHAIN_CODE_LENGTH = 32;
 
+export type { GetAddressCommandArgs, GetAddressCommandResponse };
+
+/**
+ * Retrieves an address, and the public key it derives from, from the XRP
+ * application.
+ *
+ * The device answers with
+ * `[pkLen][publicKey][addressLen][address][chainCode?]`, where the public key
+ * is compressed to 33 bytes by the app and the address is ASCII. Both are
+ * length-prefixed, so they are parsed by their prefix rather than by a fixed
+ * size.
+ */
 export class GetAddressCommand
   implements
     Command<GetAddressCommandResponse, GetAddressCommandArgs, XrpErrorCodes>
@@ -25,27 +54,96 @@ export class GetAddressCommand
 
   private readonly args: GetAddressCommandArgs;
 
+  private readonly errorHelper = new CommandErrorHelper<
+    GetAddressCommandResponse,
+    XrpErrorCodes
+  >(XRP_APP_ERRORS, XrpAppCommandErrorFactory);
+
   constructor(args: GetAddressCommandArgs) {
     this.args = args;
   }
 
   getApdu(): Apdu {
-    // TODO: Implement APDU construction based on your blockchain's protocol
-    // Example structure:
-    // const builder = new ApduBuilder({ cla: 0xe0, ins: 0x02, p1: 0x00, p2: 0x00 });
-    // Add derivation path and other data to builder
-    // return builder.build();
-    // `this.args` holds the command input; never log it, it carries
-    // derivation paths and transaction data.
-    void this.args;
-    throw new Error("GetAddressCommand.getApdu() not implemented");
+    const { derivationPath, checkOnDevice, returnChainCode } = this.args;
+
+    const getAddressArgs: ApduBuilderArgs = {
+      cla: XRP_CLA,
+      ins: INS.GET_PUBLIC_KEY,
+      p1: checkOnDevice ? P1_DISPLAY : P1_DEFAULT,
+      // P2 is a bitmask: the curve selector in the high bits, the chain code
+      // flag in the low bit.
+      p2: P2_SECP256K1 | (returnChainCode ? P2_RETURN_CHAIN_CODE : 0x00),
+    };
+
+    const builder = new ApduBuilder(getAddressArgs);
+    const path = validateDerivationPath(derivationPath);
+
+    builder.add8BitUIntToData(path.length);
+    path.forEach((element) => {
+      builder.add32BitUIntToData(element);
+    });
+
+    return builder.build();
   }
 
   parseResponse(
-    _apduResponse: ApduResponse,
+    apduResponse: ApduResponse,
   ): CommandResult<GetAddressCommandResponse, XrpErrorCodes> {
-    // TODO: Implement response parsing based on your blockchain's protocol
-    // return CommandResultFactory({ data: { ... } });
-    throw new Error("GetAddressCommand.parseResponse() not implemented");
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      const parser = new ApduParser(apduResponse);
+
+      const publicKeyLength = parser.extract8BitUInt();
+      if (publicKeyLength === undefined) {
+        return CommandResultFactory({
+          error: new InvalidResponseFormatError(
+            "Cannot extract public key length",
+          ),
+        });
+      }
+      if (!parser.testMinimalLength(publicKeyLength)) {
+        return CommandResultFactory({
+          error: new InvalidResponseFormatError("Cannot extract public key"),
+        });
+      }
+      const publicKey = parser.encodeToHexaString(
+        parser.extractFieldByLength(publicKeyLength),
+      );
+
+      const addressLength = parser.extract8BitUInt();
+      if (addressLength === undefined) {
+        return CommandResultFactory({
+          error: new InvalidResponseFormatError(
+            "Cannot extract address length",
+          ),
+        });
+      }
+      if (!parser.testMinimalLength(addressLength)) {
+        return CommandResultFactory({
+          error: new InvalidResponseFormatError("Cannot extract address"),
+        });
+      }
+      // The app returns the address as ASCII, so it is passed through as-is.
+      const address = parser.encodeToString(
+        parser.extractFieldByLength(addressLength),
+      );
+
+      let chainCode: string | undefined = undefined;
+      if (this.args.returnChainCode) {
+        if (!parser.testMinimalLength(CHAIN_CODE_LENGTH)) {
+          return CommandResultFactory({
+            error: new InvalidResponseFormatError("Cannot extract chain code"),
+          });
+        }
+        chainCode = parser.encodeToHexaString(
+          parser.extractFieldByLength(CHAIN_CODE_LENGTH),
+        );
+      }
+
+      return CommandResultFactory({
+        data: { publicKey, address, chainCode },
+      });
+    });
   }
 }

--- a/packages/signer/signer-xrp/src/internal/app-binder/command/utils/apduHeaderUtils.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/command/utils/apduHeaderUtils.ts
@@ -11,3 +11,15 @@ export const INS = {
 
 export const P1_DEFAULT = 0x00 as const;
 export const P2_DEFAULT = 0x00 as const;
+
+/** P1 asking the app to display the address and wait for a confirmation. */
+export const P1_DISPLAY = 0x01 as const;
+
+/**
+ * P2 curve selector. The app rejects a P2 that names no curve, so this is
+ * always set.
+ */
+export const P2_SECP256K1 = 0x40 as const;
+
+/** P2 flag, OR-ed with the curve selector, asking for the chain code. */
+export const P2_RETURN_CHAIN_CODE = 0x01 as const;

--- a/packages/signer/signer-xrp/src/internal/app-binder/command/utils/validateDerivationPath.test.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/command/utils/validateDerivationPath.test.ts
@@ -1,0 +1,52 @@
+import {
+  DerivationPathTooLongError,
+  MAX_DERIVATION_PATH_LENGTH,
+  validateDerivationPath,
+} from "./validateDerivationPath";
+
+describe("validateDerivationPath", () => {
+  it("should split a path into its elements, hardening with 0x80000000", () => {
+    // WHEN
+    const path = validateDerivationPath("44'/144'/0'/0/0");
+
+    // THEN
+    expect(path).toStrictEqual([
+      0x8000002c, 0x80000090, 0x80000000, 0x00000000, 0x00000000,
+    ]);
+  });
+
+  it("should accept a path of exactly the maximum length", () => {
+    // GIVEN
+    const derivationPath = Array(MAX_DERIVATION_PATH_LENGTH)
+      .fill("0")
+      .join("/");
+
+    // WHEN
+    const path = validateDerivationPath(derivationPath);
+
+    // THEN
+    expect(path).toHaveLength(MAX_DERIVATION_PATH_LENGTH);
+  });
+
+  it("should reject a path longer than the maximum length", () => {
+    // GIVEN
+    const derivationPath = Array(MAX_DERIVATION_PATH_LENGTH + 1)
+      .fill("0")
+      .join("/");
+
+    // WHEN / THEN
+    expect(() => validateDerivationPath(derivationPath)).toThrow(
+      DerivationPathTooLongError,
+    );
+    expect(() => validateDerivationPath(derivationPath)).toThrow(
+      `Derivation path has 11 elements, the XRP app accepts at most 10`,
+    );
+  });
+
+  it("should propagate the split error for a malformed path", () => {
+    // WHEN / THEN
+    expect(() => validateDerivationPath("44'/not-a-number")).toThrow(
+      "invalid number provided",
+    );
+  });
+});

--- a/packages/signer/signer-xrp/src/internal/app-binder/command/utils/validateDerivationPath.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/command/utils/validateDerivationPath.ts
@@ -1,0 +1,38 @@
+import { DerivationPathUtils } from "@ledgerhq/signer-utils";
+
+/**
+ * The XRP application accepts at most 10 derivation path elements
+ * (`doc/xrpapp.asc`), so a longer path is rejected here rather than being sent
+ * to the device only to come back as an opaque status word.
+ */
+export const MAX_DERIVATION_PATH_LENGTH = 10;
+
+export class DerivationPathTooLongError extends Error {
+  constructor(readonly length: number) {
+    super(
+      `Derivation path has ${length} elements, the XRP app accepts at most ${MAX_DERIVATION_PATH_LENGTH}`,
+    );
+    this.name = "DerivationPathTooLongError";
+  }
+}
+
+/**
+ * Split a BIP32 derivation path into its elements and enforce the app's limit.
+ *
+ * Shared by the GetAddress and Sign commands, which encode the path the same
+ * way: a single byte holding the number of elements, then each element as a
+ * big-endian 32-bit unsigned integer.
+ *
+ * @param derivationPath a path in BIP32 format, e.g. "44'/144'/0'/0/0"
+ * @throws DerivationPathTooLongError when the path exceeds
+ *   {@link MAX_DERIVATION_PATH_LENGTH} elements
+ */
+export function validateDerivationPath(derivationPath: string): number[] {
+  const path = DerivationPathUtils.splitPath(derivationPath);
+
+  if (path.length > MAX_DERIVATION_PATH_LENGTH) {
+    throw new DerivationPathTooLongError(path.length);
+  }
+
+  return path;
+}


### PR DESCRIPTION
> [!NOTE]
> Base of a two-PR stack: the use case and sample wiring follow in the stacked PR for [DSDK-1438](https://ledgerhq.atlassian.net/browse/DSDK-1438).

### 📝 Description

Implements `GetAddressCommand` for the XRP signer.

The command builds the `E0 02` APDU with P1 selecting display-and-confirm and P2 carrying the secp256k1 curve selector OR-ed with the return-chain-code flag, followed by the derivation path as a count byte and big-endian 32-bit elements. The length-prefixed response is parsed into `{ publicKey, address, chainCode? }`, with the address passed through as the ASCII the app returns — no `0x` prefix, unlike the Ethereum signer.

Also adds the `Address` API model and a shared `validateDerivationPath` helper enforcing the app's 10-element limit, which the sign command will reuse.

Command only — the DI / use case / sample wiring is the stacked follow-up for [DSDK-1438](https://ledgerhq.atlassian.net/browse/DSDK-1438).

#### ⚠️ Two deviations from the ticket, both deliberate

**1. ed25519 is not exposed.** The ticket scopes `api/model/Curve.ts` with `SECP256K1 = 0x40` / `ED25519 = 0x80`, and `doc/xrpapp.asc` does document both curves. But ed25519 does not work on the device:

- Against `app-xrp 2.6.1` on Speculos, an otherwise identical ed25519 request answers `6f88` — "Technical problem (Internal error, please report)" — on both `44'/144'/0'/0/0` and a fully hardened `44'/144'/0'/0'/0'`, while secp256k1 succeeds on both.
- The cause is in the app: [`handle_get_public_key`](https://github.com/LedgerHQ/app-xrp/blob/develop/src/apdu/messages/get_public_key.c) correctly selects `CX_CURVE_Ed25519` for P2 `0x80`, but [`get_public_key`](https://github.com/LedgerHQ/app-xrp/blob/develop/src/xrp/xrp_pub_key.c) then hands that curve to `bip32_derive_get_pubkey_256`, the SDK helper for 256-bit Weierstrass curves. Ed25519 needs SLIP-10 derivation via a different entry point. The non-zero result is returned straight out as the status word.
- Tellingly, `xrp_compress_public_key` has a fully written `CX_CURVE_Ed25519` branch that can never run, because derivation fails first. `sign_transaction.c` does the same curve selection, so it is likely broken identically.
- Ledger Live never passes the flag either: [`families/xrp/getAddress.ts`](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledger-live-common/src/families/xrp/getAddress.ts) calls `signer.getAddress(path, verify, false)` — three arguments — so `curveMask` is always `0x40`.

So a `curve` option would be an API surface that cannot succeed and that nothing calls. P2 is set to secp256k1 unconditionally via a `P2_SECP256K1` constant. This should be raised with the app team; if it is fixed, adding the option back is a small change.

**2. The public key is compressed, not uncompressed.** The ticket says "Public key is uncompressed (65 bytes for secp256k1)". The app returns **33 bytes**: `XRP_PUBKEY_SIZE` is 33 and `set_result_get_public_key` calls `xrp_compress_public_key` before answering. Parsing by the length prefix — which the ticket rightly asks for — handles this; the unit tests cover both a 33-byte and a 65-byte key so neither width is hardcoded.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1437](https://ledgerhq.atlassian.net/browse/DSDK-1437)
- **Feature**: XRP signer — get address

### ✅ Checklist

- [x] **Covered by automatic tests** — `GetAddressCommand.test.ts` asserts the full P1 × P2 matrix (2 display × 2 chain code), rejects paths over 10 elements, parses both compressed and 65-byte keys, covers all four truncation boundaries plus a truncated chain code, and maps app status words. `validateDerivationPath.test.ts` covers the shared guard. The APDU bytes are asserted against an independently hand-encoded path rather than against the builder itself.
- [x] **Changeset is provided** — `.changeset/xrp-get-address-command.md`
- [x] **Documentation is up-to-date** — no signer-level API change in this PR; the docs land with DSDK-1438.
- [ ] **Impact of the changes:**
  - `@ledgerhq/device-signer-kit-xrp` only.
  - `GetAddressCommand` now sends a real APDU instead of the scaffolded stub.
  - New public `Address` model; `GetAddressCommandArgs` / `GetAddressCommandResponse` move to `api/app-binder/GetAddressCommandTypes.ts`.


[DSDK-1438]: https://ledgerhq.atlassian.net/browse/DSDK-1438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSDK-1438]: https://ledgerhq.atlassian.net/browse/DSDK-1438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSDK-1437]: https://ledgerhq.atlassian.net/browse/DSDK-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ