### PR TITLE
🔖 (mock-server) [NO-ISSUE]: Bump version to 0.1.1

### DIFF
--- a/apps/device-mock-server/package.json
+++ b/apps/device-mock-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/device-mock-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
### 📝 Description

Bumps the mock server to `0.1.1` so the Docker image can be published to JFrog.

The point of the release is the Speculos passthrough fix that just landed on develop: it used to read every emulator response with `text()`, which destroyed PNGs, so `/screenshot` never returned a usable image. Until the hosted instance runs this image, the sample's device screen shows the "could not be decoded" message instead of a screen.

Image: `jfrog.ledgerlabs.net/bcs-oci-prod-green/device-mock-server:0.1.1`

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: version bump to release the mock server image.

### ✅ Checklist

- [x] **Covered by automatic tests** — version bump only, no code change. The fix it ships is already tested on develop.
- [x] **Changeset is provided** — not needed, `@ledgerhq/device-mock-server` is private.
- [x] **Documentation is up-to-date** — nothing to update.
- [ ] **Impact of the changes:**
  - Publishes `device-mock-server:0.1.1`. Once the hosted instance is redeployed, `/devices/:id/speculos/screenshot` returns real PNGs.
