### PR TITLE
✨ (signer-eth) [DSDK-1386]: Accept an optional EVM address book in the signer builder

### DIFF
--- a/.changeset/dsdk-1386-eth-address-book.md
+++ b/.changeset/dsdk-1386-eth-address-book.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": minor
+---
+
+Accept an optional EVM address book in SignerEthBuilder via withAddressBook, exposing the EvmAddressBook public model

--- a/packages/signer/signer-eth/src/api/SignerEthBuilder.test.ts
+++ b/packages/signer/signer-eth/src/api/SignerEthBuilder.test.ts
@@ -1,6 +1,7 @@
 import { type ContextModule } from "@ledgerhq/context-module";
 import { type DeviceManagementKit } from "@ledgerhq/device-management-kit";
 
+import { type EvmAddressBook } from "@api/model/EvmAddressBook";
 import { SignerEthBuilder } from "@api/SignerEthBuilder";
 import { DefaultSignerEth } from "@internal/DefaultSignerEth";
 import { externalTypes } from "@internal/externalTypes";
@@ -58,5 +59,103 @@ describe("SignerEthBuilder", () => {
     expect(
       signer["_container"].get<ContextModule>(externalTypes.ContextModule),
     ).toBe(contextModule);
+  });
+
+  test("should instanciate with an empty address book by default", () => {
+    // GIVEN
+    const builder = new SignerEthBuilder(defaultConstructorArgs);
+
+    // WHEN
+    const signer = builder.build();
+
+    // THEN
+    expect(signer).toBeInstanceOf(DefaultSignerEth);
+    expect(
+      signer["_container"].get<EvmAddressBook>(externalTypes.AddressBook),
+    ).toEqual({
+      contactGroups: [],
+      ledgerAccounts: [],
+    });
+  });
+
+  test("should instanciate with a custom address book", () => {
+    // GIVEN
+    const builder = new SignerEthBuilder(defaultConstructorArgs);
+    const addressBook: EvmAddressBook = {
+      contactGroups: [
+        {
+          contactName: "Alice",
+          groupHandle: Uint8Array.from([0x01, 0x02]),
+          hmacProof: Uint8Array.from([0x03, 0x04]),
+          externalAddresses: [
+            {
+              scope: "ETH",
+              address: "0x1111111111111111111111111111111111111111",
+              chainId: 1n,
+              hmacRest: Uint8Array.from([0x05]),
+            },
+          ],
+        },
+      ],
+      ledgerAccounts: [
+        {
+          accountName: "Main account",
+          derivationPath: "44'/60'/0'/0/0",
+          chainId: 1n,
+          hmacProof: Uint8Array.from([0x06]),
+        },
+      ],
+    };
+
+    // WHEN
+    const signer = builder.withAddressBook(addressBook).build();
+
+    // THEN
+    expect(signer).toBeInstanceOf(DefaultSignerEth);
+    expect(
+      signer["_container"].get<EvmAddressBook>(externalTypes.AddressBook),
+    ).toBe(addressBook);
+  });
+
+  test("should preserve a contact group holding several addresses across chains", () => {
+    // GIVEN
+    const builder = new SignerEthBuilder(defaultConstructorArgs);
+    const addressBook: EvmAddressBook = {
+      contactGroups: [
+        {
+          contactName: "Bob",
+          groupHandle: Uint8Array.from([0x0a]),
+          hmacProof: Uint8Array.from([0x0b]),
+          externalAddresses: [
+            {
+              scope: "ETH",
+              address: "0x2222222222222222222222222222222222222222",
+              chainId: 1n,
+              hmacRest: Uint8Array.from([0x0c]),
+            },
+            {
+              scope: "POL",
+              address: "0x2222222222222222222222222222222222222222",
+              chainId: 137n,
+              hmacRest: Uint8Array.from([0x0d]),
+            },
+          ],
+        },
+      ],
+      ledgerAccounts: [],
+    };
+
+    // WHEN
+    const signer = builder.withAddressBook(addressBook).build();
+    const bound = signer["_container"].get<EvmAddressBook>(
+      externalTypes.AddressBook,
+    );
+
+    // THEN
+    expect(bound.contactGroups).toHaveLength(1);
+    expect(bound.contactGroups[0]!.externalAddresses).toHaveLength(2);
+    expect(
+      bound.contactGroups[0]!.externalAddresses.map((a) => a.chainId),
+    ).toEqual([1n, 137n]);
   });
 });

--- a/packages/signer/signer-eth/src/api/SignerEthBuilder.ts
+++ b/packages/signer/signer-eth/src/api/SignerEthBuilder.ts
@@ -8,6 +8,7 @@ import {
   type DeviceSessionId,
 } from "@ledgerhq/device-management-kit";
 
+import { type EvmAddressBook } from "@api/model/EvmAddressBook";
 import { DefaultSignerEth } from "@internal/DefaultSignerEth";
 
 type SignerEthBuilderConstructorArgs = {
@@ -30,6 +31,7 @@ export class SignerEthBuilder {
   private _sessionId: DeviceSessionId;
   private _customContextModule: ContextModule | undefined;
   private _originToken: string | undefined;
+  private _addressBook: EvmAddressBook | undefined;
 
   constructor({
     dmk,
@@ -53,6 +55,20 @@ export class SignerEthBuilder {
   }
 
   /**
+   * Provide the EVM-compatible address book used to clear-sign contact names.
+   *
+   * The snapshot must be complete: the signer neither mutates nor persists it,
+   * and reads it as-is. Rebuild the signer to pick up later changes.
+   *
+   * @param addressBook a complete EVM address-book snapshot
+   * @returns this
+   */
+  withAddressBook(addressBook: EvmAddressBook) {
+    this._addressBook = addressBook;
+    return this;
+  }
+
+  /**
    * Build the ethereum signer
    *
    * @returns the ethereum signer
@@ -72,6 +88,7 @@ export class SignerEthBuilder {
       dmk: this._dmk,
       sessionId: this._sessionId,
       contextModule,
+      addressBook: this._addressBook,
     });
   }
 }

--- a/packages/signer/signer-eth/src/api/index.ts
+++ b/packages/signer/signer-eth/src/api/index.ts
@@ -44,6 +44,7 @@ export {
 } from "@api/app-binder/SignTypedDataDeviceActionTypes";
 export * from "@api/model/Address";
 export * from "@api/model/AddressOptions";
+export * from "@api/model/EvmAddressBook";
 export * from "@api/model/Signature";
 export * from "@api/model/TransactionOptions";
 export * from "@api/model/TransactionType";

--- a/packages/signer/signer-eth/src/api/model/EvmAddressBook.ts
+++ b/packages/signer/signer-eth/src/api/model/EvmAddressBook.ts
@@ -1,0 +1,53 @@
+/**
+ * A complete snapshot of the EVM-compatible part of the address book.
+ *
+ * The signer never mutates this snapshot and never persists it: owning,
+ * updating and persisting the address book remains the host's responsibility.
+ *
+ * Only EVM-family contacts and accounts belong here. The host filters by
+ * blockchain family while building the snapshot, so the signer's in-flow
+ * matching never needs a family discriminator and the models below do not
+ * carry one.
+ */
+export type EvmAddressBook = {
+  contactGroups: EvmContactGroup[];
+  ledgerAccounts: EvmLedgerAccountContact[];
+};
+
+/**
+ * A named contact and the external addresses registered under it.
+ *
+ * The group carries the name-level proof material that every one of its
+ * addresses reuses, so matching an address always yields its group without a
+ * lookup.
+ */
+export type EvmContactGroup = {
+  contactName: string;
+  groupHandle: Uint8Array;
+  hmacProof: Uint8Array;
+  externalAddresses: EvmExternalAddress[];
+};
+
+/**
+ * An external address registered under a contact group, for one chain.
+ *
+ * The derivation path used at registration time is deliberately absent: the
+ * signer never needs it to provide the contact to the device.
+ */
+export type EvmExternalAddress = {
+  scope: string;
+  address: `0x${string}`;
+  chainId: bigint;
+  hmacRest: Uint8Array;
+};
+
+/**
+ * A named Ledger account contact, identified by its derivation path and chain
+ * rather than by an address string.
+ */
+export type EvmLedgerAccountContact = {
+  accountName: string;
+  derivationPath: string;
+  chainId: bigint;
+  hmacProof: Uint8Array;
+};

--- a/packages/signer/signer-eth/src/internal/DefaultSignerEth.ts
+++ b/packages/signer/signer-eth/src/internal/DefaultSignerEth.ts
@@ -12,6 +12,7 @@ import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactio
 import { type SignTypedDataDAReturnType } from "@api/app-binder/SignTypedDataDeviceActionTypes";
 import { type VerifySafeAddressDAReturnType } from "@api/app-binder/VerifySafeAddressDeviceActionTypes";
 import { type AddressOptions } from "@api/model/AddressOptions";
+import { type EvmAddressBook } from "@api/model/EvmAddressBook";
 import { type MessageOptions } from "@api/model/MessageOptions";
 import { type SafeAddressOptions } from "@api/model/SafeAddressOptions";
 import { type TransactionOptions } from "@api/model/TransactionOptions";
@@ -37,13 +38,24 @@ type DefaultSignerConstructorArgs = {
   dmk: DeviceManagementKit;
   sessionId: DeviceSessionId;
   contextModule: ContextModule;
+  addressBook?: EvmAddressBook;
 };
 
 export class DefaultSignerEth implements SignerEth {
   private _container: Container;
 
-  constructor({ dmk, sessionId, contextModule }: DefaultSignerConstructorArgs) {
-    this._container = makeContainer({ dmk, sessionId, contextModule });
+  constructor({
+    dmk,
+    sessionId,
+    contextModule,
+    addressBook,
+  }: DefaultSignerConstructorArgs) {
+    this._container = makeContainer({
+      dmk,
+      sessionId,
+      contextModule,
+      addressBook,
+    });
   }
 
   signTransaction(

--- a/packages/signer/signer-eth/src/internal/di.ts
+++ b/packages/signer/signer-eth/src/internal/di.ts
@@ -6,6 +6,7 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { Container } from "inversify";
 
+import { type EvmAddressBook } from "@api/model/EvmAddressBook";
 import { addressModuleFactory } from "@internal/address/di/addressModule";
 import { appBindingModuleFactory } from "@internal/app-binder/di/appBinderModule";
 import { eip7702ModuleFactory } from "@internal/eip7702/di/eip7702Module";
@@ -19,12 +20,14 @@ export type MakeContainerProps = {
   dmk: DeviceManagementKit;
   sessionId: DeviceSessionId;
   contextModule: ContextModule;
+  addressBook?: EvmAddressBook;
 };
 
 export const makeContainer = ({
   dmk,
   sessionId,
   contextModule,
+  addressBook,
 }: MakeContainerProps) => {
   const container = new Container();
 
@@ -35,6 +38,11 @@ export const makeContainer = ({
   container
     .bind<DeviceSessionId>(externalTypes.SessionId)
     .toConstantValue(sessionId);
+  // Always bound: an absent address book is an empty one, which simply never
+  // matches, so consumers never have to handle `undefined`.
+  container
+    .bind<EvmAddressBook>(externalTypes.AddressBook)
+    .toConstantValue(addressBook ?? { contactGroups: [], ledgerAccounts: [] });
 
   container
     .bind<

--- a/packages/signer/signer-eth/src/internal/externalTypes.ts
+++ b/packages/signer/signer-eth/src/internal/externalTypes.ts
@@ -3,4 +3,5 @@ export const externalTypes = {
   SessionId: Symbol.for("SessionId"),
   ContextModule: Symbol.for("ContextModule"),
   DmkLoggerFactory: Symbol.for("DmkLoggerFactory"),
+  AddressBook: Symbol.for("AddressBook"),
 };


### PR DESCRIPTION
### 📝 Description

Adds an optional EVM address book to `SignerEthBuilder`, so that later tickets can match a transaction recipient or signing account against saved contacts and clear-sign their names on device.

This PR is **plumbing and the public model only** — no matching, no `PROVIDE CONTACT` APDU. Those are DSDK-1387 (external addresses) and DSDK-1388 (Ledger accounts).

**Public API**

```ts
const signer = new SignerEthBuilder({ dmk, sessionId, originToken })
  .withAddressBook({
    contactGroups: [
      {
        contactName: "Alice",
        groupHandle,          // Uint8Array, name-level proof material
        hmacProof,            // Uint8Array
        externalAddresses: [
          { scope: "ETH", address: "0x…", chainId: 1n, hmacRest },
        ],
      },
    ],
    ledgerAccounts: [
      { accountName: "Main account", derivationPath: "44'/60'/0'/0/0", chainId: 1n, hmacProof },
    ],
  })
  .build();
```

**Design notes**

- The snapshot must be complete. The signer never mutates or persists it — owning and persisting the address book stays the host's responsibility. Rebuild the signer to pick up later changes.
- External addresses are **nested** under the contact group that owns them. A group carries the name-level proof material that all of its addresses reuse, so matching an address always yields its group without a lookup.
- Only EVM-family entries belong here. The host filters by blockchain family while building the snapshot, so the models carry no family discriminator and the in-flow matching in DSDK-1387/1388 never needs one.
- The external-contact derivation path is deliberately absent from the public model. `HMAC_REST` covers `group_handle | scope | identifier | family | chain_id` and nothing else, so a derivation path there would be unverifiable by the device.
- `chainId` is a `bigint` because the firmware encodes `CHAIN_ID` as a fixed 8-byte field.
- The DI binding is **non-optional** and defaults to `{ contactGroups: [], ledgerAccounts: [] }` when no book is supplied, so consumers in DSDK-1387/1388 never branch on `undefined` — an empty book simply never matches, which is the same no-op behaviour. This deliberately differs from signer-solana, which binds `string | undefined` for `SolanaRPCURL`; the rationale is commented in `di.ts`.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1386](https://ledgerhq.atlassian.net/browse/DSDK-1386)

- **Feature**: Ethereum signer contact clear signing ([DSDK-1385](https://ledgerhq.atlassian.net/browse/DSDK-1385)). This PR unblocks DSDK-1387 / DSDK-1388 signer-side, and DSDK-1457 host-side in Ledger Live.

### ✅ Checklist

- [x] **Covered by automatic tests** — 3 tests added to `SignerEthBuilder.test.ts`: empty book by default, custom book bound by reference, and a contact group holding several addresses across different chains.
- [x] **Changeset is provided** — `minor` for `@ledgerhq/device-signer-kit-ethereum`.
- [x] **Documentation is up-to-date** — the new public types and `withAddressBook` are documented with TSDoc; no README change needed since no behaviour is yet observable.
- [x] **Impact of the changes:**
  - Purely additive public API. Existing behaviour is unchanged when no address book is supplied, and nothing yet reads the binding, so no signing flow is affected by this PR.
  - QA focus: none needed on device. Nothing reaches the transport in this PR.

> [!NOTE]
> `BlindSigningDetectionTask.test.ts` fails 6 tests and does not typecheck on this branch, but it does so identically on a clean `develop` checkout — it typechecks against a stale `@ledgerhq/context-module` build (`signReport` / `EthSignReportParams`). Unrelated to this PR.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[DSDK-1386]: https://ledgerhq.atlassian.net/browse/DSDK-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ