### PR TITLE
✨ (mock-server) [DSDK-1462]: Erase installed apps on OS update

### DIFF
--- a/apps/device-mock-server/src/internal/apdu/service/ApduResolverService.test.ts
+++ b/apps/device-mock-server/src/internal/apdu/service/ApduResolverService.test.ts
@@ -198,6 +198,8 @@ describe("ApduResolverService", () => {
     expect(
       repo.findDevice(record, device.id).unsafeCoerce().firmware_version,
     ).toBe("1.9.1-osu");
+    // The update erased the app storage, as it does on a real device.
+    expect(repo.findDevice(record, device.id).unsafeCoerce().apps).toEqual([]);
     // The pending operation was cleared.
     expect(
       repo.commitPendingFirmwareOperation(record, device.id).isNothing(),

--- a/apps/device-mock-server/src/internal/secure-channel/ws/SecureChannelWebSocket.test.ts
+++ b/apps/device-mock-server/src/internal/secure-channel/ws/SecureChannelWebSocket.test.ts
@@ -1,4 +1,4 @@
-import { type Server } from "node:http";
+import { createServer, type Server } from "node:http";
 import { type AddressInfo } from "node:net";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -310,34 +310,41 @@ describe("secure channel WebSocket: install commits the app to the device contex
  * from the Manager API) once the final install block is acknowledged, mirroring
  * a real device auto-flashing the final image on reboot.
  */
+const createDevice = async (
+  firmware_version: string,
+  apps?: { name: string; version: string; hash?: string }[],
+) => {
+  const token = (
+    (await (await api("/auth", { method: "POST" })).json()) as {
+      token: string;
+    }
+  ).token;
+  const device = (await (
+    await api(
+      "/devices",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          device_type: "stax",
+          firmware_version,
+          ...(apps ? { apps } : {}),
+        }),
+      },
+      token,
+    )
+  ).json()) as { id: string };
+  await api(`/devices/${device.id}/connect`, { method: "POST" }, token);
+  return { token, id: device.id };
+};
+
+const firmwareOf = async (token: string, id: string): Promise<string> =>
+  (
+    (await (await api(`/devices/${id}`, {}, token)).json()) as {
+      firmware_version: string;
+    }
+  ).firmware_version;
+
 describe("secure channel WebSocket: firmware install advances the device version", () => {
-  const createDevice = async (firmware_version: string) => {
-    const token = (
-      (await (await api("/auth", { method: "POST" })).json()) as {
-        token: string;
-      }
-    ).token;
-    const device = (await (
-      await api(
-        "/devices",
-        {
-          method: "POST",
-          body: JSON.stringify({ device_type: "stax", firmware_version }),
-        },
-        token,
-      )
-    ).json()) as { id: string };
-    await api(`/devices/${device.id}/connect`, { method: "POST" }, token);
-    return { token, id: device.id };
-  };
-
-  const firmwareOf = async (token: string, id: string): Promise<string> =>
-    (
-      (await (await api(`/devices/${id}`, {}, token)).json()) as {
-        firmware_version: string;
-      }
-    ).firmware_version;
-
   it("install fails fast when the next version cannot be resolved", async () => {
     // The Manager API is pinned to a refused address (see beforeEach), so the
     // version resolution returns Nothing and the install closes with an error
@@ -351,6 +358,96 @@ describe("secure channel WebSocket: firmware install advances the device version
     );
     expect(install.type).not.toBe("bulk");
     expect(await firmwareOf(token, id)).toBe("1.9.0");
+  });
+});
+
+/**
+ * An OS update erases the device's app storage, so the apps installed before it
+ * are gone once the update commits. Driving that end to end needs the version
+ * resolution to succeed, so this suite re-points the server at a stubbed Manager
+ * API instead of the refused address the other suites rely on.
+ */
+describe("secure channel WebSocket: firmware install erases the app storage", () => {
+  const NEXT_VERSION = "1.9.1";
+  let manager: { url: string; close: () => Promise<void> };
+
+  /**
+   * Minimal Manager API covering the four-call chain `FirmwareUpdateResolver`
+   * replays, plus the MCU catalog `GetOsVersion` consults.
+   */
+  const startManagerApi = async () => {
+    const routes: Record<string, unknown> = {
+      get_device_version: { id: 17 },
+      get_firmware_version: { id: 100 },
+      get_latest_firmware: {
+        result: "ok",
+        se_firmware_osu_version: {
+          name: `${NEXT_VERSION}-osu`,
+          next_se_firmware_final_version: 200,
+        },
+      },
+      "firmware_final_versions/200": {
+        name: NEXT_VERSION,
+        mcu_versions: [5],
+      },
+      mcu_versions: [{ id: 5, name: "5.32.3" }],
+    };
+    const stub = createServer((request, response) => {
+      const path = (request.url ?? "").split("?")[0]!.replace(/^\//, "");
+      const body = routes[path];
+      response.writeHead(body === undefined ? 404 : 200, {
+        "Content-Type": "application/json",
+      });
+      response.end(JSON.stringify(body ?? {}));
+    });
+    await new Promise<void>((resolve) => stub.listen(0, resolve));
+    const { port } = stub.address() as AddressInfo;
+    return {
+      url: `http://127.0.0.1:${port}`,
+      close: () => new Promise<void>((resolve) => stub.close(() => resolve())),
+    };
+  };
+
+  beforeEach(async () => {
+    close();
+    server.close();
+    manager = await startManagerApi();
+    const built = createMockServer({ managerApiUrl: manager.url });
+    close = built.close;
+    await new Promise<void>((resolve) => {
+      server = built.app.listen(0, resolve);
+    });
+    built.attachWebSocket(server);
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+    wsBase = `ws://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    await manager.close();
+  });
+
+  it("reports no installed apps once the update commits", async () => {
+    const { token, id } = await createDevice("1.9.0", [
+      { name: "Bitcoin", version: "2.1.0", hash: "abc123" },
+    ]);
+    const before = await drive(token, id, "apps/list");
+    expect(before.data).toEqual([
+      { flags: 0, hash: "abc123", hash_code_data: "", name: "Bitcoin" },
+    ]);
+
+    const install = await drive(
+      token,
+      id,
+      "install?firmware=abcd&targetId=857735172",
+    );
+    expect(install.type).toBe("bulk");
+    expect(await firmwareOf(token, id)).toBe(NEXT_VERSION);
+
+    // The app storage was wiped with the update: the client re-lists and finds
+    // nothing, which is what drives it into reinstalling.
+    const after = await drive(token, id, "apps/list");
+    expect(after.data).toEqual([]);
   });
 });
 

--- a/apps/device-mock-server/src/internal/session/data/InMemorySessionRepository.test.ts
+++ b/apps/device-mock-server/src/internal/session/data/InMemorySessionRepository.test.ts
@@ -254,4 +254,56 @@ describe("InMemorySessionRepository", () => {
         .firmware_version,
     ).toBe("1.9.1");
   });
+
+  it("erases the installed apps when a firmware operation commits", () => {
+    const { repo, record } = newSession();
+    const device = repo.addDevice(record, {
+      device_type: "stax",
+      firmware_version: "1.9.0",
+      apps: [{ name: "Bitcoin", version: "2.1.0" }],
+      catalog: [BTC],
+    });
+
+    repo.setPendingFirmwareOperation(record, device.id, "1.9.1");
+    const updated = repo
+      .commitPendingFirmwareOperation(record, device.id)
+      .unsafeCoerce();
+    expect(updated.firmware_version).toBe("1.9.1");
+    expect(updated.apps).toEqual([]);
+
+    // The device is reinstallable through the normal install flow afterwards.
+    repo.setPendingAppOperation(record, device.id, BTC);
+    expect(
+      repo.commitPendingAppOperation(record, device.id).unsafeCoerce().apps,
+    ).toEqual([{ name: "Bitcoin", version: "2.1.0", hash: "abc123" }]);
+  });
+
+  it("drops an app operation armed before a firmware update, and stays erased across the OSU-then-final sequence", () => {
+    const { repo, record } = newSession();
+    const device = repo.addDevice(record, {
+      device_type: "stax",
+      firmware_version: "1.9.0",
+      apps: [{ name: "Bitcoin", version: "2.1.0" }],
+      catalog: [BTC],
+    });
+
+    // An install armed but never committed must not land on the updated device.
+    repo.setPendingAppOperation(record, device.id, BTC);
+    repo.setPendingFirmwareOperation(record, device.id, "1.9.1-osu");
+    expect(
+      repo.commitPendingFirmwareOperation(record, device.id).unsafeCoerce()
+        .apps,
+    ).toEqual([]);
+    expect(repo.commitPendingAppOperation(record, device.id).isNothing()).toBe(
+      true,
+    );
+
+    // The final install wipes an already-empty list: still no apps, no throw.
+    repo.setPendingFirmwareOperation(record, device.id, "1.9.1");
+    const final = repo
+      .commitPendingFirmwareOperation(record, device.id)
+      .unsafeCoerce();
+    expect(final.firmware_version).toBe("1.9.1");
+    expect(final.apps).toEqual([]);
+  });
 });

--- a/apps/device-mock-server/src/internal/session/data/InMemorySessionRepository.ts
+++ b/apps/device-mock-server/src/internal/session/data/InMemorySessionRepository.ts
@@ -228,8 +228,15 @@ export class InMemorySessionRepository implements SessionRepository {
       return Maybe.empty();
     }
     record.pendingFirmwareOperations.delete(deviceId);
+    // An OS update erases the app storage, so an app operation armed before the
+    // update must not survive it and land on the post-update device.
+    record.pendingAppOperations.delete(deviceId);
     return this.findDevice(record, deviceId).map((device) => {
-      const updated: Device = { ...device, firmware_version: targetVersion };
+      const updated: Device = {
+        ...device,
+        firmware_version: targetVersion,
+        apps: [],
+      };
       record.devices.set(deviceId, updated);
       return updated;
     });

--- a/apps/device-mock-server/src/internal/session/data/SessionRepository.ts
+++ b/apps/device-mock-server/src/internal/session/data/SessionRepository.ts
@@ -92,8 +92,11 @@ export interface SessionRepository {
   ): void;
   /**
    * Apply a device's pending firmware operation and clear it: sets the device's
-   * `firmware_version` to the armed target. Idempotent and a no-op when nothing
-   * is pending.
+   * `firmware_version` to the armed target and erases its installed apps, the
+   * way a real OS update wipes the app storage — so the follow-up `apps/list`
+   * comes back empty and the client reinstalls. Any app operation armed but not
+   * yet committed is dropped for the same reason. Idempotent and a no-op when
+   * nothing is pending.
    */
   commitPendingFirmwareOperation(
     record: SessionRecord,


### PR DESCRIPTION
### 📝 Description

On a real Ledger device an OS (SE firmware) update **erases the app storage**: the device reboots on the new firmware with no apps installed, and the client has to reinstall them.

The mock server did not simulate this. `commitPendingFirmwareOperation` only rewrote the device's `firmware_version`:

```ts
const updated: Device = { ...device, firmware_version: targetVersion };
```

So a mock device kept its apps across an update — a state no real device can be in, which let clients skip the reinstall path entirely in tests.

**Previous behaviour**: after an OS update, `apps/list` still reported the apps installed before the update.
**New behaviour**: committing a firmware operation clears the device's apps, so the follow-up `apps/list` comes back empty and the client is driven into its reinstall path. Any app operation armed but not yet committed is dropped for the same reason, so it cannot land on the post-update device.

**Design note — the wipe is unconditional, not gated on the clean (non-OSU) target.** `FirmwareUpdateResolver.resolveNextVersion` already commits straight to the clean version (a real device auto-flashes the final image on reboot), so there is no intermediate `-osu` commit today. Wiping an already-empty list is a no-op, so an OSU-then-final sequence stays correct without the commit needing to know which leg it is — and gating on the suffix would risk never wiping if only an OSU leg ever ran.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1462](https://ledgerhq.atlassian.net/browse/DSDK-1462) (epic [DSDK-1220](https://ledgerhq.atlassian.net/browse/DSDK-1220), follows [DSDK-1324](https://ledgerhq.atlassian.net/browse/DSDK-1324))

- **Feature**: Device mock server — make an OS update erase the installed apps, as a real device does.

### ✅ Checklist

- [x] **Covered by automatic tests**
  - `InMemorySessionRepository`: apps erased on commit and reinstallable afterwards; armed-but-uncommitted app operation dropped; apps stay erased across an OSU-then-final sequence.
  - `ApduResolverService`: apps erased once the final install block (`e0f0050000`) is acknowledged.
  - `SecureChannelWebSocket`: end-to-end — `apps/list` reports Bitcoin → firmware install streams to `bulk` → version advances → `apps/list` comes back empty. This needs the Manager API resolution to succeed, which that suite deliberately pins to a refused address, so the new `describe` stands up a small local Manager API stub (the four-call chain plus the MCU catalog) and leaves the existing fail-fast test's unreachable-API setup untouched.
  - Each new assertion was verified to fail with the production change reverted.
- [ ] **Changeset is provided** — not needed: the change only affects `apps/device-mock-server`, a private package (`privatePackages.version: false`), consistent with previous mock-server-only commits.
- [x] **Documentation is up-to-date** — the `SessionRepository` interface contract now documents the wipe. No README change: the README documents nothing about firmware installs at all, so a lone sentence about the app wipe would dangle; that doc gap belongs with DSDK-1324.
- [x] **Impact of the changes:**
  - Mock devices that go through the secure-channel firmware install now report **no installed apps** afterwards. Any test or sample-app flow that assumed apps survived an OS update on a mock device will now see an empty list — which is the point, but it is a behaviour change for existing flows.
  - No change to the `firmware_version` advance, to app install/uninstall, or to any other endpoint.
  - QA focus: the Ledger Live / DMK firmware-update flow against the mock server, specifically that the post-update app reinstall path is now exercised.


[DSDK-1462]: https://ledgerhq.atlassian.net/browse/DSDK-1462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ