### PR TITLE
✨ (mock-server) [NO-ISSUE]: Add changeset-driven release scripts and skill

### DIFF
--- a/agent-files/scripts/release/mock-server/bump.cjs
+++ b/agent-files/scripts/release/mock-server/bump.cjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env zx
+
+require("zx/globals");
+const {
+  IMAGE_REPO,
+  PKG_NAME,
+  PKG_PATH,
+  fail,
+  nextVersion,
+  pendingChangesets,
+  readPackage,
+  resolveBump,
+} = require("./common.cjs");
+
+async function main() {
+  const changesets = await pendingChangesets();
+  const pkg = await readPackage();
+  const { bump, source } = resolveBump(changesets, argv.bump);
+
+  const from = pkg.version;
+  const to = nextVersion(from, bump);
+
+  pkg.version = to;
+  await fs.writeJson(PKG_PATH, pkg, { spaces: 2 });
+
+  console.log(chalk.green(`${PKG_NAME}: ${from} → ${to} [${bump}]`));
+  console.log(
+    JSON.stringify(
+      {
+        package: PKG_NAME,
+        from,
+        to,
+        bump,
+        bumpSource: source,
+        image: `${IMAGE_REPO}:${to}`,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(fail);

--- a/agent-files/scripts/release/mock-server/changelog.cjs
+++ b/agent-files/scripts/release/mock-server/changelog.cjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env zx
+
+require("zx/globals");
+const {
+  CHANGELOG_PATH,
+  PKG_NAME,
+  enrich,
+  fail,
+  pendingChangesets,
+  readPackage,
+} = require("./common.cjs");
+
+const SECTION_TITLES = {
+  major: "Major Changes",
+  minor: "Minor Changes",
+  patch: "Patch Changes",
+};
+
+function formatEntry(entry, repo) {
+  const short = entry.commit.slice(0, 7);
+  const pr = `[#${entry.prNumber}](https://github.com/${repo}/pull/${entry.prNumber})`;
+  const commitLink = `[\`${short}\`](https://github.com/${repo}/commit/${entry.commit})`;
+  const thanks = `Thanks [@${entry.author}](https://github.com/${entry.author})!`;
+
+  return `- ${pr} ${commitLink} ${thanks} - ${entry.summary}`;
+}
+
+function prepend(existing, section) {
+  if (!existing) return `# ${PKG_NAME}\n${section}`;
+
+  const firstNewline = existing.indexOf("\n");
+  if (firstNewline === -1) return existing + section;
+
+  return (
+    existing.slice(0, firstNewline) +
+    "\n" +
+    section +
+    existing.slice(firstNewline + 1)
+  );
+}
+
+async function main() {
+  const pkg = await readPackage();
+  const changesets = await pendingChangesets();
+
+  if (changesets.length === 0) {
+    console.log(
+      chalk.yellow(
+        `No changeset for ${PKG_NAME}. Nothing to add to the changelog — ` +
+          `describe the release in the PR body instead.`,
+      ),
+    );
+    process.exit(0);
+  }
+
+  let existing = "";
+  try {
+    existing = await fs.readFile(CHANGELOG_PATH, "utf-8");
+  } catch {
+    // first release, no changelog yet
+  }
+
+  if (existing.includes(`\n## ${pkg.version}\n`)) {
+    throw new Error(
+      `CHANGELOG.md already has a "## ${pkg.version}" section. ` +
+        `Did bump.cjs run before this script?`,
+    );
+  }
+
+  console.log(chalk.blue("Enriching changesets with PR/commit metadata..."));
+  const { repo } = await enrich(changesets);
+
+  const byBump = { major: [], minor: [], patch: [] };
+  for (const cs of changesets) byBump[cs.bump].push(cs);
+
+  let section = `\n## ${pkg.version}\n`;
+  for (const bump of ["major", "minor", "patch"]) {
+    if (byBump[bump].length === 0) continue;
+    section += `\n### ${SECTION_TITLES[bump]}\n\n`;
+    section += byBump[bump]
+      .map((cs) => formatEntry(cs, repo) + "\n")
+      .join("\n");
+  }
+
+  await fs.writeFile(CHANGELOG_PATH, prepend(existing, section));
+
+  console.log(
+    chalk.green(
+      `Updated ${path.relative(process.cwd(), CHANGELOG_PATH)} for ${pkg.version}`,
+    ),
+  );
+}
+
+main().catch(fail);

--- a/agent-files/scripts/release/mock-server/cleanup.cjs
+++ b/agent-files/scripts/release/mock-server/cleanup.cjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env zx
+
+require("zx/globals");
+const {
+  CHANGESET_DIR,
+  PKG_NAME,
+  fail,
+  pendingChangesets,
+} = require("./common.cjs");
+
+const ENTRY_RE = new RegExp(
+  `^[ \\t]*"?${PKG_NAME}"?:[ \\t]*(patch|minor|major)[ \\t]*\\n`,
+  "m",
+);
+
+async function main() {
+  const changesets = await pendingChangesets();
+
+  if (changesets.length === 0) {
+    console.log(chalk.yellow(`No changeset for ${PKG_NAME} to clean up.`));
+    console.log(JSON.stringify({ deleted: [], stripped: [] }, null, 2));
+    return;
+  }
+
+  const deleted = [];
+  const stripped = [];
+
+  for (const cs of changesets) {
+    const filePath = path.join(CHANGESET_DIR, cs.file);
+
+    // Danger enforces one package per changeset, but a mixed file must not
+    // take another package's pending release down with it.
+    if (cs.otherPackages.length > 0) {
+      const content = await fs.readFile(filePath, "utf-8");
+      const next = content.replace(ENTRY_RE, "");
+      if (next === content) {
+        throw new Error(
+          `Could not strip the ${PKG_NAME} entry from .changeset/${cs.file}. Edit it by hand.`,
+        );
+      }
+      await fs.writeFile(filePath, next);
+      stripped.push(cs.file);
+      console.log(
+        chalk.yellow(
+          `Stripped ${PKG_NAME} from .changeset/${cs.file} (also covers ${cs.otherPackages.join(", ")})`,
+        ),
+      );
+      continue;
+    }
+
+    await fs.remove(filePath);
+    deleted.push(cs.file);
+    console.log(chalk.gray(`Deleted .changeset/${cs.file}`));
+  }
+
+  console.log(
+    chalk.green(
+      `Removed ${deleted.length} changeset file(s)` +
+        (stripped.length ? `, edited ${stripped.length} mixed file(s).` : "."),
+    ),
+  );
+  console.log(JSON.stringify({ deleted, stripped }, null, 2));
+}
+
+main().catch(fail);

--- a/agent-files/scripts/release/mock-server/common.cjs
+++ b/agent-files/scripts/release/mock-server/common.cjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env zx
+
+require("zx/globals");
+const semver = require("semver");
+const { ROOT, readChangesets } = require("../config.cjs");
+
+const PKG_NAME = "@ledgerhq/device-mock-server";
+const DISPLAY_NAME = "Mock Server";
+const PKG_DIR = path.join(ROOT, "apps", "device-mock-server");
+const PKG_PATH = path.join(PKG_DIR, "package.json");
+const CHANGELOG_PATH = path.join(PKG_DIR, "CHANGELOG.md");
+const CHANGESET_DIR = path.join(ROOT, ".changeset");
+const IMAGE_REPO = "jfrog.ledgerlabs.net/bcs-oci-prod-green/device-mock-server";
+
+const BUMP_ORDER = { patch: 0, minor: 1, major: 2 };
+
+function readPackage() {
+  return fs.readJson(PKG_PATH);
+}
+
+/** Changesets that declare a bump for the mock server. */
+async function pendingChangesets() {
+  const all = await readChangesets();
+  return all
+    .filter((cs) => PKG_NAME in cs.packages)
+    .map((cs) => ({
+      file: cs.file,
+      bump: cs.packages[PKG_NAME],
+      summary: cs.summary,
+      otherPackages: Object.keys(cs.packages).filter((p) => p !== PKG_NAME),
+    }))
+    .sort((a, b) => a.file.localeCompare(b.file));
+}
+
+function highestBump(changesets) {
+  let best = null;
+  for (const cs of changesets) {
+    if (best === null || BUMP_ORDER[cs.bump] > BUMP_ORDER[best]) best = cs.bump;
+  }
+  return best;
+}
+
+/**
+ * `--bump <type>` wins over the changesets, so a release can still be cut for
+ * changes that never warranted a changeset (Dockerfile, CI, deps).
+ */
+function resolveBump(changesets, override) {
+  if (override) {
+    if (!(override in BUMP_ORDER)) {
+      throw new Error(
+        `Invalid --bump "${override}". Use one of: patch, minor, major.`,
+      );
+    }
+    return { bump: override, source: "override" };
+  }
+
+  const bump = highestBump(changesets);
+  if (!bump) {
+    throw new Error(
+      `No pending changeset for ${PKG_NAME}. Add one (see the changeset skill) ` +
+        `or pass --bump patch|minor|major to release without one.`,
+    );
+  }
+  return { bump, source: "changesets" };
+}
+
+function nextVersion(from, bump) {
+  const to = semver.inc(from, bump);
+  if (!to) throw new Error(`Failed to compute ${bump} bump for ${from}`);
+  return to;
+}
+
+async function readRepoSlug() {
+  try {
+    const cfg = await fs.readJson(path.join(CHANGESET_DIR, "config.json"));
+    if (Array.isArray(cfg.changelog) && cfg.changelog[1]?.repo) {
+      return cfg.changelog[1].repo;
+    }
+  } catch {}
+  return "LedgerHQ/device-sdk-ts";
+}
+
+/**
+ * Attach the commit that introduced each changeset plus its PR number and
+ * author, so entries match the format the DMK release produces. Only the mock
+ * server changesets are looked up, to keep the GitHub API calls to a minimum.
+ */
+async function enrich(changesets) {
+  const repo = await readRepoSlug();
+  const prevVerbose = $.verbose;
+  $.verbose = false;
+
+  try {
+    for (const cs of changesets) {
+      const filePath = path.join(CHANGESET_DIR, cs.file);
+      const res =
+        await $`git log --diff-filter=A --format=%H -1 -- ${filePath}`;
+      cs.commit = res.stdout.trim() || null;
+      if (!cs.commit) {
+        throw new Error(
+          `No commit found for .changeset/${cs.file}. Was it committed to git?`,
+        );
+      }
+    }
+
+    const metaBySha = new Map();
+    for (const sha of new Set(changesets.map((cs) => cs.commit))) {
+      const endpoint = `repos/${repo}/commits/${sha}/pulls`;
+      const jq = ".[0] | {number, user: .user.login}";
+      let res;
+      try {
+        res = await $`gh api ${endpoint} --jq ${jq}`;
+      } catch (err) {
+        throw new Error(
+          `Failed to fetch PR metadata for commit ${sha}. Is gh authenticated?\n${err.message}`,
+        );
+      }
+      const data = JSON.parse(res.stdout.trim());
+      if (!data.number || !data.user) {
+        throw new Error(
+          `Incomplete PR metadata for commit ${sha}: prNumber=${data.number}, author=${data.user}`,
+        );
+      }
+      metaBySha.set(sha, { prNumber: data.number, author: data.user });
+    }
+
+    for (const cs of changesets) {
+      const meta = metaBySha.get(cs.commit);
+      cs.prNumber = meta.prNumber;
+      cs.author = meta.author;
+    }
+  } finally {
+    $.verbose = prevVerbose;
+  }
+
+  return { changesets, repo };
+}
+
+function fail(err) {
+  console.error(chalk.red(err.message || String(err)));
+  process.exit(1);
+}
+
+module.exports = {
+  BUMP_ORDER,
+  CHANGELOG_PATH,
+  CHANGESET_DIR,
+  DISPLAY_NAME,
+  IMAGE_REPO,
+  PKG_DIR,
+  PKG_NAME,
+  PKG_PATH,
+  enrich,
+  fail,
+  highestBump,
+  nextVersion,
+  pendingChangesets,
+  readPackage,
+  readRepoSlug,
+  resolveBump,
+};

--- a/agent-files/scripts/release/mock-server/discover.cjs
+++ b/agent-files/scripts/release/mock-server/discover.cjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env zx
+
+require("zx/globals");
+const {
+  DISPLAY_NAME,
+  IMAGE_REPO,
+  PKG_NAME,
+  fail,
+  nextVersion,
+  pendingChangesets,
+  readPackage,
+  resolveBump,
+} = require("./common.cjs");
+
+async function main() {
+  const changesets = await pendingChangesets();
+  const pkg = await readPackage();
+
+  let bump;
+  let source;
+  try {
+    ({ bump, source } = resolveBump(changesets, argv.bump));
+  } catch (err) {
+    console.log(
+      JSON.stringify(
+        {
+          package: PKG_NAME,
+          displayName: DISPLAY_NAME,
+          version: pkg.version,
+          changesets,
+          error: err.message,
+        },
+        null,
+        2,
+      ),
+    );
+    process.exit(1);
+  }
+
+  const to = nextVersion(pkg.version, bump);
+  const mixed = changesets.filter((cs) => cs.otherPackages.length > 0);
+
+  console.log(
+    JSON.stringify(
+      {
+        package: PKG_NAME,
+        displayName: DISPLAY_NAME,
+        from: pkg.version,
+        to,
+        bump,
+        bumpSource: source,
+        changesets,
+        mixedChangesets: mixed.map((cs) => cs.file),
+        image: `${IMAGE_REPO}:${to}`,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(fail);

--- a/agent-files/skills/release-mock-server/SKILL.md
+++ b/agent-files/skills/release-mock-server/SKILL.md
@@ -1,56 +1,88 @@
 ---
 name: release-mock-server
-description: Bump the mock server version in package.json, commit, push, and trigger the Docker image publish workflow to JFrog. Activate when the user says "release mock server", "/release-mock-server", or asks to release/publish the device mock server Docker image.
+description: Release the device mock server — eat its changesets, bump the version, write the changelog, open the PR, then trigger the Docker image publish to JFrog. Activate when the user says "release mock server", "/release-mock-server", or asks to release/publish the device mock server Docker image.
 ---
 
-# Release mock server
+# Release the mock server
 
-Bump version. Commit. Push. Poke the workflow. It builds the Docker image and
-throws it at JFrog.
+Eat the changesets. Bump. Changelog. PR to develop. Once it's merged, poke the
+workflow. It builds the Docker image and throws it at JFrog.
 
-Version lives in `apps/device-mock-server/package.json`. Workflow lives in
-`.github/workflows/release_mock_server.yml`.
+Private app, never on npm. Image tag = whatever `apps/device-mock-server/package.json`
+says. Scripts live in `agent-files/scripts/release/mock-server/`, run with `pnpm exec zx`.
 
 ## Rules to remember
 
 - Need `gh` installed and logged in. Need `pnpm`. Need push rights to
   `LedgerHQ/device-sdk-ts`.
-- `gh` calls need `required_permissions: ["all"]`.
-- Workflow reads version from package.json AT THE PUSHED REF. So push the bump
-  BEFORE you trigger. No push = old version = wrong tag.
+- `gh` calls and `changelog.cjs` need `required_permissions: ["all"]`.
+- Workflow reads the version AT THE REF IT BUILDS. So trigger on `develop` AFTER
+  the PR merges. Early trigger = old tag = wrong image.
 - Do steps in order. Any step breaks → stop, tell user, do not go on.
+- Commit after every step that writes files.
 - Collect warnings along the way. Dump them at the end.
-- `$BUMP` = `patch` | `minor` | `major`. No `$BUMP` = `patch`.
+
+## Writing a changeset for it
+
+`pnpm changeset` won't list `@ledgerhq/device-mock-server` — it's `private` and
+`privatePackages.version` is `false`. Write it by hand:
+
+```bash
+pnpm changeset add --empty
+```
+
+```markdown
+---
+"@ledgerhq/device-mock-server": minor
+---
+
+Add opt-in device onboarding simulation
+```
+
+One package per file. It sits in `.changeset/` until a mock server release eats
+it — DMK releases skip it.
 
 ## The steps
 
 ```bash
-# 1. Bump type. $BUMP or patch. Not one of patch/minor/major → stop.
+# 1. Preflight. Fails → stop.
+pnpm exec zx agent-files/scripts/release/preflight.cjs
 
-# 2. On a branch? Empty = detached HEAD → stop.
-git branch --show-current
+# 2. What's pending? Show the user a table, wait for a yes.
+pnpm exec zx agent-files/scripts/release/mock-server/discover.cjs
 
-# 3. Clean tree? Non-empty = dirty → stop, user commits/stashes first.
-git status --porcelain
+# 3. Branch off develop.
+git checkout develop && git pull
+git checkout -b release/mock-server-<to>
 
-# 4. Old version (remember it for the summary).
-jq -r '.version' apps/device-mock-server/package.json
+# 4. Bump. No lockfile update needed.
+pnpm exec zx agent-files/scripts/release/mock-server/bump.cjs
+git commit -am "🔖 (mock-server): Bump version to <to>"
 
-# 5. Bump it. Remember new version.
-(cd apps/device-mock-server && pnpm version "$BUMP" --no-git-tag-version --no-commit-hooks)
-jq -r '.version' apps/device-mock-server/package.json
+# 5. Changelog. After step 4 — it reads the bumped version.
+pnpm exec zx agent-files/scripts/release/mock-server/changelog.cjs
+git add apps/device-mock-server/CHANGELOG.md
+git commit -m "📝 (mock-server): Generate changelog"
 
-# 6. Commit just the package.json. Gitmoji style.
-git add apps/device-mock-server/package.json
-git commit -m "🔖 (mock-server): Bump version to <new_version>"
+# 6. Eat the changesets.
+pnpm exec zx agent-files/scripts/release/mock-server/cleanup.cjs
+git commit -am "🔥 (mock-server): Clean up consumed changesets"
 
-# 7. Push. Rejected/non-fast-forward → tell user to `git pull --rebase`
-#    (or `git push --force` if they mean it). Other error → stop, report.
+# 7. Push. PR to develop, NOT main. Report the URL and STOP.
 git push -u origin HEAD
+gh pr create --base develop --title "🔖 (mock-server) [NO-ISSUE]: Release <to>" --body "..."
 
-# 8. Fire the workflow at the branch.
-gh workflow run "release_mock_server.yml" -f ref=<branch>
+# 8. Only once it's merged: fire the workflow.
+gh workflow run "release_mock_server.yml" -f ref=develop
 ```
+
+Step 2 prints JSON: `from`, `to`, `bump`, `changesets[]`, `image`.
+
+- Exits 1 with an `error` field = nothing pending. Ask if they want to release
+  anyway (Dockerfile / CI / deps change). If yes, add `--bump patch|minor|major`
+  to steps 2 and 4, and skip step 5 — no changeset, nothing to write.
+- `mixedChangesets` non-empty = that changeset also covers another package.
+  Warn: step 6 strips only the mock server line and leaves the file behind.
 
 ## Find the run
 
@@ -81,8 +113,8 @@ gh run list --workflow=release_mock_server.yml --status completed --limit 20 --j
 ```
 Mock server Docker image release triggered
 
-- Branch:   <branch>
 - Version:  <old> → <new> (<bump>)
+- PR:       <pr url>
 - Image:    jfrog.ledgerlabs.net/bcs-oci-prod-green/device-mock-server:<new>
 - Run:      [<run name> (<status>)](<run url>)
 - ETA:      ~<avg> min (last 5 good builds)   # or: Unknown (no good builds yet)
@@ -93,8 +125,10 @@ Add a **Warnings** list only if you collected any.
 
 ## Things that bite
 
-- Image tag = `jfrog.ledgerlabs.net/bcs-oci-prod-green/device-mock-server:<version>`.
+- Image tag is exactly the package version. No `v` prefix, no `latest`.
 - Build context is the WHOLE monorepo root. The Dockerfile's pnpm workspace
   install needs it.
 - Runs on the `ledgerhq-device-sdk` private runner. JFrog is invisible from
   public runners.
+- `openapi.yaml` has its own `info.version`. That's the HTTP contract, not the
+  package version. Leave it alone unless the contract changed.


### PR DESCRIPTION
### 📝 Description

Makes the mock server release changeset-driven, like the DMK release minus everything npm-specific.

Today `/release-mock-server` just runs `pnpm version`, pushes, and fires the Docker workflow. No changelog, no changesets. This adds the missing pieces.

New scripts in `agent-files/scripts/release/mock-server/`, reusing `agent-files/scripts/release/config.cjs`:

| Script | What it does |
| --- | --- |
| `common.cjs` | Finds pending mock-server changesets, resolves the bump, enriches with PR/commit/author via `gh` |
| `discover.cjs` | JSON preview — `from`, `to`, `bump`, `changesets[]`, `image` tag |
| `bump.cjs` | Writes the new version to `apps/device-mock-server/package.json` |
| `changelog.cjs` | Prepends a `## <version>` section to `apps/device-mock-server/CHANGELOG.md` |
| `cleanup.cjs` | Deletes the consumed changesets |

Not applicable, so dropped: `set-private`, `pin-deps`, `unpin-deps`, `revert-private`, lockfile update, `getting-started.mdx`. `preflight.cjs` is reused as-is.

The `/release-mock-server` skill was rewritten around those scripts rather than duplicated into a second skill — two skills triggering on "release mock server" would collide. All the Docker/JFrog knowledge from the previous version is kept.

The release now lands as a PR to `develop`, and the Docker workflow is triggered on `develop` **after** the merge. The workflow reads the version from the ref it builds, so triggering early would tag the image with the old version.

Two things worth knowing:

- `pnpm changeset` won't offer `@ledgerhq/device-mock-server` in its picker — the package is `private: true` and `.changeset/config.json` sets `privatePackages.version: false`, which filters it out of `getVersionableChangedPackages`. The skill documents `pnpm changeset add --empty` plus writing the frontmatter by hand. Those changesets survive DMK releases untouched, since those scripts only consider public, non-`apps/` packages.
- A `--bump patch|minor|major` override lets an infra-only release (Dockerfile, CI, deps) be cut without a changeset.

Left alone: `openapi.yaml` / `openapi/definition.ts` carry their own `info.version` (`0.1.0`, already drifted from the package's `0.1.1`). That's the HTTP contract version, documented as such in the skill rather than silently synced.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]

- **Feature**: Release tooling for the device mock server Docker image.

### ✅ Checklist

- [x] **Covered by automatic tests** — no automated tests: agent-facing release scripts, no test harness for them in the repo, same as the existing `agent-files/scripts/release/` scripts. Verified by running them against a temporary changeset: bump `0.1.1 → 0.2.0`, changelog output byte-identical in format to `packages/devtools/websocket-common/CHANGELOG.md`, prepend-on-second-release correct, the "section already exists" guard fires, cleanup deletes single-package changesets and strips only the mock-server line from a mixed one. Test artifacts reverted.
- [x] **Changeset is provided** — not needed, changes only affect internal tooling (`agent-files/`), not a published package.
- [x] **Documentation is up-to-date** — the skill is the documentation, and it's rewritten.
- [x] **Impact of the changes:**
  - `agent-files/scripts/release/mock-server/` — new scripts, no effect on the DMK release flow
  - `agent-files/skills/release-mock-server/SKILL.md` — rewritten; the flow now opens a PR instead of pushing straight to the current branch
  - No runtime or published-package code touched
