### PR TITLE
✨ (mock-server) [NO-ISSUE]: Add changeset-driven release scripts and skill

### DIFF
--- a/agent-files/scripts/release/mock-server/bump.cjs
+++ b/agent-files/scripts/release/mock-server/bump.cjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env zx
+
+require("zx/globals");
+const {
+  IMAGE_REPO,
+  PKG_NAME,
+  PKG_PATH,
+  fail,
+  nextVersion,
+  pendingChangesets,
+  readPackage,
+  resolveBump,
+} = require("./common.cjs");
+
+async function main() {
+  const changesets = await pendingChangesets();
+  const pkg = await readPackage();
+  const { bump, source } = resolveBump(changesets, argv.bump);
+
+  const from = pkg.version;
+  const to = nextVersion(from, bump);
+
+  pkg.version = to;
+  await fs.writeJson(PKG_PATH, pkg, { spaces: 2 });
+
+  console.log(chalk.green(`${PKG_NAME}: ${from} → ${to} [${bump}]`));
+  console.log(
+    JSON.stringify(
+      {
+        package: PKG_NAME,
+        from,
+        to,
+        bump,
+        bumpSource: source,
+        image: `${IMAGE_REPO}:${to}`,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(fail);

--- a/agent-files/scripts/release/mock-server/changelog.cjs
+++ b/agent-files/scripts/release/mock-server/changelog.cjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env zx
+
+require("zx/globals");
+const {
+  CHANGELOG_PATH,
+  PKG_NAME,
+  enrich,
+  fail,
+  pendingChangesets,
+  readPackage,
+} = require("./common.cjs");
+
+const SECTION_TITLES = {
+  major: "Major Changes",
+  minor: "Minor Changes",
+  patch: "Patch Changes",
+};
+
+function formatEntry(entry, repo) {
+  const short = entry.commit.slice(0, 7);
+  const pr = `[#${entry.prNumber}](https://github.com/${repo}/pull/${entry.prNumber})`;
+  const commitLink = `[\`${short}\`](https://github.com/${repo}/commit/${entry.commit})`;
+  const thanks = `Thanks [@${entry.author}](https://github.com/${entry.author})!`;
+
+  return `- ${pr} ${commitLink} ${thanks} - ${entry.summary}`;
+}
+
+function prepend(existing, section) {
+  if (!existing) return `# ${PKG_NAME}\n${section}`;
+
+  const firstNewline = existing.indexOf("\n");
+  if (firstNewline === -1) return existing + section;
+
+  return (
+    existing.slice(0, firstNewline) +
+    "\n" +
+    section +
+    existing.slice(firstNewline + 1)
+  );
+}
+
+async function main() {
+  const pkg = await readPackage();
+  const changesets = await pendingChangesets();
+
+  if (changesets.length === 0) {
+    console.log(
+      chalk.yellow(
+        `No changeset for ${PKG_NAME}. Nothing to add to the changelog — ` +
+          `describe the release in the PR body instead.`,
+      ),
+    );
+    process.exit(0);
+  }
+
+  let existing = "";
+  try {
+    existing = await fs.readFile(CHANGELOG_PATH, "utf-8");
+  } catch {
+    // first release, no changelog yet
+  }
+
+  if (existing.includes(`\n## ${pkg.version}\n`)) {
+    throw new Error(
+      `CHANGELOG.md already has a "## ${pkg.version}" section. ` +
+        `Did bump.cjs run before this script?`,
+    );
+  }
+
+  console.log(chalk.blue("Enriching changesets with PR/commit metadata..."));
+  const { repo } = await enrich(changesets);
+
+  const byBump = { major: [], minor: [], patch: [] };
+  for (const cs of changesets) byBump[cs.bump].push(cs);
+
+  let section = `\n## ${pkg.version}\n`;
+  for (const bump of ["major", "minor", "patch"]) {
+    if (byBump[bump].length === 0) continue;
+    section += `\n### ${SECTION_TITLES[bump]}\n\n`;
+    section += byBump[bump]
+      .map((cs) => formatEntry(cs, repo) + "\n")
+      .join("\n");
+  }
+
+  await fs.writeFile(CHANGELOG_PATH, prepend(existing, section));
+
+  console.log(
+    chalk.green(
+      `Updated ${path.relative(process.cwd(), CHANGELOG_PATH)} for ${pkg.version}`,
+    ),
+  );
+}
+
+main().catch(fail);

--- a/agent-files/scripts/release/mock-server/cleanup.cjs
+++ b/agent-files/scripts/release/mock-server/cleanup.cjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env zx
+
+require("zx/globals");
+const {
+  CHANGESET_DIR,
+  PKG_NAME,
+  fail,
+  pendingChangesets,
+} = require("./common.cjs");
+
+const ENTRY_RE = new RegExp(
+  `^[ \\t]*"?${PKG_NAME}"?:[ \\t]*(patch|minor|major)[ \\t]*\\n`,
+  "m",
+);
+
+async function main() {
+  const changesets = await pendingChangesets();
+
+  if (changesets.length === 0) {
+    console.log(chalk.yellow(`No changeset for ${PKG_NAME} to clean up.`));
+    console.log(JSON.stringify({ deleted: [], stripped: [] }, null, 2));
+    return;
+  }
+
+  const deleted = [];
+  const stripped = [];
+
+  for (const cs of changesets) {
+    const filePath = path.join(CHANGESET_DIR, cs.file);
+
+    // Danger enforces one package per changeset, but a mixed file must not
+    // take another package's pending release down with it.
+    if (cs.otherPackages.length > 0) {
+      const content = await fs.readFile(filePath, "utf-8");
+      const next = content.replace(ENTRY_RE, "");
+      if (next === content) {
+        throw new Error(
+          `Could not strip the ${PKG_NAME} entry from .changeset/${cs.file}. Edit it by hand.`,
+        );
+      }
+      await fs.writeFile(filePath, next);
+      stripped.push(cs.file);
+      console.log(
+        chalk.yellow(
+          `Stripped ${PKG_NAME} from .changeset/${cs.file} (also covers ${cs.otherPackages.join(", ")})`,
+        ),
+      );
+      continue;
+    }
+
+    await fs.remove(filePath);
+    deleted.push(cs.file);
+    console.log(chalk.gray(`Deleted .changeset/${cs.file}`));
+  }
+
+  console.log(
+    chalk.green(
+      `Removed ${deleted.length} changeset file(s)` +
+        (stripped.length ? `, edited ${stripped.length} mixed file(s).` : "."),
+    ),
+  );
+  console.log(JSON.stringify({ deleted, stripped }, null, 2));
+}
+
+main().catch(fail);

--- a/agent-files/scripts/release/mock-server/common.cjs
+++ b/agent-files/scripts/release/mock-server/common.cjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env zx
+
+require("zx/globals");
+const semver = require("semver");
+const { ROOT, readChangesets } = require("../config.cjs");
+
+const PKG_NAME = "@ledgerhq/device-mock-server";
+const DISPLAY_NAME = "Mock Server";
+const PKG_DIR = path.join(ROOT, "apps", "device-mock-server");
+const PKG_PATH = path.join(PKG_DIR, "package.json");
+const CHANGELOG_PATH = path.join(PKG_DIR, "CHANGELOG.md");
+const CHANGESET_DIR = path.join(ROOT, ".changeset");
+const IMAGE_REPO = "jfrog.ledgerlabs.net/bcs-oci-prod-green/device-mock-server";
+
+const BUMP_ORDER = { patch: 0, minor: 1, major: 2 };
+
+function readPackage() {
+  return fs.readJson(PKG_PATH);
+}
+
+/** Changesets that declare a bump for the mock server. */
+async function pendingChangesets() {
+  const all = await readChangesets();
+  return all
+    .filter((cs) => PKG_NAME in cs.packages)
+    .map((cs) => ({
+      file: cs.file,
+      bump: cs.packages[PKG_NAME],
+      summary: cs.summary,
+      otherPackages: Object.keys(cs.packages).filter((p) => p !== PKG_NAME),
+    }))
+    .sort((a, b) => a.file.localeCompare(b.file));
+}
+
+function highestBump(changesets) {
+  let best = null;
+  for (const cs of changesets) {
+    if (best === null || BUMP_ORDER[cs.bump] > BUMP_ORDER[best]) best = cs.bump;
+  }
+  return best;
+}
+
+/**
+ * `--bump <type>` wins over the changesets, so a release can still be cut for
+ * changes that never warranted a changeset (Dockerfile, CI, deps).
+ */
+function resolveBump(changesets, override) {
+  if (override) {
+    if (!(override in BUMP_ORDER)) {
+      throw new Error(
+        `Invalid --bump "${override}". Use one of: patch, minor, major.`,
+      );
+    }
+    return { bump: override, source: "override" };
+  }
+
+  const bump = highestBump(changesets);
+  if (!bump) {
+    throw new Error(
+      `No pending changeset for ${PKG_NAME}. Add one (see the changeset skill) ` +
+        `or pass --bump patch|minor|major to release without one.`,
+    );
+  }
+  return { bump, source: "changesets" };
+}
+
+function nextVersion(from, bump) {
+  const to = semver.inc(from, bump);
+  if (!to) throw new Error(`Failed to compute ${bump} bump for ${from}`);
+  return to;
+}
+
+async function readRepoSlug() {
+  try {
+    const cfg = await fs.readJson(path.join(CHANGESET_DIR, "config.json"));
+    if (Array.isArray(cfg.changelog) && cfg.changelog[1]?.repo) {
+      return cfg.changelog[1].repo;
+    }
+  } catch {}
+  return "LedgerHQ/device-sdk-ts";
+}
+
+/**
+ * Attach the commit that introduced each changeset plus its PR number and
+ * author, so entries match the format the DMK release produces. Only the mock
+ * server changesets are looked up, to keep the GitHub API calls to a minimum.
+ */
+async function enrich(changesets) {
+  const repo = await readRepoSlug();
+  const prevVerbose = $.verbose;
+  $.verbose = false;
+
+  try {
+    for (const cs of changesets) {
+      const filePath = path.join(CHANGESET_DIR, cs.file);
+      const res =
+        await $`git log --diff-filter=A --format=%H -1 -- ${filePath}`;
+      cs.commit = res.stdout.trim() || null;
+      if (!cs.commit) {
+        throw new Error(
+          `No commit found for .changeset/${cs.file}. Was it committed to git?`,
+        );
+      }
+    }
+
+    const metaBySha = new Map();
+    for (const sha of new Set(changesets.map((cs) => cs.commit))) {
+      const endpoint = `repos/${repo}/commits/${sha}/pulls`;
+      const jq = ".[0] | {number, user: .user.login}";
+      let res;
+      try {
+        res = await $`gh api ${endpoint} --jq ${jq}`;
+      } catch (err) {
+        throw new Error(
+          `Failed to fetch PR metadata for commit ${sha}. Is gh authenticated?\n${err.message}`,
+        );
+      }
+      const data = JSON.parse(res.stdout.trim());
+      if (!data.number || !data.user) {
+        throw new Error(
+          `Incomplete PR metadata for commit ${sha}: prNumber=${data.number}, author=${data.user}`,
+        );
+      }
+      metaBySha.set(sha, { prNumber: data.number, author: data.user });
+    }
+
+    for (const cs of changesets) {
+      const meta = metaBySha.get(cs.commit);
+      cs.prNumber = meta.prNumber;
+      cs.author = meta.author;
+    }
+  } finally {
+    $.verbose = prevVerbose;
+  }
+
+  return { changesets, repo };
+}
+
+function fail(err) {
+  console.error(chalk.red(err.message || String(err)));
+  process.exit(1);
+}
+
+module.exports = {
+  BUMP_ORDER,
+  CHANGELOG_PATH,
+  CHANGESET_DIR,
+  DISPLAY_NAME,
+  IMAGE_REPO,
+  PKG_DIR,
+  PKG_NAME,
+  PKG_PATH,
+  enrich,
+  fail,
+  highestBump,
+  nextVersion,
+  pendingChangesets,
+  readPackage,
+  readRepoSlug,
+  resolveBump,
+};

--- a/agent-files/scripts/release/mock-server/discover.cjs
+++ b/agent-files/scripts/release/mock-server/discover.cjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env zx
+
+require("zx/globals");
+const {
+  DISPLAY_NAME,
+  IMAGE_REPO,
+  PKG_NAME,
+  fail,
+  nextVersion,
+  pendingChangesets,
+  readPackage,
+  resolveBump,
+} = require("./common.cjs");
+
+async function main() {
+  const changesets = await pendingChangesets();
+  const pkg = await readPackage();
+
+  let bump;
+  let source;
+  try {
+    ({ bump, source } = resolveBump(changesets, argv.bump));
+  } catch (err) {
+    console.log(
+      JSON.stringify(
+        {
+          package: PKG_NAME,
+          displayName: DISPLAY_NAME,
+          version: pkg.version,
+          changesets,
+          error: err.message,
+        },
+        null,
+        2,
+      ),
+    );
+    process.exit(1);
+  }
+
+  const to = nextVersion(pkg.version, bump);
+  const mixed = changesets.filter((cs) => cs.otherPackages.length > 0);
+
+  console.log(
+    JSON.stringify(
+      {
+        package: PKG_NAME,
+        displayName: DISPLAY_NAME,
+        from: pkg.version,
+        to,
+        bump,
+        bumpSource: source,
+        changesets,
+        mixedChangesets: mixed.map((cs) => cs.file),
+        image: `${IMAGE_REPO}:${to}`,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(fail);

--- a/agent-files/skills/release-mock-server/SKILL.md
+++ b/agent-files/skills/release-mock-server/SKILL.md
@@ -1,100 +1,210 @@
 ---
 name: release-mock-server
-description: Bump the mock server version in package.json, commit, push, and trigger the Docker image publish workflow to JFrog. Activate when the user says "release mock server", "/release-mock-server", or asks to release/publish the device mock server Docker image.
+description: Release the device mock server — consume its changesets, bump the version, generate the changelog, open the release PR, then trigger the Docker image publish to JFrog. Activate when the user says "release mock server", "/release-mock-server", or asks to release/publish the device mock server Docker image.
 ---
 
-# Release mock server
+# Release the mock server
 
-Bump version. Commit. Push. Poke the workflow. It builds the Docker image and
-throws it at JFrog.
+The mock server is a **private** workspace app (`apps/device-mock-server`). It is
+never published to npm — the deliverable is a Docker image on JFrog, tagged with
+the version in its `package.json`.
 
-Version lives in `apps/device-mock-server/package.json`. Workflow lives in
-`.github/workflows/release_mock_server.yml`.
+Same shape as the `release` skill, minus everything npm-specific: no release
+scope, no dependency pinning, no lockfile update. Scripts live in
+`agent-files/scripts/release/mock-server/` and run with `pnpm exec zx`.
 
-## Rules to remember
+## Adding a changeset for the mock server
 
-- Need `gh` installed and logged in. Need `pnpm`. Need push rights to
-  `LedgerHQ/device-sdk-ts`.
-- `gh` calls need `required_permissions: ["all"]`.
-- Workflow reads version from package.json AT THE PUSHED REF. So push the bump
-  BEFORE you trigger. No push = old version = wrong tag.
-- Do steps in order. Any step breaks → stop, tell user, do not go on.
-- Collect warnings along the way. Dump them at the end.
-- `$BUMP` = `patch` | `minor` | `major`. No `$BUMP` = `patch`.
-
-## The steps
+`pnpm changeset` will **not** offer `@ledgerhq/device-mock-server` in its
+interactive picker — the package is `private: true` and `.changeset/config.json`
+sets `privatePackages.version: false`. So write the changeset by hand:
 
 ```bash
-# 1. Bump type. $BUMP or patch. Not one of patch/minor/major → stop.
-
-# 2. On a branch? Empty = detached HEAD → stop.
-git branch --show-current
-
-# 3. Clean tree? Non-empty = dirty → stop, user commits/stashes first.
-git status --porcelain
-
-# 4. Old version (remember it for the summary).
-jq -r '.version' apps/device-mock-server/package.json
-
-# 5. Bump it. Remember new version.
-(cd apps/device-mock-server && pnpm version "$BUMP" --no-git-tag-version --no-commit-hooks)
-jq -r '.version' apps/device-mock-server/package.json
-
-# 6. Commit just the package.json. Gitmoji style.
-git add apps/device-mock-server/package.json
-git commit -m "🔖 (mock-server): Bump version to <new_version>"
-
-# 7. Push. Rejected/non-fast-forward → tell user to `git pull --rebase`
-#    (or `git push --force` if they mean it). Other error → stop, report.
-git push -u origin HEAD
-
-# 8. Fire the workflow at the branch.
-gh workflow run "release_mock_server.yml" -f ref=<branch>
+pnpm changeset add --empty
 ```
 
-## Find the run
+Then fill the new `.changeset/*.md` file:
 
-Wait 5s. Then hunt the fresh run:
+```markdown
+---
+"@ledgerhq/device-mock-server": minor
+---
+
+Add opt-in device onboarding simulation
+```
+
+One package per changeset (the danger bot enforces it). These files sit in
+`.changeset/` until a mock server release consumes them — the DMK release
+scripts skip them, because they only look at public, non-`apps/` packages.
+
+## Permission prompts
+
+These need network, the GitHub CLI, or both, so they trigger a permission prompt
+(Claude Code) or need `required_permissions: ["all"]` (Cursor):
+
+- `preflight.cjs` (Step 1 — `gh auth status`)
+- `mock-server/changelog.cjs` (Step 5 — GitHub API via `gh`)
+- `gh pr create` (Step 7) and `gh workflow run` / `gh run list` (Step 8)
+
+`discover`, `bump` and `cleanup` run fine inside the sandbox.
+
+## Release flow
+
+Commit after every step that touches files — it keeps the release PR readable.
+
+### Step 1 — Preflight
+
+```bash
+pnpm exec zx agent-files/scripts/release/preflight.cjs
+```
+
+Must pass before anything else. Same script as the DMK release.
+
+### Step 2 — Discover & confirm
+
+```bash
+pnpm exec zx agent-files/scripts/release/mock-server/discover.cjs
+```
+
+Prints JSON: `from`, `to`, `bump`, `bumpSource`, `changesets[]`, `image`.
+Show the user a table and **wait for confirmation**:
+
+```
+| Package | From | To | Bump | Changesets |
+|---------|------|----|------|------------|
+| @ledgerhq/device-mock-server | 0.1.1 | 0.2.0 | minor | bold-tigers-run, easy-rings-bake |
+```
+
+- **No pending changeset** → the script exits 1 with an `error` field. Ask the
+  user whether to release anyway (an infra-only change: Dockerfile, CI, deps).
+  If yes, pass `--bump patch|minor|major` to `discover.cjs` **and** `bump.cjs`.
+  Step 5 then has nothing to write — say so, and put the summary in the PR body.
+- **`mixedChangesets` non-empty** → a changeset covers the mock server *and*
+  another package. Warn the user: Step 6 will strip only the mock server line
+  and leave the file for the other package's release.
+
+### Step 3 — Create the release branch
+
+```bash
+git checkout develop && git pull
+git checkout -b release/mock-server-<to>
+```
+
+### Step 4 — Bump the version
+
+```bash
+pnpm exec zx agent-files/scripts/release/mock-server/bump.cjs
+```
+
+Writes the new version to `apps/device-mock-server/package.json`. No lockfile
+update is needed — a workspace app's own version is not recorded in
+`pnpm-lock.yaml`.
+
+```bash
+git add apps/device-mock-server/package.json
+git commit -m "🔖 (mock-server): Bump version to <to>"
+```
+
+### Step 5 — Generate the changelog
+
+```bash
+pnpm exec zx agent-files/scripts/release/mock-server/changelog.cjs
+```
+
+Prepends a `## <version>` section to `apps/device-mock-server/CHANGELOG.md`,
+with the PR link, commit link and author for each changeset — same format the
+DMK release produces. Creates the file on the first release.
+
+Run it **after** Step 4: it reads the already-bumped version, and refuses to
+write a section that already exists.
+
+```bash
+git add apps/device-mock-server/CHANGELOG.md
+git commit -m "📝 (mock-server): Generate changelog"
+```
+
+### Step 6 — Clean up consumed changesets
+
+```bash
+pnpm exec zx agent-files/scripts/release/mock-server/cleanup.cjs
+```
+
+Deletes the changesets this release consumed. A changeset that also covers
+another package is edited instead of deleted, and reported under `stripped`.
+
+```bash
+git add .changeset
+git commit -m "🔥 (mock-server): Clean up consumed changesets"
+```
+
+### Step 7 — Push and open the PR
+
+```bash
+git push -u origin HEAD
+gh pr create --base develop --title "🔖 (mock-server): Release <to>" --body "..."
+```
+
+- Target is **develop**, not `main` — the mock server is not part of the npm
+  release train.
+- Body: version, bump type, and the changelog section from Step 5.
+- Rejected push / non-fast-forward → tell the user to `git pull --rebase`. Any
+  other error → stop and report.
+- Report the PR URL and stop. **Do not trigger the Docker build yet.**
+
+### Step 8 — After the PR merges: publish the image
+
+The workflow reads the version from `package.json` **at the ref it builds**, so
+it must run on `develop` after the merge, or the image gets the old tag.
+
+```bash
+gh workflow run "release_mock_server.yml" -f ref=develop
+```
+
+Wait 5s, then find the fresh run:
 
 ```bash
 gh run list --workflow=release_mock_server.yml --limit 5 --json url,name,status,createdAt
 ```
 
-- No `--branch` filter. `workflow_dispatch` runs hang off the default branch,
-  not your `ref`.
-- Keep runs that are `queued`, `in_progress`, or `pending`. Newest `createdAt`
-  wins.
-- Empty list? Retry up to 6 times, 5s apart.
+- No `--branch` filter: `workflow_dispatch` runs hang off the default branch,
+  not the `ref` input.
+- Keep runs that are `queued`, `in_progress` or `pending`; newest `createdAt`
+  wins. Empty list → retry up to 6 times, 5s apart.
 
-## Guess the build time
+Estimate the build time from recent successes:
 
 ```bash
 gh run list --workflow=release_mock_server.yml --status completed --limit 20 --json conclusion,createdAt,updatedAt
 ```
 
-- Keep `conclusion == success`. Take up to 5 newest.
-- Duration = `updatedAt - createdAt` in minutes. Average them, round.
-- No successes = can't guess.
+Keep `conclusion == success`, take up to 5 newest, average `updatedAt - createdAt`
+in minutes, round. No successes → can't guess.
 
-## Tell the user
+## Report to the user
 
 ```
 Mock server Docker image release triggered
 
-- Branch:   <branch>
-- Version:  <old> → <new> (<bump>)
-- Image:    jfrog.ledgerlabs.net/bcs-oci-prod-green/device-mock-server:<new>
+- Version:  <from> → <to> (<bump>)
+- PR:       <pr url>
+- Image:    jfrog.ledgerlabs.net/bcs-oci-prod-green/device-mock-server:<to>
 - Run:      [<run name> (<status>)](<run url>)
 - ETA:      ~<avg> min (last 5 good builds)   # or: Unknown (no good builds yet)
 - All runs: https://github.com/LedgerHQ/device-sdk-ts/actions/workflows/release_mock_server.yml
 ```
 
-Add a **Warnings** list only if you collected any.
+Add a **Warnings** list only if you collected any along the way.
 
 ## Things that bite
 
-- Image tag = `jfrog.ledgerlabs.net/bcs-oci-prod-green/device-mock-server:<version>`.
-- Build context is the WHOLE monorepo root. The Dockerfile's pnpm workspace
-  install needs it.
-- Runs on the `ledgerhq-device-sdk` private runner. JFrog is invisible from
+- Any step fails → stop, tell the user, do not carry on.
+- Needs `gh` installed and authenticated, `pnpm`, and push rights to
+  `LedgerHQ/device-sdk-ts`.
+- Image tag is exactly the `package.json` version — no `v` prefix, no `latest`.
+- The Docker build context is the **whole monorepo root**; the Dockerfile's pnpm
+  workspace install needs it.
+- Runs on the `ledgerhq-device-sdk` private runner — JFrog is invisible from
   public runners.
+- `openapi.yaml` / `openapi/definition.ts` carry their own `info.version` for the
+  API contract. It is **not** the package version and this flow does not touch
+  it. Bump it only when the HTTP contract itself changes.


### PR DESCRIPTION
### 📝 Description

Turns the mock server release into a proper changeset-driven flow, mirroring the DMK release (`/release`) minus everything npm-specific.

Until now, `/release-mock-server` just ran `pnpm version`, pushed, and fired the Docker workflow — no changelog, no changesets. This PR adds the missing pieces.

**New scripts** in `agent-files/scripts/release/mock-server/`, reusing `agent-files/scripts/release/config.cjs`:

| Script | What it does |
| --- | --- |
| `common.cjs` | Shared: finds pending mock-server changesets, resolves the bump, enriches with PR/commit/author via `gh` |
| `discover.cjs` | JSON preview — `from`, `to`, `bump`, `changesets[]`, `image` tag |
| `bump.cjs` | Writes the new version to `apps/device-mock-server/package.json` |
| `changelog.cjs` | Prepends a `## <version>` section to `apps/device-mock-server/CHANGELOG.md` |
| `cleanup.cjs` | Deletes the consumed changesets |

Dropped from the DMK flow as not applicable: `set-private`, `pin-deps`, `unpin-deps`, `revert-private`, lockfile update, `getting-started.mdx`. `preflight.cjs` is reused as-is.

**The `/release-mock-server` skill** was rewritten around those scripts rather than duplicated into a second skill — two skills triggering on "release mock server" would collide. All the Docker/JFrog knowledge from the previous version is preserved.

The release now lands as a **PR to `develop`**, and the Docker workflow is triggered on `develop` *after* the merge — the workflow reads the version from the ref it builds, so triggering early would tag the image with the old version.

**Two things worth knowing:**

- `pnpm changeset` will not offer `@ledgerhq/device-mock-server` in its interactive picker — the package is `private: true` and `.changeset/config.json` sets `privatePackages.version: false`, which filters it out of `getVersionableChangedPackages`. The skill documents using `pnpm changeset add --empty` and writing the frontmatter by hand. Those changesets then survive DMK releases untouched, since those scripts only consider public, non-`apps/` packages.
- A `--bump patch|minor|major` override is supported so an infra-only release (Dockerfile, CI, deps) can still be cut without a changeset.

Not touched: `openapi.yaml` / `openapi/definition.ts` carry their own `info.version` (currently `0.1.0`, already drifted from the package's `0.1.1`). Treated as an independent API-contract version and documented in the skill rather than silently synced.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]

- **Feature**: Release tooling for the device mock server Docker image.

### ✅ Checklist

- [x] **Covered by automatic tests** — no automated tests: these are agent-facing release scripts with no test harness in the repo, consistent with the existing `agent-files/scripts/release/` scripts. Verified by running them against a temporary changeset: bump `0.1.1 → 0.2.0`, changelog output byte-identical in format to `packages/devtools/websocket-common/CHANGELOG.md`, prepend-on-second-release correct, the "section already exists" guard fires, and cleanup deletes single-package changesets while stripping only the mock-server line from a mixed one. Test artifacts reverted.
- [x] **Changeset is provided** — not needed, changes only affect internal tooling (`agent-files/`), not a published package.
- [x] **Documentation is up-to-date** — the skill itself is the documentation and is fully rewritten.
- [x] **Impact of the changes:**
  - `agent-files/scripts/release/mock-server/` — new scripts, no effect on the existing DMK release flow
  - `agent-files/skills/release-mock-server/SKILL.md` — rewritten; the flow now opens a PR instead of pushing straight to the current branch
  - No runtime or published-package code is touched
