### PR TITLE
✨ (mock-server) [DSDK-1460]: Add opt-in device onboarding simulation

### DIFF
--- a/agent-files/skills/mock-server/SKILL.md
+++ b/agent-files/skills/mock-server/SKILL.md
@@ -148,6 +148,38 @@ curl -s -X PUT $BASE/sessions/current/seed -H "$AUTH" -H "$JSON" \
 ⚠️ **Not secure.** Stored in plaintext in server memory and sent over plain
 HTTP. Use only test/dummy mnemonics — never a real production key.
 
+## Onboarding
+
+Make a fresh, not-onboarded device and walk it through Ledger Live's
+SyncOnboarding steps. Ask for `onboarded: false` at create time (omit it, or
+`true`, for a normal onboarded device):
+
+```bash
+curl -s -X POST $BASE/devices -H "$AUTH" -H "$JSON" \
+  -d '{"name":"Ledger Nano X","device_type":"nanoX","firmware_version":"1.3.0","onboarded":false}'
+```
+
+State lives in the GetOsVersion (`e001000000`) answer's `seFlags`: byte 0 has
+the onboarded bit, byte 3 the step. Poll `e001000000` to read it and to move
+the flow along.
+
+- Starts at WELCOME (step `00`), not onboarded. Dwells here until you send
+  `e0030000` (enter early check).
+- Now at EARLY_CHECK (step `0f`). Dwells here until you send `e0030001`
+  (exit early check).
+- After exit, each `e001000000` poll auto-advances one step:
+  ChooseName `0c` -> Pin `06` -> SetupChoice `05` -> NewDevice `07` ->
+  NewDeviceConfirming `08` -> SafetyWarning `0a` -> Ready `0b`.
+- At Ready, byte 0 flips to `e6` (onboarded set) and `GET /devices/<id>` now
+  says `onboarded: true`.
+
+```bash
+# Walk it: enter, exit, then poll until Ready.
+curl -s -X POST $BASE/devices/<id>/apdu -H "$AUTH" -H "$JSON" -d '{"apdu":"e0030000"}'  # enter early check
+curl -s -X POST $BASE/devices/<id>/apdu -H "$AUTH" -H "$JSON" -d '{"apdu":"e0030001"}'  # exit early check
+curl -s -X POST $BASE/devices/<id>/apdu -H "$AUTH" -H "$JSON" -d '{"apdu":"e001000000"}' # poll (repeat to advance)
+```
+
 ## Newest firmware
 
 Server has no "latest" list. Read the real version from Ledger, then `PATCH`:

--- a/apps/device-mock-server/src/api/createMockServer.test.ts
+++ b/apps/device-mock-server/src/api/createMockServer.test.ts
@@ -233,6 +233,70 @@ describe("createMockServer (HTTP contract)", () => {
       );
       expect(res.status).toBe(404);
     });
+
+    // The 4-byte seFlags in a GetOsVersion response: targetId (4 bytes) +
+    // seVersion LV + seFlags LV (len byte + flags). seVersion "1.3.0" is fixed,
+    // so the flags are a fixed slice. byte0 & 0x04 = onboarded, byte3 = step.
+    const seFlagsOf = (response: string): string => response.slice(22, 30);
+
+    it("walks a not-onboarded device through the onboarding steps", async () => {
+      const token = await authenticate();
+      const created = (await (
+        await api(
+          "/devices",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              device_type: "nanoX",
+              firmware_version: "1.3.0",
+              onboarded: false,
+            }),
+          },
+          token,
+        )
+      ).json()) as { id: string };
+      const id = created.id;
+
+      // Starts not onboarded at WELCOME and dwells there until the enter APDU.
+      const welcome = await sendApdu(token, id, "e001000000");
+      expect(seFlagsOf(welcome.body.response!)).toBe("00000000");
+      const stillWelcome = await sendApdu(token, id, "e001000000");
+      expect(seFlagsOf(stillWelcome.body.response!)).toBe("00000000");
+
+      // Enter the early security check, then dwell there until the exit APDU.
+      expect((await sendApdu(token, id, "e0030000")).body.response).toBe(
+        "9000",
+      );
+      const early = await sendApdu(token, id, "e001000000");
+      expect(seFlagsOf(early.body.response!)).toBe("0000000f");
+      const stillEarly = await sendApdu(token, id, "e001000000");
+      expect(seFlagsOf(stillEarly.body.response!)).toBe("0000000f");
+
+      // Exit, then successive polls walk to READY with the onboarded bit set.
+      expect((await sendApdu(token, id, "e0030001")).body.response).toBe(
+        "9000",
+      );
+      const steps: string[] = [];
+      for (let i = 0; i < 7; i += 1) {
+        const res = await sendApdu(token, id, "e001000000");
+        steps.push(seFlagsOf(res.body.response!));
+      }
+      expect(steps).toEqual([
+        "0000000c",
+        "00000006",
+        "00000005",
+        "00000007",
+        "00000008",
+        "0000000a",
+        "e600000b",
+      ]);
+
+      // The device is now reported as onboarded.
+      const fetched = (await (
+        await api(`/devices/${id}`, {}, token)
+      ).json()) as { onboarded?: boolean };
+      expect(fetched.onboarded).toBe(true);
+    });
   });
 
   describe("mock validation", () => {

--- a/apps/device-mock-server/src/internal/apdu/service/ApduResolverService.test.ts
+++ b/apps/device-mock-server/src/internal/apdu/service/ApduResolverService.test.ts
@@ -49,7 +49,7 @@ const setup = () => {
     firmware_version: "1.3.0",
     apps: [{ name: "Bitcoin", version: "2.1.0" }],
   });
-  const os = new OsApduService(stubFirmwareResolver);
+  const os = new OsApduService(repo, stubFirmwareResolver);
   const secureChannel = new SecureChannelApduService();
   return { repo, record, device, os, secureChannel };
 };

--- a/apps/device-mock-server/src/internal/apdu/service/ApduResolverService.ts
+++ b/apps/device-mock-server/src/internal/apdu/service/ApduResolverService.ts
@@ -136,8 +136,10 @@ export class ApduResolverService {
       });
     }
 
-    // 3. Derived OS responses synthesized from the device metadata.
-    const osResponse = await this.os.resolve(device, apdu);
+    // 3. Derived OS responses synthesized from the device metadata (and the
+    //    onboarding simulation, which lives in the derived layer so an explicit
+    //    per-device mock still overrides it).
+    const osResponse = await this.os.resolve(record, device, apdu);
     if (osResponse) {
       logger.info(`APDU [${device.id}] ${apdu} -> ${osResponse} (os)`);
       return osResponse;

--- a/apps/device-mock-server/src/internal/onboarding/onboarding.test.ts
+++ b/apps/device-mock-server/src/internal/onboarding/onboarding.test.ts
@@ -1,0 +1,100 @@
+import {
+  advanceOnboarding,
+  deriveOnboardingSeFlags,
+  initialOnboardingState,
+  type OnboardingRuntimeState,
+  OnboardingStep,
+  onEarlyCheckToggle,
+} from "./onboarding";
+
+const state = (
+  step: OnboardingStep,
+  completed = false,
+): OnboardingRuntimeState => ({ step, completed });
+
+describe("initialOnboardingState", () => {
+  it("starts not onboarded at WELCOME", () => {
+    expect(initialOnboardingState()).toEqual({
+      step: OnboardingStep.Welcome,
+      completed: false,
+    });
+  });
+});
+
+describe("deriveOnboardingSeFlags", () => {
+  it("encodes the step in byte 3 and clears the onboarded bit while onboarding", () => {
+    expect(deriveOnboardingSeFlags(state(OnboardingStep.Welcome))).toBe(
+      "00000000",
+    );
+    expect(deriveOnboardingSeFlags(state(OnboardingStep.EarlyCheck))).toBe(
+      "0000000f",
+    );
+    expect(deriveOnboardingSeFlags(state(OnboardingStep.ChooseName))).toBe(
+      "0000000c",
+    );
+  });
+
+  it("sets the onboarded byte once completed", () => {
+    expect(deriveOnboardingSeFlags(state(OnboardingStep.Ready, true))).toBe(
+      "e600000b",
+    );
+  });
+});
+
+describe("onEarlyCheckToggle", () => {
+  it("enters the early check from WELCOME", () => {
+    expect(onEarlyCheckToggle(state(OnboardingStep.Welcome), true)).toEqual(
+      state(OnboardingStep.EarlyCheck),
+    );
+  });
+
+  it("exits the early check to the first walk step", () => {
+    expect(onEarlyCheckToggle(state(OnboardingStep.EarlyCheck), false)).toEqual(
+      state(OnboardingStep.ChooseName),
+    );
+  });
+
+  it("is a no-op outside the gated steps", () => {
+    expect(onEarlyCheckToggle(state(OnboardingStep.Pin), true)).toEqual(
+      state(OnboardingStep.Pin),
+    );
+    expect(onEarlyCheckToggle(state(OnboardingStep.Welcome), false)).toEqual(
+      state(OnboardingStep.Welcome),
+    );
+  });
+});
+
+describe("advanceOnboarding", () => {
+  it("does not auto-advance on the gated steps", () => {
+    expect(advanceOnboarding(state(OnboardingStep.Welcome))).toEqual(
+      state(OnboardingStep.Welcome),
+    );
+    expect(advanceOnboarding(state(OnboardingStep.EarlyCheck))).toEqual(
+      state(OnboardingStep.EarlyCheck),
+    );
+  });
+
+  it("walks one step per call and completes at READY", () => {
+    const walk = [
+      OnboardingStep.ChooseName,
+      OnboardingStep.Pin,
+      OnboardingStep.SetupChoice,
+      OnboardingStep.NewDevice,
+      OnboardingStep.NewDeviceConfirming,
+      OnboardingStep.SafetyWarning,
+      OnboardingStep.Ready,
+    ];
+    let current = state(OnboardingStep.ChooseName);
+    for (let i = 1; i < walk.length; i += 1) {
+      current = advanceOnboarding(current);
+      expect(current.step).toBe(walk[i]);
+    }
+    expect(current).toEqual({ step: OnboardingStep.Ready, completed: true });
+  });
+
+  it("stays put once completed", () => {
+    expect(advanceOnboarding(state(OnboardingStep.Ready, true))).toEqual(
+      state(OnboardingStep.Ready, true),
+    );
+  });
+});

--- a/apps/device-mock-server/src/internal/onboarding/onboarding.ts
+++ b/apps/device-mock-server/src/internal/onboarding/onboarding.ts
@@ -1,0 +1,120 @@
+/**
+ * Onboarding simulation for a mocked device.
+ *
+ * A device created with `onboarded: false` starts not onboarded and walks
+ * itself through Ledger Live's SyncOnboarding steps as it is polled. Everything
+ * Ledger Live observes is derived from the GetOsVersion (`e001`) `seFlags`
+ * bytes (see `extractOnboardingState` in live-common): `flags[0] & 0x04` is the
+ * onboarded bit and `flags[3]` is the onboarding step. The WELCOME and
+ * EARLY_CHECK steps are gated by the toggleOnboardingEarlyCheck APDU (`e003`);
+ * the remaining steps auto-advance one per GetOsVersion poll until READY.
+ */
+
+/**
+ * Onboarding step, valued with the `flags[3]` code Ledger Live's
+ * `extractOnboardingState` decodes it to.
+ */
+export enum OnboardingStep {
+  Welcome = 0x00,
+  EarlyCheck = 0x0f,
+  ChooseName = 0x0c,
+  Pin = 0x06,
+  SetupChoice = 0x05,
+  NewDevice = 0x07,
+  NewDeviceConfirming = 0x08,
+  SafetyWarning = 0x0a,
+  Ready = 0x0b,
+}
+
+/**
+ * The auto-advancing part of the flow, walked one step per GetOsVersion poll
+ * once the device leaves the early-security-check step. Ordered per Ledger Live
+ * Desktop's SyncOnboarding companion mapping.
+ */
+export const ONBOARDING_WALK: readonly OnboardingStep[] = [
+  OnboardingStep.ChooseName,
+  OnboardingStep.Pin,
+  OnboardingStep.SetupChoice,
+  OnboardingStep.NewDevice,
+  OnboardingStep.NewDeviceConfirming,
+  OnboardingStep.SafetyWarning,
+  OnboardingStep.Ready,
+];
+
+/** Per-device onboarding simulation state. */
+export interface OnboardingRuntimeState {
+  step: OnboardingStep;
+  /** True once the device has reached READY and reports itself onboarded. */
+  completed: boolean;
+}
+
+/** `seFlags` byte 0 while onboarding: nothing set (not onboarded). */
+const SE_FLAGS_BYTE0_ONBOARDING = 0x00;
+/** `seFlags` byte 0 once onboarded: matches the default onboarded device. */
+const SE_FLAGS_BYTE0_ONBOARDED = 0xe6;
+
+const toHexByte = (n: number): string =>
+  (n & 0xff).toString(16).padStart(2, "0");
+
+/** Initial onboarding state for a device opting into the simulation. */
+export function initialOnboardingState(): OnboardingRuntimeState {
+  return { step: OnboardingStep.Welcome, completed: false };
+}
+
+/**
+ * The 4-byte `seFlags` (hex) reported for an onboarding state: `[byte0][00][00]
+ * [step]`, where byte 0 carries the onboarded bit and byte 3 the step. Byte 2
+ * is `0x00`, which Ledger Live decodes as a 24-word seed at index 0 (a valid
+ * value it requires at every step).
+ */
+export function deriveOnboardingSeFlags(state: OnboardingRuntimeState): string {
+  const byte0 = state.completed
+    ? SE_FLAGS_BYTE0_ONBOARDED
+    : SE_FLAGS_BYTE0_ONBOARDING;
+  return toHexByte(byte0) + "0000" + toHexByte(state.step);
+}
+
+/**
+ * Apply a toggleOnboardingEarlyCheck (`e003`) transition:
+ * - `enter` (p2 = 0x00) moves WELCOME -> EARLY_CHECK,
+ * - `exit` (p2 = 0x01) moves EARLY_CHECK -> the first walk step (CHOOSE_NAME).
+ *
+ * Returns the (possibly unchanged) next state; the command always succeeds.
+ */
+export function onEarlyCheckToggle(
+  state: OnboardingRuntimeState,
+  enter: boolean,
+): OnboardingRuntimeState {
+  if (enter && state.step === OnboardingStep.Welcome) {
+    return { ...state, step: OnboardingStep.EarlyCheck };
+  }
+  if (!enter && state.step === OnboardingStep.EarlyCheck) {
+    return { ...state, step: ONBOARDING_WALK[0]! };
+  }
+  return state;
+}
+
+/**
+ * Advance one step on a GetOsVersion poll. WELCOME and EARLY_CHECK do not
+ * auto-advance (they wait for the `e003` enter/exit APDUs). Within the walk,
+ * each poll moves to the next step; reaching READY marks the device onboarded.
+ * A completed device stays put.
+ */
+export function advanceOnboarding(
+  state: OnboardingRuntimeState,
+): OnboardingRuntimeState {
+  if (
+    state.completed ||
+    state.step === OnboardingStep.Welcome ||
+    state.step === OnboardingStep.EarlyCheck
+  ) {
+    return state;
+  }
+  const index = ONBOARDING_WALK.indexOf(state.step);
+  if (index === -1 || index === ONBOARDING_WALK.length - 1) {
+    // Already at (or off) the last walk step: settle on READY + onboarded.
+    return { step: OnboardingStep.Ready, completed: true };
+  }
+  const next = ONBOARDING_WALK[index + 1]!;
+  return { step: next, completed: next === OnboardingStep.Ready };
+}

--- a/apps/device-mock-server/src/internal/os/service/OsApduService.test.ts
+++ b/apps/device-mock-server/src/internal/os/service/OsApduService.test.ts
@@ -1,0 +1,104 @@
+import { Maybe } from "purify-ts";
+import { vi } from "vitest";
+
+import { OsApduService } from "@internal/os/service/OsApduService";
+import { type FirmwareUpdateResolver } from "@internal/secure-channel/service/FirmwareUpdateResolver";
+import { InMemorySessionRepository } from "@internal/session/data/InMemorySessionRepository";
+import { type SessionRecord } from "@internal/session/model/SessionModels";
+
+const GET_OS_VERSION = "e001000000";
+const EARLY_CHECK_ENTER = "e0030000";
+const EARLY_CHECK_EXIT = "e0030001";
+
+const firmwareResolver: FirmwareUpdateResolver = {
+  resolveNextVersion: vi.fn().mockResolvedValue(Maybe.empty()),
+  resolveCurrentMcuVersion: vi.fn().mockResolvedValue(Maybe.of("2.30")),
+} as unknown as FirmwareUpdateResolver;
+
+const setup = (onboarded?: boolean) => {
+  const repo = new InMemorySessionRepository({});
+  const { token } = repo.createSession();
+  const record = repo.findByToken(token).unsafeCoerce() as SessionRecord;
+  const device = repo.addDevice(record, {
+    device_type: "nanoX",
+    firmware_version: "1.3.0",
+    onboarded,
+  });
+  const os = new OsApduService(repo, firmwareResolver);
+  return { repo, record, device, os };
+};
+
+/**
+ * Extracts the 4-byte `seFlags` (hex) from a synthesized GetOsVersion response.
+ * Layout: targetId (4 bytes) + seVersion LV + seFlags LV (len byte `04` + flags).
+ * With seVersion "1.3.0" (5 bytes) the flags are a fixed slice.
+ */
+const seFlagsOf = (response: string): string => response.slice(22, 30);
+
+describe("OsApduService onboarding", () => {
+  it("reports a normal onboarded device when not simulating onboarding", async () => {
+    const { os, record, device } = setup();
+    const response = await os.resolve(record, device, GET_OS_VERSION);
+    expect(seFlagsOf(response!)).toBe("e6000000");
+  });
+
+  it("reports not-onboarded WELCOME and dwells until the early-check enter", async () => {
+    const { os, record, device } = setup(false);
+
+    const first = await os.resolve(record, device, GET_OS_VERSION);
+    expect(seFlagsOf(first!)).toBe("00000000");
+
+    // WELCOME does not auto-advance: another poll stays at WELCOME.
+    const second = await os.resolve(record, device, GET_OS_VERSION);
+    expect(seFlagsOf(second!)).toBe("00000000");
+  });
+
+  it("enters and dwells on the early-security-check step until exit", async () => {
+    const { os, record, device } = setup(false);
+    await os.resolve(record, device, GET_OS_VERSION); // WELCOME
+
+    expect(await os.resolve(record, device, EARLY_CHECK_ENTER)).toBe("9000");
+
+    const early = await os.resolve(record, device, GET_OS_VERSION);
+    expect(seFlagsOf(early!)).toBe("0000000f");
+
+    // EARLY_CHECK dwells until the exit APDU.
+    const stillEarly = await os.resolve(record, device, GET_OS_VERSION);
+    expect(seFlagsOf(stillEarly!)).toBe("0000000f");
+  });
+
+  it("walks to READY and flips the onboarded bit after the exit", async () => {
+    const { os, repo, record, device } = setup(false);
+    await os.resolve(record, device, GET_OS_VERSION); // WELCOME
+    await os.resolve(record, device, EARLY_CHECK_ENTER);
+    await os.resolve(record, device, GET_OS_VERSION); // EARLY_CHECK
+    expect(await os.resolve(record, device, EARLY_CHECK_EXIT)).toBe("9000");
+
+    const walkedSteps: string[] = [];
+    for (let i = 0; i < 7; i += 1) {
+      const response = await os.resolve(record, device, GET_OS_VERSION);
+      walkedSteps.push(seFlagsOf(response!));
+    }
+
+    expect(walkedSteps).toEqual([
+      "0000000c", // CHOOSE_NAME
+      "00000006", // PIN
+      "00000005", // SETUP_CHOICE
+      "00000007", // NEW_DEVICE
+      "00000008", // NEW_DEVICE_CONFIRMING
+      "0000000a", // SAFETY_WARNING
+      "e600000b", // READY, onboarded
+    ]);
+
+    // The device metadata reflects completion.
+    expect(repo.findDevice(record, device.id).unsafeCoerce().onboarded).toBe(
+      true,
+    );
+  });
+
+  it("does not intercept the early-check APDU outside onboarding", async () => {
+    const { os, record, device } = setup();
+    // Not onboarding: e003 is not a derived OS response, so it falls through.
+    expect(await os.resolve(record, device, EARLY_CHECK_ENTER)).toBeUndefined();
+  });
+});

--- a/apps/device-mock-server/src/internal/os/service/OsApduService.test.ts
+++ b/apps/device-mock-server/src/internal/os/service/OsApduService.test.ts
@@ -9,6 +9,10 @@ import { type SessionRecord } from "@internal/session/model/SessionModels";
 const GET_OS_VERSION = "e001000000";
 const EARLY_CHECK_ENTER = "e0030000";
 const EARLY_CHECK_EXIT = "e0030001";
+// Same cla+ins+p1 as the early-check toggle, but not one of its two p2 values.
+const OTHER_E003 = "e0030002";
+// How the toggle actually arrives from a transport: p2 followed by Lc = 00.
+const EARLY_CHECK_ENTER_WITH_LC = "e003000000";
 
 const firmwareResolver: FirmwareUpdateResolver = {
   resolveNextVersion: vi.fn().mockResolvedValue(Maybe.empty()),
@@ -94,6 +98,65 @@ describe("OsApduService onboarding", () => {
     expect(repo.findDevice(record, device.id).unsafeCoerce().onboarded).toBe(
       true,
     );
+  });
+
+  it("leaves an unrelated e003 APDU alone while onboarding", async () => {
+    const { os, record, device } = setup(false);
+    await os.resolve(record, device, GET_OS_VERSION); // WELCOME
+
+    // Not the early-check command: it falls through rather than being
+    // acknowledged, and the onboarding step is untouched.
+    expect(await os.resolve(record, device, OTHER_E003)).toBeUndefined();
+    const still = await os.resolve(record, device, GET_OS_VERSION);
+    expect(seFlagsOf(still!)).toBe("00000000");
+  });
+
+  it("handles the toggle as it arrives on the wire, with its Lc byte", async () => {
+    const { os, record, device } = setup(false);
+    await os.resolve(record, device, GET_OS_VERSION); // WELCOME
+
+    expect(await os.resolve(record, device, EARLY_CHECK_ENTER_WITH_LC)).toBe(
+      "9000",
+    );
+    const early = await os.resolve(record, device, GET_OS_VERSION);
+    expect(seFlagsOf(early!)).toBe("0000000f");
+  });
+
+  it("restarts the walk when a completed device is set back to not onboarded", async () => {
+    const { os, repo, record, device } = setup(false);
+    await os.resolve(record, device, GET_OS_VERSION);
+    await os.resolve(record, device, EARLY_CHECK_ENTER);
+    await os.resolve(record, device, GET_OS_VERSION);
+    await os.resolve(record, device, EARLY_CHECK_EXIT);
+    for (let i = 0; i < 7; i += 1) {
+      await os.resolve(record, device, GET_OS_VERSION);
+    }
+    const ready = await os.resolve(record, device, GET_OS_VERSION);
+    expect(seFlagsOf(ready!)).toBe("e600000b");
+
+    // Asking for a not-onboarded device again walks it from WELCOME, rather
+    // than leaving the finished simulation reporting itself onboarded.
+    const reset = repo
+      .editDevice(record, device.id, { onboarded: false })
+      .unsafeCoerce();
+    expect(reset.onboarded).toBe(false);
+    const welcome = await os.resolve(record, reset, GET_OS_VERSION);
+    expect(seFlagsOf(welcome!)).toBe("00000000");
+  });
+
+  it("keeps a walk in progress where it is when the device is edited", async () => {
+    const { os, repo, record, device } = setup(false);
+    await os.resolve(record, device, GET_OS_VERSION);
+    await os.resolve(record, device, EARLY_CHECK_ENTER);
+    const early = await os.resolve(record, device, GET_OS_VERSION);
+    expect(seFlagsOf(early!)).toBe("0000000f");
+
+    const edited = repo
+      .editDevice(record, device.id, { onboarded: false, name: "Renamed" })
+      .unsafeCoerce();
+
+    const stillEarly = await os.resolve(record, edited, GET_OS_VERSION);
+    expect(seFlagsOf(stillEarly!)).toBe("0000000f");
   });
 
   it("does not intercept the early-check APDU outside onboarding", async () => {

--- a/apps/device-mock-server/src/internal/os/service/OsApduService.ts
+++ b/apps/device-mock-server/src/internal/os/service/OsApduService.ts
@@ -2,32 +2,73 @@ import { type Device } from "@ledgerhq/device-mockserver-client";
 import { inject, injectable, optional } from "inversify";
 
 import {
+  deriveGetOsVersion,
   deriveOsApduResponse,
   GET_OS_VERSION_PREFIX,
   resolveTargetId,
 } from "@internal/os/service/osApdus";
 import { secureChannelTypes } from "@internal/secure-channel/di/secureChannelTypes";
 import { type FirmwareUpdateResolver } from "@internal/secure-channel/service/FirmwareUpdateResolver";
+import { type SessionRepository } from "@internal/session/data/SessionRepository";
+import { sessionTypes } from "@internal/session/di/sessionTypes";
+import { type SessionRecord } from "@internal/session/model/SessionModels";
+
+/**
+ * toggleOnboardingEarlyCheck (cla=0xe0, ins=0x03, p1=0x00); p2 selects
+ * enter (0x00) or exit (0x01) of the early-security-check step. Ledger Live
+ * sends this during onboarding (see live-common's `toggleOnboardingEarlyCheck`).
+ */
+const TOGGLE_EARLY_CHECK_PREFIX = "e00300";
+const TOGGLE_EARLY_CHECK_ENTER_P2 = "00";
+
+const STATUS_OK = "9000";
 
 /**
  * Synthesizes the OS-handshake APDU responses (GetOsVersion / GetAppAndVersion /
  * GetBatteryStatus) from a device's metadata, so a device connects without any
- * seeded mock.
+ * seeded mock. Also drives the onboarding simulation for devices created with
+ * `onboarded: false`.
  */
 @injectable()
 export class OsApduService {
   constructor(
+    @inject(sessionTypes.Repository)
+    private readonly repository: SessionRepository,
     @optional()
     @inject(secureChannelTypes.FirmwareUpdateResolver)
     private readonly firmwareResolver?: FirmwareUpdateResolver,
   ) {}
 
   /** Derived OS-handshake response for an APDU, or `undefined`. */
-  async resolve(device: Device, apdu: string): Promise<string | undefined> {
+  async resolve(
+    record: SessionRecord,
+    device: Device,
+    apdu: string,
+  ): Promise<string | undefined> {
+    const onboarding = this.repository.onboardingActive(record, device.id);
+
     if (apdu.startsWith(GET_OS_VERSION_PREFIX)) {
       const mcuVersion = await this.resolveMcuVersion(device);
+      if (onboarding && mcuVersion) {
+        const seFlags = this.repository
+          .currentOnboardingSeFlags(record, device.id)
+          .extract();
+        const response = deriveGetOsVersion(device, mcuVersion, seFlags);
+        // Report the current step, then advance the walk for the next poll.
+        this.repository.advanceOnboarding(record, device.id);
+        return response;
+      }
       return deriveOsApduResponse(device, apdu, mcuVersion);
     }
+
+    // toggleOnboardingEarlyCheck moves the device in/out of the early-security
+    // -check step; only meaningful while onboarding. Always acknowledges.
+    if (onboarding && apdu.startsWith(TOGGLE_EARLY_CHECK_PREFIX)) {
+      const enter = apdu.slice(6, 8) === TOGGLE_EARLY_CHECK_ENTER_P2;
+      this.repository.toggleOnboardingEarlyCheck(record, device.id, enter);
+      return STATUS_OK;
+    }
+
     return deriveOsApduResponse(device, apdu);
   }
 

--- a/apps/device-mock-server/src/internal/os/service/OsApduService.ts
+++ b/apps/device-mock-server/src/internal/os/service/OsApduService.ts
@@ -20,6 +20,7 @@ import { type SessionRecord } from "@internal/session/model/SessionModels";
  */
 const TOGGLE_EARLY_CHECK_PREFIX = "e00300";
 const TOGGLE_EARLY_CHECK_ENTER_P2 = "00";
+const TOGGLE_EARLY_CHECK_EXIT_P2 = "01";
 
 const STATUS_OK = "9000";
 
@@ -62,11 +63,22 @@ export class OsApduService {
     }
 
     // toggleOnboardingEarlyCheck moves the device in/out of the early-security
-    // -check step; only meaningful while onboarding. Always acknowledges.
+    // -check step; only meaningful while onboarding. Always acknowledges. Only
+    // the two p2 values the command defines are ours: anything else sharing the
+    // cla+ins+p1 is a different APDU and falls through to the other resolvers.
     if (onboarding && apdu.startsWith(TOGGLE_EARLY_CHECK_PREFIX)) {
-      const enter = apdu.slice(6, 8) === TOGGLE_EARLY_CHECK_ENTER_P2;
-      this.repository.toggleOnboardingEarlyCheck(record, device.id, enter);
-      return STATUS_OK;
+      const p2 = apdu.slice(6, 8);
+      if (
+        p2 === TOGGLE_EARLY_CHECK_ENTER_P2 ||
+        p2 === TOGGLE_EARLY_CHECK_EXIT_P2
+      ) {
+        this.repository.toggleOnboardingEarlyCheck(
+          record,
+          device.id,
+          p2 === TOGGLE_EARLY_CHECK_ENTER_P2,
+        );
+        return STATUS_OK;
+      }
     }
 
     return deriveOsApduResponse(device, apdu);

--- a/apps/device-mock-server/src/internal/os/service/osApdus.ts
+++ b/apps/device-mock-server/src/internal/os/service/osApdus.ts
@@ -178,6 +178,7 @@ export function resolveTargetId(device: Device): number | undefined {
 export function deriveGetOsVersion(
   device: Device,
   mcuVersion: string,
+  seFlagsOverride?: string,
 ): string | undefined {
   const model = normalizeModel(device.device_type);
   const mask = device.masks?.[0] ?? TARGET_ID_MASK[model];
@@ -187,7 +188,8 @@ export function deriveGetOsVersion(
 
   let hex = uint32Hex(targetId); // targetId
   hex += lvAscii(seVersion); // seVersion
-  hex += lvHex("e6000000"); // seFlags (onboarded, pin-validated, ...)
+  // seFlags (onboarded, pin-validated, ...); overridden while onboarding.
+  hex += lvHex(seFlagsOverride ?? "e6000000");
   hex += lvAscii(mcuVersion); // mcuSephVersion
   if (isBootloaderVersionSupported(seVersion, model)) {
     hex += lvAscii("1.16"); // mcuBootloaderVersion
@@ -329,9 +331,12 @@ export function deriveOsApduResponse(
   device: Device,
   apdu: string,
   mcuVersion?: string,
+  seFlagsOverride?: string,
 ): string | undefined {
   if (apdu.startsWith(GET_OS_VERSION_PREFIX)) {
-    return mcuVersion ? deriveGetOsVersion(device, mcuVersion) : undefined;
+    return mcuVersion
+      ? deriveGetOsVersion(device, mcuVersion, seFlagsOverride)
+      : undefined;
   }
   if (apdu.startsWith(GET_APP_AND_VERSION_PREFIX)) {
     return deriveGetAppAndVersion(device);

--- a/apps/device-mock-server/src/internal/server/openapi/definition.ts
+++ b/apps/device-mock-server/src/internal/server/openapi/definition.ts
@@ -75,6 +75,13 @@ export const openapiDefinition: OAS3Definition = {
           },
           masks: { type: "array", items: { type: "integer" } },
           connected: { type: "boolean" },
+          onboarded: {
+            type: "boolean",
+            description:
+              "Whether the device is onboarded. Set to false to start the " +
+              "onboarding simulation (the device reports itself as not " +
+              "onboarded and auto-advances through the onboarding steps).",
+          },
         },
         required: ["id", "name", "device_type", "connectivity_type"],
       },
@@ -95,6 +102,12 @@ export const openapiDefinition: OAS3Definition = {
             type: "array",
             description: "Device-scoped APDU mocks (used on attach / import).",
             items: { $ref: "#/components/schemas/MockConfig" },
+          },
+          onboarded: {
+            type: "boolean",
+            description:
+              "Whether the device is onboarded. Omit (or true) for a normal " +
+              "onboarded device; false starts the onboarding simulation.",
           },
         },
       },

--- a/apps/device-mock-server/src/internal/session/data/InMemorySessionRepository.ts
+++ b/apps/device-mock-server/src/internal/session/data/InMemorySessionRepository.ts
@@ -15,6 +15,12 @@ import { Maybe } from "purify-ts";
 import { type MockServerConfig } from "@api/model/MockServerConfig";
 import { DEFAULT_DEVICE } from "@internal/defaults";
 import { appTypes } from "@internal/di/types";
+import {
+  advanceOnboarding as advanceOnboardingState,
+  deriveOnboardingSeFlags,
+  initialOnboardingState,
+  onEarlyCheckToggle,
+} from "@internal/onboarding/onboarding";
 import { type SessionRepository } from "@internal/session/data/SessionRepository";
 import {
   type SessionRecord,
@@ -56,6 +62,7 @@ export class InMemorySessionRepository implements SessionRepository {
       catalog: new Map(),
       pendingAppOperations: new Map(),
       pendingFirmwareOperations: new Map(),
+      onboarding: new Map(),
     };
     this.sessions.set(record.token, record);
     return { token: record.token, expiresAt: this.expiresAt(record) };
@@ -118,6 +125,11 @@ export class InMemorySessionRepository implements SessionRepository {
     record.devices.set(id, device);
     record.deviceMocks.set(id, new Map());
     record.deviceMockCursors.set(id, new Map());
+    // Opt a device into the onboarding simulation: it starts not onboarded and
+    // walks itself through the onboarding steps as it is polled.
+    if (config.onboarded === false) {
+      record.onboarding.set(id, initialOnboardingState());
+    }
     // Seed the session-wide app store with the installable apps the client may
     // later install (resolved from their install hash by the secure channel).
     for (const app of config.catalog ?? []) {
@@ -144,6 +156,13 @@ export class InMemorySessionRepository implements SessionRepository {
     return this.findDevice(record, deviceId).map((current) => {
       const updated: Device = { ...current, ...config, id: current.id };
       record.devices.set(deviceId, updated);
+      // Start/stop the onboarding simulation in place so the device id stays
+      // stable (a client bound to it, e.g. Ledger Live, keeps its connection).
+      if (config.onboarded === false && !record.onboarding.has(deviceId)) {
+        record.onboarding.set(deviceId, initialOnboardingState());
+      } else if (config.onboarded === true) {
+        record.onboarding.delete(deviceId);
+      }
       return updated;
     });
   }
@@ -156,6 +175,7 @@ export class InMemorySessionRepository implements SessionRepository {
     record.speculos.delete(deviceId);
     record.deviceMocks.delete(deviceId);
     record.deviceMockCursors.delete(deviceId);
+    record.onboarding.delete(deviceId);
     return { removed: record.devices.delete(deviceId), proxy };
   }
 
@@ -323,6 +343,44 @@ export class InMemorySessionRepository implements SessionRepository {
     return mock.responses[index % mock.responses.length] ?? "";
   }
 
+  // --- Onboarding simulation ------------------------------------------------
+
+  onboardingActive(record: SessionRecord, deviceId: string): boolean {
+    return record.onboarding.has(deviceId);
+  }
+
+  currentOnboardingSeFlags(
+    record: SessionRecord,
+    deviceId: string,
+  ): Maybe<string> {
+    return Maybe.fromNullable(record.onboarding.get(deviceId)).map(
+      deriveOnboardingSeFlags,
+    );
+  }
+
+  advanceOnboarding(record: SessionRecord, deviceId: string): void {
+    const state = record.onboarding.get(deviceId);
+    if (!state) return;
+    const next = advanceOnboardingState(state);
+    record.onboarding.set(deviceId, next);
+    // Reflect completion on the device metadata so `GET /devices` shows it.
+    if (next.completed && !state.completed) {
+      this.findDevice(record, deviceId).ifJust((device) =>
+        record.devices.set(deviceId, { ...device, onboarded: true }),
+      );
+    }
+  }
+
+  toggleOnboardingEarlyCheck(
+    record: SessionRecord,
+    deviceId: string,
+    enter: boolean,
+  ): void {
+    const state = record.onboarding.get(deviceId);
+    if (!state) return;
+    record.onboarding.set(deviceId, onEarlyCheckToggle(state, enter));
+  }
+
   // --- Import / Export ------------------------------------------------------
 
   exportSession(record: SessionRecord): SessionExport {
@@ -344,6 +402,7 @@ export class InMemorySessionRepository implements SessionRepository {
     record.catalog.clear();
     record.pendingAppOperations.clear();
     record.pendingFirmwareOperations.clear();
+    record.onboarding.clear();
     for (const device of snapshot.devices) {
       this.addDevice(record, device);
     }
@@ -363,6 +422,7 @@ export class InMemorySessionRepository implements SessionRepository {
       apps: config.apps,
       masks: config.masks,
       connected: false,
+      onboarded: config.onboarded,
     };
   }
 
@@ -393,5 +453,6 @@ function toDeviceConfig(device: Device): DeviceConfig {
     firmware_version: device.firmware_version,
     apps: device.apps,
     masks: device.masks,
+    onboarded: device.onboarded,
   };
 }

--- a/apps/device-mock-server/src/internal/session/data/InMemorySessionRepository.ts
+++ b/apps/device-mock-server/src/internal/session/data/InMemorySessionRepository.ts
@@ -158,8 +158,14 @@ export class InMemorySessionRepository implements SessionRepository {
       record.devices.set(deviceId, updated);
       // Start/stop the onboarding simulation in place so the device id stays
       // stable (a client bound to it, e.g. Ledger Live, keeps its connection).
-      if (config.onboarded === false && !record.onboarding.has(deviceId)) {
-        record.onboarding.set(deviceId, initialOnboardingState());
+      // A device that already finished onboarding starts over, so the same
+      // device can be walked through the flow again; a walk in progress is left
+      // where it is, so an unrelated edit does not rewind it.
+      if (config.onboarded === false) {
+        const state = record.onboarding.get(deviceId);
+        if (!state || state.completed) {
+          record.onboarding.set(deviceId, initialOnboardingState());
+        }
       } else if (config.onboarded === true) {
         record.onboarding.delete(deviceId);
       }

--- a/apps/device-mock-server/src/internal/session/data/SessionRepository.ts
+++ b/apps/device-mock-server/src/internal/session/data/SessionRepository.ts
@@ -132,6 +132,23 @@ export interface SessionRepository {
   clearMocks(record: SessionRecord, deviceId: string): void;
   consumeResponse(record: SessionRecord, deviceId: string, mock: Mock): string;
 
+  // --- Onboarding simulation ------------------------------------------------
+  /** Whether a device is running the onboarding simulation. */
+  onboardingActive(record: SessionRecord, deviceId: string): boolean;
+  /** The 4-byte GetOsVersion `seFlags` (hex) for the device's current step. */
+  currentOnboardingSeFlags(
+    record: SessionRecord,
+    deviceId: string,
+  ): Maybe<string>;
+  /** Advance one onboarding step (called per GetOsVersion poll). */
+  advanceOnboarding(record: SessionRecord, deviceId: string): void;
+  /** Apply a toggleOnboardingEarlyCheck transition (`enter`/`exit`). */
+  toggleOnboardingEarlyCheck(
+    record: SessionRecord,
+    deviceId: string,
+    enter: boolean,
+  ): void;
+
   // --- Import / Export ------------------------------------------------------
   exportSession(record: SessionRecord): SessionExport;
   importSession(record: SessionRecord, snapshot: SessionExport): SessionExport;

--- a/apps/device-mock-server/src/internal/session/model/SessionModels.ts
+++ b/apps/device-mock-server/src/internal/session/model/SessionModels.ts
@@ -4,6 +4,8 @@ import {
   type Mock,
 } from "@ledgerhq/device-mockserver-client";
 
+import { type OnboardingRuntimeState } from "@internal/onboarding/onboarding";
+
 /**
  * A device that has opened an app and is now proxying its APDUs to a live
  * Speculos instance managed by the Speculinho operator.
@@ -53,4 +55,9 @@ export interface SessionRecord {
    * and to the clean `<next>` for the final install.
    */
   pendingFirmwareOperations: Map<string, string>;
+  /**
+   * Per-device onboarding simulation state, present only for devices created
+   * with `onboarded: false`: deviceId -> current onboarding state.
+   */
+  onboarding: Map<string, OnboardingRuntimeState>;
 }

--- a/packages/mockserver-client/src/model/Device.ts
+++ b/packages/mockserver-client/src/model/Device.ts
@@ -50,6 +50,13 @@ export interface Device {
   readonly apps?: DeviceApp[];
   readonly masks?: number[];
   readonly connected?: boolean;
+  /**
+   * Whether the device is onboarded. Omitted/`true` reports a normal onboarded
+   * device; `false` starts the onboarding simulation (the device reports itself
+   * as not onboarded and auto-advances through the onboarding steps as it is
+   * polled).
+   */
+  readonly onboarded?: boolean;
 }
 
 export const deviceCodec = Codec.interface({
@@ -61,6 +68,7 @@ export const deviceCodec = Codec.interface({
   apps: optional(array(deviceAppCodec)),
   masks: optional(array(number)),
   connected: optional(boolean),
+  onboarded: optional(boolean),
 });
 
 /**
@@ -77,6 +85,11 @@ export interface DeviceConfig {
   readonly mocks?: MockConfig[];
   /** Installable apps the mock "app store" can resolve from an install hash. */
   readonly catalog?: CatalogApp[];
+  /**
+   * Whether the device is onboarded. Omitted/`true` reports a normal onboarded
+   * device; `false` starts the onboarding simulation.
+   */
+  readonly onboarded?: boolean;
 }
 
 export const deviceConfigCodec = Codec.interface({
@@ -88,4 +101,5 @@ export const deviceConfigCodec = Codec.interface({
   masks: optional(array(number)),
   mocks: optional(array(mockConfigCodec)),
   catalog: optional(array(catalogAppCodec)),
+  onboarded: optional(boolean),
 });


### PR DESCRIPTION
### 📝 Description

The mock server always reports a device as onboarded: `seFlags` is hardcoded to `e6000000` in the derived `GetOsVersion`, so the only way to get a non-onboarded device today is to shadow the whole handshake with an APDU mock — which pins the firmware version into the response bytes and simulates nothing.

This adds an opt-in onboarding simulation. A device created or edited with `onboarded: false` starts not onboarded and auto-advances through Ledger Live's SyncOnboarding steps as it is polled, driven by `GetOsVersion` (`e001`) and `toggleOnboardingEarlyCheck` (`e003`):

- **WELCOME** (step `00`) — dwells until `e0030000` (enter early check)
- **EARLY_CHECK** (`0f`) — dwells until `e0030001` (exit early check)
- then each `e001` poll advances one step: ChooseName `0c` → Pin `06` → SetupChoice `05` → NewDevice `07` → NewDeviceConfirming `08` → SafetyWarning `0a` → Ready `0b`
- at **Ready**, byte 0 of `seFlags` flips to `e6` and `GET /devices/<id>` reports `onboarded: true`

Editing the flag toggles the simulation in place, so the device id stays stable and a connected client keeps its session. The simulation lives in the derived layer, below the explicit-mock and Speculos-proxy branches of `ApduResolverService`, so a per-device mock still overrides it.

```bash
curl -s -X POST $BASE/devices -H "$AUTH" -H "$JSON" \
  -d '{"name":"Ledger Nano X","device_type":"nanoX","firmware_version":"1.3.0","onboarded":false}'
```

> The two feature commits were written in July on `feat/no-issue-mock-server-onboarding-simulation` and never opened as a PR. This branch is that work rebased onto current develop (346 commits of drift); the only conflict was the mock-server skill doc, where develop had added a "Speculos seed" section in the same slot — both sections are kept.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1460](https://ledgerhq.atlassian.net/browse/DSDK-1460)
- **Feature**: Device mock server — device onboarding simulation.

### ✅ Checklist

- [x] **Covered by automatic tests** — `onboarding.test.ts` (the step walk and its transitions), `OsApduService.test.ts` (GetOsVersion seFlags per step, early-check toggle, advance-on-poll), and an HTTP-contract test in `createMockServer.test.ts` walking a device from WELCOME to Ready. 190/190 mock-server tests and 30/30 client tests pass after the rebase.
- [x] **Changeset is provided** — `@ledgerhq/device-mockserver-client` minor, for the new `onboarded` field on `Device` / `DeviceConfig`. The mock server app itself is private.
- [x] **Documentation is up-to-date** — the OpenAPI definition gains the field, and the mock-server skill gains an "Onboarding" section with the walk-through commands.
- [x] **Impact of the changes:**
  - Purely additive: a device without `onboarded` (or with `true`) behaves exactly as before, and the derived handshake is unchanged for it. QA should focus on the SyncOnboarding flow in Ledger Live / the sample against a device created with `onboarded: false`, and confirm normal devices still connect unchanged.
  - Needs a mock-server release + redeploy before the hosted instance honours the flag.


[DSDK-1460]: https://ledgerhq.atlassian.net/browse/DSDK-1460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ