### PR TITLE
✨ (signer-xrp) [DSDK-1439]: Add SignTransaction command

### DIFF
--- a/.changeset/xrp-sign-transaction-command.md
+++ b/.changeset/xrp-sign-transaction-command.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-xrp": minor
+---
+
+Implement the XRP `SignTransactionCommand`. It builds the `E0 04` APDU for a single chunk, encoding its position in the sequence into P1 (`00` first and last, `80` first with more to come, `81` a middle chunk, `01` the last of several) and selecting secp256k1 in P2. The chunk is written as-is, so splitting the payload stays with the signing task. `parseResponse` returns `Maybe<Signature>` — the DER signature on the final chunk, `Nothing` for the empty body that acknowledges the others. `Signature` is now a `Uint8Array`, since DER signatures are variable length and are not the Ethereum signer's `{ r, s, v }`.

--- a/packages/signer/signer-xrp/src/api/model/Signature.ts
+++ b/packages/signer/signer-xrp/src/api/model/Signature.ts
@@ -1,6 +1,6 @@
-export type Signature = {
-  r: string;
-  s: string;
-  v?: number;
-  // Adjust based on your blockchain's signature format
-};
+/**
+ * A transaction signature as the XRP application returns it: DER-encoded for
+ * secp256k1. Its length varies, so it is kept as raw bytes rather than being
+ * split into `{ r, s, v }` the way the Ethereum signer does.
+ */
+export type Signature = Uint8Array;

--- a/packages/signer/signer-xrp/src/internal/app-binder/command/SignTransactionCommand.test.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/command/SignTransactionCommand.test.ts
@@ -1,0 +1,187 @@
+import {
+  ApduResponse,
+  isSuccessCommandResult,
+} from "@ledgerhq/device-management-kit";
+
+import { SignTransactionCommand } from "@internal/app-binder/command/SignTransactionCommand";
+import {
+  INS,
+  XRP_CLA,
+} from "@internal/app-binder/command/utils/apduHeaderUtils";
+import { type XrpAppCommandError } from "@internal/app-binder/command/utils/xrpApplicationErrors";
+
+// A stand-in payload; the command writes whatever chunk it is given.
+const CHUNK = Uint8Array.from([0xde, 0xad, 0xbe, 0xef]);
+
+// P2 is the curve alone on this instruction — secp256k1, no chain code bit.
+const P2 = 0x40;
+
+const buildExpectedApdu = (p1: number) =>
+  Uint8Array.from([XRP_CLA, INS.SIGN, p1, P2, CHUNK.length, ...CHUNK]);
+
+// A short DER-encoded ECDSA signature: SEQUENCE { INTEGER, INTEGER }.
+const DER_SIGNATURE = [
+  0x30,
+  0x44,
+  0x02,
+  0x20,
+  ...Array.from({ length: 32 }, (_, i) => (i + 1) & 0xff),
+  0x02,
+  0x20,
+  ...Array.from({ length: 32 }, (_, i) => (i + 33) & 0xff),
+];
+
+const success = (data: number[]) =>
+  new ApduResponse({
+    statusCode: Uint8Array.from([0x90, 0x00]),
+    data: Uint8Array.from(data),
+  });
+
+describe("SignTransactionCommand", () => {
+  describe("name", () => {
+    it("should be 'SignTransaction'", () => {
+      expect(
+        new SignTransactionCommand({
+          chunkedData: CHUNK,
+          isFirstChunk: true,
+          isLastChunk: true,
+        }).name,
+      ).toBe("SignTransaction");
+    });
+  });
+
+  describe("getApdu", () => {
+    // The app reads P1 as an order bit (clear on the first chunk) and a more
+    // bit (set while further chunks follow).
+    it.each([
+      { isFirstChunk: true, isLastChunk: true, p1: 0x00 },
+      { isFirstChunk: true, isLastChunk: false, p1: 0x80 },
+      { isFirstChunk: false, isLastChunk: false, p1: 0x81 },
+      { isFirstChunk: false, isLastChunk: true, p1: 0x01 },
+    ])(
+      "should build P1=$p1 when isFirstChunk=$isFirstChunk and isLastChunk=$isLastChunk",
+      ({ isFirstChunk, isLastChunk, p1 }) => {
+        // GIVEN
+        const command = new SignTransactionCommand({
+          chunkedData: CHUNK,
+          isFirstChunk,
+          isLastChunk,
+        });
+
+        // WHEN
+        const apdu = command.getApdu();
+
+        // THEN
+        expect(apdu.getRawApdu()).toStrictEqual(buildExpectedApdu(p1));
+      },
+    );
+
+    it("should always select secp256k1 in P2", () => {
+      // GIVEN
+      const command = new SignTransactionCommand({
+        chunkedData: CHUNK,
+        isFirstChunk: true,
+        isLastChunk: true,
+      });
+
+      // WHEN
+      const apdu = command.getApdu().getRawApdu();
+
+      // THEN
+      expect(apdu[3]).toBe(0x40);
+    });
+
+    it("should write the chunk as-is, without touching its contents", () => {
+      // GIVEN a chunk that already carries an encoded derivation path
+      const firstChunk = Uint8Array.from([
+        0x05, 0x80, 0x00, 0x00, 0x2c, 0x80, 0x00, 0x00, 0x90, 0x11, 0x22,
+      ]);
+      const command = new SignTransactionCommand({
+        chunkedData: firstChunk,
+        isFirstChunk: true,
+        isLastChunk: false,
+      });
+
+      // WHEN
+      const apdu = command.getApdu().getRawApdu();
+
+      // THEN
+      expect(apdu.slice(5)).toStrictEqual(firstChunk);
+      expect(apdu[4]).toBe(firstChunk.length);
+    });
+  });
+
+  describe("parseResponse", () => {
+    const command = new SignTransactionCommand({
+      chunkedData: CHUNK,
+      isFirstChunk: true,
+      isLastChunk: true,
+    });
+
+    it("should return the DER signature from the final chunk", () => {
+      // WHEN
+      const result = command.parseResponse(success(DER_SIGNATURE));
+
+      // THEN
+      if (!isSuccessCommandResult(result)) {
+        assert.fail("Expected a success");
+      }
+      expect(result.data.isJust()).toBe(true);
+      // Returned whole: variable length, and the status word is already kept
+      // out of the data by ApduResponse.
+      expect(result.data.extract()).toStrictEqual(
+        Uint8Array.from(DER_SIGNATURE),
+      );
+    });
+
+    it("should return Nothing when the body is empty", () => {
+      // GIVEN the acknowledgement of a non-final chunk
+      // WHEN
+      const result = command.parseResponse(success([]));
+
+      // THEN
+      if (!isSuccessCommandResult(result)) {
+        assert.fail("Expected a success");
+      }
+      expect(result.data.isNothing()).toBe(true);
+    });
+
+    it("should map a rejection to an XRP app error", () => {
+      // WHEN
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x69, 0x85]),
+          data: new Uint8Array(0),
+        }),
+      );
+
+      // THEN
+      if (isSuccessCommandResult(result)) {
+        assert.fail("Expected an error");
+      }
+      const error = result.error as XrpAppCommandError;
+      expect(error.errorCode).toBe("6985");
+      expect(error.message).toBe(
+        "Condition of use not satisfied (Rejected by user)",
+      );
+    });
+
+    it("should map a transaction too large status word", () => {
+      // WHEN
+      const result = command.parseResponse(
+        new ApduResponse({
+          statusCode: Uint8Array.from([0x67, 0x00]),
+          data: new Uint8Array(0),
+        }),
+      );
+
+      // THEN
+      if (isSuccessCommandResult(result)) {
+        assert.fail("Expected an error");
+      }
+      const error = result.error as XrpAppCommandError;
+      expect(error.errorCode).toBe("6700");
+      expect(error.message).toBe("Incorrect length, or transaction too large");
+    });
+  });
+});

--- a/packages/signer/signer-xrp/src/internal/app-binder/command/SignTransactionCommand.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/command/SignTransactionCommand.ts
@@ -1,25 +1,56 @@
 import {
   type Apdu,
+  ApduBuilder,
+  type ApduBuilderArgs,
+  ApduParser,
   type ApduResponse,
   type Command,
   type CommandResult,
+  CommandResultFactory,
 } from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Just, Maybe, Nothing } from "purify-ts";
 
-import { type XrpErrorCodes } from "./utils/xrpApplicationErrors";
+import { type Signature } from "@api/model/Signature";
+
+import {
+  INS,
+  P1_MORE_CHUNKS,
+  P1_SUBSEQUENT_CHUNK,
+  P2_SECP256K1,
+  XRP_CLA,
+} from "./utils/apduHeaderUtils";
+import {
+  XRP_APP_ERRORS,
+  XrpAppCommandErrorFactory,
+  type XrpErrorCodes,
+} from "./utils/xrpApplicationErrors";
+
+/**
+ * The signature, once the app has one. Non-final chunks are acknowledged with
+ * an empty body, which is reported as `Nothing`.
+ */
+export type SignTransactionCommandResponse = Maybe<Signature>;
 
 export type SignTransactionCommandArgs = {
-  derivationPath: string;
-  transaction: Uint8Array;
+  /**
+   * One chunk of the payload. The first chunk is expected to already carry the
+   * encoded derivation path (`[nDerivations][index x n]`) ahead of the
+   * transaction bytes — this command writes the chunk as-is and only decides
+   * P1 from the flags below.
+   */
+  readonly chunkedData: Uint8Array;
+  readonly isFirstChunk: boolean;
+  readonly isLastChunk: boolean;
 };
 
-export type SignTransactionCommandResponse = {
-  signature: {
-    r: string;
-    s: string;
-    v?: number;
-  };
-};
-
+/**
+ * Sends one chunk of a transaction to the XRP application for signing.
+ *
+ * Chunk-agnostic on purpose: splitting the payload and looping over it belongs
+ * to the signing task, so this command only encodes where the chunk sits in
+ * the sequence.
+ */
 export class SignTransactionCommand
   implements
     Command<
@@ -32,27 +63,60 @@ export class SignTransactionCommand
 
   private readonly args: SignTransactionCommandArgs;
 
+  private readonly errorHelper = new CommandErrorHelper<
+    SignTransactionCommandResponse,
+    XrpErrorCodes
+  >(XRP_APP_ERRORS, XrpAppCommandErrorFactory);
+
   constructor(args: SignTransactionCommandArgs) {
     this.args = args;
   }
 
   getApdu(): Apdu {
-    // TODO: Implement APDU construction based on your blockchain's protocol
-    // Example structure:
-    // const builder = new ApduBuilder({ cla: 0xe0, ins: 0x02, p1: 0x00, p2: 0x00 });
-    // Add derivation path and other data to builder
-    // return builder.build();
-    // `this.args` holds the command input; never log it, it carries
-    // derivation paths and transaction data.
-    void this.args;
-    throw new Error("SignTransactionCommand.getApdu() not implemented");
+    const { chunkedData, isFirstChunk, isLastChunk } = this.args;
+
+    const signTransactionArgs: ApduBuilderArgs = {
+      cla: XRP_CLA,
+      ins: INS.SIGN,
+      // `00` first and last, `80` first with more to come, `81` a middle
+      // chunk, `01` the last of several.
+      p1:
+        (isFirstChunk ? 0x00 : P1_SUBSEQUENT_CHUNK) |
+        (isLastChunk ? 0x00 : P1_MORE_CHUNKS),
+      // Unlike GetAddress, P2 carries the curve alone — there is no chain code
+      // flag on this instruction.
+      p2: P2_SECP256K1,
+    };
+
+    return new ApduBuilder(signTransactionArgs)
+      .addBufferToData(chunkedData)
+      .build();
   }
 
   parseResponse(
-    _apduResponse: ApduResponse,
+    apduResponse: ApduResponse,
   ): CommandResult<SignTransactionCommandResponse, XrpErrorCodes> {
-    // TODO: Implement response parsing based on your blockchain's protocol
-    // return CommandResultFactory({ data: { ... } });
-    throw new Error("SignTransactionCommand.parseResponse() not implemented");
+    return Maybe.fromNullable(
+      this.errorHelper.getError(apduResponse),
+    ).orDefaultLazy(() => {
+      const parser = new ApduParser(apduResponse);
+      const length = parser.getUnparsedRemainingLength();
+
+      // Only the final chunk carries a signature; the others are acknowledged
+      // with an empty body.
+      if (length === 0) {
+        return CommandResultFactory({ data: Nothing });
+      }
+
+      const signature = parser.extractFieldByLength(length);
+      if (signature === undefined) {
+        return CommandResultFactory({ data: Nothing });
+      }
+
+      // The signature is DER-encoded and variable length, so it is returned
+      // whole. `ApduResponse` already keeps the status word out of the data,
+      // so nothing has to be sliced off the end.
+      return CommandResultFactory({ data: Just(signature) });
+    });
   }
 }

--- a/packages/signer/signer-xrp/src/internal/app-binder/command/utils/apduHeaderUtils.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/command/utils/apduHeaderUtils.ts
@@ -23,3 +23,12 @@ export const P2_SECP256K1 = 0x40 as const;
 
 /** P2 flag, OR-ed with the curve selector, asking for the chain code. */
 export const P2_RETURN_CHAIN_CODE = 0x01 as const;
+
+/**
+ * P1 flags for the chunked Sign APDU. The app reads P1 as two bits
+ * (`P1_MASK_ORDER` / `P1_MASK_MORE` in its `apdu/constants.h`): the order bit
+ * is clear on the first chunk, and the more bit is set while further chunks
+ * are still to come.
+ */
+export const P1_SUBSEQUENT_CHUNK = 0x01 as const;
+export const P1_MORE_CHUNKS = 0x80 as const;

--- a/packages/signer/signer-xrp/src/internal/app-binder/task/SignTransactionTask.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/task/SignTransactionTask.ts
@@ -2,6 +2,7 @@ import {
   type CommandResult,
   CommandResultFactory,
   type InternalApi,
+  InvalidResponseFormatError,
   isSuccessCommandResult,
 } from "@ledgerhq/device-management-kit";
 
@@ -21,16 +22,14 @@ export class SignTransactionTask {
   ) {}
 
   async run(): Promise<CommandResult<Signature, XrpErrorCodes>> {
-    // TODO: Adapt this implementation to your blockchain's signing protocol
-    // For transactions larger than a single APDU, you may need to:
-    // 1. Split the transaction into chunks
-    // 2. Send each chunk with appropriate first/continue flags
-    // 3. Collect the final signature from the last response
-
+    // TODO: chunk the payload (DSDK-1440). This sends the transaction as a
+    // single first-and-last chunk, which only holds for payloads that fit in
+    // one APDU, and it does not yet prepend the encoded derivation path.
     const result = await this.api.sendCommand(
       new SignTransactionCommand({
-        derivationPath: this.args.derivationPath,
-        transaction: this.args.transaction,
+        chunkedData: this.args.transaction,
+        isFirstChunk: true,
+        isLastChunk: true,
       }),
     );
 
@@ -38,8 +37,14 @@ export class SignTransactionTask {
       return result;
     }
 
-    return CommandResultFactory({
-      data: result.data.signature,
+    return result.data.caseOf({
+      Just: (signature) => CommandResultFactory({ data: signature }),
+      Nothing: () =>
+        CommandResultFactory<Signature, XrpErrorCodes>({
+          error: new InvalidResponseFormatError(
+            "No signature returned for the final chunk",
+          ),
+        }),
     });
   }
 }


### PR DESCRIPTION
> [!NOTE]
> Base of a three-PR stack: the chunking task follows in [DSDK-1440](https://ledgerhq.atlassian.net/browse/DSDK-1440), and the use case plus sample wiring in [DSDK-1441](https://ledgerhq.atlassian.net/browse/DSDK-1441).

### 📝 Description

Implements `SignTransactionCommand` for the XRP signer — a single APDU, chunk-agnostic.

It builds the `E0 04` APDU, encoding the chunk's position in the sequence into P1 (`00` first and last, `80` first with more to come, `81` a middle chunk, `01` the last of several) and selecting secp256k1 in P2, which on this instruction carries the curve alone with no chain-code bit. The chunk is written as-is, so splitting the payload and prepending the encoded derivation path stay with the signing task.

`parseResponse` returns `Maybe<Signature>`: the DER signature on the final chunk, `Nothing` for the empty body that acknowledges the others. Nothing is sliced off the end — unlike `hw-transport`, `ApduResponse` already keeps the status word out of the data.

`Signature` becomes a `Uint8Array`, since DER signatures are variable length rather than the Ethereum signer's `{ r, s, v }`.

#### ⚠️ No `curve` argument

The ticket scopes args `{ chunkedData, isFirstChunk, isLastChunk, curve }` and asks for both P2 curve values to be asserted. ed25519 is not exposed, for the same reason it was dropped from `GetAddress` in #1782: `sign_transaction.c` validates P2 and then hands the chosen curve to `bip32_derive_init_privkey_256`, the SDK's 256-bit Weierstrass helper, so an ed25519 request cannot succeed on the device. Its `curve == CX_CURVE_256K1` branch for ECDSA-vs-EdDSA is unreachable as a result. Ledger Live never passes the flag either. Worth raising with the app team; re-adding the argument is small once it is fixed.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1439](https://ledgerhq.atlassian.net/browse/DSDK-1439)
- **Feature**: XRP signer — sign transaction

### ✅ Checklist

- [x] **Covered by automatic tests** — `SignTransactionCommand.test.ts` asserts all four P1 values, the P2 curve selector, that the chunk is written through untouched, the DER signature parsed from the final chunk, `Nothing` for an empty body, and mapped app status words.
- [x] **Changeset is provided** — `.changeset/xrp-sign-transaction-command.md`
- [x] **Documentation is up-to-date** — no signer-level API change here; the docs land with DSDK-1441.
- [ ] **Impact of the changes:**
  - `@ledgerhq/device-signer-kit-xrp` only.
  - `Signature` changes from `{ r, s, v }` to `Uint8Array` — a breaking change to that type, though nothing consumed it yet.
  - `SignTransactionCommand` now sends a real APDU instead of the scaffolded stub.


[DSDK-1440]: https://ledgerhq.atlassian.net/browse/DSDK-1440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSDK-1441]: https://ledgerhq.atlassian.net/browse/DSDK-1441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSDK-1439]: https://ledgerhq.atlassian.net/browse/DSDK-1439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ