### PR TITLE
✨ (signer-xrp) [DSDK-1440]: Add SendSignTransaction task

### DIFF
--- a/.changeset/xrp-send-sign-transaction-task.md
+++ b/.changeset/xrp-send-sign-transaction-task.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-xrp": minor
+---
+
+Add the XRP `SendSignTransactionTask`, the chunking loop driving `SignTransactionCommand`. It prepends the encoded derivation path to the transaction, splits the result into `APDU_MAX_PAYLOAD` sized chunks and sends each with the right first/last flags, returning the signature the app answers with on the last one. Empty transactions and paths longer than 10 elements are rejected before anything reaches the device.

--- a/packages/signer/signer-xrp/src/internal/app-binder/task/SendSignTransactionTask.test.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/task/SendSignTransactionTask.test.ts
@@ -1,0 +1,256 @@
+import {
+  APDU_MAX_PAYLOAD,
+  CommandResultFactory,
+  type InternalApi,
+  isSuccessCommandResult,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+import { Just, Nothing } from "purify-ts";
+import { vi } from "vitest";
+
+import { type SignTransactionCommand } from "@internal/app-binder/command/SignTransactionCommand";
+import { XrpAppCommandError } from "@internal/app-binder/command/utils/xrpApplicationErrors";
+
+import { SendSignTransactionTask } from "./SendSignTransactionTask";
+
+const DERIVATION_PATH = "44'/144'/0'/0/0";
+const SIGNATURE = Uint8Array.from([0x30, 0x44, 0x02, 0x20, 0x01, 0x02]);
+
+// `[nDerivations][index x n]` ahead of the transaction bytes.
+const prefixLength = (elements: number) => 1 + elements * 4;
+const PREFIX = prefixLength(5);
+
+// How many transaction bytes the first APDU can still hold.
+const FIRST_CHUNK_BUDGET = APDU_MAX_PAYLOAD - PREFIX;
+
+const loggerFactory = () =>
+  ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    subscribers: [],
+  }) as unknown as LoggerPublisherService;
+
+/** A transaction of `length` bytes, each byte distinct enough to spot a slice. */
+const transactionOfLength = (length: number) =>
+  Uint8Array.from({ length }, (_, i) => i & 0xff);
+
+/**
+ * Drive the task against a stubbed device that acknowledges every chunk and
+ * answers the last one with a signature, then return the APDUs it emitted.
+ */
+const runTask = async (
+  serializedTransaction: Uint8Array,
+  {
+    derivationPath = DERIVATION_PATH,
+    failAtChunk,
+  }: { derivationPath?: string; failAtChunk?: number } = {},
+) => {
+  const commands: SignTransactionCommand[] = [];
+  let call = 0;
+
+  const sendCommand = vi.fn((command: SignTransactionCommand) => {
+    commands.push(command);
+    const index = call++;
+
+    if (failAtChunk !== undefined && index === failAtChunk) {
+      return Promise.resolve(
+        CommandResultFactory({
+          error: new XrpAppCommandError({
+            message: "Condition of use not satisfied (Rejected by user)",
+            errorCode: "6985",
+          }),
+        }),
+      );
+    }
+
+    // The app answers a signature only on the final chunk, which is the one
+    // whose P1 does not carry the "more to come" bit.
+    const isLast = command.getApdu().getRawApdu()[2]! < 0x80;
+    return Promise.resolve(
+      CommandResultFactory({ data: isLast ? Just(SIGNATURE) : Nothing }),
+    );
+  });
+
+  const api = { sendCommand } as unknown as InternalApi;
+  const result = await new SendSignTransactionTask(api, {
+    derivationPath,
+    serializedTransaction,
+    loggerFactory,
+  }).run();
+
+  const apdus = commands.map((c) => c.getApdu().getRawApdu());
+  return {
+    result,
+    apdus,
+    p1s: apdus.map((a) => a[2]),
+    // The data each APDU carried, past the 5 byte header.
+    payloads: apdus.map((a) => a.slice(5)),
+  };
+};
+
+describe("SendSignTransactionTask", () => {
+  describe("a transaction fitting one APDU", () => {
+    it("should send a single first-and-last chunk and return the signature", async () => {
+      // GIVEN a transaction that exactly fills one payload alongside the path
+      const { result, apdus, p1s } = await runTask(
+        transactionOfLength(FIRST_CHUNK_BUDGET),
+      );
+
+      // THEN
+      expect(apdus).toHaveLength(1);
+      expect(p1s).toStrictEqual([0x00]);
+      expect(apdus[0]![4]).toBe(APDU_MAX_PAYLOAD);
+      if (!isSuccessCommandResult(result)) {
+        assert.fail("Expected a success");
+      }
+      expect(result.data).toStrictEqual(SIGNATURE);
+    });
+  });
+
+  describe("the payload boundary", () => {
+    it("should stay on one chunk when the payload is exactly full", async () => {
+      // WHEN
+      const { p1s } = await runTask(transactionOfLength(FIRST_CHUNK_BUDGET));
+
+      // THEN
+      expect(p1s).toStrictEqual([0x00]);
+    });
+
+    it("should split into two chunks one byte later", async () => {
+      // GIVEN one byte more than a single payload holds
+      const { apdus, p1s } = await runTask(
+        transactionOfLength(FIRST_CHUNK_BUDGET + 1),
+      );
+
+      // THEN the first chunk announces more, the second closes the sequence
+      expect(p1s).toStrictEqual([0x80, 0x01]);
+      expect(apdus[0]![4]).toBe(APDU_MAX_PAYLOAD);
+      expect(apdus[1]![4]).toBe(1);
+    });
+  });
+
+  it("should emit 80, 81... 01 across three or more chunks", async () => {
+    // GIVEN a payload spanning four chunks
+    const { p1s } = await runTask(
+      transactionOfLength(APDU_MAX_PAYLOAD * 3 + 10),
+    );
+
+    // THEN
+    expect(p1s).toStrictEqual([0x80, 0x81, 0x81, 0x01]);
+  });
+
+  it("should shrink the first chunk's transaction budget for a 10 element path", async () => {
+    // GIVEN the longest path the app accepts
+    const longPath = "44'/144'/0'/0/0/0/0/0/0/0";
+    const longPrefix = prefixLength(10);
+    const transactionLength = APDU_MAX_PAYLOAD * 2;
+    const { apdus } = await runTask(transactionOfLength(transactionLength), {
+      derivationPath: longPath,
+    });
+
+    // THEN the first APDU is still full, but carries fewer transaction bytes,
+    // so what spills into the following chunks grows by the same amount.
+    expect(apdus[0]![4]).toBe(APDU_MAX_PAYLOAD);
+    expect(apdus[0]!.slice(5, 6)).toStrictEqual(Uint8Array.from([10]));
+    expect(apdus[1]![4]).toBe(APDU_MAX_PAYLOAD);
+    expect(apdus[2]![4]).toBe(longPrefix);
+  });
+
+  describe("what reaches the device", () => {
+    it("should reassemble to the encoded path followed by the transaction", async () => {
+      // GIVEN a transaction spanning several chunks
+      const transaction = transactionOfLength(APDU_MAX_PAYLOAD * 2 + 7);
+
+      // WHEN
+      const { payloads } = await runTask(transaction);
+
+      // THEN concatenating every chunk gives back exactly what the app has to
+      // read: the encoded path, then the transaction, with nothing repeated
+      // and nothing dropped at the seams.
+      const sent = Uint8Array.from(payloads.flatMap((p) => Array.from(p)));
+      const expected = Uint8Array.from([
+        0x05,
+        0x80,
+        0x00,
+        0x00,
+        0x2c,
+        0x80,
+        0x00,
+        0x00,
+        0x90,
+        0x80,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        ...transaction,
+      ]);
+      expect(sent).toStrictEqual(expected);
+    });
+
+    it("should never exceed the APDU payload limit", async () => {
+      // WHEN
+      const { payloads } = await runTask(
+        transactionOfLength(APDU_MAX_PAYLOAD * 3 + 42),
+      );
+
+      // THEN
+      payloads.forEach((payload) => {
+        expect(payload.length).toBeLessThanOrEqual(APDU_MAX_PAYLOAD);
+      });
+    });
+  });
+
+  it("should propagate an error raised mid-loop and stop sending", async () => {
+    // GIVEN the device rejects on the second of four chunks
+    const { result, apdus } = await runTask(
+      transactionOfLength(APDU_MAX_PAYLOAD * 3 + 10),
+      { failAtChunk: 1 },
+    );
+
+    // THEN
+    if (isSuccessCommandResult(result)) {
+      assert.fail("Expected an error");
+    }
+    expect((result.error as XrpAppCommandError).errorCode).toBe("6985");
+    expect(apdus).toHaveLength(2);
+  });
+
+  it("should reject an empty transaction without sending anything", async () => {
+    // WHEN
+    const { result, apdus } = await runTask(new Uint8Array(0));
+
+    // THEN
+    if (isSuccessCommandResult(result)) {
+      assert.fail("Expected an error");
+    }
+    expect(result.error).toEqual(
+      expect.objectContaining({
+        originalError: new Error("Cannot sign an empty transaction"),
+      }),
+    );
+    expect(apdus).toHaveLength(0);
+  });
+
+  it("should reject a derivation path longer than 10 elements", async () => {
+    // WHEN
+    const { result, apdus } = await runTask(transactionOfLength(10), {
+      derivationPath: "44'/144'/0'/0/0/0/0/0/0/0/0",
+    });
+
+    // THEN
+    if (isSuccessCommandResult(result)) {
+      assert.fail("Expected an error");
+    }
+    expect(apdus).toHaveLength(0);
+  });
+});

--- a/packages/signer/signer-xrp/src/internal/app-binder/task/SendSignTransactionTask.ts
+++ b/packages/signer/signer-xrp/src/internal/app-binder/task/SendSignTransactionTask.ts
@@ -1,0 +1,129 @@
+import {
+  APDU_MAX_PAYLOAD,
+  ByteArrayBuilder,
+  type CommandResult,
+  CommandResultFactory,
+  type InternalApi,
+  InvalidArgumentError,
+  isSuccessCommandResult,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+import { Nothing } from "purify-ts";
+
+import { type Signature } from "@api/model/Signature";
+import {
+  SignTransactionCommand,
+  type SignTransactionCommandResponse,
+} from "@internal/app-binder/command/SignTransactionCommand";
+import { validateDerivationPath } from "@internal/app-binder/command/utils/validateDerivationPath";
+import { type XrpErrorCodes } from "@internal/app-binder/command/utils/xrpApplicationErrors";
+
+const PATH_SIZE = 4;
+
+type SendSignTransactionTaskArgs = {
+  derivationPath: string;
+  serializedTransaction: Uint8Array;
+  loggerFactory: (tag: string) => LoggerPublisherService;
+};
+
+/**
+ * Drives {@link SignTransactionCommand} over a whole transaction: prepends the
+ * encoded derivation path, splits the result into APDU-sized chunks and
+ * returns the signature the app answers with on the last one.
+ */
+export class SendSignTransactionTask {
+  private readonly _logger: LoggerPublisherService;
+
+  constructor(
+    private api: InternalApi,
+    private args: SendSignTransactionTaskArgs,
+  ) {
+    this._logger = args.loggerFactory("SendSignTransactionTask");
+  }
+
+  async run(): Promise<CommandResult<Signature, XrpErrorCodes>> {
+    const { derivationPath, serializedTransaction } = this.args;
+
+    if (serializedTransaction.length === 0) {
+      return CommandResultFactory({
+        error: new InvalidArgumentError("Cannot sign an empty transaction"),
+      });
+    }
+
+    let paths: number[];
+    try {
+      paths = validateDerivationPath(derivationPath);
+    } catch (error) {
+      return CommandResultFactory({
+        error: new InvalidArgumentError(
+          error instanceof Error ? error.message : "Invalid derivation path",
+        ),
+      });
+    }
+
+    const chunks = this.getChunks(paths, serializedTransaction);
+    this._logger.debug("[run] Sending transaction in chunks", {
+      data: {
+        chunksCount: chunks.length,
+        transactionLength: serializedTransaction.length,
+      },
+    });
+
+    let resultData: SignTransactionCommandResponse = Nothing;
+    for (let i = 0; i < chunks.length; i++) {
+      const result = await this.api.sendCommand(
+        new SignTransactionCommand({
+          chunkedData: chunks[i]!,
+          isFirstChunk: i === 0,
+          isLastChunk: i === chunks.length - 1,
+        }),
+      );
+
+      if (!isSuccessCommandResult(result)) {
+        this._logger.error("[run] Failed to send transaction chunk", {
+          data: { chunkIndex: i, error: result.error },
+        });
+        return result;
+      }
+
+      resultData = result.data;
+    }
+
+    return resultData.mapOrDefault(
+      (signature) =>
+        CommandResultFactory<Signature, XrpErrorCodes>({ data: signature }),
+      CommandResultFactory<Signature, XrpErrorCodes>({
+        error: new InvalidArgumentError("No signature returned"),
+      }),
+    );
+  }
+
+  /**
+   * Build `[nDerivations][index x n] ++ transaction` and cut it into
+   * APDU-sized chunks.
+   *
+   * The path prefix is part of the buffer rather than a special case for the
+   * first chunk: the app reads the payload as one stream, so a uniform cut
+   * gives it the same bytes with less arithmetic.
+   */
+  private getChunks(
+    paths: number[],
+    serializedTransaction: Uint8Array,
+  ): Uint8Array[] {
+    const builder = new ByteArrayBuilder(
+      1 + paths.length * PATH_SIZE + serializedTransaction.length,
+    );
+    builder.add8BitUIntToData(paths.length);
+    paths.forEach((path) => {
+      builder.add32BitUIntToData(path);
+    });
+    builder.addBufferToData(serializedTransaction);
+    const buffer = builder.build();
+
+    const chunks: Uint8Array[] = [];
+    for (let offset = 0; offset < buffer.length; offset += APDU_MAX_PAYLOAD) {
+      chunks.push(buffer.slice(offset, offset + APDU_MAX_PAYLOAD));
+    }
+    return chunks;
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> Stacked on top of #1788 ([DSDK-1439](https://ledgerhq.atlassian.net/browse/DSDK-1439)) — this PR targets `feat/dsdk-1439-xrp-sign-transaction-command`, so review only the last commit. Retarget to `develop` once #1788 is merged.

### 📝 Description

Implements `SendSignTransactionTask`, the chunking loop driving `SignTransactionCommand`.

It prepends the encoded derivation path to the transaction, splits the result into `APDU_MAX_PAYLOAD` sized chunks and sends each with the right first/last flags, returning the signature the app answers with on the last one. Empty transactions and paths longer than 10 elements are rejected before anything reaches the device, reusing `validateDerivationPath`.

The path prefix is part of the buffer rather than a special case for the first chunk: the app reads the payload as one stream, so a uniform cut gives it the same bytes with less arithmetic.

#### On the chunk size

The legacy `hw-app-xrp` client chunks at [150](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledgerjs/packages/hw-app-xrp/src/Xrp.ts#L145) rather than the full payload. That number appears **nowhere** in the application or its spec: `handle_apdu` reads `Lc` as a single byte and bounds only the accumulated total at `MAX_RAW_TX` (10000), `limitations.h` has no per-APDU constant, and `doc/xrpapp.asc` lists `Lc` as "variable" with no maximum. It is a client convention with no stated justification.

Verified on device rather than assumed: a 425 byte transaction (446 with the path prefix) was signed both at 150 — 3 chunks — and at the full payload — 2 chunks, the first one 255 bytes — and **produced a byte-identical signature**. So chunk size affects only transport framing, and this task uses the transport's own `APDU_MAX_PAYLOAD` instead of restating a size of its own.

⚠️ This does diverge from what Ledger Live ships today, and it was verified on Stax 1.10.1 / XRP 2.6.1 only. Nano S has tighter buffers (`MAX_FIELD_LEN 128` under `TARGET_NANOS`), so if 150 was a deliberate lowest-common-denominator the app team would be the ones to confirm it.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1440](https://ledgerhq.atlassian.net/browse/DSDK-1440)
- **Feature**: XRP signer — sign transaction

### ✅ Checklist

- [x] **Covered by automatic tests** — `SendSignTransactionTask.test.ts` covers a single-APDU transaction, the full-payload boundary (the `00` → `80`/`01` transition), a four-chunk `80, 81, 81, 01` sequence, a 10-element path shrinking the first chunk's transaction budget, an error raised mid-loop stopping the sequence, an empty transaction and an over-long path. Two size-agnostic invariants replace the previous parity-with-legacy assertions: the chunks reassemble to exactly `[path] ++ transaction` with nothing duplicated or dropped at the seams, and no chunk exceeds the payload limit. The expectations derive from `APDU_MAX_PAYLOAD` rather than hardcoding a number.
- [x] **Changeset is provided** — `.changeset/xrp-send-sign-transaction-task.md`
- [x] **Documentation is up-to-date** — no signer-level API change here; the docs land with DSDK-1441.
- [ ] **Impact of the changes:**
  - `@ledgerhq/device-signer-kit-xrp` only. The task is not yet reachable from the sample — DSDK-1441 wires it in.
  - Uses the DMK's `APDU_MAX_PAYLOAD`; no XRP-specific size constant is introduced.
  - Emitted APDU sequences differ from the legacy client's for payloads over 150 bytes, by design. Signatures are unchanged.
  - Input validation failures use `InvalidArgumentError` rather than the Ethereum task's `InvalidStatusWordError`, which is about status words rather than arguments.


[DSDK-1439]: https://ledgerhq.atlassian.net/browse/DSDK-1439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSDK-1440]: https://ledgerhq.atlassian.net/browse/DSDK-1440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ