### PR TITLE
✨ (contacts-kit) [DSDK-1379]: Edit an external address identifier

### DIFF
--- a/.changeset/contacts-edit-external-address-identifier.md
+++ b/.changeset/contacts-edit-external-address-identifier.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-contacts-kit": minor
+---
+
+Add `ContactsManager.editExternalAddressIdentifier`: the EDIT IDENTIFIER operation (replace the identifier bytes of an existing external-address entry within a contact group), with a version-guarded device action that opens the app by default, checks the Contacts version requirements, and supports `skipOpenApp`. Rotates only the address-level `hmacRest` and preserves the contact-group `hmacProof`.

--- a/packages/device-contacts-kit/src/api/ContactsManager.ts
+++ b/packages/device-contacts-kit/src/api/ContactsManager.ts
@@ -1,5 +1,7 @@
+import { type EditExternalAddressIdentifierDAReturnType } from "@api/app-binder/EditExternalAddressIdentifierDeviceActionTypes";
 import { type RegisterExternalAddressDAReturnType } from "@api/app-binder/RegisterExternalAddressDeviceActionTypes";
 import { type RenameContactDAReturnType } from "@api/app-binder/RenameContactDeviceActionTypes";
+import { type EditExternalAddressIdentifierInput } from "@api/model/EditExternalAddressIdentifier";
 import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
 import { type RenameContactInput } from "@api/model/RenameContact";
 
@@ -34,4 +36,16 @@ export interface ContactsManager {
    * persist.
    */
   renameContact(input: RenameContactInput): RenameContactDAReturnType;
+
+  /**
+   * Edit an external address's identifier (EDIT IDENTIFIER) — replace an entry's
+   * address bytes within a contact group. Opens the app by default (`skipOpenApp:
+   * true` skips it; the version guard still runs) and checks the Contacts version
+   * requirements. Pass the previous/new identifiers, `groupHandle`, `hmacProof`,
+   * and current `hmacRest`; returns the replacement `hmacRest` (the `hmacProof`
+   * is unchanged).
+   */
+  editExternalAddressIdentifier(
+    input: EditExternalAddressIdentifierInput,
+  ): EditExternalAddressIdentifierDAReturnType;
 }

--- a/packages/device-contacts-kit/src/api/app-binder/EditExternalAddressIdentifierDeviceActionTypes.ts
+++ b/packages/device-contacts-kit/src/api/app-binder/EditExternalAddressIdentifierDeviceActionTypes.ts
@@ -1,0 +1,65 @@
+import {
+  type CommandErrorResult,
+  type DeviceActionState,
+  type ExecuteDeviceActionReturnType,
+  type OpenAppDAError,
+  type OpenAppDARequiredInteraction,
+  type UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+
+import {
+  type EditExternalAddressIdentifierInput,
+  type EditExternalAddressIdentifierOutput,
+} from "@api/model/EditExternalAddressIdentifier";
+import {
+  type ContactsErrorCodes,
+  type ContactsVersionRequirementError,
+} from "@internal/app-binder/model/contactsErrors";
+import { type ContactsValidationError } from "@internal/app-binder/model/contactsValidation";
+
+/** Machine input: the public input plus the injected embedded-app name. */
+export type EditExternalAddressIdentifierDAInput =
+  EditExternalAddressIdentifierInput & {
+    readonly appName: string;
+  };
+
+export type EditExternalAddressIdentifierDAOutput =
+  EditExternalAddressIdentifierOutput;
+
+export type EditExternalAddressIdentifierDAError =
+  | OpenAppDAError
+  | ContactsValidationError
+  | ContactsVersionRequirementError
+  | CommandErrorResult<ContactsErrorCodes>["error"];
+
+export type EditExternalAddressIdentifierDARequiredInteraction =
+  | OpenAppDARequiredInteraction
+  | UserInteractionRequired.RegisterWallet;
+
+export type EditExternalAddressIdentifierDAIntermediateValue = {
+  readonly requiredUserInteraction: EditExternalAddressIdentifierDARequiredInteraction;
+};
+
+export type EditExternalAddressIdentifierDAState = DeviceActionState<
+  EditExternalAddressIdentifierDAOutput,
+  EditExternalAddressIdentifierDAError,
+  EditExternalAddressIdentifierDAIntermediateValue
+>;
+
+export type EditExternalAddressIdentifierDAInternalState = {
+  readonly error: EditExternalAddressIdentifierDAError | null;
+  /** The running app read freshly by WaitForAppAndVersion, for the version guard. */
+  readonly appAndVersion: {
+    readonly name: string;
+    readonly version: string;
+  } | null;
+  /** The rotated address-level proof returned by the device on success. */
+  readonly hmacRest: Uint8Array | null;
+};
+
+export type EditExternalAddressIdentifierDAReturnType =
+  ExecuteDeviceActionReturnType<
+    EditExternalAddressIdentifierDAOutput,
+    EditExternalAddressIdentifierDAError,
+    EditExternalAddressIdentifierDAIntermediateValue
+  >;

--- a/packages/device-contacts-kit/src/api/index.ts
+++ b/packages/device-contacts-kit/src/api/index.ts
@@ -1,4 +1,13 @@
 export {
+  type EditExternalAddressIdentifierDAError,
+  type EditExternalAddressIdentifierDAInput,
+  type EditExternalAddressIdentifierDAIntermediateValue,
+  type EditExternalAddressIdentifierDAOutput,
+  type EditExternalAddressIdentifierDARequiredInteraction,
+  type EditExternalAddressIdentifierDAReturnType,
+  type EditExternalAddressIdentifierDAState,
+} from "@api/app-binder/EditExternalAddressIdentifierDeviceActionTypes";
+export {
   type RegisterExternalAddressDAError,
   type RegisterExternalAddressDAInput,
   type RegisterExternalAddressDAIntermediateValue,
@@ -30,6 +39,10 @@ export {
   isVersionAtLeast,
   resolveContactsVersionRequirements,
 } from "@api/model/ContactsVersionRequirements";
+export {
+  type EditExternalAddressIdentifierInput,
+  type EditExternalAddressIdentifierOutput,
+} from "@api/model/EditExternalAddressIdentifier";
 export {
   type ExistingContactGroup,
   type RegisterExternalAddressInput,

--- a/packages/device-contacts-kit/src/api/model/EditExternalAddressIdentifier.ts
+++ b/packages/device-contacts-kit/src/api/model/EditExternalAddressIdentifier.ts
@@ -1,0 +1,58 @@
+/**
+ * Public input/output types for `ContactsManager.editExternalAddressIdentifier`.
+ *
+ * EDIT IDENTIFIER replaces an entry's identifier bytes within an existing
+ * contact group. Only the address-level `hmacRest` rotates; the group-level
+ * `hmacProof` passes through unchanged. Proof material is raw bytes (the host
+ * owns persistence); `derivationPath` is kit-internal and not exposed.
+ */
+
+export type EditExternalAddressIdentifierInput = {
+  /** The contact's name, proven to the device via `hmacProof`. */
+  readonly contactName: string;
+  /** The entry's current label/scope; shown on the approval screen. */
+  readonly scope: string;
+  /** The current (pre-edit) address bytes, proven via `hmacRest`. */
+  readonly previousIdentifier: Uint8Array;
+  /** The replacement address bytes (20 bytes for Ethereum). */
+  readonly newIdentifier: Uint8Array;
+  /** Blockchain family name, e.g. "ethereum" (v1 supports Ethereum only). */
+  readonly blockchainFamily: string;
+  readonly chainId?: bigint;
+  /** 64-byte group handle returned by the group's Register Identity. */
+  readonly groupHandle: Uint8Array;
+  /**
+   * The contact-group name proof (device `hmac_name`) — passed back so the
+   * device can verify the entry belongs to the group. Unchanged by the edit.
+   */
+  readonly hmacProof: Uint8Array;
+  /**
+   * The entry's current 32-byte address proof (`hmac_rest`) — passed back so the
+   * device can verify continuity before approving. Replaced by the returned
+   * `hmacRest` on success.
+   */
+  readonly hmacRest: Uint8Array;
+  /**
+   * When `true`, the open-app step is skipped (the caller guarantees the app is
+   * already open). The app-version guard still runs.
+   */
+  readonly skipOpenApp?: boolean;
+};
+
+export type EditExternalAddressIdentifierOutput = {
+  /** Echoed input, needed by the host to locate the entry it is replacing. */
+  readonly contactName: string;
+  readonly scope: string;
+  /** Echoed previous address bytes, to match the entry being replaced. */
+  readonly previousIdentifier: Uint8Array;
+  /** The new address bytes now bound to the entry. */
+  readonly identifier: Uint8Array;
+  readonly blockchainFamily: string;
+  readonly chainId?: bigint;
+  /** Echoed group handle, unchanged by the edit. */
+  readonly groupHandle: Uint8Array;
+  /** Echoed group-level name proof, unchanged by the edit. */
+  readonly hmacProof: Uint8Array;
+  /** The replacement address-level proof (rotated `hmac_rest`) to persist. */
+  readonly hmacRest: Uint8Array;
+};

--- a/packages/device-contacts-kit/src/internal/DefaultContactsManager.test.ts
+++ b/packages/device-contacts-kit/src/internal/DefaultContactsManager.test.ts
@@ -1,5 +1,6 @@
 import { type DeviceManagementKit } from "@ledgerhq/device-management-kit";
 
+import { type EditExternalAddressIdentifierInput } from "@api/model/EditExternalAddressIdentifier";
 import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
 import { type RenameContactInput } from "@api/model/RenameContact";
 
@@ -18,6 +19,18 @@ const VALID_RENAME_INPUT: RenameContactInput = {
   newContactName: "Bob",
   groupHandle: new Uint8Array(64).fill(0xcc),
   hmacProof: new Uint8Array(32).fill(0xdd),
+};
+
+const VALID_EDIT_INPUT: EditExternalAddressIdentifierInput = {
+  contactName: "Alice",
+  scope: "Eth main",
+  previousIdentifier: new Uint8Array(20).fill(0x11),
+  newIdentifier: new Uint8Array(20).fill(0x22),
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+  groupHandle: new Uint8Array(64).fill(0xcc),
+  hmacProof: new Uint8Array(32).fill(0xdd),
+  hmacRest: new Uint8Array(32).fill(0xaa),
 };
 
 describe("DefaultContactsManager", () => {
@@ -75,6 +88,28 @@ describe("DefaultContactsManager", () => {
     });
 
     const result = manager.renameContact(VALID_RENAME_INPUT);
+
+    expect(executeDeviceAction).toHaveBeenCalledTimes(1);
+    const call = executeDeviceAction.mock.calls[0]![0] as {
+      sessionId: string;
+      deviceAction: unknown;
+    };
+    expect(call.sessionId).toBe("session-id");
+    expect(call.deviceAction).toBeDefined();
+    expect(result).toBe("DA_RETURN");
+  });
+
+  it("editExternalAddressIdentifier flows manager -> use-case -> binder -> dmk.executeDeviceAction", () => {
+    const executeDeviceAction = vi.fn().mockReturnValue("DA_RETURN");
+    const dmk = { executeDeviceAction } as unknown as DeviceManagementKit;
+
+    const manager = new DefaultContactsManager({
+      dmk,
+      sessionId: "session-id",
+      appName: "Ethereum",
+    });
+
+    const result = manager.editExternalAddressIdentifier(VALID_EDIT_INPUT);
 
     expect(executeDeviceAction).toHaveBeenCalledTimes(1);
     const call = executeDeviceAction.mock.calls[0]![0] as {

--- a/packages/device-contacts-kit/src/internal/DefaultContactsManager.ts
+++ b/packages/device-contacts-kit/src/internal/DefaultContactsManager.ts
@@ -4,13 +4,16 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { type Container } from "inversify";
 
+import { type EditExternalAddressIdentifierDAReturnType } from "@api/app-binder/EditExternalAddressIdentifierDeviceActionTypes";
 import { type RegisterExternalAddressDAReturnType } from "@api/app-binder/RegisterExternalAddressDeviceActionTypes";
 import { type RenameContactDAReturnType } from "@api/app-binder/RenameContactDeviceActionTypes";
 import { type ContactsManager } from "@api/ContactsManager";
+import { type EditExternalAddressIdentifierInput } from "@api/model/EditExternalAddressIdentifier";
 import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
 import { type RenameContactInput } from "@api/model/RenameContact";
 import { makeContainer } from "@internal/di";
 import { useCaseTypes } from "@internal/use-cases/di/useCaseTypes";
+import { type EditExternalAddressIdentifierUseCase } from "@internal/use-cases/EditExternalAddressIdentifierUseCase";
 import { type RegisterExternalAddressUseCase } from "@internal/use-cases/RegisterExternalAddressUseCase";
 import { type RenameContactUseCase } from "@internal/use-cases/RenameContactUseCase";
 
@@ -44,6 +47,16 @@ export class DefaultContactsManager implements ContactsManager {
   renameContact(input: RenameContactInput): RenameContactDAReturnType {
     return this._container
       .get<RenameContactUseCase>(useCaseTypes.RenameContactUseCase)
+      .execute(input);
+  }
+
+  editExternalAddressIdentifier(
+    input: EditExternalAddressIdentifierInput,
+  ): EditExternalAddressIdentifierDAReturnType {
+    return this._container
+      .get<EditExternalAddressIdentifierUseCase>(
+        useCaseTypes.EditExternalAddressIdentifierUseCase,
+      )
       .execute(input);
   }
 

--- a/packages/device-contacts-kit/src/internal/app-binder/ContactsAppBinder.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/ContactsAppBinder.ts
@@ -4,10 +4,13 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { inject, injectable } from "inversify";
 
+import { type EditExternalAddressIdentifierDAReturnType } from "@api/app-binder/EditExternalAddressIdentifierDeviceActionTypes";
 import { type RegisterExternalAddressDAReturnType } from "@api/app-binder/RegisterExternalAddressDeviceActionTypes";
 import { type RenameContactDAReturnType } from "@api/app-binder/RenameContactDeviceActionTypes";
+import { type EditExternalAddressIdentifierInput } from "@api/model/EditExternalAddressIdentifier";
 import { type RegisterExternalAddressInput } from "@api/model/RegisterExternalAddress";
 import { type RenameContactInput } from "@api/model/RenameContact";
+import { EditExternalAddressIdentifierDeviceAction } from "@internal/app-binder/device-action/EditExternalAddressIdentifier/EditExternalAddressIdentifierDeviceAction";
 import { RegisterExternalAddressDeviceAction } from "@internal/app-binder/device-action/RegisterExternalAddress/RegisterExternalAddressDeviceAction";
 import { RenameContactDeviceAction } from "@internal/app-binder/device-action/RenameContact/RenameContactDeviceAction";
 import { externalTypes } from "@internal/externalTypes";
@@ -44,6 +47,17 @@ export class ContactsAppBinder {
     return this.dmk.executeDeviceAction({
       sessionId: this.sessionId,
       deviceAction: new RenameContactDeviceAction({ input }),
+    });
+  }
+
+  editExternalAddressIdentifier(
+    input: EditExternalAddressIdentifierInput,
+  ): EditExternalAddressIdentifierDAReturnType {
+    return this.dmk.executeDeviceAction({
+      sessionId: this.sessionId,
+      deviceAction: new EditExternalAddressIdentifierDeviceAction({
+        input: { ...input, appName: this.appName },
+      }),
     });
   }
 }

--- a/packages/device-contacts-kit/src/internal/app-binder/command/EditExternalAddressIdentifierCommand.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/command/EditExternalAddressIdentifierCommand.test.ts
@@ -1,0 +1,160 @@
+// Thin chunk-framer: wraps a pre-framed chunk under B0 10 03 <P2> and parses
+// the 33-byte edit response (struct_type 0x31 + hmac_rest) on the final chunk.
+// TLV byte-parity is asserted in SendEditExternalAddressIdentifierTask.test.ts.
+import {
+  type ApduResponse,
+  CommandResultStatus,
+} from "@ledgerhq/device-management-kit";
+
+import {
+  CONTACT_SEED_MISMATCH_ERROR_CODE,
+  ContactsCommandError,
+} from "@internal/app-binder/model/contactsErrors";
+
+import { EditExternalAddressIdentifierCommand } from "./EditExternalAddressIdentifierCommand";
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    out[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return out;
+}
+
+// Device response: struct_type(0x31) + rotated hmac_rest(32).
+const HMAC_REST = hexToBytes("88".repeat(32));
+const RESPONSE_HEX = "31" + "88".repeat(32);
+
+function makeResponse(hex: string): ApduResponse {
+  return {
+    data: Buffer.from(hexToBytes(hex)),
+    statusCode: Buffer.from([0x90, 0x00]),
+  };
+}
+
+describe("EditExternalAddressIdentifierCommand", () => {
+  describe("getApdu", () => {
+    it("wraps the framed chunk under B0 10 03 with P2=0x00 for the first/only chunk", () => {
+      const data = Uint8Array.from([0x00, 0x03, 0xaa, 0xbb, 0xcc]);
+
+      const apdu = new EditExternalAddressIdentifierCommand({
+        data,
+        p2: 0x00,
+      }).getApdu();
+
+      expect(apdu.getRawApdu()).toStrictEqual(
+        Uint8Array.from([
+          0xb0, 0x10, 0x03, 0x00, 0x05, 0x00, 0x03, 0xaa, 0xbb, 0xcc,
+        ]),
+      );
+    });
+
+    it("uses P2=0x80 for continuation chunks", () => {
+      const data = Uint8Array.from([0xaa, 0xbb]);
+
+      const apdu = new EditExternalAddressIdentifierCommand({
+        data,
+        p2: 0x80,
+      }).getApdu();
+
+      expect(apdu.getRawApdu()).toStrictEqual(
+        Uint8Array.from([0xb0, 0x10, 0x03, 0x80, 0x02, 0xaa, 0xbb]),
+      );
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("returns an empty payload for an intermediate chunk (SW=0x9000, no data)", () => {
+      const result = new EditExternalAddressIdentifierCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      }).parseResponse({
+        data: Buffer.from([]),
+        statusCode: Buffer.from([0x90, 0x00]),
+      });
+
+      expect(result).toStrictEqual({
+        status: CommandResultStatus.Success,
+        data: {},
+      });
+    });
+
+    it("extracts the rotated hmac_rest from the final-chunk response", () => {
+      const command = new EditExternalAddressIdentifierCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      });
+
+      const result = command.parseResponse(makeResponse(RESPONSE_HEX));
+
+      expect(result).toStrictEqual({
+        status: CommandResultStatus.Success,
+        data: { hmacRest: HMAC_REST },
+      });
+    });
+
+    it("returns InvalidStatusWordError when struct_type is wrong", () => {
+      const wrongType = "ee" + RESPONSE_HEX.slice(2); // replace 0x31 with 0xee
+      const command = new EditExternalAddressIdentifierCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      });
+
+      const result = command.parseResponse(makeResponse(wrongType));
+
+      expect(result.status).toBe(CommandResultStatus.Error);
+    });
+
+    it("returns InvalidStatusWordError when hmac_rest is truncated", () => {
+      const truncated = "31" + "88".repeat(16); // only 16 of 32 bytes
+      const command = new EditExternalAddressIdentifierCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      });
+
+      const result = command.parseResponse(makeResponse(truncated));
+
+      expect(result.status).toBe(CommandResultStatus.Error);
+    });
+
+    it("maps a known SW (0x6985) to a ContactsCommandError", () => {
+      const command = new EditExternalAddressIdentifierCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      });
+
+      const result = command.parseResponse({
+        data: Buffer.from([]),
+        statusCode: Buffer.from([0x69, 0x85]),
+      });
+
+      expect(result.status).toBe(CommandResultStatus.Error);
+      if (result.status === CommandResultStatus.Error) {
+        expect(result.error).toBeInstanceOf(ContactsCommandError);
+        expect((result.error as ContactsCommandError).errorCode).toBe("6985");
+      }
+    });
+
+    it("maps SW=0x6982 to a seed-mismatch ContactsCommandError", () => {
+      // The device returns 0x6982 when the seed-bound HMAC / group-handle
+      // verification fails — i.e. the entry was registered with another seed.
+      const command = new EditExternalAddressIdentifierCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      });
+
+      const result = command.parseResponse({
+        data: Buffer.from([]),
+        statusCode: Buffer.from([0x69, 0x82]),
+      });
+
+      expect(result.status).toBe(CommandResultStatus.Error);
+      if (result.status === CommandResultStatus.Error) {
+        expect(result.error).toBeInstanceOf(ContactsCommandError);
+        expect((result.error as ContactsCommandError).errorCode).toBe(
+          CONTACT_SEED_MISMATCH_ERROR_CODE,
+        );
+      }
+    });
+  });
+});

--- a/packages/device-contacts-kit/src/internal/app-binder/command/EditExternalAddressIdentifierCommand.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/command/EditExternalAddressIdentifierCommand.ts
@@ -1,0 +1,136 @@
+// Edit Identifier — sub-command P1=0x03 of the address-book APDU (CLA 0xB0 /
+// INS 0x10). Frames one chunk; on the final chunk parses the 33-byte response
+// struct_type(0x31) + hmac_rest(32) (the rotated address-level proof).
+// Intermediate chunks ack SW=0x9000 with no data. SW 0x6982 = seed/handle
+// mismatch, surfaced via the shared error helper before any device UI.
+// Protocol: Address Book Final Specifications — Edit Identifier.
+import {
+  type Apdu,
+  ApduBuilder,
+  ApduParser,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import {
+  CONTACTS_APDU_CLA,
+  CONTACTS_APDU_INS,
+  HMAC_REST_BYTES,
+  SUB_CMD_EDIT_IDENTIFIER,
+} from "@internal/app-binder/model/contactsConstants";
+import {
+  CONTACTS_APP_ERRORS,
+  contactsCommandErrorFactory,
+  type ContactsErrorCodes,
+} from "@internal/app-binder/model/contactsErrors";
+import { STRUCT_TYPE_EDIT_IDENTIFIER } from "@internal/app-binder/services/contactsTlvSerializer";
+
+export type EditExternalAddressIdentifierCommandArgs = {
+  /** One framed chunk built by sendFramedContactsPayload. */
+  readonly data: Uint8Array;
+  /** 0x00 for the first/only chunk, 0x80 for continuation chunks. */
+  readonly p2: number;
+};
+
+export type EditExternalAddressIdentifierCommandResponse = {
+  /**
+   * Present only on the final chunk — the device returns struct_type(0x31) +
+   * hmac_rest(32) there. Intermediate chunks return SW=0x9000 with no data.
+   * This is the replacement address-level proof (rotated `hmac_rest`).
+   */
+  readonly hmacRest?: Uint8Array;
+};
+
+const RESPONSE_STRUCT_TYPE = STRUCT_TYPE_EDIT_IDENTIFIER;
+
+/**
+ * Extract `length` bytes as a freshly-owned plain `Uint8Array` (the parser may
+ * hand back a `Buffer` view backed by the response), or `undefined` if the
+ * response is too short.
+ */
+function extractField(
+  parser: ApduParser,
+  length: number,
+): Uint8Array | undefined {
+  const field = parser.extractFieldByLength(length);
+  if (!field || field.length !== length) return undefined;
+  return Uint8Array.from(field);
+}
+
+export class EditExternalAddressIdentifierCommand
+  implements
+    Command<
+      EditExternalAddressIdentifierCommandResponse,
+      EditExternalAddressIdentifierCommandArgs,
+      ContactsErrorCodes
+    >
+{
+  readonly name = "editExternalAddressIdentifier";
+  readonly args: EditExternalAddressIdentifierCommandArgs;
+  private readonly errorHelper = new CommandErrorHelper<
+    EditExternalAddressIdentifierCommandResponse,
+    ContactsErrorCodes
+  >(CONTACTS_APP_ERRORS, contactsCommandErrorFactory);
+
+  constructor(args: EditExternalAddressIdentifierCommandArgs) {
+    this.args = args;
+  }
+
+  getApdu(): Apdu {
+    return new ApduBuilder({
+      cla: CONTACTS_APDU_CLA,
+      ins: CONTACTS_APDU_INS,
+      p1: SUB_CMD_EDIT_IDENTIFIER,
+      p2: this.args.p2,
+    })
+      .addBufferToData(this.args.data)
+      .build();
+  }
+
+  parseResponse(
+    response: ApduResponse,
+  ): CommandResult<
+    EditExternalAddressIdentifierCommandResponse,
+    ContactsErrorCodes
+  > {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(response),
+    ).orDefaultLazy(() => {
+      if (response.data.length === 0) {
+        // Intermediate chunk — device acks with SW=0x9000 and no payload.
+        return CommandResultFactory({ data: {} });
+      }
+
+      const parser = new ApduParser(response);
+
+      const structType = parser.extract8BitUInt();
+      if (structType !== RESPONSE_STRUCT_TYPE) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError(
+            `Expected struct_type 0x${RESPONSE_STRUCT_TYPE.toString(16)}, got ${
+              structType === undefined
+                ? "undefined"
+                : `0x${structType.toString(16)}`
+            }`,
+          ),
+        });
+      }
+
+      const hmacRest = extractField(parser, HMAC_REST_BYTES);
+      if (!hmacRest) {
+        return CommandResultFactory({
+          error: new InvalidStatusWordError("hmac_rest missing or truncated"),
+        });
+      }
+
+      return CommandResultFactory({
+        data: { hmacRest },
+      });
+    });
+  }
+}

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/EditExternalAddressIdentifier/EditExternalAddressIdentifierDeviceAction.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/EditExternalAddressIdentifier/EditExternalAddressIdentifierDeviceAction.test.ts
@@ -1,0 +1,544 @@
+import {
+  CommandResultFactory,
+  type DeviceActionState,
+  DeviceActionStatus,
+  DeviceModelId,
+  DeviceSessionStateType,
+  DeviceStatus,
+  UnknownDAError,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+import { beforeEach, describe, it, vi } from "vitest";
+
+import {
+  type EditExternalAddressIdentifierDAError,
+  type EditExternalAddressIdentifierDAInput,
+  type EditExternalAddressIdentifierDAIntermediateValue,
+  type EditExternalAddressIdentifierDAOutput,
+} from "@api/app-binder/EditExternalAddressIdentifierDeviceActionTypes";
+import { makeDeviceActionInternalApiMock } from "@internal/app-binder/device-action/__test-utils__/makeInternalApi";
+import { setupOpenAppDAMock } from "@internal/app-binder/device-action/__test-utils__/setupOpenAppDAMock";
+import { setupWaitForAppAndVersionDAMock } from "@internal/app-binder/device-action/__test-utils__/setupWaitForAppAndVersionDAMock";
+import { testDeviceActionStates } from "@internal/app-binder/device-action/__test-utils__/testDeviceActionStates";
+import {
+  ContactsCommandError,
+  ContactsVersionRequirementError,
+} from "@internal/app-binder/model/contactsErrors";
+
+import { EditExternalAddressIdentifierDeviceAction } from "./EditExternalAddressIdentifierDeviceAction";
+import { validateEditExternalAddressIdentifierInput } from "./validateEditExternalAddressIdentifierInput";
+
+vi.mock("@ledgerhq/device-management-kit", async (importOriginal) => {
+  const original =
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    await importOriginal<typeof import("@ledgerhq/device-management-kit")>();
+  return {
+    ...original,
+    OpenAppDeviceAction: vi.fn(() => ({
+      makeStateMachine: vi.fn(),
+    })),
+    WaitForAppAndVersionDeviceAction: vi.fn(() => ({
+      makeStateMachine: vi.fn(),
+    })),
+  };
+});
+
+const FRESH_APP = { name: "Ethereum", version: "1.15.0" };
+
+const GROUP_HANDLE = new Uint8Array(64).fill(0xcc);
+const HMAC_PROOF = new Uint8Array(32).fill(0xdd);
+const HMAC_REST_OLD = new Uint8Array(32).fill(0xaa);
+const HMAC_REST_NEW = new Uint8Array(32).fill(0x88);
+const PREVIOUS_IDENTIFIER = new Uint8Array(20).fill(0x11);
+const NEW_IDENTIFIER = new Uint8Array(20).fill(0x22);
+
+const OK_PROOF = { hmacRest: HMAC_REST_NEW };
+
+const BASE_INPUT = {
+  contactName: "Alice",
+  scope: "Eth main",
+  previousIdentifier: PREVIOUS_IDENTIFIER,
+  newIdentifier: NEW_IDENTIFIER,
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+  groupHandle: GROUP_HANDLE,
+  hmacProof: HMAC_PROOF,
+  hmacRest: HMAC_REST_OLD,
+  appName: "Ethereum",
+};
+
+const EXPECTED_OUTPUT = {
+  contactName: "Alice",
+  scope: "Eth main",
+  previousIdentifier: PREVIOUS_IDENTIFIER,
+  identifier: NEW_IDENTIFIER,
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+  groupHandle: GROUP_HANDLE,
+  // Preserved: the group-level name proof is unchanged by an identifier edit.
+  hmacProof: HMAC_PROOF,
+  // Rotated: only the address-level proof changes.
+  hmacRest: HMAC_REST_NEW,
+};
+
+describe("EditExternalAddressIdentifierDeviceAction", () => {
+  let apiMock: ReturnType<typeof makeDeviceActionInternalApiMock>;
+  let isSupportedMock: ReturnType<typeof vi.fn>;
+  let editIdentifierMock: ReturnType<typeof vi.fn>;
+
+  function extractDeps() {
+    return {
+      isSupported: isSupportedMock,
+      editIdentifier: editIdentifierMock,
+    };
+  }
+
+  beforeEach(() => {
+    apiMock = makeDeviceActionInternalApiMock();
+    setupWaitForAppAndVersionDAMock(FRESH_APP);
+    isSupportedMock = vi.fn().mockReturnValue(true);
+    editIdentifierMock = vi
+      .fn()
+      .mockResolvedValue(CommandResultFactory({ data: OK_PROOF }));
+    apiMock.getDeviceSessionState.mockReturnValue({
+      sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+      deviceStatus: DeviceStatus.CONNECTED,
+      installedApps: [],
+      currentApp: { name: "Ethereum", version: "1.15.0" },
+      deviceModelId: DeviceModelId.FLEX,
+      isSecureConnectionAllowed: true,
+    });
+  });
+
+  function makeAction(input: EditExternalAddressIdentifierDAInput) {
+    const action = new EditExternalAddressIdentifierDeviceAction({ input });
+    vi.spyOn(action, "extractDependencies").mockReturnValue(extractDeps());
+    return action;
+  }
+
+  it("open-app path: OpenApp -> VersionGuard -> EditIdentifier -> Completed", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: false });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.RegisterWallet,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          output: EXPECTED_OUTPUT,
+          status: DeviceActionStatus.Completed,
+        },
+      ] as DeviceActionState<
+        EditExternalAddressIdentifierDAOutput,
+        EditExternalAddressIdentifierDAError,
+        EditExternalAddressIdentifierDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+    }));
+
+  it("skip-open-app path: VersionGuard -> EditIdentifier -> Completed, preserving the group proof", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: true });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.RegisterWallet,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          output: EXPECTED_OUTPUT,
+          status: DeviceActionStatus.Completed,
+        },
+      ] as DeviceActionState<
+        EditExternalAddressIdentifierDAOutput,
+        EditExternalAddressIdentifierDAError,
+        EditExternalAddressIdentifierDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: () => {
+          try {
+            // The device rotates only the address-level hmac_rest; the contact
+            // group's name proof passes through unchanged.
+            expect(EXPECTED_OUTPUT.hmacProof).toBe(HMAC_PROOF);
+            expect(EXPECTED_OUTPUT.hmacRest).toBe(HMAC_REST_NEW);
+            expect(EXPECTED_OUTPUT.hmacRest).not.toBe(HMAC_REST_OLD);
+            resolve();
+          } catch (e) {
+            reject(e as Error);
+          }
+        },
+        onError: reject,
+      });
+    }));
+
+  it("version guard rejects on skip-open-app path without running EDIT IDENTIFIER", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      isSupportedMock.mockReturnValue(false);
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: true });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: new ContactsVersionRequirementError(),
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        EditExternalAddressIdentifierDAOutput,
+        EditExternalAddressIdentifierDAError,
+        EditExternalAddressIdentifierDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+      expect(editIdentifierMock).not.toHaveBeenCalled();
+    }));
+
+  it("surfaces an open-app failure as the device action error", () =>
+    new Promise<void>((resolve, reject) => {
+      const openAppError = new UnknownDAError("open app failed");
+      setupOpenAppDAMock(openAppError);
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: false });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: openAppError,
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        EditExternalAddressIdentifierDAOutput,
+        EditExternalAddressIdentifierDAError,
+        EditExternalAddressIdentifierDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+      expect(isSupportedMock).not.toHaveBeenCalled();
+    }));
+
+  it("surfaces an Edit Identifier command error", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const commandError = new ContactsCommandError({
+        errorCode: "6982",
+        message: "seed mismatch",
+      });
+      editIdentifierMock.mockResolvedValue(
+        CommandResultFactory({ error: commandError }),
+      );
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: true });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.RegisterWallet,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: commandError,
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        EditExternalAddressIdentifierDAOutput,
+        EditExternalAddressIdentifierDAError,
+        EditExternalAddressIdentifierDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+    }));
+
+  it("surfaces invalid input as a typed error state on the skip-open-app path", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const invalidInput = {
+        ...BASE_INPUT,
+        skipOpenApp: true,
+        contactName: "",
+      };
+      const validationError =
+        validateEditExternalAddressIdentifierInput(invalidInput);
+      const action = makeAction(invalidInput);
+
+      const expected = [
+        {
+          error: validationError,
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        EditExternalAddressIdentifierDAOutput,
+        EditExternalAddressIdentifierDAError,
+        EditExternalAddressIdentifierDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+      expect(isSupportedMock).not.toHaveBeenCalled();
+      expect(editIdentifierMock).not.toHaveBeenCalled();
+    }));
+
+  it("validates only after opening the app on the default path", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const invalidInput = {
+        ...BASE_INPUT,
+        skipOpenApp: false,
+        contactName: "",
+      };
+      const validationError =
+        validateEditExternalAddressIdentifierInput(invalidInput);
+      const action = makeAction(invalidInput);
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.ConfirmOpenApp,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: validationError,
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        EditExternalAddressIdentifierDAOutput,
+        EditExternalAddressIdentifierDAError,
+        EditExternalAddressIdentifierDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+      expect(editIdentifierMock).not.toHaveBeenCalled();
+    }));
+
+  it("evaluates support from the fresh WaitForAppAndVersion result, not stale session state", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const freshApp = { name: "Ethereum", version: "9.9.9" };
+      setupWaitForAppAndVersionDAMock(freshApp);
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: true });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.RegisterWallet,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          output: EXPECTED_OUTPUT,
+          status: DeviceActionStatus.Completed,
+        },
+      ] as DeviceActionState<
+        EditExternalAddressIdentifierDAOutput,
+        EditExternalAddressIdentifierDAError,
+        EditExternalAddressIdentifierDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: () => {
+          try {
+            expect(isSupportedMock).toHaveBeenCalledWith(freshApp);
+            resolve();
+          } catch (e) {
+            reject(e as Error);
+          }
+        },
+        onError: reject,
+      });
+    }));
+
+  it("surfaces a WaitForAppAndVersion failure as the device action error", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      const waitError = new UnknownDAError("could not read app and version");
+      setupWaitForAppAndVersionDAMock({ error: waitError });
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: true });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          error: waitError,
+          status: DeviceActionStatus.Error,
+        },
+      ] as DeviceActionState<
+        EditExternalAddressIdentifierDAOutput,
+        EditExternalAddressIdentifierDAError,
+        EditExternalAddressIdentifierDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+      expect(isSupportedMock).not.toHaveBeenCalled();
+      expect(editIdentifierMock).not.toHaveBeenCalled();
+    }));
+
+  it("propagates the UnlockDevice interaction emitted by WaitForAppAndVersion", () =>
+    new Promise<void>((resolve, reject) => {
+      setupOpenAppDAMock();
+      setupWaitForAppAndVersionDAMock(
+        FRESH_APP,
+        UserInteractionRequired.UnlockDevice,
+      );
+      const action = makeAction({ ...BASE_INPUT, skipOpenApp: true });
+
+      const expected = [
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.None,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.UnlockDevice,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          intermediateValue: {
+            requiredUserInteraction: UserInteractionRequired.RegisterWallet,
+          },
+          status: DeviceActionStatus.Pending,
+        },
+        {
+          output: EXPECTED_OUTPUT,
+          status: DeviceActionStatus.Completed,
+        },
+      ] as DeviceActionState<
+        EditExternalAddressIdentifierDAOutput,
+        EditExternalAddressIdentifierDAError,
+        EditExternalAddressIdentifierDAIntermediateValue
+      >[];
+
+      testDeviceActionStates(action, expected, apiMock, {
+        onDone: resolve,
+        onError: reject,
+      });
+    }));
+});

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/EditExternalAddressIdentifier/EditExternalAddressIdentifierDeviceAction.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/EditExternalAddressIdentifier/EditExternalAddressIdentifierDeviceAction.ts
@@ -1,0 +1,342 @@
+import {
+  type DeviceActionStateMachine,
+  type InternalApi,
+  isSuccessCommandResult,
+  OpenAppDeviceAction,
+  type StateMachineTypes,
+  UnknownDAError,
+  UserInteractionRequired,
+  WaitForAppAndVersionDeviceAction,
+  XStateDeviceAction,
+} from "@ledgerhq/device-management-kit";
+import { Left, Right } from "purify-ts";
+import { assign, fromPromise, setup } from "xstate";
+
+import {
+  type EditExternalAddressIdentifierDAError,
+  type EditExternalAddressIdentifierDAInput,
+  type EditExternalAddressIdentifierDAIntermediateValue,
+  type EditExternalAddressIdentifierDAInternalState,
+  type EditExternalAddressIdentifierDAOutput,
+} from "@api/app-binder/EditExternalAddressIdentifierDeviceActionTypes";
+import {
+  isContactsSupportedForSession,
+  type RunningApp,
+} from "@internal/app-binder/isContactsSupportedForSession";
+import { ContactsVersionRequirementError } from "@internal/app-binder/model/contactsErrors";
+import {
+  type EditIdentifierProof,
+  SendEditExternalAddressIdentifierTask,
+} from "@internal/app-binder/task/SendEditExternalAddressIdentifierTask";
+
+import { validateEditExternalAddressIdentifierInput } from "./validateEditExternalAddressIdentifierInput";
+
+export type EditExternalAddressIdentifierMachineDependencies = {
+  readonly isSupported: (app: RunningApp) => boolean;
+  readonly editIdentifier: (
+    input: EditExternalAddressIdentifierDAInput,
+  ) => Promise<
+    Awaited<ReturnType<SendEditExternalAddressIdentifierTask["run"]>>
+  >;
+};
+
+export class EditExternalAddressIdentifierDeviceAction extends XStateDeviceAction<
+  EditExternalAddressIdentifierDAOutput,
+  EditExternalAddressIdentifierDAInput,
+  EditExternalAddressIdentifierDAError,
+  EditExternalAddressIdentifierDAIntermediateValue,
+  EditExternalAddressIdentifierDAInternalState
+> {
+  makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    EditExternalAddressIdentifierDAOutput,
+    EditExternalAddressIdentifierDAInput,
+    EditExternalAddressIdentifierDAError,
+    EditExternalAddressIdentifierDAIntermediateValue,
+    EditExternalAddressIdentifierDAInternalState
+  > {
+    type types = StateMachineTypes<
+      EditExternalAddressIdentifierDAOutput,
+      EditExternalAddressIdentifierDAInput,
+      EditExternalAddressIdentifierDAError,
+      EditExternalAddressIdentifierDAIntermediateValue,
+      EditExternalAddressIdentifierDAInternalState
+    >;
+
+    const { isSupported, editIdentifier } =
+      this.extractDependencies(internalApi);
+    const appName = this.input.appName;
+
+    return setup({
+      types: {
+        input: {} as types["input"],
+        context: {} as types["context"],
+        output: {} as types["output"],
+      },
+      actors: {
+        openAppStateMachine: new OpenAppDeviceAction({
+          input: { appName },
+        }).makeStateMachine(internalApi),
+        waitForAppAndVersionStateMachine: new WaitForAppAndVersionDeviceAction({
+          input: {},
+        }).makeStateMachine(internalApi),
+        editIdentifier: fromPromise(
+          ({ input }: { input: EditExternalAddressIdentifierDAInput }) =>
+            editIdentifier(input),
+        ),
+      },
+      guards: {
+        skipOpenApp: ({ context }) => context.input.skipOpenApp === true,
+        noInternalError: ({ context }) => context._internalState.error === null,
+        contactsSupported: ({ context }) => {
+          const { appAndVersion } = context._internalState;
+          return appAndVersion !== null && isSupported(appAndVersion);
+        },
+      },
+      actions: {
+        assignValidationError: assign({
+          _internalState: ({ context }) => {
+            const error = validateEditExternalAddressIdentifierInput(
+              context.input,
+            );
+            return error
+              ? { ...context._internalState, error }
+              : context._internalState;
+          },
+        }),
+        assignVersionError: assign({
+          _internalState: ({ context }) => ({
+            ...context._internalState,
+            error: new ContactsVersionRequirementError(),
+          }),
+        }),
+        assignErrorFromEvent: assign({
+          _internalState: ({ context, event }) => ({
+            ...context._internalState,
+            error: new UnknownDAError(
+              event["error"] instanceof Error
+                ? event["error"].message
+                : String(event["error"]),
+            ),
+          }),
+        }),
+      },
+    }).createMachine({
+      id: "EditExternalAddressIdentifierDeviceAction",
+      initial: "InitialState",
+      context: ({ input }) => ({
+        input,
+        intermediateValue: {
+          requiredUserInteraction: UserInteractionRequired.None,
+        },
+        _internalState: {
+          error: null,
+          appAndVersion: null,
+          hmacRest: null,
+        },
+      }),
+      states: {
+        InitialState: {
+          always: [
+            { target: "ValidateInput", guard: "skipOpenApp" },
+            { target: "OpenAppDeviceAction" },
+          ],
+        },
+        OpenAppDeviceAction: {
+          invoke: {
+            id: "openAppStateMachine",
+            src: "openAppStateMachine",
+            input: () => ({ appName }),
+            onSnapshot: {
+              actions: assign({
+                intermediateValue: ({ event }) =>
+                  event.snapshot.context.intermediateValue,
+              }),
+            },
+            onDone: {
+              target: "CheckOpenAppResult",
+              actions: assign({
+                _internalState: ({ event, context }) =>
+                  event.output.caseOf<EditExternalAddressIdentifierDAInternalState>(
+                    {
+                      Right: () => context._internalState,
+                      Left: (error) => ({ ...context._internalState, error }),
+                    },
+                  ),
+              }),
+            },
+          },
+        },
+        CheckOpenAppResult: {
+          always: [
+            { target: "ValidateInput", guard: "noInternalError" },
+            { target: "Error" },
+          ],
+        },
+        // Input validation runs inside the device action (after the app is
+        // opened) so invalid caller input surfaces as a typed terminal error
+        // state on the observable instead of a synchronous throw. Runs on both
+        // the open-app and skip-open-app paths.
+        ValidateInput: {
+          entry: "assignValidationError",
+          always: [
+            { target: "WaitForAppAndVersion", guard: "noInternalError" },
+            { target: "Error" },
+          ],
+        },
+        // Read the running app + version freshly from the device (rather than
+        // the possibly-stale session state) so the version guard evaluates the
+        // app that is actually running — e.g. when open-app is skipped and the
+        // app was changed outside DMK. Runs on both paths.
+        WaitForAppAndVersion: {
+          // Start the phase from a clean value, clearing any interaction left
+          // over from the OpenApp phase (e.g. ConfirmOpenApp).
+          entry: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          }),
+          invoke: {
+            id: "waitForAppAndVersion",
+            src: "waitForAppAndVersionStateMachine",
+            input: () => ({}),
+            // Propagate the child DA's intermediate value so a consuming client
+            // can render, e.g., a "please unlock your device" prompt when the
+            // device is locked. Mirrors the OpenAppDeviceAction invoke above.
+            onSnapshot: {
+              actions: assign({
+                intermediateValue: ({ event }) =>
+                  event.snapshot.context.intermediateValue,
+              }),
+            },
+            onDone: {
+              target: "CheckAppAndVersion",
+              actions: assign({
+                _internalState: ({ event, context }) =>
+                  event.output.caseOf<EditExternalAddressIdentifierDAInternalState>(
+                    {
+                      Right: (appAndVersion) => ({
+                        ...context._internalState,
+                        appAndVersion: {
+                          name: appAndVersion.name,
+                          version: appAndVersion.version,
+                        },
+                      }),
+                      Left: (error) => ({ ...context._internalState, error }),
+                    },
+                  ),
+              }),
+            },
+          },
+        },
+        CheckAppAndVersion: {
+          always: [
+            { target: "VersionGuard", guard: "noInternalError" },
+            { target: "Error" },
+          ],
+        },
+        // Version guard evaluates support from the fresh WaitForAppAndVersion
+        // result. Runs on both the open-app and skip-open-app paths.
+        VersionGuard: {
+          always: [
+            { target: "EditIdentifier", guard: "contactsSupported" },
+            { target: "Error", actions: "assignVersionError" },
+          ],
+        },
+        EditIdentifier: {
+          entry: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.RegisterWallet,
+            },
+          }),
+          exit: assign({
+            intermediateValue: {
+              requiredUserInteraction: UserInteractionRequired.None,
+            },
+          }),
+          invoke: {
+            id: "editIdentifier",
+            src: "editIdentifier",
+            input: ({ context }) => context.input,
+            onDone: {
+              target: "EditIdentifierResultCheck",
+              actions: assign({
+                _internalState: ({ event, context }) =>
+                  isSuccessCommandResult(event.output)
+                    ? {
+                        ...context._internalState,
+                        hmacRest: event.output.data.hmacRest,
+                      }
+                    : {
+                        ...context._internalState,
+                        error: event.output.error,
+                      },
+              }),
+            },
+            onError: {
+              target: "Error",
+              actions: "assignErrorFromEvent",
+            },
+          },
+        },
+        EditIdentifierResultCheck: {
+          always: [
+            { target: "Success", guard: "noInternalError" },
+            { target: "Error" },
+          ],
+        },
+        Success: { type: "final" },
+        Error: { type: "final" },
+      },
+      output: ({ context }) => {
+        const { hmacRest, error } = context._internalState;
+        if (hmacRest) {
+          const { input } = context;
+          return Right({
+            contactName: input.contactName,
+            scope: input.scope,
+            previousIdentifier: input.previousIdentifier,
+            identifier: input.newIdentifier,
+            blockchainFamily: input.blockchainFamily,
+            chainId: input.chainId,
+            groupHandle: input.groupHandle,
+            // Preserved: the group-level name proof is untouched by an identifier
+            // edit — only `hmacRest` (the address-level proof) rotates.
+            hmacProof: input.hmacProof,
+            hmacRest,
+          });
+        }
+        return Left(error ?? new UnknownDAError("No error in final state"));
+      },
+    });
+  }
+
+  extractDependencies(
+    internalApi: InternalApi,
+  ): EditExternalAddressIdentifierMachineDependencies {
+    const isSupported = (app: RunningApp) =>
+      isContactsSupportedForSession(internalApi, app);
+
+    const editIdentifier = (
+      input: EditExternalAddressIdentifierDAInput,
+    ): Promise<
+      Awaited<ReturnType<SendEditExternalAddressIdentifierTask["run"]>>
+    > =>
+      new SendEditExternalAddressIdentifierTask(internalApi, {
+        contactName: input.contactName,
+        scope: input.scope,
+        previousIdentifier: input.previousIdentifier,
+        newIdentifier: input.newIdentifier,
+        blockchainFamily: input.blockchainFamily,
+        chainId: input.chainId,
+        groupHandle: input.groupHandle,
+        hmacProof: input.hmacProof,
+        hmacRest: input.hmacRest,
+      }).run();
+
+    return { isSupported, editIdentifier };
+  }
+}
+
+export type { EditIdentifierProof };

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/EditExternalAddressIdentifier/validateEditExternalAddressIdentifierInput.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/EditExternalAddressIdentifier/validateEditExternalAddressIdentifierInput.test.ts
@@ -1,0 +1,94 @@
+import { type EditExternalAddressIdentifierInput } from "@api/model/EditExternalAddressIdentifier";
+import { ContactsValidationError } from "@internal/app-binder/model/contactsValidation";
+
+import { validateEditExternalAddressIdentifierInput } from "./validateEditExternalAddressIdentifierInput";
+
+const VALID_INPUT: EditExternalAddressIdentifierInput = {
+  contactName: "Alice",
+  scope: "Eth main",
+  previousIdentifier: new Uint8Array(20).fill(0x11),
+  newIdentifier: new Uint8Array(20).fill(0x22),
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+  groupHandle: new Uint8Array(64).fill(0xcc),
+  hmacProof: new Uint8Array(32).fill(0xdd),
+  hmacRest: new Uint8Array(32).fill(0xaa),
+};
+
+describe("validateEditExternalAddressIdentifierInput", () => {
+  it("returns null for a valid input", () => {
+    expect(validateEditExternalAddressIdentifierInput(VALID_INPUT)).toBeNull();
+  });
+
+  it("rejects an empty contactName", () => {
+    const error = validateEditExternalAddressIdentifierInput({
+      ...VALID_INPUT,
+      contactName: "",
+    });
+    expect(error).toBeInstanceOf(ContactsValidationError);
+  });
+
+  it("rejects a non-printable scope", () => {
+    const error = validateEditExternalAddressIdentifierInput({
+      ...VALID_INPUT,
+      scope: "café", // 0xC3 0xA9 is non-ASCII
+    });
+    expect(error).toBeInstanceOf(ContactsValidationError);
+  });
+
+  it("rejects an unsupported blockchain family", () => {
+    const error = validateEditExternalAddressIdentifierInput({
+      ...VALID_INPUT,
+      blockchainFamily: "dogecoin",
+    });
+    expect(error).toBeInstanceOf(ContactsValidationError);
+  });
+
+  it("rejects a previousIdentifier of the wrong length for Ethereum", () => {
+    const error = validateEditExternalAddressIdentifierInput({
+      ...VALID_INPUT,
+      previousIdentifier: new Uint8Array(19).fill(0x11),
+    });
+    expect(error).toBeInstanceOf(ContactsValidationError);
+  });
+
+  it("rejects a newIdentifier of the wrong length for Ethereum", () => {
+    const error = validateEditExternalAddressIdentifierInput({
+      ...VALID_INPUT,
+      newIdentifier: new Uint8Array(21).fill(0x22),
+    });
+    expect(error).toBeInstanceOf(ContactsValidationError);
+  });
+
+  it("requires chainId for the Ethereum family", () => {
+    const error = validateEditExternalAddressIdentifierInput({
+      ...VALID_INPUT,
+      chainId: undefined,
+    });
+    expect(error).toBeInstanceOf(ContactsValidationError);
+  });
+
+  it("rejects a groupHandle of the wrong length", () => {
+    const error = validateEditExternalAddressIdentifierInput({
+      ...VALID_INPUT,
+      groupHandle: new Uint8Array(63).fill(0xcc),
+    });
+    expect(error).toBeInstanceOf(ContactsValidationError);
+  });
+
+  it("rejects an hmacProof of the wrong length", () => {
+    const error = validateEditExternalAddressIdentifierInput({
+      ...VALID_INPUT,
+      hmacProof: new Uint8Array(31).fill(0xdd),
+    });
+    expect(error).toBeInstanceOf(ContactsValidationError);
+  });
+
+  it("rejects an hmacRest of the wrong length", () => {
+    const error = validateEditExternalAddressIdentifierInput({
+      ...VALID_INPUT,
+      hmacRest: new Uint8Array(33).fill(0xaa),
+    });
+    expect(error).toBeInstanceOf(ContactsValidationError);
+  });
+});

--- a/packages/device-contacts-kit/src/internal/app-binder/device-action/EditExternalAddressIdentifier/validateEditExternalAddressIdentifierInput.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/device-action/EditExternalAddressIdentifier/validateEditExternalAddressIdentifierInput.ts
@@ -1,0 +1,93 @@
+import { type EditExternalAddressIdentifierInput } from "@api/model/EditExternalAddressIdentifier";
+import { BLOCKCHAIN_FAMILY_BY_NAME } from "@internal/app-binder/model/contactsConstants";
+import {
+  CONTACT_NAME_BUFFER_LENGTH,
+  ContactsValidationError,
+  ETH_ADDRESS_BYTES,
+  GROUP_HANDLE_SIZE,
+  HMAC_PROOF_LENGTH,
+  SCOPE_BUFFER_LENGTH,
+  validateByteLength,
+  validateChainId,
+  validatePrintableLabel,
+} from "@internal/app-binder/model/contactsValidation";
+
+// The address-level proof (`hmac_rest`) shares the 32-byte HMAC width.
+const HMAC_REST_LENGTH = HMAC_PROOF_LENGTH;
+
+/**
+ * Validate the caller input for Edit External Address Identifier. Returns the
+ * first `ContactsValidationError`, or `null` when valid. Non-throwing so the
+ * device action can surface it as a typed terminal error state.
+ */
+export function validateEditExternalAddressIdentifierInput(
+  input: EditExternalAddressIdentifierInput,
+): ContactsValidationError | null {
+  try {
+    validatePrintableLabel(input.contactName, {
+      field: "contactName",
+      bufferLength: CONTACT_NAME_BUFFER_LENGTH,
+    });
+    validatePrintableLabel(input.scope, {
+      field: "scope",
+      bufferLength: SCOPE_BUFFER_LENGTH,
+    });
+
+    const family = input.blockchainFamily.toLowerCase();
+    if (!(family in BLOCKCHAIN_FAMILY_BY_NAME)) {
+      throw new ContactsValidationError(
+        `Unsupported blockchain family: ${input.blockchainFamily}`,
+      );
+    }
+    if (family === "ethereum") {
+      validateByteLength(input.previousIdentifier, {
+        field: "previousIdentifier",
+        expectedBytes: ETH_ADDRESS_BYTES,
+      });
+      validateByteLength(input.newIdentifier, {
+        field: "newIdentifier",
+        expectedBytes: ETH_ADDRESS_BYTES,
+      });
+      // CHAIN_ID is mandatory for the Ethereum family (multiple networks share
+      // the same address format).
+      if (input.chainId === undefined) {
+        throw new ContactsValidationError(
+          "chainId is required for the Ethereum blockchain family.",
+        );
+      }
+    } else {
+      if (input.previousIdentifier.length === 0) {
+        throw new ContactsValidationError(
+          "previousIdentifier must not be empty.",
+        );
+      }
+      if (input.newIdentifier.length === 0) {
+        throw new ContactsValidationError("newIdentifier must not be empty.");
+      }
+    }
+
+    if (input.chainId !== undefined) {
+      validateChainId(input.chainId);
+    }
+
+    validateByteLength(input.groupHandle, {
+      field: "groupHandle",
+      expectedBytes: GROUP_HANDLE_SIZE,
+    });
+    validateByteLength(input.hmacProof, {
+      field: "hmacProof",
+      expectedBytes: HMAC_PROOF_LENGTH,
+    });
+    validateByteLength(input.hmacRest, {
+      field: "hmacRest",
+      expectedBytes: HMAC_REST_LENGTH,
+    });
+
+    return null;
+  } catch (error) {
+    if (error instanceof ContactsValidationError) {
+      return error;
+    }
+    throw error;
+  }
+}

--- a/packages/device-contacts-kit/src/internal/app-binder/model/contactsConstants.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/model/contactsConstants.ts
@@ -15,6 +15,21 @@ export const CONTACTS_APDU_INS = 0x10;
 export const SUB_CMD_REGISTER_IDENTITY = 0x01;
 
 /**
+ * P1 sub-command selector for EDIT IDENTIFIER — an address-book app sub-command
+ * (CLA 0xB0 / INS 0x10) served by the coin app, never OS-dispatched.
+ */
+export const SUB_CMD_EDIT_IDENTIFIER = 0x03;
+
+/**
+ * BIP32 segments (`m/44'/60'/0'/0/0`) sent with EDIT IDENTIFIER. Temporary: the
+ * coin app currently requires a DERIVATION_PATH TLV, so the kit sends one fixed,
+ * unexposed path; it will be removed once firmware stops requiring it.
+ */
+export const EXTERNAL_ADDRESS_DERIVATION_PATH_SEGMENTS: readonly number[] = [
+  0x8000002c, 0x8000003c, 0x80000000, 0x00000000, 0x00000000,
+];
+
+/**
  * EDIT CONTACT NAME (rename) is a blockchain-agnostic OS/dashboard command with
  * its own CLA/INS — NOT a sub-command of the address-book app APDU (0xB0/0x10).
  * The OS serves it directly, so it must run on the dashboard. P1 is a fixed

--- a/packages/device-contacts-kit/src/internal/app-binder/task/SendEditExternalAddressIdentifierTask.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/task/SendEditExternalAddressIdentifierTask.test.ts
@@ -1,0 +1,153 @@
+// Asserts the op-3 (Edit Identifier) framed chunk (2-byte BE length + TLV) is
+// byte-for-byte parity with the signer-eth `edit_external_address` fixture.
+import {
+  CommandResultFactory,
+  type InternalApi,
+  InvalidStatusWordError,
+} from "@ledgerhq/device-management-kit";
+
+import { EditExternalAddressIdentifierCommand } from "@internal/app-binder/command/EditExternalAddressIdentifierCommand";
+
+import { SendEditExternalAddressIdentifierTask } from "./SendEditExternalAddressIdentifierTask";
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    out[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return out;
+}
+
+// Framed chunk = "00 ec" (2-byte BE total TLV length = 236) + TLV.
+const FRAMED_CHUNK = hexToBytes(
+  "00ec" +
+    "010131" +
+    "020101" +
+    "81f005416c696365" +
+    "81f108457468206d61696e" +
+    "81f2145555555555555555555555555555555555555555" +
+    "81f41400000000000000000000000000000000deadbeef" +
+    "81f640" +
+    "cc".repeat(64) +
+    "6915058000002c8000003c800000000000000000000000" +
+    "230101" +
+    "2920" +
+    "dd".repeat(32) +
+    "81f720" +
+    "aa".repeat(32) +
+    "510101",
+);
+
+const OK_PROOF = { hmacRest: hexToBytes("88".repeat(32)) };
+
+const BASE_ARGS = {
+  contactName: "Alice",
+  scope: "Eth main",
+  newIdentifier: hexToBytes("55".repeat(20)),
+  previousIdentifier: hexToBytes("00000000000000000000000000000000deadbeef"),
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+  groupHandle: hexToBytes("cc".repeat(64)),
+  hmacProof: hexToBytes("dd".repeat(32)),
+  hmacRest: hexToBytes("aa".repeat(32)),
+};
+
+function makeApiMock(): InternalApi & {
+  sendCommand: ReturnType<typeof vi.fn>;
+} {
+  return { sendCommand: vi.fn() } as unknown as InternalApi & {
+    sendCommand: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("SendEditExternalAddressIdentifierTask", () => {
+  it("assembles the framed chunk byte-equal to the fixture and dispatches EditExternalAddressIdentifierCommand", async () => {
+    const api = makeApiMock();
+    api.sendCommand.mockResolvedValueOnce(
+      CommandResultFactory({ data: OK_PROOF }),
+    );
+
+    const result = await new SendEditExternalAddressIdentifierTask(
+      api,
+      BASE_ARGS,
+    ).run();
+
+    expect(api.sendCommand.mock.calls).toHaveLength(1);
+    expect(api.sendCommand.mock.calls[0]![0]).toStrictEqual(
+      new EditExternalAddressIdentifierCommand({
+        data: FRAMED_CHUNK,
+        p2: 0x00,
+      }),
+    );
+    expect(result).toStrictEqual(CommandResultFactory({ data: OK_PROOF }));
+  });
+
+  it("omits the CHAIN_ID TLV when chainId is not provided", async () => {
+    const api = makeApiMock();
+    api.sendCommand.mockResolvedValueOnce(
+      CommandResultFactory({ data: OK_PROOF }),
+    );
+
+    await new SendEditExternalAddressIdentifierTask(api, {
+      ...BASE_ARGS,
+      chainId: undefined,
+    }).run();
+
+    const command = api.sendCommand.mock
+      .calls[0]![0] as EditExternalAddressIdentifierCommand;
+    const framedHex = Buffer.from(command.args.data).toString("hex");
+    // No `23 01 ..` CHAIN_ID TLV; HMAC_PROOF (29 20 ..) follows the path directly.
+    expect(framedHex).not.toContain("230101");
+    expect(framedHex.endsWith("510101")).toBe(true);
+  });
+
+  it("propagates command-level errors", async () => {
+    const api = makeApiMock();
+    api.sendCommand.mockResolvedValueOnce(
+      CommandResultFactory({
+        error: new InvalidStatusWordError("user cancelled"),
+      }),
+    );
+
+    const result = await new SendEditExternalAddressIdentifierTask(
+      api,
+      BASE_ARGS,
+    ).run();
+
+    expect(result).toStrictEqual(
+      CommandResultFactory({
+        error: new InvalidStatusWordError("user cancelled"),
+      }),
+    );
+  });
+
+  it("errors when the final-chunk response does not carry hmac_rest", async () => {
+    const api = makeApiMock();
+    api.sendCommand.mockResolvedValueOnce(CommandResultFactory({ data: {} }));
+
+    const result = await new SendEditExternalAddressIdentifierTask(
+      api,
+      BASE_ARGS,
+    ).run();
+
+    expect(result).toStrictEqual(
+      CommandResultFactory({
+        error: new InvalidStatusWordError(
+          "EditIdentifier final-chunk response did not carry hmac_rest",
+        ),
+      }),
+    );
+  });
+
+  it("throws on an unsupported blockchain family", async () => {
+    const api = makeApiMock();
+
+    await expect(
+      new SendEditExternalAddressIdentifierTask(api, {
+        ...BASE_ARGS,
+        blockchainFamily: "dogecoin",
+      }).run(),
+    ).rejects.toThrow(/Unsupported blockchain family/);
+    expect(api.sendCommand).not.toHaveBeenCalled();
+  });
+});

--- a/packages/device-contacts-kit/src/internal/app-binder/task/SendEditExternalAddressIdentifierTask.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/task/SendEditExternalAddressIdentifierTask.ts
@@ -1,0 +1,140 @@
+// Builds the op-3 (Edit Identifier) TLV and dispatches it via the shared
+// chunked framing; the device returns struct_type + hmac_rest on the final
+// chunk. Tag order: STRUCT_TYPE, STRUCT_VERSION, CONTACT_NAME, SCOPE,
+// ACCOUNT_IDENTIFIER (new), PREVIOUS_IDENTIFIER (old), GROUP_HANDLE,
+// DERIVATION_PATH, CHAIN_ID (Ethereum only), HMAC_PROOF, HMAC_REST (old),
+// BLOCKCHAIN_FAMILY. DERIVATION_PATH is a temporary coin-app requirement: the
+// kit sends one fixed, unexposed path and will drop it once firmware does.
+// Reference: Address Book Final Specifications — Edit Identifier.
+import {
+  ByteArrayBuilder,
+  type CommandResult,
+  DmkResultFactory,
+  type InternalApi,
+  InvalidStatusWordError,
+  isSuccessCommandResult,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+
+import { EditExternalAddressIdentifierCommand } from "@internal/app-binder/command/EditExternalAddressIdentifierCommand";
+import {
+  BLOCKCHAIN_FAMILY_BY_NAME,
+  EXTERNAL_ADDRESS_DERIVATION_PATH_SEGMENTS,
+  SUB_CMD_EDIT_IDENTIFIER,
+} from "@internal/app-binder/model/contactsConstants";
+import { type ContactsErrorCodes } from "@internal/app-binder/model/contactsErrors";
+import {
+  CONTACTS_TLV_TAG,
+  encodeTlvAscii,
+  encodeTlvBuffer,
+  encodeTlvChainId,
+  encodeTlvUInt8,
+  packDerivationPath,
+  STRUCT_TYPE_EDIT_IDENTIFIER,
+  STRUCT_VERSION_VALUE,
+} from "@internal/app-binder/services/contactsTlvSerializer";
+import { sendFramedContactsPayload } from "@internal/app-binder/services/sendFramedContactsPayload";
+
+export type EditIdentifierProof = {
+  readonly hmacRest: Uint8Array;
+};
+
+export type SendEditExternalAddressIdentifierTaskArgs = {
+  readonly contactName: string;
+  readonly scope: string;
+  readonly previousIdentifier: Uint8Array;
+  readonly newIdentifier: Uint8Array;
+  readonly blockchainFamily: string;
+  readonly chainId?: bigint;
+  readonly groupHandle: Uint8Array;
+  readonly hmacProof: Uint8Array;
+  readonly hmacRest: Uint8Array;
+  readonly logger?: LoggerPublisherService;
+};
+
+export class SendEditExternalAddressIdentifierTask {
+  constructor(
+    private readonly api: InternalApi,
+    private readonly args: SendEditExternalAddressIdentifierTaskArgs,
+  ) {}
+
+  async run(): Promise<CommandResult<EditIdentifierProof, ContactsErrorCodes>> {
+    const payload = this.buildPayload(this.args);
+
+    const result = (await sendFramedContactsPayload(this.api, {
+      payload,
+      p1: SUB_CMD_EDIT_IDENTIFIER,
+      makeCommand: (chunk, p2) =>
+        new EditExternalAddressIdentifierCommand({ data: chunk, p2 }),
+      logger: this.args.logger,
+      commandTag: "SendEditExternalAddressIdentifierTask",
+    })) as CommandResult<
+      { readonly hmacRest?: Uint8Array },
+      ContactsErrorCodes
+    >;
+
+    if (!isSuccessCommandResult(result)) {
+      return result;
+    }
+
+    const { hmacRest } = result.data;
+    if (!hmacRest) {
+      return DmkResultFactory({
+        error: new InvalidStatusWordError(
+          "EditIdentifier final-chunk response did not carry hmac_rest",
+        ),
+      });
+    }
+    return DmkResultFactory({ data: { hmacRest } });
+  }
+
+  private buildPayload(
+    args: SendEditExternalAddressIdentifierTaskArgs,
+  ): Uint8Array {
+    const family =
+      BLOCKCHAIN_FAMILY_BY_NAME[args.blockchainFamily.toLowerCase()];
+    if (family === undefined) {
+      throw new Error(
+        `Unsupported blockchain family: ${args.blockchainFamily}`,
+      );
+    }
+
+    const pathBytes = packDerivationPath([
+      ...EXTERNAL_ADDRESS_DERIVATION_PATH_SEGMENTS,
+    ]);
+
+    const builder = new ByteArrayBuilder();
+    encodeTlvUInt8(
+      builder,
+      CONTACTS_TLV_TAG.STRUCT_TYPE,
+      STRUCT_TYPE_EDIT_IDENTIFIER,
+    );
+    encodeTlvUInt8(
+      builder,
+      CONTACTS_TLV_TAG.STRUCT_VERSION,
+      STRUCT_VERSION_VALUE,
+    );
+    encodeTlvAscii(builder, CONTACTS_TLV_TAG.CONTACT_NAME, args.contactName);
+    encodeTlvAscii(builder, CONTACTS_TLV_TAG.SCOPE, args.scope);
+    encodeTlvBuffer(
+      builder,
+      CONTACTS_TLV_TAG.ACCOUNT_IDENTIFIER,
+      args.newIdentifier,
+    );
+    encodeTlvBuffer(
+      builder,
+      CONTACTS_TLV_TAG.PREVIOUS_IDENTIFIER,
+      args.previousIdentifier,
+    );
+    encodeTlvBuffer(builder, CONTACTS_TLV_TAG.GROUP_HANDLE, args.groupHandle);
+    encodeTlvBuffer(builder, CONTACTS_TLV_TAG.DERIVATION_PATH, pathBytes);
+    if (args.chainId !== undefined) {
+      encodeTlvChainId(builder, CONTACTS_TLV_TAG.CHAIN_ID, args.chainId);
+    }
+    encodeTlvBuffer(builder, CONTACTS_TLV_TAG.HMAC_PROOF, args.hmacProof);
+    encodeTlvBuffer(builder, CONTACTS_TLV_TAG.HMAC_REST, args.hmacRest);
+    encodeTlvUInt8(builder, CONTACTS_TLV_TAG.BLOCKCHAIN_FAMILY, family);
+
+    return builder.build();
+  }
+}

--- a/packages/device-contacts-kit/src/internal/use-cases/EditExternalAddressIdentifierUseCase.test.ts
+++ b/packages/device-contacts-kit/src/internal/use-cases/EditExternalAddressIdentifierUseCase.test.ts
@@ -1,0 +1,48 @@
+import { type EditExternalAddressIdentifierInput } from "@api/model/EditExternalAddressIdentifier";
+import { type ContactsAppBinder } from "@internal/app-binder/ContactsAppBinder";
+
+import { EditExternalAddressIdentifierUseCase } from "./EditExternalAddressIdentifierUseCase";
+
+function makeUseCase() {
+  const editExternalAddressIdentifier = vi.fn().mockReturnValue("DA_RETURN");
+  const appBinder = {
+    editExternalAddressIdentifier,
+  } as unknown as ContactsAppBinder;
+  return {
+    useCase: new EditExternalAddressIdentifierUseCase(appBinder),
+    editExternalAddressIdentifier,
+  };
+}
+
+const VALID_INPUT: EditExternalAddressIdentifierInput = {
+  contactName: "Alice",
+  scope: "Eth main",
+  previousIdentifier: new Uint8Array(20).fill(0x11),
+  newIdentifier: new Uint8Array(20).fill(0x22),
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+  groupHandle: new Uint8Array(64).fill(0xcc),
+  hmacProof: new Uint8Array(32).fill(0xdd),
+  hmacRest: new Uint8Array(32).fill(0xaa),
+};
+
+describe("EditExternalAddressIdentifierUseCase", () => {
+  it("delegates to the app binder", () => {
+    const { useCase, editExternalAddressIdentifier } = makeUseCase();
+
+    const result = useCase.execute(VALID_INPUT);
+
+    expect(editExternalAddressIdentifier).toHaveBeenCalledWith(VALID_INPUT);
+    expect(result).toBe("DA_RETURN");
+  });
+
+  it("does not validate — invalid input is forwarded, not thrown", () => {
+    // Validation now lives in the device action and surfaces as a typed DA
+    // error state; the use case must never throw for bad input.
+    const { useCase, editExternalAddressIdentifier } = makeUseCase();
+
+    const invalidInput = { ...VALID_INPUT, contactName: "" };
+    expect(() => useCase.execute(invalidInput)).not.toThrow();
+    expect(editExternalAddressIdentifier).toHaveBeenCalledWith(invalidInput);
+  });
+});

--- a/packages/device-contacts-kit/src/internal/use-cases/EditExternalAddressIdentifierUseCase.ts
+++ b/packages/device-contacts-kit/src/internal/use-cases/EditExternalAddressIdentifierUseCase.ts
@@ -1,0 +1,25 @@
+import { inject, injectable } from "inversify";
+
+import { type EditExternalAddressIdentifierDAReturnType } from "@api/app-binder/EditExternalAddressIdentifierDeviceActionTypes";
+import { type EditExternalAddressIdentifierInput } from "@api/model/EditExternalAddressIdentifier";
+import { ContactsAppBinder } from "@internal/app-binder/ContactsAppBinder";
+import { appBinderTypes } from "@internal/app-binder/di/appBinderTypes";
+
+/**
+ * Delegates to `ContactsAppBinder`, which constructs and executes the
+ * `EditExternalAddressIdentifierDeviceAction`. Input validation lives in the
+ * device action (surfaced as a typed error state), not here.
+ */
+@injectable()
+export class EditExternalAddressIdentifierUseCase {
+  constructor(
+    @inject(appBinderTypes.AppBinder)
+    private readonly appBinder: ContactsAppBinder,
+  ) {}
+
+  execute(
+    input: EditExternalAddressIdentifierInput,
+  ): EditExternalAddressIdentifierDAReturnType {
+    return this.appBinder.editExternalAddressIdentifier(input);
+  }
+}

--- a/packages/device-contacts-kit/src/internal/use-cases/di/useCaseModule.ts
+++ b/packages/device-contacts-kit/src/internal/use-cases/di/useCaseModule.ts
@@ -1,5 +1,6 @@
 import { ContainerModule } from "inversify";
 
+import { EditExternalAddressIdentifierUseCase } from "@internal/use-cases/EditExternalAddressIdentifierUseCase";
 import { RegisterExternalAddressUseCase } from "@internal/use-cases/RegisterExternalAddressUseCase";
 import { RenameContactUseCase } from "@internal/use-cases/RenameContactUseCase";
 
@@ -11,4 +12,7 @@ export const useCaseModuleFactory = () =>
       RegisterExternalAddressUseCase,
     );
     bind(useCaseTypes.RenameContactUseCase).to(RenameContactUseCase);
+    bind(useCaseTypes.EditExternalAddressIdentifierUseCase).to(
+      EditExternalAddressIdentifierUseCase,
+    );
   });

--- a/packages/device-contacts-kit/src/internal/use-cases/di/useCaseTypes.ts
+++ b/packages/device-contacts-kit/src/internal/use-cases/di/useCaseTypes.ts
@@ -1,4 +1,7 @@
 export const useCaseTypes = {
   RegisterExternalAddressUseCase: Symbol.for("RegisterExternalAddressUseCase"),
   RenameContactUseCase: Symbol.for("RenameContactUseCase"),
+  EditExternalAddressIdentifierUseCase: Symbol.for(
+    "EditExternalAddressIdentifierUseCase",
+  ),
 } as const;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Adds `ContactsManager.editExternalAddressIdentifier()` the **EDIT IDENTIFIER** Address Book operation, which replaces the identifier (address bytes) of an existing external-address entry within a contact group, keeping the same contact and label.

Follows the DSDK-1377 register slice: `EditExternalAddressIdentifierCommand` (sub-command `B0 10 03`), `SendEditExternalAddressIdentifierTask` (TLV + chunked framing), a version-guarded `EditExternalAddressIdentifierDeviceAction` (opens the coin app by default, supports `skipOpenApp`, checks the DSDK-1376 version requirements), and `EditExternalAddressIdentifierUseCase`. The device rotates only the address-level `hmacRest`; the contact-group `hmacProof` is preserved and passed through. `derivationPath` is a temporary coin-app requirement owned internally by the kit (a single fixed path) and is not exposed publicly.

```ts
const { observable } = manager.editExternalAddressIdentifier({
  contactName, scope,
  previousIdentifier, newIdentifier,
  blockchainFamily: "ethereum", chainId: 1n,
  groupHandle, hmacProof, hmacRest, // current proofs
});
```

### ❓ Context

- **JIRA or GitHub link**: DSDK-1379

- **Feature**: @ledgerhq/device-contacts-kit — Editing an external address identifier (Address Book op 3)

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [X] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [X] **Changeset is provided** <!-- Please provide a changeset -->
- [X] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
   - New public method ContactsManager.editExternalAddressIdentifier() + EditExternalAddressIdentifier input/output and DA types. Additive only.
   - QA focus: on-device EDIT IDENTIFIER approval flow and that the returned hmacRest round-trips (persist + reuse); wire format not yet validated on real hardware.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
