### PR TITLE
✨ (signer-concordium) [LIVE-36566]: Send the max fee for PLT on-device display

### DIFF
--- a/.changeset/concordium-plt-max-fee-display.md
+++ b/.changeset/concordium-plt-max-fee-display.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-concordium": minor
+---
+
+Send the max fee on the PLT signing INIT frame so the device displays it

--- a/packages/signer/signer-concordium/src/api/SignerConcordium.ts
+++ b/packages/signer/signer-concordium/src/api/SignerConcordium.ts
@@ -24,7 +24,8 @@ export interface SignerConcordium {
    * TokenUpdate (27, PLT).
    *
    * @param maxFee - Maximum fee in µCCD, shown on the device review screens.
-   *   Ignored for PLT transactions, whose review screens display no fee.
+   *   Used for every supported kind, PLT included. The device does not hash it,
+   *   so it affects the display only.
    */
   signTransaction: (
     derivationPath: string,

--- a/packages/signer/signer-concordium/src/internal/app-binder/command/SignPltCommand.test.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/command/SignPltCommand.test.ts
@@ -21,6 +21,7 @@ describe("SignPltCommand", () => {
     it("should build the INIT frame with INS=0x27, P1=0x00 and P2=0x00", () => {
       const command = new SignPltCommand({
         p1: P1.PLT_INIT,
+        p2: P2.NONE,
         data: new Uint8Array(80).fill(0x01),
       });
 
@@ -36,6 +37,7 @@ describe("SignPltCommand", () => {
     it("should build the CONT frame with P1=0x01", () => {
       const command = new SignPltCommand({
         p1: P1.PLT_CONT,
+        p2: P2.NONE,
         data: new Uint8Array(9).fill(0xcc),
       });
 
@@ -46,23 +48,25 @@ describe("SignPltCommand", () => {
       expect(raw[3]).toBe(P2.NONE);
     });
 
-    it("should keep P2 at 0x00 and not accept a fee-display flag", () => {
-      const init = new SignPltCommand({
-        p1: P1.PLT_INIT,
-        data: new Uint8Array(4),
-      });
-      const cont = new SignPltCommand({
-        p1: P1.PLT_CONT,
-        data: new Uint8Array(4),
-      });
+    // The command forwards P2 verbatim; choosing it per frame is the caller's
+    // job, because the device accepts fee display only on INIT.
+    it("should forward P2 to the APDU rather than pinning it", () => {
+      const build = (p2: number) =>
+        new SignPltCommand({ p1: P1.PLT_INIT, p2, data: new Uint8Array(4) })
+          .getApdu()
+          .getRawApdu()[3];
 
-      expect(init.getApdu().getRawApdu()[3]).toBe(0x00);
-      expect(cont.getApdu().getRawApdu()[3]).toBe(0x00);
+      expect(build(P2.NONE)).toBe(0x00);
+      expect(build(P2.FEE_DISPLAY)).toBe(0x01);
     });
 
     it("should include the data in the APDU payload", () => {
       const data = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
-      const command = new SignPltCommand({ p1: P1.PLT_CONT, data });
+      const command = new SignPltCommand({
+        p1: P1.PLT_CONT,
+        p2: P2.NONE,
+        data,
+      });
 
       const raw = command.getApdu().getRawApdu();
 
@@ -74,6 +78,7 @@ describe("SignPltCommand", () => {
     it("should return an empty signature for INIT and intermediate CONT frames", () => {
       const command = new SignPltCommand({
         p1: P1.PLT_INIT,
+        p2: P2.NONE,
         data: new Uint8Array(4),
       });
 
@@ -88,6 +93,7 @@ describe("SignPltCommand", () => {
     it("should extract the 64-byte signature from the final CONT frame", () => {
       const command = new SignPltCommand({
         p1: P1.PLT_CONT,
+        p2: P2.NONE,
         data: new Uint8Array(9),
       });
       const signature = new Uint8Array(64).fill(0xab);
@@ -118,6 +124,7 @@ describe("SignPltCommand", () => {
     ])("should map status word %s to a typed error", (statusCode, expected) => {
       const command = new SignPltCommand({
         p1: P1.PLT_CONT,
+        p2: P2.NONE,
         data: new Uint8Array(4),
       });
 

--- a/packages/signer/signer-concordium/src/internal/app-binder/command/SignPltCommand.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/command/SignPltCommand.ts
@@ -16,10 +16,11 @@ import {
   ConcordiumAppCommandErrorFactory,
   type ConcordiumErrorCodes,
 } from "@internal/app-binder/command/utils/ConcordiumApplicationErrors";
-import { INS, LEDGER_CLA, P2 } from "@internal/app-binder/constants";
+import { INS, LEDGER_CLA } from "@internal/app-binder/constants";
 
 export type SignPltCommandArgs = {
   readonly p1: number;
+  readonly p2: number;
   readonly data: Uint8Array;
 };
 
@@ -32,9 +33,10 @@ export type SignPltCommandResponse = Signature;
 /**
  * PLT (Protocol Level Token) signing, INS 0x27.
  *
- * P2 is fixed at 0x00 — the handler returns 0x6B00 for any other value, so it
- * is not exposed as an argument. The PLT review screens display no fee, so the
- * fee-display extension used by the CCD signing paths does not apply here.
+ * P2 selects fee display on the INIT frame: `0x00` sends no fee, `0x01` appends
+ * an 8-byte big-endian µCCD suffix and the device renders a "Max fees" step.
+ * A CONT frame must use `0x00`, and returns 0x6B00 otherwise, so the caller
+ * chooses P2 per frame rather than reusing one value for the whole flow.
  */
 export class SignPltCommand
   implements
@@ -58,7 +60,7 @@ export class SignPltCommand
       cla: LEDGER_CLA,
       ins: INS.SIGN_PLT,
       p1: this.args.p1,
-      p2: P2.NONE,
+      p2: this.args.p2,
     });
 
     apduBuilder.addBufferToData(this.args.data);

--- a/packages/signer/signer-concordium/src/internal/app-binder/task/SendPltTask.test.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/task/SendPltTask.test.ts
@@ -13,10 +13,12 @@ import {
   ConcordiumErrorCodes,
 } from "@internal/app-binder/command/utils/ConcordiumApplicationErrors";
 import { encodeDerivationPath } from "@internal/app-binder/command/utils/EncodeDerivationPath";
-import { INS, LEDGER_CLA, P1 } from "@internal/app-binder/constants";
+import { encodeMaxFeeBigEndian } from "@internal/app-binder/command/utils/EncodeMaxFee";
+import { INS, LEDGER_CLA, P1, P2 } from "@internal/app-binder/constants";
 import { SendPltTask } from "@internal/app-binder/task/SendPltTask";
 
 const DERIVATION_PATH = "44'/919'/0'/0'/0'";
+const MAX_FEE = 726_675n;
 const HEADER = new Uint8Array(60).fill(0x11);
 const KIND_TOKEN_UPDATE = 0x1b;
 const SIGNATURE = new Uint8Array(64).fill(0xab);
@@ -86,7 +88,7 @@ describe("SendPltTask", () => {
 
     const result = await new SendPltTask(
       api,
-      { derivationPath: DERIVATION_PATH, transaction },
+      { derivationPath: DERIVATION_PATH, transaction, maxFee: MAX_FEE },
       makeLogger(),
     ).run();
 
@@ -105,7 +107,7 @@ describe("SendPltTask", () => {
 
     await new SendPltTask(
       api,
-      { derivationPath: DERIVATION_PATH, transaction },
+      { derivationPath: DERIVATION_PATH, transaction, maxFee: MAX_FEE },
       makeLogger(),
     ).run();
 
@@ -121,6 +123,7 @@ describe("SendPltTask", () => {
       0x00,
       0x00,
       cbor.length,
+      ...encodeMaxFeeBigEndian(MAX_FEE),
     ]);
 
     expect(init.cla).toBe(LEDGER_CLA);
@@ -129,13 +132,13 @@ describe("SendPltTask", () => {
     expect(init.data).toStrictEqual(expected);
   });
 
-  it("should carry P2=0x00 on the INIT frame and append no fee suffix", async () => {
+  it("should carry P2=0x01 on the INIT frame and end with the 8-byte fee", async () => {
     const { api, sentCommands } = makeApiMock();
     const transaction = buildTransaction();
 
     await new SendPltTask(
       api,
-      { derivationPath: DERIVATION_PATH, transaction },
+      { derivationPath: DERIVATION_PATH, transaction, maxFee: MAX_FEE },
       makeLogger(),
     ).run();
 
@@ -143,11 +146,48 @@ describe("SendPltTask", () => {
     const pathBytes = encodeDerivationPath(DERIVATION_PATH);
     const tokenIdLength = 3;
 
-    expect(init.p2).toBe(0x00);
-    // Ends exactly at cbor_total_length: no trailing 8-byte fee.
+    expect(init.p2).toBe(P2.FEE_DISPLAY);
     expect(init.data).toHaveLength(
-      pathBytes.length + 60 + 1 + 1 + tokenIdLength + 4,
+      pathBytes.length + 60 + 1 + 1 + tokenIdLength + 4 + 8,
     );
+    expect(init.data.slice(-8)).toStrictEqual(encodeMaxFeeBigEndian(MAX_FEE));
+  });
+
+  // The device accepts fee display only on INIT; a CONT frame with 0x01 gets 0x6B00.
+  it("should carry P2=0x00 on every CONT frame", async () => {
+    const { api, sentCommands } = makeApiMock();
+    const transaction = buildTransaction({ cbor: new Uint8Array(300) });
+
+    await new SendPltTask(
+      api,
+      { derivationPath: DERIVATION_PATH, transaction, maxFee: MAX_FEE },
+      makeLogger(),
+    ).run();
+
+    const contP2 = sentCommands.slice(1).map((cmd) => apduOf(cmd).p2);
+
+    expect(contP2.length).toBeGreaterThan(1);
+    expect(contP2.every((p2) => p2 === P2.NONE)).toBe(true);
+  });
+
+  it("should not change the signed bytes when the fee changes", async () => {
+    const run = async (maxFee: bigint) => {
+      const { api, sentCommands } = makeApiMock();
+      await new SendPltTask(
+        api,
+        {
+          derivationPath: DERIVATION_PATH,
+          transaction: buildTransaction(),
+          maxFee,
+        },
+        makeLogger(),
+      ).run();
+      const init = apduOf(sentCommands[0]!);
+      // Everything before the fee suffix is what the device hashes.
+      return Buffer.from(init.data.slice(0, -8)).toString("hex");
+    };
+
+    expect(await run(1n)).toBe(await run(999_999n));
   });
 
   it("should send the CBOR payload as CONT frames of at most APDU_MAX_PAYLOAD bytes", async () => {
@@ -158,7 +198,7 @@ describe("SendPltTask", () => {
 
     await new SendPltTask(
       api,
-      { derivationPath: DERIVATION_PATH, transaction },
+      { derivationPath: DERIVATION_PATH, transaction, maxFee: MAX_FEE },
       makeLogger(),
     ).run();
 
@@ -183,7 +223,7 @@ describe("SendPltTask", () => {
 
     await new SendPltTask(
       api,
-      { derivationPath: DERIVATION_PATH, transaction },
+      { derivationPath: DERIVATION_PATH, transaction, maxFee: MAX_FEE },
       makeLogger(),
     ).run();
 
@@ -201,7 +241,11 @@ describe("SendPltTask", () => {
 
     const result = await new SendPltTask(
       api,
-      { derivationPath: "44'/919'/0'/0'/0'", transaction },
+      {
+        derivationPath: "44'/919'/0'/0'/0'",
+        transaction,
+        maxFee: MAX_FEE,
+      },
       makeLogger(),
     ).run();
 
@@ -220,7 +264,11 @@ describe("SendPltTask", () => {
 
     const result = await new SendPltTask(
       api,
-      { derivationPath: DERIVATION_PATH, transaction: buildTransaction() },
+      {
+        derivationPath: DERIVATION_PATH,
+        transaction: buildTransaction(),
+        maxFee: MAX_FEE,
+      },
       makeLogger(),
     ).run();
 
@@ -241,6 +289,7 @@ describe("SendPltTask", () => {
       {
         derivationPath: DERIVATION_PATH,
         transaction: buildTransaction({ cbor }),
+        maxFee: MAX_FEE,
       },
       makeLogger(),
     ).run();
@@ -249,9 +298,8 @@ describe("SendPltTask", () => {
     expect(isSuccessCommandResult(result)).toBe(false);
   });
 
-  describe("firmware fixture parity", () => {
-    // Fixtures from app-concordium/tests/standalone/test_sign_plt.py.
-    // _HEADER_60: sender[32] + seq_num[8]=10 + energy[8]=100 + payload_size[4]
+  describe("device contract parity", () => {
+    // header(60): sender[32] + seqNum[8]=10 + energy[8]=100 + payloadSize[4]
     // + expiry[8]=0x63de5da7.
     const FIXTURE_HEADER = Uint8Array.from(
       Buffer.from(
@@ -263,9 +311,9 @@ describe("SendPltTask", () => {
         "hex",
       ),
     );
-    // _TOKEN_ID_MIN = b"T"
+    // Shortest token id the device accepts: one byte.
     const FIXTURE_TOKEN_ID = new Uint8Array([0x54]);
-    // _CBOR_SMALL = array(1) [ map(1) { "pause": map(0) } ]
+    // array(1) [ map(1) { "pause": map(0) } ]
     const FIXTURE_CBOR = new Uint8Array([
       0x81, 0xa1, 0x65, 0x70, 0x61, 0x75, 0x73, 0x65, 0xa0,
     ]);
@@ -275,12 +323,7 @@ describe("SendPltTask", () => {
     // regression in encodeDerivationPath fails this test rather than being
     // cancelled out by using the same function on both sides.
     //
-    // [depth:1 = 8][node:4 BE] x 8, every node hardened. The firmware fixture
-    // sends these nodes UNhardened, because ragger's pack_derivation_path only
-    // sets the hardened bit for elements written with a "\'" suffix. That is not
-    // a divergence in practice: parse_derivation_path() calls
-    // harden_derivation_path() unconditionally (derivation_path.c:119), so the
-    // device hardens every node whatever arrives on the wire.
+    // [depth:1 = 8][node:4 BE] x 8, every node hardened.
     const FIXTURE_PATH_BYTES = Uint8Array.from(
       Buffer.from(
         "08" +
@@ -315,14 +358,13 @@ describe("SendPltTask", () => {
         {
           derivationPath: FIXTURE_PATH,
           transaction: fixtureTransaction(FIXTURE_CBOR),
+          maxFee: MAX_FEE,
         },
         makeLogger(),
       ).run();
 
       const init = apduOf(sentCommands[0]!);
-      // test_sign_plt_ui.py:450 —
-      // pack_derivation_path(path) + header_60 + [0x1B, len(token_id)]
-      // + token_id + len(cbor).to_bytes(4, "big")
+      // cborLength is 4 bytes big-endian, then the 8-byte fee suffix.
       const expected = new Uint8Array([
         ...FIXTURE_PATH_BYTES,
         ...FIXTURE_HEADER,
@@ -333,8 +375,10 @@ describe("SendPltTask", () => {
         0x00,
         0x00,
         FIXTURE_CBOR.length,
+        ...encodeMaxFeeBigEndian(MAX_FEE),
       ]);
 
+      expect(init.p2).toBe(P2.FEE_DISPLAY);
       expect(init.data).toStrictEqual(expected);
     });
 
@@ -344,13 +388,17 @@ describe("SendPltTask", () => {
       );
     });
 
-    it("should split a 512-byte payload as 255 + 255 + 2, matching test_sign_plt_exact_cbor_max", async () => {
+    it("should split a payload at the 512-byte CBOR maximum as 255 + 255 + 2", async () => {
       const { api, sentCommands } = makeApiMock();
       const cbor = new Uint8Array(512);
 
       await new SendPltTask(
         api,
-        { derivationPath: FIXTURE_PATH, transaction: fixtureTransaction(cbor) },
+        {
+          derivationPath: FIXTURE_PATH,
+          transaction: fixtureTransaction(cbor),
+          maxFee: MAX_FEE,
+        },
         makeLogger(),
       ).run();
 
@@ -361,13 +409,17 @@ describe("SendPltTask", () => {
       expect(contLengths).toStrictEqual([255, 255, 2]);
     });
 
-    it("should send a 300-byte payload as two CONT frames, matching test_sign_plt_multi_cont_frame", async () => {
+    it("should send a 300-byte payload as two CONT frames", async () => {
       const { api, sentCommands } = makeApiMock();
       const cbor = new Uint8Array(300);
 
       await new SendPltTask(
         api,
-        { derivationPath: FIXTURE_PATH, transaction: fixtureTransaction(cbor) },
+        {
+          derivationPath: FIXTURE_PATH,
+          transaction: fixtureTransaction(cbor),
+          maxFee: MAX_FEE,
+        },
         makeLogger(),
       ).run();
 
@@ -385,7 +437,7 @@ describe("SendPltTask", () => {
 
       const result = await new SendPltTask(
         api,
-        { derivationPath: DERIVATION_PATH, transaction },
+        { derivationPath: DERIVATION_PATH, transaction, maxFee: MAX_FEE },
         makeLogger(),
       ).run();
 

--- a/packages/signer/signer-concordium/src/internal/app-binder/task/SendPltTask.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/task/SendPltTask.ts
@@ -14,11 +14,17 @@ import {
 } from "@internal/app-binder/command/SignPltCommand";
 import { type ConcordiumErrorCodes } from "@internal/app-binder/command/utils/ConcordiumApplicationErrors";
 import { encodeDerivationPath } from "@internal/app-binder/command/utils/EncodeDerivationPath";
+import { encodeMaxFeeBigEndian } from "@internal/app-binder/command/utils/EncodeMaxFee";
 import { InvalidPltTransactionError } from "@internal/app-binder/command/utils/InvalidPltTransactionError";
-import { P1 } from "@internal/app-binder/constants";
+import { FEE_DISPLAY_SIZE, P1, P2 } from "@internal/app-binder/constants";
 
 // Serialized TokenUpdate transaction layout:
 // [header:60][kind:1 = 0x1B][tokenIdLength:1][tokenId:1..128][cborTotalLength:4 BE][cbor:N]
+//
+// The INIT frame is everything up to and including cborTotalLength, prefixed
+// with the derivation path and suffixed with the 8-byte max fee. Worst case with
+// a 5-node path and a 128-byte token id: 21 + 60 + 1 + 1 + 128 + 4 + 8 = 223
+// bytes, still inside APDU_MAX_PAYLOAD but with less headroom than it looks.
 
 const HEADER_LENGTH = 60;
 const KIND_LENGTH = 1;
@@ -27,9 +33,9 @@ const CBOR_LENGTH_FIELD = 4;
 
 const TRANSACTION_KIND_TOKEN_UPDATE = 0x1b;
 
-/** PLT_TOKEN_ID_MAX in the app (`src/helpers/app_sizes.h`). */
+/** Maximum token-id length the device accepts, per CIS-7. */
 const TOKEN_ID_MAX = 128;
-/** APP_PLT_CBOR_MAX in the app (`src/helpers/app_sizes.h`). */
+/** Maximum PLT CBOR operations blob the device will buffer. */
 const CBOR_MAX = 512;
 
 const MIN_TRANSACTION_LENGTH =
@@ -43,17 +49,25 @@ const MIN_TRANSACTION_LENGTH =
 type SendPltTaskArgs = {
   derivationPath: string;
   transaction: Uint8Array;
+  /** Max fee in µCCD, rendered as a "Max fees" step on the review screens. */
+  maxFee: bigint;
 };
 
 /**
  * Streams a PLT (TokenUpdate) transaction to the device over INS 0x27.
  *
  * One INIT frame (P1=0x00) carries the derivation path and everything up to and
- * including the CBOR length, then CONT frames (P1=0x01) carry the CBOR payload.
- * Chunking is byte-oriented: a CBOR field may span a frame boundary, since the
- * device buffers the whole payload before parsing it.
+ * including the CBOR length, plus the 8-byte big-endian µCCD max fee. CONT
+ * frames (P1=0x01) then carry the CBOR payload. Chunking is byte-oriented: a
+ * CBOR field may span a frame boundary, since the device buffers the whole
+ * payload before parsing it.
  *
- * `maxFee` is not part of this flow — the PLT review screens display no fee.
+ * Fee display is unconditional here. The factory only reaches this task on an
+ * app at or above `MIN_APP_VERSION_FOR_PLT`, and that release ships PLT signing
+ * and clear-signing together, so a PLT-capable app always accepts the suffix.
+ *
+ * The fee suffix is not hashed by the device, so the signature is identical
+ * whether or not it is sent.
  */
 export class SendPltTask {
   constructor(
@@ -65,7 +79,7 @@ export class SendPltTask {
   async run(): Promise<
     CommandResult<SignPltCommandResponse, ConcordiumErrorCodes>
   > {
-    const { derivationPath, transaction } = this.args;
+    const { derivationPath, transaction, maxFee } = this.args;
 
     this.logger.debug("[run] Starting SendPltTask", {
       data: {
@@ -119,9 +133,13 @@ export class SendPltTask {
     }
 
     const pathBytes = encodeDerivationPath(derivationPath);
-    const initPayload = new Uint8Array(pathBytes.length + cborOffset);
+    const feeSuffix = encodeMaxFeeBigEndian(maxFee);
+    const initPayload = new Uint8Array(
+      pathBytes.length + cborOffset + FEE_DISPLAY_SIZE,
+    );
     initPayload.set(pathBytes, 0);
     initPayload.set(transaction.slice(0, cborOffset), pathBytes.length);
+    initPayload.set(feeSuffix, pathBytes.length + cborOffset);
 
     if (initPayload.length > APDU_MAX_PAYLOAD) {
       return this.reject(
@@ -130,7 +148,11 @@ export class SendPltTask {
     }
 
     const initResult = await this.api.sendCommand(
-      new SignPltCommand({ p1: P1.PLT_INIT, data: initPayload }),
+      new SignPltCommand({
+        p1: P1.PLT_INIT,
+        p2: P2.FEE_DISPLAY,
+        data: initPayload,
+      }),
     );
 
     if (!isSuccessCommandResult(initResult)) {
@@ -148,7 +170,7 @@ export class SendPltTask {
         SignPltCommandResponse,
         ConcordiumErrorCodes
       > = await this.api.sendCommand(
-        new SignPltCommand({ p1: P1.PLT_CONT, data: chunk }),
+        new SignPltCommand({ p1: P1.PLT_CONT, p2: P2.NONE, data: chunk }),
       );
 
       if (!isSuccessCommandResult(contResult)) {

--- a/packages/signer/signer-concordium/src/internal/app-binder/task/SignTransactionTaskFactory.test.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/task/SignTransactionTaskFactory.test.ts
@@ -56,6 +56,11 @@ function getApduP2(cmd: Command<unknown, unknown>): number {
   return cmd.getApdu().getRawApdu()[3]!;
 }
 
+/** APDU data field: everything after the 5-byte CLA/INS/P1/P2/Lc header. */
+function getApduData(cmd: Command<unknown, unknown>): Uint8Array {
+  return cmd.getApdu().getRawApdu().slice(5);
+}
+
 describe("createSignTransactionTask", () => {
   let loggerFactory: (tag: string) => LoggerPublisherService;
   let loggerTags: string[];
@@ -132,7 +137,9 @@ describe("createSignTransactionTask", () => {
       expect(loggerTags).toContain("SendPltTask");
     });
 
-    it("should send P2=0x00 on the PLT INIT frame regardless of fee-display support", async () => {
+    // Fee display needs no separate version gate: the app release that ships
+    // PLT signing ships clear-signing too, so reaching this branch is enough.
+    it("should send P2=0x01 on the PLT INIT frame at the minimum PLT version", async () => {
       const { api, sentCommands } = makeApiMock(
         makeReadyDeviceState(MIN_APP_VERSION_FOR_PLT),
       );
@@ -148,7 +155,29 @@ describe("createSignTransactionTask", () => {
       )();
 
       expect(sentCommands.length).toBeGreaterThanOrEqual(1);
-      expect(getApduP2(sentCommands[0]!)).toBe(0x00);
+      expect(getApduP2(sentCommands[0]!)).toBe(0x01);
+    });
+
+    it("should forward maxFee to the PLT task as an 8-byte big-endian suffix", async () => {
+      const { api, sentCommands } = makeApiMock(
+        makeReadyDeviceState(MIN_APP_VERSION_FOR_PLT),
+      );
+
+      await createSignTransactionTask(
+        api,
+        {
+          derivationPath: DERIVATION_PATH,
+          transaction: buildPltTransaction(),
+          maxFee: 726_675n,
+        },
+        loggerFactory,
+      )();
+
+      const init = getApduData(sentCommands[0]!);
+
+      expect(Buffer.from(init.slice(-8)).toString("hex")).toBe(
+        "00000000000b1693",
+      );
     });
 
     it("should reject PLT with UnsupportedAppVersionError on an older app", async () => {

--- a/packages/signer/signer-concordium/src/internal/app-binder/task/SignTransactionTaskFactory.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/task/SignTransactionTaskFactory.ts
@@ -81,6 +81,7 @@ export function createSignTransactionTask(
         {
           derivationPath: args.derivationPath,
           transaction: args.transaction,
+          maxFee: args.maxFee,
         },
         logger,
       ).run();


### PR DESCRIPTION
### 📝 Description

The Concordium app added an optional max-fee display to the PLT signing instruction (INS `0x27`). This threads `maxFee` into the PLT path so a PLT transfer shows its fee on device, as a CCD transfer already does.

LIVE-33617 deliberately left the fee plumbing out: the handler rejected `P2 != 0x00` at the time.

**Device contract**

| P2 | INIT frame | Result |
| --- | --- | --- |
| `0x00` | ends at `cbor_total_length` | no fee screen; any trailing byte is `0x6A80` |
| `0x01` | plus exactly 8 bytes, big-endian µCCD | renders a "Max fees" step; any other length is `0x6A80` |

A CONT frame must use `0x00` and returns `0x6B00` otherwise, so P2 is chosen per frame rather than once per flow. The suffix is not hashed, so the signature is unchanged either way.

**Changes**

- `SignPltCommand` takes a `p2` argument instead of pinning `0x00`.
- `SendPltTask` takes `maxFee`, appends the 8-byte suffix to INIT, and sends `P2.FEE_DISPLAY` there and `P2.NONE` on every CONT. The `APDU_MAX_PAYLOAD` check covers the longer frame; worst case is 223 bytes with a 5-node path and a 128-byte token id.
- `SignTransactionTaskFactory` forwards `maxFee`.
- `signTransaction`'s docstring no longer says `maxFee` is ignored for PLT.

**No new version gate.** Fee display is unconditional on the PLT path: the branch is already behind `MIN_APP_VERSION_FOR_PLT`, and the app release shipping PLT signing ships clear-signing with it, so a PLT-capable app always accepts the suffix. `MIN_APP_VERSION_FOR_PLT` is also above `MIN_APP_VERSION_FOR_FEE_DISPLAY`, so no version can satisfy the PLT gate and reject `P2=0x01`.

Nothing here is released — the package exists only as a snapshot — so this completes the initial PLT implementation rather than changing shipped behaviour.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-36566](https://ledgerhq.atlassian.net/browse/LIVE-36566)
- **Feature**: PLT max-fee display, under epic [LIVE-32855](https://ledgerhq.atlassian.net/browse/LIVE-32855)

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date**
- [ ] **Impact of the changes:**
  - PLT signing only. CCD transfer, transfer-with-memo and credential deployment are untouched.
  - QA focus: a PLT transfer now shows a "Max fees" step, and the amount must match what the wallet displays. Multi-frame CBOR payloads still sign, since P2 differs between INIT and CONT.
  - The signature is unaffected: the fee suffix is not hashed, and a test asserts the hashed prefix is identical across different fees.
  - Requires a Concordium app with PLT clear-signing. An older app is rejected by the existing version gate.


[LIVE-36566]: https://ledgerhq.atlassian.net/browse/LIVE-36566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ