### PR TITLE
✨ (signer-solana) [NO-ISSUE]: Request a trusted name for each instruction program

### DIFF
--- a/.changeset/solana-program-trusted-name.md
+++ b/.changeset/solana-program-trusted-name.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": patch
+---
+
+Resolve a trusted name for each instruction's program address in generic clear signing

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/buildRequirements.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/buildRequirements.test.ts
@@ -240,10 +240,11 @@ describe("buildRequirements", () => {
     ]);
   });
 
-  it("emits TRUSTED_NAME for PARAM_TRUSTED_NAME fields (account path + constant)", () => {
+  it("emits TRUSTED_NAME for the program and for PARAM_TRUSTED_NAME fields (account path + constant)", () => {
     const constantAddr = new Uint8Array(32).fill(5);
     const result = run([
       matched({
+        programId: "Prog",
         accounts: [account("ignored"), account("namedAccount")],
         descriptor: {
           displayFields: [
@@ -254,9 +255,19 @@ describe("buildRequirements", () => {
       }),
     ]);
     expect(result.trustedNames).toEqual([
+      "Prog",
       "namedAccount",
       DefaultBs58Encoder.encode(constantAddr),
     ]);
+  });
+
+  it("emits one TRUSTED_NAME per distinct program across instructions", () => {
+    const result = run([
+      matched({ programId: "ProgA", discriminator: "01", accounts: [] }),
+      matched({ programId: "ProgB", discriminator: "02", accounts: [] }),
+      matched({ programId: "ProgA", discriminator: "03", accounts: [] }),
+    ]);
+    expect(result.trustedNames).toEqual(["ProgA", "ProgB"]);
   });
 
   it("decodes selected enum variants via the default decoder", () => {

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.test.ts
@@ -45,7 +45,7 @@ describe("applyTrustedNameRule", () => {
       ],
       ["ignored", "named"],
     );
-    expect(result).toEqual(["named"]);
+    expect(result).toEqual(["P", "named"]);
   });
 
   it("encodes a 32-byte CONSTANT trusted-name target", () => {
@@ -59,7 +59,7 @@ describe("applyTrustedNameRule", () => {
       ],
       [],
     );
-    expect(result).toEqual([DefaultBs58Encoder.encode(addr)]);
+    expect(result).toEqual(["P", DefaultBs58Encoder.encode(addr)]);
   });
 
   it("resolves an ACCOUNT display field target (best-effort CAL name)", () => {
@@ -75,7 +75,7 @@ describe("applyTrustedNameRule", () => {
       ],
       ["account"],
     );
-    expect(result).toEqual(["account"]);
+    expect(result).toEqual(["P", "account"]);
   });
 
   it("deduplicates an address referenced by ACCOUNT and TRUSTED_NAME fields", () => {
@@ -98,9 +98,30 @@ describe("applyTrustedNameRule", () => {
       ],
       ["shared"],
     );
-    expect(result).toEqual(["shared"]);
+    expect(result).toEqual(["P", "shared"]);
   });
 
+  it("always targets the instruction's program address", () => {
+    expect(run([], [])).toEqual(["P"]);
+  });
+
+  it("does not duplicate the program address when a field also targets it", () => {
+    const result = run(
+      [
+        {
+          paramType: PARAM_TYPE_ACCOUNT,
+          value: {
+            source: ValueSource.ACCOUNT_PATH,
+            payload: Uint8Array.of(0),
+          },
+        },
+      ],
+      ["P"],
+    );
+    expect(result).toEqual(["P"]);
+  });
+
+  // Only the program address survives: the display fields contribute nothing.
   it("ignores non-trusted-name fields and unresolved account targets", () => {
     const nonTrusted = run(
       [
@@ -114,7 +135,7 @@ describe("applyTrustedNameRule", () => {
       ],
       ["a"],
     );
-    expect(nonTrusted).toEqual([]);
+    expect(nonTrusted).toEqual(["P"]);
 
     const unresolved = run(
       [
@@ -128,6 +149,6 @@ describe("applyTrustedNameRule", () => {
       ],
       [undefined],
     );
-    expect(unresolved).toEqual([]);
+    expect(unresolved).toEqual(["P"]);
   });
 });

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.ts
@@ -16,6 +16,12 @@ import {
  * that may have a CAL name. For `PARAM_ACCOUNT` this is best-effort: the device
  * shows the name if a descriptor is found and falls back to the base58 address
  * otherwise.
+ *
+ * The instruction's own program address is added on the same best-effort basis
+ * (a program is a `smart_contract`-type trusted name): if CAL knows it, the
+ * device displays the program name instead of the raw key. Deduplication across
+ * instructions is handled by the accumulator, so a program used by several
+ * instructions is fetched once.
  */
 export function applyTrustedNameRule(
   parsed: ParsedInstruction,
@@ -23,6 +29,8 @@ export function applyTrustedNameRule(
   accumulator: RequirementAccumulator,
   bs58Encoder: Bs58Encoder = DefaultBs58Encoder,
 ): void {
+  accumulator.addTrustedName(instruction.programId);
+
   for (const field of parsed.displayFields) {
     if (
       (field.paramType !== PARAM_TYPE_TRUSTED_NAME &&


### PR DESCRIPTION
### 📝 Description

In generic clear signing, each parsed instruction now requests a trusted name for its **own program address**, in addition to the trusted names already derived from `PARAM_TRUSTED_NAME` and `PARAM_ACCOUNT` display fields.

A program is a `smart_contract`-type trusted name, so this is best-effort: when CAL knows the program, the device displays the program name instead of the raw base58 key; otherwise it falls back to the address as before.

Deduplication is handled by the requirement accumulator, so:

- a program used by several instructions is fetched **once**,
- a program address that a display field also targets is **not** requested twice.

The implementation is a single line in `applyTrustedNameRule` (`accumulator.addTrustedName(instruction.programId)`) plus a doc comment explaining the best-effort semantics; the rest of the diff is test coverage.

### ❓ Context

- **JIRA or GitHub link**: NO-ISSUE
- **Feature**: Show human-readable program names on device during Solana generic clear signing instead of raw program addresses.

### ✅ Checklist

- [x] **Covered by automatic tests** <!-- new cases in trustedNameRule.test.ts (program always targeted, no duplication when a field targets it) and buildRequirements.test.ts (one trusted name per distinct program across instructions); existing expectations updated -->
- [x] **Changeset is provided** <!-- .changeset/solana-program-trusted-name.md — patch on @ledgerhq/device-signer-kit-solana -->
- [x] **Documentation is up-to-date** <!-- doc comment on applyTrustedNameRule updated; no public API change -->
- [ ] **Impact of the changes:**
  - Solana generic clear signing now issues one extra trusted-name requirement per distinct program in the transaction — QA should check that program names appear on device when CAL knows them, and that unknown programs still fall back to the base58 address.
  - Slightly more trusted-name descriptor fetches per transaction; verify no regression in clear-signing latency, nor for transactions with many instructions sharing a single program.
