### PR TITLE
🐛 (signer-solana) [NO-ISSUE]: Request ALT resolution for every account the device dereferences

### DIFF
--- a/.changeset/yummy-keys-fly.md
+++ b/.changeset/yummy-keys-fly.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-solana": patch
+---
+
+Request ALT_RESOLUTION for every ALT-backed account the device dereferences at finalize: writable instruction accounts, all value-flow-port candidates, port token references, PARAM_TOKEN_AMOUNT token refs and account-reset targets, on top of the display-field and mint-association accounts already covered

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/buildRequirements.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/buildRequirements.test.ts
@@ -34,8 +34,9 @@ const NO_ENUMS: EnumVariantSelector = () => Right([]);
 function account(
   address?: string,
   altRef?: RequirementAccount["altRef"],
+  isWritable = false,
 ): RequirementAccount {
-  return { address, altRef };
+  return { address, altRef, isWritable };
 }
 
 function port(
@@ -240,6 +241,39 @@ describe("buildRequirements", () => {
     ]);
   });
 
+  it("routes a read-only ALT mint from MINT_ASSOCIATION to mintAltRefs", () => {
+    const result = run([
+      matched({
+        accounts: [
+          account(undefined, { altAddress: "ALT", entryIndex: 4 }), // token account
+          account(undefined, { altAddress: "ALT", entryIndex: 6 }), // mint, read-only
+        ],
+        descriptor: { mintAssociations: [mintAssociation(0, 1)] },
+      }),
+    ]);
+    // The mint stays out of altResolutions: the provide phase holds it and
+    // conditionally streams TOKEN_INFO after the 0x6d10 signal.
+    expect(result.altResolutions).toEqual([
+      { altAddress: "ALT", entryIndex: 4 },
+    ]);
+    expect(result.mintAltRefs).toEqual([{ altAddress: "ALT", entryIndex: 6 }]);
+  });
+
+  it("emits ALT_RESOLUTION for a writable ALT account named by no descriptor field", () => {
+    const result = run([
+      matched({
+        accounts: [
+          account("staticKey"),
+          account(undefined, { altAddress: "ALT", entryIndex: 3 }, true),
+          account(undefined, { altAddress: "ALT", entryIndex: 9 }), // read-only
+        ],
+      }),
+    ]);
+    expect(result.altResolutions).toEqual([
+      { altAddress: "ALT", entryIndex: 3 },
+    ]);
+  });
+
   it("emits TRUSTED_NAME for PARAM_TRUSTED_NAME fields (account path + constant)", () => {
     const constantAddr = new Uint8Array(32).fill(5);
     const result = run([
@@ -342,9 +376,8 @@ describe("buildRequirements", () => {
       DefaultBs58Encoder.encode(inMint),
       DefaultBs58Encoder.encode(outMint),
     ]);
-    // account[2] is ALT-backed but not referenced by any display field or
-    // MINT_ASSOC, so it is excluded from altResolutions (stays within the
-    // device's 16-entry ALT cache limit).
+    // account[2] is ALT-backed but read-only and named by nothing, so it is
+    // excluded from altResolutions (the deliberate exclusion of the rule).
     expect(result.altResolutions).toEqual([]);
   });
 

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/model.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/model.ts
@@ -16,10 +16,16 @@ export type AltEntryKey = { altAddress: string; entryIndex: number };
  * it is `undefined` for ALT-supplied slots that are not resolved at
  * requirement-build time (DMK does not talk to RPC) — those still carry an
  * `altRef` so an `ALT_RESOLUTION` requirement can be emitted.
+ *
+ * `isWritable` mirrors the slot's writability as compiled in the message (its
+ * header plus the ALT writable/read-only index lists). The device needs every
+ * writable slot resolved to report its writable-account list complete, so the
+ * ALT rule reads this flag; no RPC call is involved.
  */
 export type RequirementAccount = {
   address?: string;
   altRef?: AltEntryKey;
+  isWritable: boolean;
 };
 
 export type RequirementInstruction = {

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/altResolutionRule.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/altResolutionRule.test.ts
@@ -1,6 +1,12 @@
-import { type RequirementInstruction } from "@internal/app-binder/clear-sign/requirements/model";
 import {
+  type RequirementAccount,
+  type RequirementInstruction,
+} from "@internal/app-binder/clear-sign/requirements/model";
+import {
+  OptionalAccountStrategy,
+  PARAM_TYPE_TOKEN_AMOUNT,
   type ParsedInstruction,
+  TokenKind,
   ValueSource,
 } from "@internal/app-binder/clear-sign/requirements/records";
 import { RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
@@ -16,6 +22,30 @@ function emptyParsed(): ParsedInstruction {
   };
 }
 
+/** An ALT-backed slot at `entryIndex` of the "ALT" table. */
+function alt(entryIndex: number, isWritable = false): RequirementAccount {
+  return { altRef: { altAddress: "ALT", entryIndex }, isWritable };
+}
+
+/** A statically resolved slot. */
+function addr(address: string, isWritable = false): RequirementAccount {
+  return { address, isWritable };
+}
+
+function accountPath(index: number) {
+  return {
+    source: ValueSource.ACCOUNT_PATH,
+    payload: Uint8Array.from([index]),
+  };
+}
+
+function instructionOf(
+  accounts: RequirementAccount[],
+  programId = "P",
+): RequirementInstruction {
+  return { programId, accounts, data: new Uint8Array() };
+}
+
 function run(
   parsed: ParsedInstruction,
   instruction: RequirementInstruction,
@@ -26,36 +56,121 @@ function run(
 }
 
 describe("applyAltResolutionRule", () => {
+  it("emits ALT_RESOLUTION for a writable ALT account named by nothing", () => {
+    // Regression: the device's writable-account walk dereferences every
+    // writable slot; an unresolved one marks the list incomplete and stops the
+    // merge scan.
+    const instruction = instructionOf([
+      addr("static", true),
+      alt(3, true),
+      alt(9),
+    ]);
+    expect(run(emptyParsed(), instruction)).toEqual([
+      { altAddress: "ALT", entryIndex: 3 },
+    ]);
+  });
+
+  it("emits nothing for a read-only ALT account named by nothing", () => {
+    const instruction = instructionOf([alt(1), alt(2)]);
+    expect(run(emptyParsed(), instruction)).toEqual([]);
+  });
+
   it("emits ALT_RESOLUTION for ALT-backed DISPLAY_FIELD ACCOUNT_PATH accounts", () => {
     const parsed: ParsedInstruction = {
       ...emptyParsed(),
       displayFields: [
-        {
-          // ACCOUNT_PATH field — account at index 1 is ALT-backed
-          value: {
-            source: ValueSource.ACCOUNT_PATH,
-            payload: Uint8Array.from([1]),
-          },
-        },
-        {
-          // Another ACCOUNT_PATH field — account at index 0 is static
-          value: {
-            source: ValueSource.ACCOUNT_PATH,
-            payload: Uint8Array.from([0]),
-          },
-        },
+        // ACCOUNT_PATH field — account at index 1 is ALT-backed
+        { value: accountPath(1) },
+        // Another ACCOUNT_PATH field — account at index 0 is static
+        { value: accountPath(0) },
       ],
     };
-    const instruction: RequirementInstruction = {
-      programId: "P",
-      data: new Uint8Array(),
-      accounts: [
-        { address: "static" },
-        { altRef: { altAddress: "ALT", entryIndex: 3 } },
-      ],
-    };
+    const instruction = instructionOf([addr("static"), alt(3)]);
     expect(run(parsed, instruction)).toEqual([
       { altAddress: "ALT", entryIndex: 3 },
+    ]);
+  });
+
+  it("emits ALT_RESOLUTION for every ALT-backed candidate of a port", () => {
+    // The device walks the candidate array in order and refuses on the first
+    // in-range candidate it cannot resolve, so all of them are requested.
+    const parsed: ParsedInstruction = {
+      ...emptyParsed(),
+      valueFlowPorts: [
+        {
+          accountIndices: [0, 1, 2],
+          optionalAccountStrategy: OptionalAccountStrategy.PROGRAM_ID,
+        },
+      ],
+    };
+    const instruction = instructionOf([alt(1), addr("static"), alt(2)]);
+    expect(run(parsed, instruction)).toEqual([
+      { altAddress: "ALT", entryIndex: 1 },
+      { altAddress: "ALT", entryIndex: 2 },
+    ]);
+  });
+
+  it("emits ALT_RESOLUTION for a RESOLVE port's token account", () => {
+    const parsed: ParsedInstruction = {
+      ...emptyParsed(),
+      valueFlowPorts: [
+        {
+          accountIndices: [0],
+          optionalAccountStrategy: OptionalAccountStrategy.PROGRAM_ID,
+          tokenValue: { kind: TokenKind.RESOLVE, accountIndex: 2 },
+        },
+      ],
+    };
+    const instruction = instructionOf([addr("port"), addr("other"), alt(6)]);
+    expect(run(parsed, instruction)).toEqual([
+      { altAddress: "ALT", entryIndex: 6 },
+    ]);
+  });
+
+  it("falls back to the port's own account when a RESOLVE port carries no token account", () => {
+    const parsed: ParsedInstruction = {
+      ...emptyParsed(),
+      valueFlowPorts: [
+        {
+          accountIndices: [1],
+          optionalAccountStrategy: OptionalAccountStrategy.PROGRAM_ID,
+          tokenValue: { kind: TokenKind.RESOLVE },
+        },
+      ],
+    };
+    const instruction = instructionOf([addr("static"), alt(4)]);
+    expect(run(parsed, instruction)).toEqual([
+      { altAddress: "ALT", entryIndex: 4 },
+    ]);
+  });
+
+  it("emits ALT_RESOLUTION for an ACCOUNT_PATH port token value", () => {
+    const parsed: ParsedInstruction = {
+      ...emptyParsed(),
+      valueFlowPorts: [
+        {
+          accountIndices: [0],
+          optionalAccountStrategy: OptionalAccountStrategy.PROGRAM_ID,
+          tokenValue: { kind: TokenKind.DIRECT, value: accountPath(1) },
+        },
+      ],
+    };
+    const instruction = instructionOf([addr("port"), alt(8)]);
+    expect(run(parsed, instruction)).toEqual([
+      { altAddress: "ALT", entryIndex: 8 },
+    ]);
+  });
+
+  it("emits ALT_RESOLUTION for a PARAM_TOKEN_AMOUNT ACCOUNT_PATH token reference", () => {
+    const parsed: ParsedInstruction = {
+      ...emptyParsed(),
+      displayFields: [
+        { paramType: PARAM_TYPE_TOKEN_AMOUNT, token: accountPath(1) },
+      ],
+    };
+    const instruction = instructionOf([addr("static"), alt(11)]);
+    expect(run(parsed, instruction)).toEqual([
+      { altAddress: "ALT", entryIndex: 11 },
     ]);
   });
 
@@ -68,14 +183,8 @@ describe("applyAltResolutionRule", () => {
         mintAssociations: [{ accountIndex: 0, mintIndex: 1 }],
       },
     };
-    const instruction: RequirementInstruction = {
-      programId: "P",
-      data: new Uint8Array(),
-      accounts: [
-        { altRef: { altAddress: "ALT", entryIndex: 5 } }, // token account
-        { altRef: { altAddress: "ALT", entryIndex: 7 } }, // mint — NOT emitted here
-      ],
-    };
+    // token account at 0, mint at 1 — the mint is NOT emitted here
+    const instruction = instructionOf([alt(5), alt(7)]);
     // Only the token-account position (accountIndex=0) is emitted; the
     // mint position (mintIndex=1) is handled by the mintAltRef pass.
     expect(run(parsed, instruction)).toEqual([
@@ -83,38 +192,59 @@ describe("applyAltResolutionRule", () => {
     ]);
   });
 
-  it("does not emit ALT_RESOLUTION for accounts not referenced by display fields or MINT_ASSOC", () => {
-    // All accounts are ALT-backed but none appear in display fields or MINT_ASSOC
-    const parsed: ParsedInstruction = emptyParsed();
-    const instruction: RequirementInstruction = {
-      programId: "P",
-      data: new Uint8Array(),
-      accounts: [
-        { altRef: { altAddress: "ALT", entryIndex: 1 } },
-        { altRef: { altAddress: "ALT", entryIndex: 2 } },
-      ],
+  it("emits ALT_RESOLUTION for an ALT-backed ACCOUNT_RESET target", () => {
+    const parsed: ParsedInstruction = {
+      ...emptyParsed(),
+      accountResets: [{ accountIndex: 1, requirePreBalanceZero: false }],
     };
-    expect(run(parsed, instruction)).toEqual([]);
+    const instruction = instructionOf([addr("static"), alt(12)]);
+    expect(run(parsed, instruction)).toEqual([
+      { altAddress: "ALT", entryIndex: 12 },
+    ]);
+  });
+
+  it("emits one requirement for an ALT entry reached through several categories", () => {
+    const parsed: ParsedInstruction = {
+      ...emptyParsed(),
+      valueFlowPorts: [
+        {
+          accountIndices: [0],
+          optionalAccountStrategy: OptionalAccountStrategy.PROGRAM_ID,
+          tokenValue: { kind: TokenKind.RESOLVE, accountIndex: 0 },
+        },
+      ],
+      accountResets: [{ accountIndex: 0, requirePreBalanceZero: false }],
+      displayFields: [{ value: accountPath(0) }],
+    };
+    // Writable, port candidate, port token account, reset target and display
+    // field all point at the same slot.
+    const instruction = instructionOf([alt(2, true)]);
+    expect(run(parsed, instruction)).toEqual([
+      { altAddress: "ALT", entryIndex: 2 },
+    ]);
   });
 
   it("emits nothing when no account is ALT-supplied", () => {
     const parsed: ParsedInstruction = {
       ...emptyParsed(),
-      displayFields: [
+      displayFields: [{ value: accountPath(0) }],
+    };
+    expect(run(parsed, instructionOf([addr("static", true)]))).toEqual([]);
+  });
+
+  it("ignores out-of-range references", () => {
+    const parsed: ParsedInstruction = {
+      ...emptyParsed(),
+      valueFlowPorts: [
         {
-          value: {
-            source: ValueSource.ACCOUNT_PATH,
-            payload: Uint8Array.from([0]),
-          },
+          accountIndices: [],
+          optionalAccountStrategy: OptionalAccountStrategy.PROGRAM_ID,
+          tokenValue: { kind: TokenKind.RESOLVE },
         },
       ],
+      accountResets: [{ accountIndex: 9, requirePreBalanceZero: false }],
+      displayFields: [{ value: accountPath(9) }],
     };
-    expect(
-      run(parsed, {
-        programId: "P",
-        data: new Uint8Array(),
-        accounts: [{ address: "static" }],
-      }),
-    ).toEqual([]);
+    expect(run(parsed, instructionOf([alt(1)]))).toEqual([]);
   });
 });

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/altResolutionRule.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/altResolutionRule.ts
@@ -1,58 +1,98 @@
 import { type RequirementInstruction } from "@internal/app-binder/clear-sign/requirements/model";
 import {
+  PARAM_TYPE_TOKEN_AMOUNT,
   type ParsedInstruction,
+  type ParsedValue,
+  TokenKind,
   ValueSource,
 } from "@internal/app-binder/clear-sign/requirements/records";
 import { type RequirementAccumulator } from "@internal/app-binder/clear-sign/requirements/RequirementAccumulator";
+import { resolvePortAccountIndex } from "@internal/app-binder/clear-sign/requirements/valueResolution";
 
 /**
- * Emit `ALT_RESOLUTION` requirements for every ALT-backed account that the
- * device's finalize walk resolves via `pubkey_from_account_index`. The ALT
- * cache on the device is capped at 16 entries, so only the accounts that
- * finalize actually dereferences are added:
+ * Emit `ALT_RESOLUTION` requirements for the ALT-backed accounts the device's
+ * finalize walk dereferences through `pubkey_from_account_index`. That helper
+ * returns NULL for an ALT slot with no attested resolution, and the device then
+ * either marks a result incomplete or refuses to sign. The covered categories:
  *
- * 1. DISPLAY_FIELD ACCOUNT_PATH entries — the device reads the pubkey for
- *    rendering, trusted-name lookup, etc.
- * 2. MINT_ASSOCIATION token-account positions — seeded into the mint-binding
- *    map. Mint positions are handled separately as `mintAltRefs` so they can
- *    be paired with a TOKEN_INFO attempt for display.
+ * 1. Every **writable** account of the instruction's raw account list. This is
+ *    what lets `collect_writable_accounts` report `complete`, without which the
+ *    merge scan stops at the instruction and two mergeable screens stay apart.
+ * 2. Every `VALUE_FLOW_PORT` account candidate — the whole candidate array, not
+ *    just the first: the device walks them in order and refuses on the first
+ *    in-range candidate it cannot resolve.
+ * 3. Every port token reference: the `RESOLVE` token account (with the port's
+ *    own account as its fallback) and any `ACCOUNT_PATH` token value.
+ * 4. Every `DISPLAY_FIELD` `ACCOUNT_PATH` address — read for rendering,
+ *    trusted-name lookup, etc.
+ * 5. Every `PARAM_TOKEN_AMOUNT` token reference sourced from an `ACCOUNT_PATH`.
+ * 6. Every `MINT_ASSOCIATION` token-account position, seeded into the
+ *    mint-binding map. Mint positions are handled separately as `mintAltRefs`
+ *    so they can be paired with a TOKEN_INFO attempt for display.
+ * 7. Every `ACCOUNT_RESET` account index.
  *
- * VALUE_FLOW_PORT account indices and all other instruction accounts are
- * intentionally excluded: they are resolved host-side via TOKEN_INFO /
- * TOKEN_ACCOUNT_STATE and the device never dereferences them at finalize.
+ * Deliberately excluded, to keep device heap use down: read-only ALT accounts
+ * that no port, token reference, display field, association or reset names. The
+ * only site that reads them is `collect_all_accounts`, and a slot missing there
+ * only weakens `condition_account_used_elsewhere` — it cannot cost merge
+ * compaction, it can only make the device show more screens, never fewer and
+ * never a wrong value.
  */
 export function applyAltResolutionRule(
   parsed: ParsedInstruction,
   instruction: RequirementInstruction,
   accumulator: RequirementAccumulator,
 ): void {
-  // DISPLAY_FIELD ACCOUNT_PATH: address rendered or looked up at finalize.
-  for (const field of parsed.displayFields) {
-    if (
-      field.value?.source === ValueSource.ACCOUNT_PATH &&
-      field.value.payload.length > 0
-    ) {
-      const accountIndex = field.value.payload[0]!;
-      const account = instruction.accounts[accountIndex];
-      if (account?.altRef !== undefined) {
-        accumulator.addAltResolution(
-          account.altRef.altAddress,
-          account.altRef.entryIndex,
-        );
-      }
-    }
-  }
+  // Requests a resolution for one account slot; out-of-range slots and
+  // statically-resolved ones are no-ops. The accumulator dedupes on
+  // `(altAddress, entryIndex)`, so overlapping categories cost nothing.
+  const requestAccount = (accountIndex: number | undefined): void => {
+    if (accountIndex === undefined) return;
+    const altRef = instruction.accounts[accountIndex]?.altRef;
+    if (altRef === undefined) return;
+    accumulator.addAltResolution(altRef.altAddress, altRef.entryIndex);
+  };
 
-  // MINT_ASSOCIATION token-account positions: resolved to build the
-  // mint-binding map. Mint positions (mintIndex) are emitted by the
-  // separate mintAltRef pass so the provide phase can also attempt TOKEN_INFO.
-  for (const { accountIndex } of parsed.info.mintAssociations) {
-    const account = instruction.accounts[accountIndex];
-    if (account?.altRef !== undefined) {
-      accumulator.addAltResolution(
-        account.altRef.altAddress,
-        account.altRef.entryIndex,
+  const requestValue = (value: ParsedValue | undefined): void => {
+    if (value?.source !== ValueSource.ACCOUNT_PATH) return;
+    if (value.payload.length === 0) return;
+    requestAccount(value.payload[0]!);
+  };
+
+  // 1. Writable accounts of the raw account list.
+  instruction.accounts.forEach((account, index) => {
+    if (account.isWritable) requestAccount(index);
+  });
+
+  // 2 + 3. Port account candidates and their token references.
+  for (const port of parsed.valueFlowPorts) {
+    for (const candidate of port.accountIndices) requestAccount(candidate);
+
+    const { tokenValue } = port;
+    if (tokenValue === undefined) continue;
+    if (tokenValue.kind === TokenKind.RESOLVE) {
+      requestAccount(
+        tokenValue.accountIndex ?? resolvePortAccountIndex(port, instruction),
       );
     }
+    requestValue(tokenValue.value);
+  }
+
+  // 4 + 5. DISPLAY_FIELD addresses and PARAM_TOKEN_AMOUNT token references.
+  for (const field of parsed.displayFields) {
+    requestValue(field.value);
+    if (field.paramType === PARAM_TYPE_TOKEN_AMOUNT) requestValue(field.token);
+  }
+
+  // 6. MINT_ASSOCIATION token-account positions. Mint positions (mintIndex) are
+  // emitted by the separate mintAltRef pass so the provide phase can also
+  // attempt TOKEN_INFO.
+  for (const { accountIndex } of parsed.info.mintAssociations) {
+    requestAccount(accountIndex);
+  }
+
+  // 7. ACCOUNT_RESET targets.
+  for (const { accountIndex } of parsed.accountResets) {
+    requestAccount(accountIndex);
   }
 }

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/tokenRule.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/tokenRule.test.ts
@@ -59,7 +59,7 @@ function makeInstruction(
 ): RequirementInstruction {
   return {
     programId,
-    accounts: addresses.map((address) => ({ address })),
+    accounts: addresses.map((address) => ({ address, isWritable: false })),
     data: new Uint8Array(),
   };
 }

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/rules/trustedNameRule.test.ts
@@ -23,7 +23,7 @@ function run(
   };
   const instruction: RequirementInstruction = {
     programId: "P",
-    accounts: addresses.map((address) => ({ address })),
+    accounts: addresses.map((address) => ({ address, isWritable: false })),
     data: new Uint8Array(),
   };
   const accumulator = new RequirementAccumulator();

--- a/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/valueResolution.test.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/clear-sign/requirements/valueResolution.test.ts
@@ -16,9 +16,9 @@ const instruction: RequirementInstruction = {
   programId: "P",
   data: new Uint8Array(),
   accounts: [
-    { address: "first" },
-    { address: undefined },
-    { address: "third" },
+    { address: "first", isWritable: false },
+    { address: undefined, isWritable: false },
+    { address: "third", isWritable: false },
   ],
 };
 
@@ -93,7 +93,10 @@ describe("resolvePortAccountIndex", () => {
   const withProgramIdInSlot0: RequirementInstruction = {
     programId: "P",
     data: new Uint8Array(),
-    accounts: [{ address: "P" }, { address: "second" }],
+    accounts: [
+      { address: "P", isWritable: false },
+      { address: "second", isWritable: false },
+    ],
   };
 
   it("returns the sole candidate for a single-account port", () => {

--- a/packages/signer/signer-solana/src/internal/app-binder/task/BuildGenericClearSignContextTask.ts
+++ b/packages/signer/signer-solana/src/internal/app-binder/task/BuildGenericClearSignContextTask.ts
@@ -177,7 +177,11 @@ export class BuildGenericClearSignContextTask {
       matched.push({
         instruction: {
           programId,
-          accounts: this.toRequirementAccounts(message, ix.accountKeyIndexes),
+          accounts: this.toRequirementAccounts(
+            message,
+            ix.accountKeyIndexes,
+            ix.accountWritable,
+          ),
           data: ix.data,
         },
         descriptor,
@@ -496,18 +500,21 @@ export class BuildGenericClearSignContextTask {
   private toRequirementAccounts(
     message: NormalizedMessage,
     accountKeyIndexes: number[],
+    accountWritable: boolean[],
   ): RequirementAccount[] {
-    return accountKeyIndexes.map((keyIdx) => {
+    return accountKeyIndexes.map((keyIdx, slot) => {
+      const isWritable = accountWritable[slot] ?? false;
       const altRef = message.addressLookupRefs?.[keyIdx];
       if (altRef) {
         return {
+          isWritable,
           altRef: {
             altAddress: altRef.altAddress.toBase58(),
             entryIndex: altRef.entryIndex,
           },
         };
       }
-      return { address: message.allKeys[keyIdx]?.toBase58() };
+      return { isWritable, address: message.allKeys[keyIdx]?.toBase58() };
     });
   }
 }


### PR DESCRIPTION
### 📝 Description

The device's finalize walk dereferences ALT-backed accounts through `pubkey_from_account_index`, which returns NULL for an ALT slot with no attested resolution — the device then either marks a result incomplete or refuses to sign. We were only requesting `ALT_RESOLUTION` for two categories (DISPLAY_FIELD `ACCOUNT_PATH` entries and `MINT_ASSOCIATION` token-account positions), so any other slot the device touches went unresolved.

This PR broadens `applyAltResolutionRule` to cover every category the device actually dereferences:

1. **Writable accounts** of the instruction's raw account list — required for `collect_writable_accounts` to report `complete`; without it the merge scan stops at the instruction and two mergeable screens stay apart.
2. **All `VALUE_FLOW_PORT` account candidates** — the whole candidate array, not just the first: the device walks them in order and refuses on the first in-range candidate it cannot resolve.
3. **Port token references** — the `RESOLVE` token account (falling back to the port's own account) and any `ACCOUNT_PATH` token value.
4. **`DISPLAY_FIELD` `ACCOUNT_PATH` addresses** (already covered).
5. **`PARAM_TOKEN_AMOUNT` token references** sourced from an `ACCOUNT_PATH`.
6. **`MINT_ASSOCIATION` token-account positions** (already covered); mint positions stay in the separate `mintAltRefs` pass so they can be paired with a TOKEN_INFO attempt.
7. **`ACCOUNT_RESET` targets**.

Read-only ALT accounts that no port, token reference, display field, association or reset names are deliberately left out to keep device heap use down (the ALT cache is capped). The only site reading them is `collect_all_accounts`, and a slot missing there only weakens `condition_account_used_elsewhere`: it can make the device show *more* screens, never fewer and never a wrong value.

Supporting change: `RequirementAccount` gains an `isWritable` flag, populated in `BuildGenericClearSignContextTask.toRequirementAccounts` from the message's `accountWritable` list (header + ALT writable/read-only index lists). No RPC call is involved.

The rule body was also refactored around two small `requestAccount` / `requestValue` helpers — the accumulator already dedupes on `(altAddress, entryIndex)`, so overlapping categories cost nothing.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Solana generic clear signing — ALT resolution coverage

### ✅ Checklist

- [x] **Covered by automatic tests** <!-- altResolutionRule.test.ts extended with cases per category; buildRequirements / valueResolution / tokenRule / trustedNameRule tests updated for the new isWritable field -->
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date** <!-- rule doc comment rewritten to list the covered and deliberately-excluded categories -->
- [ ] **Impact of the changes:**
  - More `ALT_RESOLUTION` requirements are emitted per instruction for ALT-using transactions — QA should check that ALT-heavy transactions still clear-sign and that the device does not hit its ALT cache cap.
  - Screen merging on ALT transactions should improve (writable accounts now resolve, so `collect_writable_accounts` reports complete).
  - No behaviour change for transactions without address lookup tables.
