### PR TITLE
⏪️ (signer-solana) [NO-ISSUE]: Revert trusted name request for each instruction program

### DIFF
--- a/.changeset/solana-program-trusted-name.md
+++ b/.changeset/solana-program-trusted-name.md
@@ -1,5 +1,0 @@
----
-"@ledgerhq/device-signer-kit-solana": patch
----
-
-Resolve a trusted name for each instruction's program address in generic clear signing

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/buildRequirements.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/buildRequirements.test.ts
@@ -240,11 +240,10 @@ describe("buildRequirements", () => {
     ]);
   });
 
-  it("emits TRUSTED_NAME for the program and for PARAM_TRUSTED_NAME fields (account path + constant)", () => {
+  it("emits TRUSTED_NAME for PARAM_TRUSTED_NAME fields (account path + constant)", () => {
     const constantAddr = new Uint8Array(32).fill(5);
     const result = run([
       matched({
-        programId: "Prog",
         accounts: [account("ignored"), account("namedAccount")],
         descriptor: {
           displayFields: [
@@ -255,19 +254,9 @@ describe("buildRequirements", () => {
       }),
     ]);
     expect(result.trustedNames).toEqual([
-      "Prog",
       "namedAccount",
       DefaultBs58Encoder.encode(constantAddr),
     ]);
-  });
-
-  it("emits one TRUSTED_NAME per distinct program across instructions", () => {
-    const result = run([
-      matched({ programId: "ProgA", discriminator: "01", accounts: [] }),
-      matched({ programId: "ProgB", discriminator: "02", accounts: [] }),
-      matched({ programId: "ProgA", discriminator: "03", accounts: [] }),
-    ]);
-    expect(result.trustedNames).toEqual(["ProgA", "ProgB"]);
   });
 
   it("decodes selected enum variants via the default decoder", () => {

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.test.ts
@@ -45,7 +45,7 @@ describe("applyTrustedNameRule", () => {
       ],
       ["ignored", "named"],
     );
-    expect(result).toEqual(["P", "named"]);
+    expect(result).toEqual(["named"]);
   });
 
   it("encodes a 32-byte CONSTANT trusted-name target", () => {
@@ -59,7 +59,7 @@ describe("applyTrustedNameRule", () => {
       ],
       [],
     );
-    expect(result).toEqual(["P", DefaultBs58Encoder.encode(addr)]);
+    expect(result).toEqual([DefaultBs58Encoder.encode(addr)]);
   });
 
   it("resolves an ACCOUNT display field target (best-effort CAL name)", () => {
@@ -75,7 +75,7 @@ describe("applyTrustedNameRule", () => {
       ],
       ["account"],
     );
-    expect(result).toEqual(["P", "account"]);
+    expect(result).toEqual(["account"]);
   });
 
   it("deduplicates an address referenced by ACCOUNT and TRUSTED_NAME fields", () => {
@@ -98,30 +98,9 @@ describe("applyTrustedNameRule", () => {
       ],
       ["shared"],
     );
-    expect(result).toEqual(["P", "shared"]);
+    expect(result).toEqual(["shared"]);
   });
 
-  it("always targets the instruction's program address", () => {
-    expect(run([], [])).toEqual(["P"]);
-  });
-
-  it("does not duplicate the program address when a field also targets it", () => {
-    const result = run(
-      [
-        {
-          paramType: PARAM_TYPE_ACCOUNT,
-          value: {
-            source: ValueSource.ACCOUNT_PATH,
-            payload: Uint8Array.of(0),
-          },
-        },
-      ],
-      ["P"],
-    );
-    expect(result).toEqual(["P"]);
-  });
-
-  // Only the program address survives: the display fields contribute nothing.
   it("ignores non-trusted-name fields and unresolved account targets", () => {
     const nonTrusted = run(
       [
@@ -135,7 +114,7 @@ describe("applyTrustedNameRule", () => {
       ],
       ["a"],
     );
-    expect(nonTrusted).toEqual(["P"]);
+    expect(nonTrusted).toEqual([]);
 
     const unresolved = run(
       [
@@ -149,6 +128,6 @@ describe("applyTrustedNameRule", () => {
       ],
       [undefined],
     );
-    expect(unresolved).toEqual(["P"]);
+    expect(unresolved).toEqual([]);
   });
 });

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.ts
@@ -16,12 +16,6 @@ import {
  * that may have a CAL name. For `PARAM_ACCOUNT` this is best-effort: the device
  * shows the name if a descriptor is found and falls back to the base58 address
  * otherwise.
- *
- * The instruction's own program address is added on the same best-effort basis
- * (a program is a `smart_contract`-type trusted name): if CAL knows it, the
- * device displays the program name instead of the raw key. Deduplication across
- * instructions is handled by the accumulator, so a program used by several
- * instructions is fetched once.
  */
 export function applyTrustedNameRule(
   parsed: ParsedInstruction,
@@ -29,8 +23,6 @@ export function applyTrustedNameRule(
   accumulator: RequirementAccumulator,
   bs58Encoder: Bs58Encoder = DefaultBs58Encoder,
 ): void {
-  accumulator.addTrustedName(instruction.programId);
-
   for (const field of parsed.displayFields) {
     if (
       (field.paramType !== PARAM_TYPE_TRUSTED_NAME &&


### PR DESCRIPTION
## Description

Reverts #1792 (commit `17cb089`), which requested a `TRUSTED_NAME` for each matched instruction's program address in Solana generic clear signing.

We settled on another solution for this feature: **the program name is carried directly inside the `INSTRUCTION_INFO` TLV**, so there is no need to resolve a trusted name per instruction program anymore.

## Changes

- `trustedNameRule`: no longer seeds the accumulator with the instruction's program address — only `PARAM_TRUSTED_NAME` / `ACCOUNT` display fields contribute trusted names.
- Reverted the associated tests in `trustedNameRule.test.ts` and `buildRequirements.test.ts`.
- Removed the `.changeset/solana-program-trusted-name.md` changeset (it had not been released yet, so no version bump is needed).

## Checks

`pnpm vitest run src/internal/app-binder/clear-sign/requirements` → 10 files, 74 tests passing.