### PR TITLE
✨ (signer-trx) [DSDK-1390]: Accept an optional Tron address book in the signer builder

### DIFF
--- a/.changeset/dsdk-1390-tron-address-book.md
+++ b/.changeset/dsdk-1390-tron-address-book.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-tron": minor
+---
+
+Accept an optional Tron address book in SignerTrxBuilder via withAddressBook, exposing the TronAddressBook public model

--- a/packages/signer/signer-trx/src/api/SignerTrxBuilder.test.ts
+++ b/packages/signer/signer-trx/src/api/SignerTrxBuilder.test.ts
@@ -1,8 +1,10 @@
 import { type DeviceManagementKit } from "@ledgerhq/device-management-kit";
 
+import { type TronAddressBook } from "@api/model/TronAddressBook";
 import { SignerTrxBuilder } from "@api/SignerTrxBuilder";
 import { APP_NAME, INS, LEDGER_CLA } from "@internal/app-binder/constants";
 import { DefaultSignerTrx } from "@internal/DefaultSignerTrx";
+import { externalTypes } from "@internal/externalTypes";
 
 describe("SignerTrxBuilder", () => {
   const dmk = {} as DeviceManagementKit;
@@ -20,6 +22,86 @@ describe("SignerTrxBuilder", () => {
     const signer = builder.build();
 
     expect(signer).toBeInstanceOf(DefaultSignerTrx);
+  });
+  test("should build with an empty address book by default", () => {
+    const builder = new SignerTrxBuilder(defaultConstructorArgs);
+
+    const signer = builder.build();
+
+    expect(
+      signer["_container"].get<TronAddressBook>(externalTypes.AddressBook),
+    ).toEqual({ contactGroups: [], ledgerAccounts: [] });
+  });
+
+  test("should build with a custom address book", () => {
+    const builder = new SignerTrxBuilder(defaultConstructorArgs);
+    const addressBook: TronAddressBook = {
+      contactGroups: [
+        {
+          contactName: "Alice",
+          groupHandle: Uint8Array.from([0x01, 0x02]),
+          hmacProof: Uint8Array.from([0x03, 0x04]),
+          externalAddresses: [
+            {
+              scope: "TRX",
+              address: "TQ3zvJoxUCS3PtcAJ8f1FhezAxrEDbjyKh",
+              hmacRest: Uint8Array.from([0x05]),
+            },
+          ],
+        },
+      ],
+      ledgerAccounts: [
+        {
+          accountName: "Main account",
+          derivationPath: "44'/195'/0'/0/0",
+          hmacProof: Uint8Array.from([0x06]),
+        },
+      ],
+    };
+
+    const signer = builder.withAddressBook(addressBook).build();
+
+    expect(signer).toBeInstanceOf(DefaultSignerTrx);
+    expect(
+      signer["_container"].get<TronAddressBook>(externalTypes.AddressBook),
+    ).toBe(addressBook);
+  });
+
+  test("should preserve a contact group holding several addresses", () => {
+    const builder = new SignerTrxBuilder(defaultConstructorArgs);
+    const addressBook: TronAddressBook = {
+      contactGroups: [
+        {
+          contactName: "Bob",
+          groupHandle: Uint8Array.from([0x0a]),
+          hmacProof: Uint8Array.from([0x0b]),
+          externalAddresses: [
+            {
+              scope: "TRX",
+              address: "TN3W4H6rK2ce4vX9YnFQHwKENnHjoxb3m9",
+              hmacRest: Uint8Array.from([0x0c]),
+            },
+            {
+              scope: "USDT",
+              address: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+              hmacRest: Uint8Array.from([0x0d]),
+            },
+          ],
+        },
+      ],
+      ledgerAccounts: [],
+    };
+
+    const signer = builder.withAddressBook(addressBook).build();
+    const bound = signer["_container"].get<TronAddressBook>(
+      externalTypes.AddressBook,
+    );
+
+    expect(bound.contactGroups).toHaveLength(1);
+    expect(bound.contactGroups[0]!.externalAddresses).toHaveLength(2);
+    expect(
+      bound.contactGroups[0]!.externalAddresses.map((a) => a.scope),
+    ).toEqual(["TRX", "USDT"]);
   });
 });
 

--- a/packages/signer/signer-trx/src/api/SignerTrxBuilder.ts
+++ b/packages/signer/signer-trx/src/api/SignerTrxBuilder.ts
@@ -3,6 +3,7 @@ import {
   type DeviceSessionId,
 } from "@ledgerhq/device-management-kit";
 
+import { type TronAddressBook } from "@api/model/TronAddressBook";
 import { DefaultSignerTrx } from "@internal/DefaultSignerTrx";
 
 type SignerTrxBuilderConstructorArgs = {
@@ -22,10 +23,25 @@ type SignerTrxBuilderConstructorArgs = {
 export class SignerTrxBuilder {
   private readonly _dmk: DeviceManagementKit;
   private readonly _sessionId: DeviceSessionId;
+  private _addressBook: TronAddressBook | undefined;
 
   constructor({ dmk, sessionId }: SignerTrxBuilderConstructorArgs) {
     this._dmk = dmk;
     this._sessionId = sessionId;
+  }
+
+  /**
+   * Provide the Tron-compatible address book used to clear-sign contact names.
+   *
+   * The snapshot must be complete: the signer neither mutates nor persists it,
+   * and reads it as-is. Rebuild the signer to pick up later changes.
+   *
+   * @param addressBook a complete Tron address-book snapshot
+   * @returns this
+   */
+  withAddressBook(addressBook: TronAddressBook) {
+    this._addressBook = addressBook;
+    return this;
   }
 
   /**
@@ -38,6 +54,7 @@ export class SignerTrxBuilder {
     return new DefaultSignerTrx({
       dmk: this._dmk,
       sessionId: this._sessionId,
+      addressBook: this._addressBook,
     });
   }
 }

--- a/packages/signer/signer-trx/src/api/index.ts
+++ b/packages/signer/signer-trx/src/api/index.ts
@@ -40,6 +40,12 @@ export { type EcdhOptions } from "@api/model/EcdhOptions";
 export { type MessageOptions } from "@api/model/MessageOptions";
 export { type Signature } from "@api/model/Signature";
 export { type TransactionOptions } from "@api/model/TransactionOptions";
+export {
+  type TronAddressBook,
+  type TronContactGroup,
+  type TronExternalAddress,
+  type TronLedgerAccountContact,
+} from "@api/model/TronAddressBook";
 export { type SignerTrx } from "@api/SignerTrx";
 export { SignerTrxBuilder } from "@api/SignerTrxBuilder";
 export { type TronAppErrorCodes } from "@internal/app-binder/command/utils/tronApplicationErrors";

--- a/packages/signer/signer-trx/src/api/model/TronAddressBook.ts
+++ b/packages/signer/signer-trx/src/api/model/TronAddressBook.ts
@@ -1,0 +1,55 @@
+/**
+ * A complete snapshot of the Tron-compatible part of the address book.
+ *
+ * The signer never mutates this snapshot and never persists it: owning,
+ * updating and persisting the address book remains the host's responsibility.
+ *
+ * Only Tron-family contacts and accounts belong here. The host filters by
+ * blockchain family while building the snapshot, so the signer's in-flow
+ * matching never needs a family discriminator and the models below do not
+ * carry one.
+ *
+ * The Tron models carry no chain id: the firmware specification only includes
+ * one for Ethereum.
+ */
+export type TronAddressBook = {
+  contactGroups: TronContactGroup[];
+  ledgerAccounts: TronLedgerAccountContact[];
+};
+
+/**
+ * A named contact and the external addresses registered under it.
+ *
+ * The group carries the name-level proof material that every one of its
+ * addresses reuses, so matching an address always yields its group without a
+ * lookup.
+ */
+export type TronContactGroup = {
+  contactName: string;
+  groupHandle: Uint8Array;
+  hmacProof: Uint8Array;
+  externalAddresses: TronExternalAddress[];
+};
+
+/**
+ * An external address registered under a contact group.
+ *
+ * The address is a base58 Tron address. The derivation path used at
+ * registration time is deliberately absent: the signer never needs it to
+ * provide the contact to the device.
+ */
+export type TronExternalAddress = {
+  scope: string;
+  address: string;
+  hmacRest: Uint8Array;
+};
+
+/**
+ * A named Ledger account contact, identified by its derivation path rather
+ * than by an address string.
+ */
+export type TronLedgerAccountContact = {
+  accountName: string;
+  derivationPath: string;
+  hmacProof: Uint8Array;
+};

--- a/packages/signer/signer-trx/src/internal/DefaultSignerTrx.ts
+++ b/packages/signer/signer-trx/src/internal/DefaultSignerTrx.ts
@@ -14,6 +14,7 @@ import { type AddressOptions } from "@api/model/AddressOptions";
 import { type EcdhOptions } from "@api/model/EcdhOptions";
 import { type MessageOptions } from "@api/model/MessageOptions";
 import { type TransactionOptions } from "@api/model/TransactionOptions";
+import { type TronAddressBook } from "@api/model/TronAddressBook";
 import { type SignerTrx } from "@api/SignerTrx";
 import { makeContainer } from "@internal/di";
 import { addressTypes } from "@internal/use-cases/address/di/addressTypes";
@@ -31,13 +32,18 @@ import { type SignTransactionUseCase } from "@internal/use-cases/transaction/Sig
 type DefaultSignerTrxConstructorArgs = {
   dmk: DeviceManagementKit;
   sessionId: DeviceSessionId;
+  addressBook?: TronAddressBook;
 };
 
 export class DefaultSignerTrx implements SignerTrx {
   private readonly _container: Container;
 
-  constructor({ dmk, sessionId }: DefaultSignerTrxConstructorArgs) {
-    this._container = makeContainer({ dmk, sessionId });
+  constructor({
+    dmk,
+    sessionId,
+    addressBook,
+  }: DefaultSignerTrxConstructorArgs) {
+    this._container = makeContainer({ dmk, sessionId, addressBook });
   }
 
   getAddress(

--- a/packages/signer/signer-trx/src/internal/di.ts
+++ b/packages/signer/signer-trx/src/internal/di.ts
@@ -5,6 +5,7 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { Container } from "inversify";
 
+import { type TronAddressBook } from "@api/model/TronAddressBook";
 import { appBindingModuleFactory } from "@internal/app-binder/di/appBinderModule";
 import { externalTypes } from "@internal/externalTypes";
 import { addressModuleFactory } from "@internal/use-cases/address/di/addressModule";
@@ -16,15 +17,25 @@ import { transactionModuleFactory } from "@internal/use-cases/transaction/di/tra
 type MakeContainerProps = {
   dmk: DeviceManagementKit;
   sessionId: DeviceSessionId;
+  addressBook?: TronAddressBook;
 };
 
-export const makeContainer = ({ dmk, sessionId }: MakeContainerProps) => {
+export const makeContainer = ({
+  dmk,
+  sessionId,
+  addressBook,
+}: MakeContainerProps) => {
   const container = new Container();
 
   container.bind<DeviceManagementKit>(externalTypes.Dmk).toConstantValue(dmk);
   container
     .bind<DeviceSessionId>(externalTypes.SessionId)
     .toConstantValue(sessionId);
+  // Always bound: an absent address book is an empty one, which simply never
+  // matches, so consumers never have to handle `undefined`.
+  container
+    .bind<TronAddressBook>(externalTypes.AddressBook)
+    .toConstantValue(addressBook ?? { contactGroups: [], ledgerAccounts: [] });
 
   container
     .bind<

--- a/packages/signer/signer-trx/src/internal/externalTypes.ts
+++ b/packages/signer/signer-trx/src/internal/externalTypes.ts
@@ -2,4 +2,5 @@ export const externalTypes = {
   Dmk: Symbol.for("Dmk"),
   SessionId: Symbol.for("SessionId"),
   DmkLoggerFactory: Symbol.for("DmkLoggerFactory"),
+  AddressBook: Symbol.for("AddressBook"),
 } as const;


### PR DESCRIPTION
### 📝 Description

Adds an optional Tron address book to `SignerTrxBuilder`, so that later tickets can match a transaction recipient or signing account against saved contacts and clear-sign their names on device.

This PR is **plumbing and the public model only** — no matching, no `PROVIDE CONTACT` APDU. Those are DSDK-1391 (external addresses) and DSDK-1392 (Ledger accounts). It is the Tron counterpart of [#1805](https://github.com/LedgerHQ/device-sdk-ts/pull/1805) (DSDK-1386, EVM).

**Public API**

`withAddressBook` is the first `with*` option this builder has ever had.

```ts
const signer = new SignerTrxBuilder({ dmk, sessionId })
  .withAddressBook({
    contactGroups: [
      {
        contactName: "Alice",
        groupHandle,          // Uint8Array, name-level proof material
        hmacProof,            // Uint8Array
        externalAddresses: [
          { scope: "TRX", address: "TQ3zvJoxUCS3PtcAJ8f1FhezAxrEDbjyKh", hmacRest },
        ],
      },
    ],
    ledgerAccounts: [
      { accountName: "Main account", derivationPath: "44'/195'/0'/0/0", hmacProof },
    ],
  })
  .build();
```

**Design notes**

- The snapshot must be complete. The signer never mutates or persists it — owning and persisting the address book stays the host's responsibility. Rebuild the signer to pick up later changes.
- External addresses are **nested** under the contact group that owns them. A group carries the name-level proof material that all of its addresses reuse, so matching an address always yields its group without a lookup.
- Only Tron-family entries belong here. The host filters by blockchain family while building the snapshot, so the models carry no family discriminator and the in-flow matching in DSDK-1391/1392 never needs one.
- **No `chainId`** anywhere in the Tron models — the firmware specification only includes `CHAIN_ID` for Ethereum. This is the main shape difference from `EvmAddressBook`; the other is that `address` is a plain `string` (base58) rather than a `` `0x${string}` `` template type.
- The external-contact derivation path is deliberately absent, as in the EVM model: `HMAC_REST` does not cover it, so it would be unverifiable by the device.
- The DI binding is **non-optional** and defaults to `{ contactGroups: [], ledgerAccounts: [] }` when no book is supplied, so consumers in DSDK-1391/1392 never branch on `undefined` — an empty book simply never matches, which is the same no-op behaviour. Rationale is commented in `di.ts`. This matches the choice made for signer-eth.
- Public exports follow this package's existing style — explicit named `export { type X }` entries in `api/index.ts`, not `export *`.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1390](https://ledgerhq.atlassian.net/browse/DSDK-1390)

- **Feature**: Tron signer contact clear signing ([DSDK-1389](https://ledgerhq.atlassian.net/browse/DSDK-1389)). This PR unblocks DSDK-1391 / DSDK-1392 signer-side, and DSDK-1458 host-side.

> [!NOTE]
> Two open points recorded on DSDK-1390, both out of scope here:
> 1. `BLOCKCHAIN_FAMILY_BY_NAME` in `@ledgerhq/device-contacts-kit` has **no byte for Tron** (only bitcoin, ethereum, solana, polkadot, cosmos, cardano). The value must come from the firmware spec before any real Tron proof is produced. Since the family byte is covered by `HMAC_REST`, a wrong value throws nothing at registration and only surfaces as a failed clear-sign later.
> 2. Ledger Live does not use the DMK Tron signer at all — `families/tron/signer.ts` still builds `new Trx(transport)` from `@ledgerhq/hw-app-trx`. DSDK-1458 is blocked on that migration.

### ✅ Checklist

- [x] **Covered by automatic tests** — 3 tests added to `SignerTrxBuilder.test.ts`: empty book by default, custom book bound by reference, and a contact group holding several addresses. Full package suite is green: 20 files, 99 tests.
- [x] **Changeset is provided** — `minor` for `@ledgerhq/device-signer-kit-tron`.
- [x] **Documentation is up-to-date** — the new public types and `withAddressBook` carry TSDoc; no README change needed since no behaviour is yet observable.
- [x] **Impact of the changes:**
  - Purely additive public API. Existing behaviour is unchanged when no address book is supplied, and nothing yet reads the binding, so no signing flow is affected by this PR.
  - QA focus: none needed on device. Nothing reaches the transport in this PR.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[DSDK-1390]: https://ledgerhq.atlassian.net/browse/DSDK-1390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ