### PR TITLE
🐛 (device-mock-server) [NO-ISSUE]: Revert to mock mode when an app is quit on the device

### DIFF
--- a/apps/device-mock-server/README.md
+++ b/apps/device-mock-server/README.md
@@ -254,6 +254,8 @@ sequenceDiagram
 
 > The `coin_app` sent to Speculinho must be the verbatim BOLOS app name (e.g. `Ethereum`, not `eth`).
 
+An app can also be quit from the device screen itself, which exits Speculos with it — no Close App APDU is ever sent. The emulator behind the proxy is then probed whenever a forwarded APDU or a passthrough request comes back unusable, and when it turns out to be gone the app is closed on the device's behalf: the run is released, the APDU is answered in mock mode (`GetAppAndVersion` reports `BOLOS`) and the passthrough answers `409`, exactly as for a device that never opened an app.
+
 ## 🔹 Getting started
 
 Install dependencies from the **monorepo root**:

--- a/apps/device-mock-server/src/api/createMockServer.speculos.test.ts
+++ b/apps/device-mock-server/src/api/createMockServer.speculos.test.ts
@@ -17,6 +17,8 @@ const EMULATOR_URL = "https://emulator.test";
 // e0 d8 00 00 07 "Bitcoin" — Open App(Bitcoin)
 const OPEN_BITCOIN = "e0d8000007426974636f696e";
 const CLOSE_APP = "b0a7000000";
+// Derived GetAppAndVersion for a device at the dashboard: 01 |5 "BOLOS"|5 "1.3.0"| 9000
+const BOLOS_1_3_0 = "0105424f4c4f5305312e332e309000";
 
 // A PNG header: the 0x89 lead byte and the 0x0d0a1a0a run do not survive a
 // UTF-8 round trip, so this doubles as the binary-passthrough assertion.
@@ -48,6 +50,13 @@ const fakeResponse = (
     },
   }) as unknown as Response;
 
+/**
+ * Flipped by a test to stand in for the user quitting the app on the device
+ * screen: Speculos exits with its app, so the pod is gone and its gateway
+ * answers for it.
+ */
+let emulatorAlive = true;
+
 let server: Server;
 let close: () => void;
 let baseUrl: string;
@@ -63,6 +72,15 @@ const route = (url: string, init?: RequestInit): Response => {
     });
   }
   if (url.endsWith("/release")) return fakeResponse({});
+  if (url.startsWith(`${EMULATOR_URL}/`) && !emulatorAlive) {
+    return fakeResponse(
+      { error: "no healthy upstream" },
+      {
+        ok: false,
+        status: 502,
+      },
+    );
+  }
   if (url === `${EMULATOR_URL}/apdu`) return fakeResponse({ data: "ff9000" });
   // Raw passthrough (e.g. screenshot).
   if (url.startsWith(`${EMULATOR_URL}/`)) {
@@ -110,6 +128,7 @@ const sendApdu = (token: string, id: string, apdu: string) =>
   );
 
 beforeEach(async () => {
+  emulatorAlive = true;
   fetchMock = vi.fn((url: string | URL | Request, init?: RequestInit) =>
     Promise.resolve(route(String(url), init)),
   );
@@ -197,6 +216,45 @@ describe("createMockServer + Speculos (HTTP contract)", () => {
       "https://speculinho.test/release",
       expect.objectContaining({ method: "POST" }),
     );
+  });
+
+  it("reverts to mock mode when the app is quit on the device", async () => {
+    const { token, id } = await setupSession();
+    const opened = (await (await sendApdu(token, id, OPEN_BITCOIN)).json()) as {
+      response: string;
+    };
+    expect(opened.response).toBe("9000");
+
+    // Quitting the app from the device screen takes Speculos down with it: no
+    // Close App APDU is ever sent, the emulator simply stops answering.
+    emulatorAlive = false;
+
+    // The APDU that finds it gone is answered from mock mode instead: the
+    // derived GetAppAndVersion reports BOLOS, i.e. the device is back at the
+    // dashboard.
+    const appAndVersion = (await (
+      await sendApdu(token, id, "b0010000")
+    ).json()) as { response: string };
+    expect(appAndVersion.response).toBe(BOLOS_1_3_0);
+    expect((await api(`/devices/${id}/speculos`, {}, token)).status).toBe(409);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://speculinho.test/release",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("answers the screen passthrough with 409 once the emulator is gone", async () => {
+    const { token, id } = await setupSession();
+    await sendApdu(token, id, OPEN_BITCOIN);
+
+    emulatorAlive = false;
+
+    // 409 (no instance), not 502: the panel polling the screen falls back to
+    // the device's own record rather than showing an error.
+    expect(
+      (await api(`/devices/${id}/speculos/screenshot`, {}, token)).status,
+    ).toBe(409);
+    expect((await api(`/devices/${id}/speculos`, {}, token)).status).toBe(409);
   });
 
   it("rejects opening an app the device does not have installed", async () => {

--- a/apps/device-mock-server/src/internal/apdu/service/ApduResolverService.test.ts
+++ b/apps/device-mock-server/src/internal/apdu/service/ApduResolverService.test.ts
@@ -12,6 +12,7 @@ import { SpeculosError } from "@internal/speculos/model/SpeculosModels";
 import { CloseAppUseCase } from "@internal/speculos/use-case/CloseAppUseCase";
 import { ForwardApduUseCase } from "@internal/speculos/use-case/ForwardApduUseCase";
 import { type OpenAppViaSpeculosUseCase } from "@internal/speculos/use-case/OpenAppViaSpeculosUseCase";
+import { ReleaseDeadProxyUseCase } from "@internal/speculos/use-case/ReleaseDeadProxyUseCase";
 
 // e0 d8 00 00 07 "Bitcoin"
 const OPEN_BITCOIN = "e0d8000007426974636f696e";
@@ -22,6 +23,7 @@ const makeOperator = (
   acquire: vi.fn(() => EitherAsync.liftEither(Right("run-1"))),
   waitUntilReady: vi.fn(() => EitherAsync.liftEither(Right("https://x.test"))),
   release: vi.fn(() => EitherAsync.liftEither(Right(undefined))),
+  isAlive: vi.fn(() => Promise.resolve(true)),
   forwardApdu: vi.fn(() => EitherAsync.liftEither(Right("deadbeef9000"))),
   proxyRequest: vi.fn(() =>
     EitherAsync.liftEither(
@@ -95,6 +97,68 @@ describe("ApduResolverService", () => {
     expect(response).toBe("9000");
     expect(operator.release).toHaveBeenCalledWith("run-1");
     expect(repo.findProxy(record, device.id).isNothing()).toBe(true);
+  });
+
+  it("reverts to mock mode when the emulator quit with its app", async () => {
+    const { repo, record, device, os, secureChannel } = setup();
+    repo.setProxy(record, device.id, {
+      runId: "run-1",
+      speculosUrl: "https://x.test",
+      appName: "Bitcoin",
+    });
+    // Quitting the app on the device screen exits Speculos: the forward fails
+    // and the emulator no longer answers.
+    const operator = makeOperator({
+      forwardApdu: vi.fn(() =>
+        EitherAsync.liftEither(Left(new SpeculosError("connection refused"))),
+      ),
+      isAlive: vi.fn(() => Promise.resolve(false)),
+    });
+    const closeApp = new CloseAppUseCase(operator, repo);
+    const resolver = new ApduResolverService(
+      repo,
+      os,
+      secureChannel,
+      undefined,
+      new ForwardApduUseCase(operator),
+      closeApp,
+      new ReleaseDeadProxyUseCase(operator, closeApp),
+    );
+
+    // The APDU that hit the dead emulator is answered from mock mode: BOLOS.
+    expect(await resolver.resolve(record, device, "b0010000")).toBe(
+      "0105424f4c4f5305312e332e309000",
+    );
+    expect(operator.release).toHaveBeenCalledWith("run-1");
+    expect(repo.findProxy(record, device.id).isNothing()).toBe(true);
+  });
+
+  it("keeps the proxy when a forward fails but the emulator is alive", async () => {
+    const { repo, record, device, os, secureChannel } = setup();
+    repo.setProxy(record, device.id, {
+      runId: "run-1",
+      speculosUrl: "https://x.test",
+      appName: "Bitcoin",
+    });
+    const operator = makeOperator({
+      forwardApdu: vi.fn(() =>
+        EitherAsync.liftEither(Left(new SpeculosError("boom"))),
+      ),
+    });
+    const closeApp = new CloseAppUseCase(operator, repo);
+    const resolver = new ApduResolverService(
+      repo,
+      os,
+      secureChannel,
+      undefined,
+      new ForwardApduUseCase(operator),
+      closeApp,
+      new ReleaseDeadProxyUseCase(operator, closeApp),
+    );
+
+    expect(await resolver.resolve(record, device, "b0010000")).toBe("6d00");
+    expect(operator.release).not.toHaveBeenCalled();
+    expect(repo.findProxy(record, device.id).isJust()).toBe(true);
   });
 
   it("lets an explicit mock override the active speculos proxy", async () => {

--- a/apps/device-mock-server/src/internal/apdu/service/ApduResolverService.ts
+++ b/apps/device-mock-server/src/internal/apdu/service/ApduResolverService.ts
@@ -11,11 +11,16 @@ import { INSTALL_COMMIT_APDU } from "@internal/secure-channel/service/secureChan
 import { type SecureChannelApduService } from "@internal/secure-channel/service/SecureChannelApduService";
 import { type SessionRepository } from "@internal/session/data/SessionRepository";
 import { sessionTypes } from "@internal/session/di/sessionTypes";
-import { type SessionRecord } from "@internal/session/model/SessionModels";
+import {
+  type SessionRecord,
+  type SpeculosProxySession,
+} from "@internal/session/model/SessionModels";
 import { speculosTypes } from "@internal/speculos/di/speculosTypes";
+import { type SpeculosError } from "@internal/speculos/model/SpeculosModels";
 import { type CloseAppUseCase } from "@internal/speculos/use-case/CloseAppUseCase";
 import { type ForwardApduUseCase } from "@internal/speculos/use-case/ForwardApduUseCase";
 import { type OpenAppViaSpeculosUseCase } from "@internal/speculos/use-case/OpenAppViaSpeculosUseCase";
+import { type ReleaseDeadProxyUseCase } from "@internal/speculos/use-case/ReleaseDeadProxyUseCase";
 import {
   CLOSE_APP_PREFIX,
   parseOpenApp,
@@ -28,7 +33,8 @@ import {
  * Resolves the response for an incoming APDU, applying the precedence:
  * 1. explicit per-device mock (wins even while a Speculos proxy is active, so a
  *    mock can override an app response — e.g. force GetAppAndVersion to 5515),
- * 2. active Speculos proxy -> forward (Close App releases and reverts to mock),
+ * 2. active Speculos proxy -> forward (Close App — or an emulator that quit
+ *    with its app — releases it and reverts to mock),
  * 3. derived handshake (GetOsVersion / GetAppAndVersion) and relayed
  *    secure-channel APDUs (permission / GetCertificate / install block),
  * 4. unmatched Open App -> provision a Speculos instance,
@@ -52,6 +58,9 @@ export class ApduResolverService {
     @optional()
     @inject(speculosTypes.CloseAppUseCase)
     private readonly closeApp?: CloseAppUseCase,
+    @optional()
+    @inject(speculosTypes.ReleaseDeadProxyUseCase)
+    private readonly releaseDeadProxy?: ReleaseDeadProxyUseCase,
   ) {}
 
   async resolve(
@@ -121,17 +130,13 @@ export class ApduResolverService {
       }
       const result = await this.forwardApdu.execute(proxy, apdu).run();
       return result.caseOf({
-        Left: (error) => {
-          logger.error(
-            `Speculos proxy forward failed for ${device.id}: ${error.message}`,
-          );
-          return SW_PROXY_ERROR;
-        },
+        Left: (error) =>
+          this.onForwardFailed(record, device, apduHex, proxy, error),
         Right: (response) => {
           logger.info(
             `APDU [${device.id}] ${apdu} -> ${response} (speculos ${proxy.runId})`,
           );
-          return response;
+          return Promise.resolve(response);
         },
       });
     }
@@ -181,5 +186,27 @@ export class ApduResolverService {
       `APDU [${device.id}] ${apdu} -> ${UNKNOWN_APDU_RESPONSE} (no matching mock)`,
     );
     return UNKNOWN_APDU_RESPONSE;
+  }
+
+  /**
+   * An emulator can also go away without a Close App APDU: quitting the app from
+   * the device screen exits Speculos with it. When the emulator behind the proxy
+   * turns out to be gone, the app is closed and the APDU is resolved again in
+   * mock mode, the way a real device back at the dashboard answers it.
+   */
+  private async onForwardFailed(
+    record: SessionRecord,
+    device: Device,
+    apduHex: string,
+    proxy: SpeculosProxySession,
+    error: SpeculosError,
+  ): Promise<string> {
+    if (await this.releaseDeadProxy?.execute(record, device.id, proxy)) {
+      return this.resolveResponse(record, device, apduHex);
+    }
+    logger.error(
+      `Speculos proxy forward failed for ${device.id}: ${error.message}`,
+    );
+    return SW_PROXY_ERROR;
   }
 }

--- a/apps/device-mock-server/src/internal/server/routes/DeviceRoutes.ts
+++ b/apps/device-mock-server/src/internal/server/routes/DeviceRoutes.ts
@@ -15,8 +15,10 @@ import {
 } from "@internal/server/validation/requests";
 import { type SessionRepository } from "@internal/session/data/SessionRepository";
 import { sessionTypes } from "@internal/session/di/sessionTypes";
+import { type SpeculosProxySession } from "@internal/session/model/SessionModels";
 import { type SpeculosOperatorDataSource } from "@internal/speculos/data/SpeculosOperatorDataSource";
 import { speculosTypes } from "@internal/speculos/di/speculosTypes";
+import { type ReleaseDeadProxyUseCase } from "@internal/speculos/use-case/ReleaseDeadProxyUseCase";
 
 /**
  * Device resource routes: discovery, lifecycle, connection state, APDU
@@ -32,6 +34,9 @@ export class DeviceRoutes {
     @optional()
     @inject(speculosTypes.OperatorDataSource)
     private readonly operator?: SpeculosOperatorDataSource,
+    @optional()
+    @inject(speculosTypes.ReleaseDeadProxyUseCase)
+    private readonly releaseDeadProxy?: ReleaseDeadProxyUseCase,
   ) {}
 
   build(): Router {
@@ -435,6 +440,16 @@ export class DeviceRoutes {
             hasBody,
           })
           .run();
+        // Nothing usable came back: the emulator may have quit with its app, in
+        // which case the device is reverted to mock mode and answers as it does
+        // with no instance at all.
+        const unusable = result.caseOf({
+          Left: () => true,
+          Right: (response) => response.status >= 500,
+        });
+        if (unusable && (await this.discardProxyIfGone(req, resolved.proxy))) {
+          return this.noInstance(res);
+        }
         result.caseOf({
           Left: (error) => {
             logger.error(
@@ -459,6 +474,26 @@ export class DeviceRoutes {
     res.status(404).json({ error: message });
   }
 
+  private noInstance(res: Response): void {
+    res
+      .status(409)
+      .json({ error: "No active Speculos instance for this device" });
+  }
+
+  /** Forget a proxy whose emulator is gone. @returns whether it was. */
+  private async discardProxyIfGone(
+    req: AuthedRequest,
+    proxy: SpeculosProxySession,
+  ): Promise<boolean> {
+    return (
+      (await this.releaseDeadProxy?.execute(
+        getSession(req),
+        req.params["id"] ?? "",
+        proxy,
+      )) ?? false
+    );
+  }
+
   /** Resolve the device + its active Speculos proxy, or write 404/409. */
   private resolveSpeculos(req: AuthedRequest, res: Response) {
     const id = req.params["id"] ?? "";
@@ -470,9 +505,7 @@ export class DeviceRoutes {
     }
     const proxy = this.repository.findProxy(session, id).extract();
     if (!proxy) {
-      res
-        .status(409)
-        .json({ error: "No active Speculos instance for this device" });
+      this.noInstance(res);
       return undefined;
     }
     return { device, proxy };

--- a/apps/device-mock-server/src/internal/speculos/data/HttpSpeculosOperatorDataSource.test.ts
+++ b/apps/device-mock-server/src/internal/speculos/data/HttpSpeculosOperatorDataSource.test.ts
@@ -124,6 +124,34 @@ describe("HttpSpeculosOperatorDataSource", () => {
     });
   });
 
+  it("reports a live emulator from its events endpoint", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse({ events: [] }));
+
+    expect(await newOperator().isAlive("https://r.speculos.test/")).toBe(true);
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "https://r.speculos.test/events?currentscreenonly=true",
+    );
+  });
+
+  it("reports an emulator that is gone (unreachable or gateway error)", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+    expect(await newOperator().isAlive("https://r.speculos.test")).toBe(false);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ error: "bad gateway" }, false, 502),
+    );
+    expect(await newOperator().isAlive("https://r.speculos.test")).toBe(false);
+  });
+
+  it("counts an emulator that answers 4xx as alive", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ error: "not found" }, false, 404),
+    );
+    expect(await newOperator().isAlive("https://r.speculos.test")).toBe(true);
+  });
+
   it("swallows release errors (best-effort)", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
     const result = await newOperator().release("r").run();

--- a/apps/device-mock-server/src/internal/speculos/data/HttpSpeculosOperatorDataSource.ts
+++ b/apps/device-mock-server/src/internal/speculos/data/HttpSpeculosOperatorDataSource.ts
@@ -14,6 +14,8 @@ import {
 
 const DEFAULT_READY_TIMEOUT_MS = 120_000;
 const DEFAULT_POLL_INTERVAL_MS = 1_000;
+/** Liveness probe budget: a gone pod is refused well within this. */
+const LIVENESS_TIMEOUT_MS = 2_000;
 
 const stripTrailingSlashes = (url: string): string => url.replace(/\/+$/, "");
 
@@ -147,6 +149,20 @@ export class HttpSpeculosOperatorDataSource
         );
       }
     });
+  }
+
+  async isAlive(speculosUrl: string): Promise<boolean> {
+    try {
+      const res = await fetch(
+        `${stripTrailingSlashes(speculosUrl)}/events?currentscreenonly=true`,
+        { signal: AbortSignal.timeout(LIVENESS_TIMEOUT_MS) },
+      );
+      // Anything the emulator answers itself proves it is up; only a gateway
+      // error (its pod is gone) or no answer at all means it is not.
+      return res.status < 500;
+    } catch {
+      return false;
+    }
   }
 
   forwardApdu(

--- a/apps/device-mock-server/src/internal/speculos/data/SpeculosOperatorDataSource.ts
+++ b/apps/device-mock-server/src/internal/speculos/data/SpeculosOperatorDataSource.ts
@@ -25,6 +25,12 @@ export interface SpeculosOperatorDataSource {
   waitUntilReady(runId: string): EitherAsync<SpeculosError, string>;
   /** Destroy a Speculos instance (best-effort). */
   release(runId: string): EitherAsync<SpeculosError, void>;
+  /**
+   * Whether the emulator is still serving. Speculos exits together with the app
+   * it runs, so an emulator that no longer answers means the app is gone — the
+   * user quit it from the device screen.
+   */
+  isAlive(speculosUrl: string): Promise<boolean>;
   /** Forward a raw APDU (hex) to a ready emulator; resolves its hex response. */
   forwardApdu(
     speculosUrl: string,

--- a/apps/device-mock-server/src/internal/speculos/di/speculosModuleFactory.ts
+++ b/apps/device-mock-server/src/internal/speculos/di/speculosModuleFactory.ts
@@ -6,6 +6,7 @@ import { speculosTypes } from "@internal/speculos/di/speculosTypes";
 import { CloseAppUseCase } from "@internal/speculos/use-case/CloseAppUseCase";
 import { ForwardApduUseCase } from "@internal/speculos/use-case/ForwardApduUseCase";
 import { OpenAppViaSpeculosUseCase } from "@internal/speculos/use-case/OpenAppViaSpeculosUseCase";
+import { ReleaseDeadProxyUseCase } from "@internal/speculos/use-case/ReleaseDeadProxyUseCase";
 
 /**
  * Binds the Speculos operator + open-app use-case only when an operator is
@@ -26,4 +27,7 @@ export const speculosModuleFactory = (config: MockServerConfig) =>
       .to(ForwardApduUseCase)
       .inSingletonScope();
     bind(speculosTypes.CloseAppUseCase).to(CloseAppUseCase).inSingletonScope();
+    bind(speculosTypes.ReleaseDeadProxyUseCase)
+      .to(ReleaseDeadProxyUseCase)
+      .inSingletonScope();
   });

--- a/apps/device-mock-server/src/internal/speculos/di/speculosTypes.ts
+++ b/apps/device-mock-server/src/internal/speculos/di/speculosTypes.ts
@@ -4,4 +4,5 @@ export const speculosTypes = {
   OpenAppUseCase: Symbol.for("OpenAppViaSpeculosUseCase"),
   ForwardApduUseCase: Symbol.for("ForwardApduUseCase"),
   CloseAppUseCase: Symbol.for("CloseAppUseCase"),
+  ReleaseDeadProxyUseCase: Symbol.for("ReleaseDeadProxyUseCase"),
 };

--- a/apps/device-mock-server/src/internal/speculos/use-case/ForwardApduUseCase.test.ts
+++ b/apps/device-mock-server/src/internal/speculos/use-case/ForwardApduUseCase.test.ts
@@ -18,6 +18,7 @@ const makeOperator = (
   acquire: vi.fn(() => EitherAsync.liftEither(Right("run-1"))),
   waitUntilReady: vi.fn(() => EitherAsync.liftEither(Right("https://x.test"))),
   release: vi.fn(() => EitherAsync.liftEither(Right(undefined))),
+  isAlive: vi.fn(() => Promise.resolve(true)),
   forwardApdu: vi.fn(() => EitherAsync.liftEither(Right("deadbeef9000"))),
   proxyRequest: vi.fn(() =>
     EitherAsync.liftEither(

--- a/apps/device-mock-server/src/internal/speculos/use-case/OpenAppViaSpeculosUseCase.test.ts
+++ b/apps/device-mock-server/src/internal/speculos/use-case/OpenAppViaSpeculosUseCase.test.ts
@@ -17,6 +17,7 @@ const makeOperator = (
     EitherAsync.liftEither(Right("https://run-1.speculos.test")),
   ),
   release: vi.fn(() => EitherAsync.liftEither(Right(undefined))),
+  isAlive: vi.fn(() => Promise.resolve(true)),
   forwardApdu: vi.fn(() => EitherAsync.liftEither(Right("9000"))),
   proxyRequest: vi.fn(() =>
     EitherAsync.liftEither(

--- a/apps/device-mock-server/src/internal/speculos/use-case/ReleaseDeadProxyUseCase.test.ts
+++ b/apps/device-mock-server/src/internal/speculos/use-case/ReleaseDeadProxyUseCase.test.ts
@@ -4,6 +4,7 @@ import { vi } from "vitest";
 import { InMemorySessionRepository } from "@internal/session/data/InMemorySessionRepository";
 import { type SpeculosOperatorDataSource } from "@internal/speculos/data/SpeculosOperatorDataSource";
 import { CloseAppUseCase } from "@internal/speculos/use-case/CloseAppUseCase";
+import { ReleaseDeadProxyUseCase } from "@internal/speculos/use-case/ReleaseDeadProxyUseCase";
 
 const makeOperator = (
   overrides: Partial<SpeculosOperatorDataSource> = {},
@@ -35,21 +36,39 @@ const setup = () => {
     speculosUrl: "https://r.speculos.test",
     appName: "Bitcoin",
   });
-  return { repo, record, device };
+  const proxy = repo.findProxy(record, device.id).unsafeCoerce();
+  return { repo, record, device, proxy };
 };
 
-describe("CloseAppUseCase", () => {
-  it("forgets the proxy and releases the speculos instance", async () => {
-    const { repo, record, device } = setup();
-    const operator = makeOperator();
-    const proxy = repo.findProxy(record, device.id).unsafeCoerce();
+describe("ReleaseDeadProxyUseCase", () => {
+  it("closes the app when the emulator is gone", async () => {
+    const { repo, record, device, proxy } = setup();
+    const operator = makeOperator({
+      isAlive: vi.fn(() => Promise.resolve(false)),
+    });
 
-    const result = await new CloseAppUseCase(operator, repo)
-      .execute(record, device.id, proxy)
-      .run();
+    const discarded = await new ReleaseDeadProxyUseCase(
+      operator,
+      new CloseAppUseCase(operator, repo),
+    ).execute(record, device.id, proxy);
 
-    expect(result.isRight()).toBe(true);
-    expect(repo.findProxy(record, device.id).isNothing()).toBe(true);
+    expect(discarded).toBe(true);
+    expect(operator.isAlive).toHaveBeenCalledWith("https://r.speculos.test");
     expect(operator.release).toHaveBeenCalledWith("run-1");
+    expect(repo.findProxy(record, device.id).isNothing()).toBe(true);
+  });
+
+  it("keeps the proxy while the emulator still answers", async () => {
+    const { repo, record, device, proxy } = setup();
+    const operator = makeOperator();
+
+    const discarded = await new ReleaseDeadProxyUseCase(
+      operator,
+      new CloseAppUseCase(operator, repo),
+    ).execute(record, device.id, proxy);
+
+    expect(discarded).toBe(false);
+    expect(operator.release).not.toHaveBeenCalled();
+    expect(repo.findProxy(record, device.id).isJust()).toBe(true);
   });
 });

--- a/apps/device-mock-server/src/internal/speculos/use-case/ReleaseDeadProxyUseCase.ts
+++ b/apps/device-mock-server/src/internal/speculos/use-case/ReleaseDeadProxyUseCase.ts
@@ -1,0 +1,43 @@
+import { inject, injectable } from "inversify";
+
+import { logger } from "@internal/logger/logger";
+import {
+  type SessionRecord,
+  type SpeculosProxySession,
+} from "@internal/session/model/SessionModels";
+import { type SpeculosOperatorDataSource } from "@internal/speculos/data/SpeculosOperatorDataSource";
+import { speculosTypes } from "@internal/speculos/di/speculosTypes";
+import { type CloseAppUseCase } from "@internal/speculos/use-case/CloseAppUseCase";
+
+/**
+ * An app quit from the device screen takes Speculos down with it, so the
+ * emulator disappears without any Close App APDU ever reaching the server and
+ * the device is left proxying to nothing. Probes the emulator behind a proxy
+ * and, when it is gone, closes the app on the device's behalf so it reverts to
+ * mock (BOLOS) mode.
+ */
+@injectable()
+export class ReleaseDeadProxyUseCase {
+  constructor(
+    @inject(speculosTypes.OperatorDataSource)
+    private readonly operator: SpeculosOperatorDataSource,
+    @inject(speculosTypes.CloseAppUseCase)
+    private readonly closeApp: CloseAppUseCase,
+  ) {}
+
+  /** @returns whether the emulator was gone and the proxy has been discarded. */
+  async execute(
+    record: SessionRecord,
+    deviceId: string,
+    proxy: SpeculosProxySession,
+  ): Promise<boolean> {
+    if (await this.operator.isAlive(proxy.speculosUrl)) return false;
+    // The proxy is forgotten synchronously; releasing the run is best-effort and
+    // must not hold up the APDU (or passthrough) waiting on the operator.
+    void this.closeApp.execute(record, deviceId, proxy).run();
+    logger.info(
+      `Speculos ${proxy.runId} is gone (app "${proxy.appName}" quit on the device); ${deviceId} is back in mock mode`,
+    );
+    return true;
+  }
+}

--- a/apps/sample/playwright/cases/device/quit-app.spec.ts
+++ b/apps/sample/playwright/cases/device/quit-app.spec.ts
@@ -1,0 +1,125 @@
+/* eslint-disable no-restricted-imports */
+import { type DeviceConfig } from "@ledgerhq/device-mockserver-client";
+import { type Page } from "@playwright/test";
+
+import { expect, test } from "../../fixtures";
+import { type SpeculosDriver } from "../../utils/drivers/SpeculosDriver";
+
+// Nano X with Bitcoin - the combo provisioned via Speculinho in open-app.spec.
+const NANO_X_BTC: DeviceConfig = {
+  name: "Ledger Nano X",
+  device_type: "nanoX",
+  connectivity_type: "USB",
+  firmware_version: "2.7.1",
+  apps: [
+    { name: "BOLOS", version: "2.7.1" },
+    { name: "Bitcoin", version: "2.4.6" },
+  ],
+  masks: [0x33000000],
+};
+
+/** Menu entries between the app home screen and its "Quit" entry. */
+const QUIT_MAX_STEPS = 8;
+/** Time for the emulator to render the next menu entry after a press. */
+const MENU_STEP_MS = 700;
+
+interface CommandResponse {
+  status: string;
+  data?: { name: string; version: string };
+}
+
+/**
+ * Quit the running app the way a user does: page through its menu on the docked
+ * device screen and confirm on "Quit". The buttons are the sample's own, so the
+ * presses travel through the mock server's Speculos proxy.
+ */
+async function quitAppFromDeviceScreen(
+  page: Page,
+  emulator: SpeculosDriver,
+): Promise<void> {
+  for (let step = 0; step < QUIT_MAX_STEPS; step += 1) {
+    const screen = (await emulator.currentScreen()).toLowerCase();
+    if (screen.includes("quit")) {
+      await page.getByTestId("button_device-screen-both").click();
+      return;
+    }
+    await page.getByTestId("button_device-screen-right").click();
+    await page.waitForTimeout(MENU_STEP_MS);
+  }
+  throw new Error("Never reached the app's Quit entry");
+}
+
+test.describe("device: quitting an app from the device screen", () => {
+  test("reverts the mock server to BOLOS mode", async ({
+    page,
+    device,
+    commands,
+    mockClient,
+    speculos,
+  }) => {
+    // Opening an installed app provisions a real Speculos instance, which can
+    // take a while to become ready.
+    test.setTimeout(180_000);
+
+    let dev!: Awaited<ReturnType<typeof device.addAndConnect>>;
+    await test.step("Given a connected Nano X with the Bitcoin app", async () => {
+      dev = await device.addAndConnect(NANO_X_BTC);
+    });
+
+    let emulator!: SpeculosDriver;
+    await test.step("And the Bitcoin app is opened (Speculos proxy active)", async () => {
+      await commands.goto();
+      await commands.execute("Open app", {
+        inputField: "input-text_appName",
+        inputValue: "Bitcoin",
+      });
+      const response = await commands.lastResponse<CommandResponse>({
+        timeout: 90_000,
+      });
+      expect(response.status).toBe("SUCCESS");
+
+      emulator = speculos(dev);
+      await emulator.waitReady();
+      await emulator.waitForAnyScreen();
+      // The drawer covers the sidebar the device screen is docked in.
+      await commands.closeDrawer();
+      await expect(page.getByTestId("image_device-screen")).toBeVisible();
+    });
+
+    await test.step("When the app is quit from the device screen", async () => {
+      await quitAppFromDeviceScreen(page, emulator);
+    });
+
+    await test.step("Then the emulator is released and the device screen falls back to the device record", async () => {
+      // Speculos exits with the app, so the screen the panel polls is gone: it
+      // shows the mock server's own record of the device instead.
+      await expect(page.getByTestId("container_device-os-info")).toBeVisible({
+        timeout: 30_000,
+      });
+      await expect
+        .poll(
+          async () => {
+            try {
+              await mockClient.getSpeculos(dev.id);
+              return "live";
+            } catch {
+              return "released";
+            }
+          },
+          { timeout: 30_000 },
+        )
+        .toBe("released");
+    });
+
+    await test.step("And the mock server answers Get app and version with BOLOS", async () => {
+      await commands.execute("Get app and version");
+      await commands.waitForResponseCount(1);
+      const response = await commands.lastResponse<CommandResponse>();
+      expect(response.status).toBe("SUCCESS");
+      expect(response.data).toMatchObject({
+        name: "BOLOS",
+        version: NANO_X_BTC.firmware_version!,
+      });
+    });
+  });
+});


### PR DESCRIPTION
### 📝 Description

Quitting an app **from the device screen** exits Speculos with it, so the emulator pod disappears without any Close App APDU ever reaching the mock server. The device kept its proxy and stayed in app mode, forwarding every APDU to a pod that was gone.

| Before | After |
| ------ | ----- |
| `GetAppAndVersion` answered `6d00` forever (proxy forward to a dead pod) | Answered from mock mode: `BOLOS` + the device firmware version, as a real device back at the dashboard does |
| The screen passthrough answered `502` on every poll, so the sample's docked device screen showed an error | Answers `409`, so the panel falls back to the device's own record |
| `GET /devices/:id/speculos` reported a live instance that no longer existed | Reports `409`; the Speculinho run is released |

**How it is detected.** The operator port gains a liveness probe (`isAlive`, a 2s GET on the emulator's `/events`). A forwarded APDU or a passthrough request that comes back unusable now probes the emulator before giving up:

- probe fails (no answer, or a gateway `5xx` — its pod is gone) → `ReleaseDeadProxyUseCase` closes the app on the device's behalf: the proxy is forgotten, the run released, and the APDU is **resolved again in mock mode**, so the very APDU that hit the dead pod already answers `BOLOS`;
- probe succeeds → nothing changes: still `6d00`, proxy kept. A transient blip does not drop a live session.

Because the sample polls the screen every 500ms, the revert happens within a second of the quit, with no APDU needed.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Device mock server — Speculos proxy lifecycle.

### ✅ Checklist

- [x] **Covered by automatic tests**
  - Unit: `ReleaseDeadProxyUseCase` (gone → closes / alive → keeps), `isAlive` (live, unreachable, gateway `5xx`, `4xx`-is-alive), `ApduResolverService` (reverts to `BOLOS` when the emulator quit with its app / keeps the proxy when the emulator is alive).
  - HTTP contract (`createMockServer.speculos.test.ts`): after the emulator stops answering, the next APDU returns the derived `BOLOS` response and `/speculos` returns `409`; the screen passthrough returns `409` rather than `502`.
  - E2E (`apps/sample/playwright/cases/device/quit-app.spec.ts`): opens Bitcoin on a Nano X, pages the app menu to **Quit** with the sidebar's own device-screen buttons — the presses travel through the mock server's Speculos proxy, as a user's do — then asserts the panel falls back to the device record, the emulator is released, and `Get app and version` reports `BOLOS`.
- [ ] **Changeset is provided** — not needed: only private packages are touched (`apps/device-mock-server`, `apps/sample`).
- [x] **Documentation is up-to-date** — the Speculos integration section of the mock server README documents the on-device quit path.
- [x] **Impact of the changes:**
  - The Speculos proxy is now dropped whenever the emulator behind it stops answering, so a device can no longer be stuck in app mode. QA should focus on: opening an app then quitting it on the device screen (Nano and touch models), and on long signing flows, to confirm a live emulator is never released by mistake.
  - ⚠️ The E2E test targets the **hosted** mock server, so it only passes once this fix is released and the image deployed.
