### PR TITLE
✨ (signer-eth) [DSDK-1387]: Provide matching external contacts before signing

### DIFF
--- a/.changeset/contacts-kit-drop-derivation-path.md
+++ b/.changeset/contacts-kit-drop-derivation-path.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-contacts-kit": patch
+---
+
+Stop sending the DERIVATION_PATH TLV on Register Identity and Edit Contact Name. Current embedded apps reject a payload carrying it.

--- a/.changeset/dsdk-1387-contacts-provide-contact.md
+++ b/.changeset/dsdk-1387-contacts-provide-contact.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-contacts-kit": minor
+---
+
+Add the PROVIDE CONTACT operation, so a signer can have the device show a registered contact name while reviewing.

--- a/.changeset/dsdk-1387-eth-provide-contacts.md
+++ b/.changeset/dsdk-1387-eth-provide-contacts.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": minor
+---
+
+Show a saved contact name in place of the raw recipient address when reviewing a transaction, matched against the address book given to `withAddressBook`. Only the transaction recipient is matched, and a contact the device rejects never costs the signature.

--- a/apps/docs/content/docs/references/signers/eth.mdx
+++ b/apps/docs/content/docs/references/signers/eth.mdx
@@ -66,6 +66,53 @@ const signerEth = new SignerEthBuilder({ sdk, sessionId })
   .build();
 ```
 
+### Address book
+
+Give the signer the user's address book to have the device show a saved contact
+name in place of the raw recipient address when it reviews a transaction:
+
+```typescript
+const signerEth = new SignerEthBuilder({ sdk, sessionId })
+  .withAddressBook({
+    contactGroups: [
+      {
+        contactName: "Alice",
+        groupHandle, // returned when the contact was registered on the device
+        hmacProof,
+        externalAddresses: [
+          {
+            scope: "Ethereum",
+            address: "0x...",
+            chainId: 1n,
+            hmacRest,
+          },
+        ],
+      },
+    ],
+    ledgerAccounts: [],
+  })
+  .build();
+```
+
+Points to know:
+
+- The snapshot must be complete, and it is read as-is: the signer neither
+  mutates nor persists it. Build a new signer to pick up later changes.
+- Only EVM entries belong here. Filter by blockchain family before you build the
+  snapshot.
+- A contact matches on address **and** `chainId`, and only against the
+  transaction recipient. A recipient carried in calldata — an ERC-20 `transfer`,
+  for example — still reviews as a raw address.
+- A matched contact replaces the trusted name (ENS) for the same recipient.
+- Nothing here can break a signature. An address book you do not supply, a
+  recipient that does not match, an app too old to support contacts, or a
+  contact the device rejects all leave the transaction signing as before,
+  against the raw address.
+
+> **Note:** Contacts are supported on Stax, Flex and Apex, and need a recent
+> enough Ethereum app. Register contacts on the device with
+> [`@ledgerhq/device-contacts-kit`](https://github.com/LedgerHQ/device-sdk-ts/tree/develop/packages/device-contacts-kit).
+
 ## 🔹 Use Cases
 
 The `SignerEthBuilder.build()` method will return a `SignerEth` instance that exposes 6 dedicated methods, each of which calls an independent use case. Each use case will return an object that contains an observable and a method called `cancel`.

--- a/packages/device-contacts-kit/src/api/index.ts
+++ b/packages/device-contacts-kit/src/api/index.ts
@@ -56,6 +56,7 @@ export {
   type EditExternalAddressScopeInput,
   type EditExternalAddressScopeOutput,
 } from "@api/model/EditExternalAddressScope";
+export { type ProvideContactInput } from "@api/model/ProvideContact";
 export {
   type ExistingContactGroup,
   type RegisterExternalAddressInput,
@@ -66,3 +67,9 @@ export {
   type RenameContactInput,
   type RenameContactOutput,
 } from "@api/model/RenameContact";
+export { type ContactsErrorCodes } from "@internal/app-binder/model/contactsErrors";
+export {
+  buildProvideContactPayload,
+  sendProvideContactPayload,
+  type SendProvideContactPayloadArgs,
+} from "@internal/app-binder/services/provideContact";

--- a/packages/device-contacts-kit/src/api/model/ProvideContact.ts
+++ b/packages/device-contacts-kit/src/api/model/ProvideContact.ts
@@ -1,0 +1,19 @@
+/**
+ * Everything the device needs to accept a registered external contact as a
+ * decoration for an upcoming signing flow: the name-level material shared by
+ * the whole contact group, plus the address-level material of the one matched
+ * address.
+ */
+export type ProvideContactInput = {
+  readonly contactName: string;
+  readonly scope: string;
+  /** Raw bytes, chain-dependent: a 20-byte address for Ethereum. */
+  readonly identifier: Uint8Array;
+  readonly groupHandle: Uint8Array;
+  readonly hmacProof: Uint8Array;
+  readonly hmacRest: Uint8Array;
+  /** Lowercase family name, e.g. `"ethereum"`. */
+  readonly blockchainFamily: string;
+  /** Mandatory for Ethereum, omitted for every other family. */
+  readonly chainId?: bigint;
+};

--- a/packages/device-contacts-kit/src/internal/app-binder/command/ProvideContactCommand.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/command/ProvideContactCommand.test.ts
@@ -1,0 +1,84 @@
+import { CommandResultStatus } from "@ledgerhq/device-management-kit";
+
+import {
+  CONTACT_SEED_MISMATCH_ERROR_CODE,
+  ContactsCommandError,
+} from "@internal/app-binder/model/contactsErrors";
+
+import { ProvideContactCommand } from "./ProvideContactCommand";
+
+describe("ProvideContactCommand", () => {
+  describe("getApdu", () => {
+    it("wraps the framed chunk under B0 10 20 with P2=0x00 for the first/only chunk", () => {
+      const data = Uint8Array.from([0x00, 0x03, 0xaa, 0xbb, 0xcc]);
+
+      const apdu = new ProvideContactCommand({ data, p2: 0x00 }).getApdu();
+
+      expect(apdu.getRawApdu()).toStrictEqual(
+        Uint8Array.from([
+          0xb0, 0x10, 0x20, 0x00, 0x05, 0x00, 0x03, 0xaa, 0xbb, 0xcc,
+        ]),
+      );
+    });
+
+    it("uses P2=0x80 for continuation chunks", () => {
+      const data = Uint8Array.from([0xaa, 0xbb]);
+
+      const apdu = new ProvideContactCommand({ data, p2: 0x80 }).getApdu();
+
+      expect(apdu.getRawApdu()).toStrictEqual(
+        Uint8Array.from([0xb0, 0x10, 0x20, 0x80, 0x02, 0xaa, 0xbb]),
+      );
+    });
+  });
+
+  describe("parseResponse", () => {
+    it("succeeds with no data on SW=0x9000", () => {
+      const result = new ProvideContactCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      }).parseResponse({
+        data: Buffer.from([]),
+        statusCode: Buffer.from([0x90, 0x00]),
+      });
+
+      expect(result).toStrictEqual({
+        status: CommandResultStatus.Success,
+        data: undefined,
+      });
+    });
+
+    it("maps SW=0x6982 to a seed-mismatch ContactsCommandError", () => {
+      const result = new ProvideContactCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      }).parseResponse({
+        data: Buffer.from([]),
+        statusCode: Buffer.from([0x69, 0x82]),
+      });
+
+      expect(result.status).toBe(CommandResultStatus.Error);
+      if (result.status === CommandResultStatus.Error) {
+        expect(result.error).toBeInstanceOf(ContactsCommandError);
+        expect((result.error as ContactsCommandError).errorCode).toBe(
+          CONTACT_SEED_MISMATCH_ERROR_CODE,
+        );
+      }
+    });
+
+    it("maps SW=0x6a80 to a ContactsCommandError", () => {
+      const result = new ProvideContactCommand({
+        data: new Uint8Array(),
+        p2: 0x00,
+      }).parseResponse({
+        data: Buffer.from([]),
+        statusCode: Buffer.from([0x6a, 0x80]),
+      });
+
+      expect(result.status).toBe(CommandResultStatus.Error);
+      if (result.status === CommandResultStatus.Error) {
+        expect((result.error as ContactsCommandError).errorCode).toBe("6a80");
+      }
+    });
+  });
+});

--- a/packages/device-contacts-kit/src/internal/app-binder/command/ProvideContactCommand.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/command/ProvideContactCommand.ts
@@ -1,0 +1,81 @@
+// Provide Contact — sub-command P1=0x20 of the address-book APDU (CLA 0xB0 /
+// INS 0x10). Sent before a signing APDU so the device renders a registered
+// contact name in place of the raw recipient address. Caller
+// (sendProvideContactPayload) assembles the TLV, prepends the 2-byte BE total
+// length and slices into <=255B chunks; this command frames one chunk. Every
+// chunk answers with SW=0x9000 and no data — the outcome is a device-side
+// effect, not a returned value.
+// Protocol: Address Book Final Specifications — Provide Contact.
+import {
+  type Apdu,
+  ApduBuilder,
+  type ApduResponse,
+  type Command,
+  type CommandResult,
+  CommandResultFactory,
+} from "@ledgerhq/device-management-kit";
+import { CommandErrorHelper } from "@ledgerhq/signer-utils";
+import { Maybe } from "purify-ts";
+
+import {
+  CONTACTS_APDU_CLA,
+  CONTACTS_APDU_INS,
+  SUB_CMD_PROVIDE_CONTACT,
+} from "@internal/app-binder/model/contactsConstants";
+import {
+  CONTACTS_APP_ERRORS,
+  contactsCommandErrorFactory,
+  type ContactsErrorCodes,
+} from "@internal/app-binder/model/contactsErrors";
+
+export type ProvideContactCommandArgs = {
+  /** One framed chunk built by sendProvideContactPayload. */
+  readonly data: Uint8Array;
+  /** 0x00 for the first/only chunk, 0x80 for continuation chunks. */
+  readonly p2: number;
+};
+
+export type ProvideContactCommandResponse = void;
+
+export class ProvideContactCommand
+  implements
+    Command<
+      ProvideContactCommandResponse,
+      ProvideContactCommandArgs,
+      ContactsErrorCodes
+    >
+{
+  readonly name = "provideContact";
+  readonly args: ProvideContactCommandArgs;
+  private readonly errorHelper = new CommandErrorHelper<
+    ProvideContactCommandResponse,
+    ContactsErrorCodes
+  >(CONTACTS_APP_ERRORS, contactsCommandErrorFactory);
+
+  constructor(args: ProvideContactCommandArgs) {
+    this.args = args;
+  }
+
+  getApdu(): Apdu {
+    return new ApduBuilder({
+      cla: CONTACTS_APDU_CLA,
+      ins: CONTACTS_APDU_INS,
+      p1: SUB_CMD_PROVIDE_CONTACT,
+      p2: this.args.p2,
+    })
+      .addBufferToData(this.args.data)
+      .build();
+  }
+
+  parseResponse(
+    response: ApduResponse,
+  ): CommandResult<ProvideContactCommandResponse, ContactsErrorCodes> {
+    return Maybe.fromNullable(
+      this.errorHelper.getError(response),
+    ).orDefaultLazy(() =>
+      CommandResultFactory<ProvideContactCommandResponse, ContactsErrorCodes>({
+        data: undefined,
+      }),
+    );
+  }
+}

--- a/packages/device-contacts-kit/src/internal/app-binder/model/contactsConstants.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/model/contactsConstants.ts
@@ -14,6 +14,9 @@ export const CONTACTS_APDU_INS = 0x10;
 /** P1 sub-command selector for REGISTER IDENTITY (register external address). */
 export const SUB_CMD_REGISTER_IDENTITY = 0x01;
 
+/** P1 sub-command selector for PROVIDE CONTACT (pre-signing decoration). */
+export const SUB_CMD_PROVIDE_CONTACT = 0x20;
+
 /**
  * P1 sub-command selector for EDIT IDENTIFIER — an address-book app sub-command
  * (CLA 0xB0 / INS 0x10) served by the coin app, never OS-dispatched.

--- a/packages/device-contacts-kit/src/internal/app-binder/services/provideContact.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/services/provideContact.test.ts
@@ -1,0 +1,138 @@
+import {
+  bufferToHexaString,
+  CommandResultFactory,
+  CommandResultStatus,
+} from "@ledgerhq/device-management-kit";
+
+import { type ProvideContactInput } from "@api/model/ProvideContact";
+import { ProvideContactCommand } from "@internal/app-binder/command/ProvideContactCommand";
+import { makeDeviceActionInternalApiMock } from "@internal/app-binder/device-action/__test-utils__/makeInternalApi";
+import { ContactsCommandError } from "@internal/app-binder/model/contactsErrors";
+
+import {
+  buildProvideContactPayload,
+  sendProvideContactPayload,
+} from "./provideContact";
+
+const IDENTIFIER = new Uint8Array(20).fill(0x11);
+const GROUP_HANDLE = new Uint8Array(64).fill(0x22);
+const HMAC_PROOF = new Uint8Array(32).fill(0x33);
+const HMAC_REST = new Uint8Array(32).fill(0x44);
+
+const INPUT: ProvideContactInput = {
+  contactName: "Alice",
+  scope: "Ethereum",
+  identifier: IDENTIFIER,
+  groupHandle: GROUP_HANDLE,
+  hmacProof: HMAC_PROOF,
+  hmacRest: HMAC_REST,
+  blockchainFamily: "ethereum",
+  chainId: 1n,
+};
+
+// Tags >= 0x80 use the DER long form (0x81 then the tag), hence the "81" prefix
+// on CONTACT_NAME (0xf0), SCOPE (0xf1), ACCOUNT_IDENTIFIER (0xf2),
+// GROUP_HANDLE (0xf6) and HMAC_REST (0xf7).
+const STRUCT_TYPE_TLV = "010133";
+const STRUCT_VERSION_TLV = "020101";
+const CONTACT_NAME_TLV = "81f005" + "416c696365"; // "Alice"
+const SCOPE_TLV = "81f108" + "457468657265756d"; // "Ethereum"
+const IDENTIFIER_TLV = "81f214" + "11".repeat(20);
+const GROUP_HANDLE_TLV = "81f640" + "22".repeat(64);
+const CHAIN_ID_TLV = "230101";
+const FAMILY_TLV = "510101";
+const HMAC_PROOF_TLV = "2920" + "33".repeat(32);
+const HMAC_REST_TLV = "81f720" + "44".repeat(32);
+
+describe("buildProvideContactPayload", () => {
+  it("encodes every tag in the order the spec lists", () => {
+    const payload = buildProvideContactPayload(INPUT);
+
+    expect(bufferToHexaString(payload, false)).toBe(
+      STRUCT_TYPE_TLV +
+        STRUCT_VERSION_TLV +
+        CONTACT_NAME_TLV +
+        SCOPE_TLV +
+        IDENTIFIER_TLV +
+        GROUP_HANDLE_TLV +
+        CHAIN_ID_TLV +
+        FAMILY_TLV +
+        HMAC_PROOF_TLV +
+        HMAC_REST_TLV,
+    );
+  });
+
+  it("fits an Ethereum contact in a single 255-byte chunk", () => {
+    expect(buildProvideContactPayload(INPUT).length).toBeLessThanOrEqual(253);
+  });
+
+  it("omits CHAIN_ID for a family that does not carry one", () => {
+    const payload = buildProvideContactPayload({
+      ...INPUT,
+      blockchainFamily: "bitcoin",
+      chainId: undefined,
+    });
+
+    expect(bufferToHexaString(payload, false)).toContain(
+      GROUP_HANDLE_TLV + "510100",
+    );
+  });
+
+  it("encodes a multi-byte chain id big-endian with no leading zeroes", () => {
+    const payload = buildProvideContactPayload({ ...INPUT, chainId: 8453n });
+
+    expect(bufferToHexaString(payload, false)).toContain("2302" + "2105");
+  });
+
+  it("accepts the family name case-insensitively", () => {
+    expect(
+      buildProvideContactPayload({ ...INPUT, blockchainFamily: "Ethereum" }),
+    ).toStrictEqual(buildProvideContactPayload(INPUT));
+  });
+
+  it("throws on an unknown blockchain family", () => {
+    expect(() =>
+      buildProvideContactPayload({ ...INPUT, blockchainFamily: "dogecoin" }),
+    ).toThrow("Unsupported blockchain family: dogecoin");
+  });
+});
+
+describe("sendProvideContactPayload", () => {
+  it("sends one chunk under P2=0x00, prefixed with the 2-byte BE total length", async () => {
+    const api = makeDeviceActionInternalApiMock();
+    api.sendCommand.mockResolvedValue(
+      CommandResultFactory({ data: undefined }),
+    );
+    const payload = buildProvideContactPayload(INPUT);
+
+    const result = await sendProvideContactPayload(api, { payload });
+
+    expect(api.sendCommand).toHaveBeenCalledTimes(1);
+    const command = api.sendCommand.mock.calls[0]![0] as ProvideContactCommand;
+    expect(command).toBeInstanceOf(ProvideContactCommand);
+    expect(command.args.p2).toBe(0x00);
+    expect(command.args.data.slice(0, 2)).toStrictEqual(
+      Uint8Array.from([(payload.length >> 8) & 0xff, payload.length & 0xff]),
+    );
+    expect(command.args.data.slice(2)).toStrictEqual(payload);
+    expect(result.status).toBe(CommandResultStatus.Success);
+  });
+
+  it("propagates a device rejection instead of throwing", async () => {
+    const api = makeDeviceActionInternalApiMock();
+    api.sendCommand.mockResolvedValue(
+      CommandResultFactory({
+        error: new ContactsCommandError({
+          errorCode: "6982",
+          message: "wrong seed",
+        }),
+      }),
+    );
+
+    const result = await sendProvideContactPayload(api, {
+      payload: buildProvideContactPayload(INPUT),
+    });
+
+    expect(result.status).toBe(CommandResultStatus.Error);
+  });
+});

--- a/packages/device-contacts-kit/src/internal/app-binder/services/provideContact.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/services/provideContact.ts
@@ -1,0 +1,94 @@
+// TLV assembly and transport for op 0x20 (Provide Contact), dispatched via the
+// chunked-framing scheme shared with the other address-book ops.
+//
+// Reference: Address Book Final Specifications — Provide Contact. Tag order:
+//   STRUCT_TYPE, STRUCT_VERSION, CONTACT_NAME, SCOPE, ACCOUNT_IDENTIFIER,
+//   GROUP_HANDLE, CHAIN_ID (Ethereum only), BLOCKCHAIN_FAMILY, HMAC_PROOF,
+//   HMAC_REST. No DERIVATION_PATH — that tag is Ledger-Account only.
+//
+// Device replies SW=0x9000 with empty data on success — no fields to extract.
+import {
+  ByteArrayBuilder,
+  type CommandResult,
+  type InternalApi,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+
+import { type ProvideContactInput } from "@api/model/ProvideContact";
+import { ProvideContactCommand } from "@internal/app-binder/command/ProvideContactCommand";
+import {
+  BLOCKCHAIN_FAMILY_BY_NAME,
+  SUB_CMD_PROVIDE_CONTACT,
+} from "@internal/app-binder/model/contactsConstants";
+import { type ContactsErrorCodes } from "@internal/app-binder/model/contactsErrors";
+import {
+  CONTACTS_TLV_TAG,
+  encodeTlvAscii,
+  encodeTlvBuffer,
+  encodeTlvChainId,
+  encodeTlvUInt8,
+  STRUCT_TYPE_PROVIDE_CONTACT,
+  STRUCT_VERSION_VALUE,
+} from "@internal/app-binder/services/contactsTlvSerializer";
+import { sendFramedContactsPayload } from "@internal/app-binder/services/sendFramedContactsPayload";
+
+/**
+ * Encode a matched contact as the PROVIDE CONTACT TLV payload, without the
+ * chunk framing. Pure, so callers can build it while matching a recipient
+ * against the address book, with no device involved.
+ */
+export function buildProvideContactPayload(
+  input: ProvideContactInput,
+): Uint8Array {
+  const family =
+    BLOCKCHAIN_FAMILY_BY_NAME[input.blockchainFamily.toLowerCase()];
+  if (family === undefined) {
+    throw new Error(`Unsupported blockchain family: ${input.blockchainFamily}`);
+  }
+
+  const builder = new ByteArrayBuilder();
+  encodeTlvUInt8(
+    builder,
+    CONTACTS_TLV_TAG.STRUCT_TYPE,
+    STRUCT_TYPE_PROVIDE_CONTACT,
+  );
+  encodeTlvUInt8(
+    builder,
+    CONTACTS_TLV_TAG.STRUCT_VERSION,
+    STRUCT_VERSION_VALUE,
+  );
+  encodeTlvAscii(builder, CONTACTS_TLV_TAG.CONTACT_NAME, input.contactName);
+  encodeTlvAscii(builder, CONTACTS_TLV_TAG.SCOPE, input.scope);
+  encodeTlvBuffer(
+    builder,
+    CONTACTS_TLV_TAG.ACCOUNT_IDENTIFIER,
+    input.identifier,
+  );
+  encodeTlvBuffer(builder, CONTACTS_TLV_TAG.GROUP_HANDLE, input.groupHandle);
+  if (input.chainId !== undefined) {
+    encodeTlvChainId(builder, CONTACTS_TLV_TAG.CHAIN_ID, input.chainId);
+  }
+  encodeTlvUInt8(builder, CONTACTS_TLV_TAG.BLOCKCHAIN_FAMILY, family);
+  encodeTlvBuffer(builder, CONTACTS_TLV_TAG.HMAC_PROOF, input.hmacProof);
+  encodeTlvBuffer(builder, CONTACTS_TLV_TAG.HMAC_REST, input.hmacRest);
+
+  return builder.build();
+}
+
+export type SendProvideContactPayloadArgs = {
+  readonly payload: Uint8Array;
+  readonly logger?: LoggerPublisherService;
+};
+
+export function sendProvideContactPayload(
+  api: InternalApi,
+  { payload, logger }: SendProvideContactPayloadArgs,
+): Promise<CommandResult<void, ContactsErrorCodes>> {
+  return sendFramedContactsPayload(api, {
+    payload,
+    p1: SUB_CMD_PROVIDE_CONTACT,
+    makeCommand: (chunk, p2) => new ProvideContactCommand({ data: chunk, p2 }),
+    logger,
+    commandTag: "provideContact",
+  }) as Promise<CommandResult<void, ContactsErrorCodes>>;
+}

--- a/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterIdentityTask.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterIdentityTask.test.ts
@@ -1,8 +1,8 @@
 // Validates that the TLV serializer + tag ordering + chunk framing produce the
 // expected wire bytes for op 1 (Register Identity): tags >= 0x80 use the 2-byte
-// DER form [0x81, tag], and Register Identity carries NO DERIVATION_PATH (the
-// Ethereum app rejects the tag on external-address ops). The framed chunk =
-// 2-byte BE total length + TLV.
+// DER form [0x81, tag], and no DERIVATION_PATH is sent (the SDK removed tag
+// 0x69 from REGISTER_IDENTITY_TAGS on 2026-08-10 and rejects payloads carrying
+// it). The framed chunk = 2-byte BE total length + TLV.
 import {
   CommandResultFactory,
   type InternalApi,
@@ -24,7 +24,7 @@ function hexToBytes(hex: string): Uint8Array {
 // Framed chunk = "00 <Lc>" (2-byte BE total TLV length) + TLV. Tag order:
 // STRUCT_TYPE, STRUCT_VERSION, CONTACT_NAME, SCOPE, ACCOUNT_IDENTIFIER,
 // CHAIN_ID, BLOCKCHAIN_FAMILY, then optional GROUP_HANDLE + HMAC_PROOF. Tags
-// >= 0x80 are encoded as [0x81, tag]. No DERIVATION_PATH TLV.
+// >= 0x80 are encoded as [0x81, tag].
 const FRESH_FRAMED_CHUNK = hexToBytes(
   "003601012d020101" +
     "81f005416c696365" +

--- a/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterIdentityTask.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterIdentityTask.ts
@@ -5,12 +5,22 @@
 //
 // Reference: Address Book Final Specifications — Register Identity. Tag order:
 //   STRUCT_TYPE, STRUCT_VERSION, CONTACT_NAME, SCOPE, ACCOUNT_IDENTIFIER,
-//   CHAIN_ID (Ethereum only), BLOCKCHAIN_FAMILY, then optional
-//   GROUP_HANDLE + HMAC_PROOF when extending an existing group.
+//   CHAIN_ID (Ethereum only), BLOCKCHAIN_FAMILY, then optional GROUP_HANDLE +
+//   HMAC_PROOF when extending an existing group.
 //
-// No DERIVATION_PATH: external-address ops carry no path. The current Ethereum
-// app rejects the tag when present (0x6a80) and no longer requires it; the tag
-// is Ledger-Account only (verified on-device, DSDK-1465).
+// No DERIVATION_PATH. The tag's status changed three times in the BOLOS SDK,
+// and the address-book TLV parser is compiled into the app (app_features/), so
+// the SDK revision the app was *built* against decides — not the app version,
+// which reads 1.23.0-dev either way:
+//   - before 2026-08-07: tag 0x69 present and MANDATORY, omitting it -> 0x6a80
+//   - 8e7e7a4f (2026-08-07): made optional, both forms accepted
+//   - a0bb21f5 (2026-08-10): removed, sending it -> 0x6a80 (unknown tag)
+// Omitting it is therefore correct for any app built from 2026-08-07 onward,
+// and wrong for one built before. Both ends verified on hardware: a Flex
+// running a pre-08-07 build of app-ethereum a79f9f8f rejects the payload
+// without the tag in 9ms and no review screen; Speculos running a post-08-10
+// build of the same commit rejects it *with* the tag, the same way.
+// The OS derives the HMAC key from a fixed internal path.
 import {
   ByteArrayBuilder,
   type CommandResult,

--- a/packages/device-contacts-kit/src/internal/app-binder/task/SendRenameContactTask.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/task/SendRenameContactTask.test.ts
@@ -1,9 +1,10 @@
 // Validates that the TLV serializer + tag ordering + chunk framing produce the
 // expected wire bytes for the Rename Contact (EDIT CONTACT NAME) op. The framed
 // chunk = 2-byte BE total length + TLV. Tag order: STRUCT_TYPE, STRUCT_VERSION,
-// CONTACT_NAME (new), PREVIOUS_CONTACT_NAME (old), GROUP_HANDLE, DERIVATION_PATH,
-// HMAC_PROOF — with tags >= 0x80 (0xf0/0xf3/0xf6) encoded as the 2-byte DER form
-// [0x81, tag].
+// CONTACT_NAME (new), PREVIOUS_CONTACT_NAME (old), GROUP_HANDLE, HMAC_PROOF —
+// with tags >= 0x80 (0xf0/0xf3/0xf6) encoded as the 2-byte DER form [0x81, tag].
+// No DERIVATION_PATH: the SDK removed tag 0x69 from EDIT_CONTACT_NAME_TAGS on
+// 2026-08-10 and rejects payloads carrying it.
 import {
   CommandResultFactory,
   type InternalApi,
@@ -26,24 +27,21 @@ const GROUP_HANDLE = hexToBytes("cc".repeat(64));
 const HMAC_PROOF_IN = hexToBytes("dd".repeat(32));
 const HMAC_PROOF_OUT = hexToBytes("ee".repeat(32));
 
-// Framed chunk = "00 90" (2-byte BE total TLV length = 144) + TLV:
+// Framed chunk = "00 79" (2-byte BE total TLV length = 121) + TLV:
 //   01 01 2e            STRUCT_TYPE = EDIT_CONTACT_NAME (0x2e)
 //   02 01 01            STRUCT_VERSION = 1
 //   81 f0 03 "Bob"      CONTACT_NAME (new), tag 0xf0 -> [81 f0]
 //   81 f3 05 "Alice"    PREVIOUS_CONTACT_NAME (old), tag 0xf3 -> [81 f3]
 //   81 f6 40 <64x cc>   GROUP_HANDLE, tag 0xf6 -> [81 f6]
-//   69 15 05 <5x path>  DERIVATION_PATH (0x69), m/44'/60'/0'/0/0
 //   29 20 <32x dd>      HMAC_PROOF
-const DERIVATION_PATH_TLV = "6915058000002c8000003c800000000000000000000000";
 const FRAMED_CHUNK = hexToBytes(
-  "0090" +
+  "0079" +
     "01012e" +
     "020101" +
     "81f003426f62" +
     "81f305416c696365" +
     "81f640" +
     "cc".repeat(64) +
-    DERIVATION_PATH_TLV +
     "2920" +
     "dd".repeat(32),
 );
@@ -79,7 +77,7 @@ describe("SendRenameContactTask", () => {
     );
   });
 
-  it("emits the DERIVATION_PATH tag immediately before HMAC_PROOF", async () => {
+  it("does not emit a DERIVATION_PATH tag", async () => {
     const api = makeApiMock();
     api.sendCommand.mockResolvedValueOnce(
       CommandResultFactory({ data: { hmacProof: HMAC_PROOF_OUT } }),
@@ -92,12 +90,14 @@ describe("SendRenameContactTask", () => {
       hmacProof: HMAC_PROOF_IN,
     }).run();
 
-    // The Ethereum app requires DERIVATION_PATH (0x69); it sits immediately
-    // before HMAC_PROOF (0x29), matching Register Identity.
+    // api-level 27 dropped tag 0x69 from EDIT_CONTACT_NAME_TAGS: a payload
+    // carrying it fails to parse and the device answers 0x6a80. HMAC_PROOF
+    // (0x29) therefore follows GROUP_HANDLE directly.
     const command = api.sendCommand.mock.calls[0]![0] as RenameContactCommand;
     const framedHex = Buffer.from(command.args.data).toString("hex");
+    expect(framedHex).not.toContain("691505");
     expect(
-      framedHex.endsWith(DERIVATION_PATH_TLV + "2920" + "dd".repeat(32)),
+      framedHex.endsWith("81f640" + "cc".repeat(64) + "2920" + "dd".repeat(32)),
     ).toBe(true);
   });
 

--- a/packages/device-contacts-kit/src/internal/app-binder/task/SendRenameContactTask.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/task/SendRenameContactTask.ts
@@ -11,7 +11,20 @@
 //
 // Reference: Address Book Final Specifications — Edit Contact Name. Tag order:
 //   STRUCT_TYPE, STRUCT_VERSION, CONTACT_NAME (new), PREVIOUS_CONTACT_NAME
-//   (old), GROUP_HANDLE, DERIVATION_PATH, HMAC_PROOF.
+//   (old), GROUP_HANDLE, HMAC_PROOF.
+//
+// No DERIVATION_PATH. The tag's status changed three times in the BOLOS SDK,
+// and the address-book TLV parser is compiled into the app (app_features/), so
+// the SDK revision the app was *built* against decides — not the app version,
+// which reads 1.23.0-dev either way:
+//   - before 2026-08-07: tag 0x69 present and MANDATORY, omitting it -> 0x6a80
+//   - 8e7e7a4f (2026-08-07): made optional, both forms accepted
+//   - a0bb21f5 (2026-08-10): removed, sending it -> 0x6a80 (unknown tag)
+// Omitting it is therefore correct for any app built from 2026-08-07 onward,
+// and wrong for one built before. Both ends verified on hardware: a Flex
+// running a pre-08-07 build of app-ethereum a79f9f8f rejects the payload
+// without the tag in 9ms and no review screen; Speculos running a post-08-10
+// build of the same commit rejects it *with* the tag, the same way.
 import {
   ByteArrayBuilder,
   type CommandResult,
@@ -30,7 +43,6 @@ import {
   encodeTlvAscii,
   encodeTlvBuffer,
   encodeTlvUInt8,
-  packDerivationPath,
   STRUCT_TYPE_EDIT_CONTACT_NAME,
   STRUCT_VERSION_VALUE,
 } from "@internal/app-binder/services/contactsTlvSerializer";
@@ -102,13 +114,6 @@ export class SendRenameContactTask {
       args.previousContactName,
     );
     encodeTlvBuffer(builder, CONTACTS_TLV_TAG.GROUP_HANDLE, args.groupHandle);
-    // The Ethereum app requires DERIVATION_PATH on Edit Contact Name (0x6a80
-    // without it), same as Register Identity. Default m/44'/60'/0'/0/0.
-    encodeTlvBuffer(
-      builder,
-      CONTACTS_TLV_TAG.DERIVATION_PATH,
-      packDerivationPath([0x8000002c, 0x8000003c, 0x80000000, 0, 0]),
-    );
     encodeTlvBuffer(builder, CONTACTS_TLV_TAG.HMAC_PROOF, args.hmacProof);
 
     return builder.build();

--- a/packages/signer/signer-eth/README.md
+++ b/packages/signer/signer-eth/README.md
@@ -54,6 +54,49 @@ const signerEth = new SignerEthBuilder({ sdk, sessionId })
   .build();
 ```
 
+### Address book
+
+Give the signer the user's address book to have the device show a saved contact
+name in place of the raw recipient address when it reviews a transaction:
+
+```typescript
+const signerEth = new SignerEthBuilder({ sdk, sessionId })
+  .withAddressBook({
+    contactGroups: [
+      {
+        contactName: "Alice",
+        groupHandle, // returned when the contact was registered on the device
+        hmacProof,
+        externalAddresses: [
+          {
+            scope: "Ethereum",
+            address: "0x...",
+            chainId: 1n,
+            hmacRest,
+          },
+        ],
+      },
+    ],
+    ledgerAccounts: [],
+  })
+  .build();
+```
+
+Points to know:
+
+- The snapshot must be complete, and it is read as-is: the signer neither
+  mutates nor persists it. Build a new signer to pick up later changes.
+- Only EVM entries belong here. Filter by blockchain family before you build the
+  snapshot.
+- A contact matches on address **and** `chainId`, and only against the
+  transaction recipient. A recipient carried in calldata — an ERC-20 `transfer`,
+  for example — still reviews as a raw address.
+- A matched contact replaces the trusted name (ENS) for the same recipient.
+- Nothing here can break a signature. An address book you do not supply, a
+  recipient that does not match, an app too old to support contacts, or a
+  contact the device rejects all leave the transaction signing as before,
+  against the raw address.
+
 ## 🔹 Use Cases
 
 The `SignerEthBuilder.build()` method will return a `SignerEth` instance that exposes 6 dedicated methods, each of which calls an independent use case. Each use case will return an object that contains an observable and a method called `cancel`.

--- a/packages/signer/signer-eth/package.json
+++ b/packages/signer/signer-eth/package.json
@@ -39,6 +39,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@ledgerhq/device-contacts-kit": "workspace:^",
     "@ledgerhq/signer-utils": "workspace:^",
     "ethers": "catalog:",
     "inversify": "catalog:",

--- a/packages/signer/signer-eth/src/api/app-binder/SignTransactionDeviceActionFactory.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignTransactionDeviceActionFactory.ts
@@ -11,6 +11,7 @@ import {
   type SignTransactionDAInternalState,
   type SignTransactionDAOutput,
 } from "@api/app-binder/SignTransactionDeviceActionTypes";
+import { type EvmAddressBook } from "@api/model/EvmAddressBook";
 import { type TransactionOptions } from "@api/model/TransactionOptions";
 import { SignTransactionDeviceAction } from "@internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction";
 import { EthersTransactionMapperService } from "@internal/transaction/service/mapper/EthersTransactionMapperService";
@@ -20,6 +21,7 @@ export const SignTransactionDeviceActionFactory = (args: {
   derivationPath: string;
   transaction: Uint8Array;
   contextModule: ContextModule;
+  addressBook?: EvmAddressBook;
   options?: TransactionOptions;
   inspect?: boolean;
   loggerFactory?: (tag: string) => LoggerPublisherService;
@@ -35,6 +37,7 @@ export const SignTransactionDeviceActionFactory = (args: {
       derivationPath: args.derivationPath,
       transaction: args.transaction,
       contextModule: args.contextModule,
+      addressBook: args.addressBook,
       options: args.options ?? {},
       mapper: new EthersTransactionMapperService(),
       parser: new TransactionParserService(),

--- a/packages/signer/signer-eth/src/api/app-binder/SignTransactionDeviceActionTypes.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignTransactionDeviceActionTypes.ts
@@ -13,6 +13,7 @@ import {
 
 import { type GetConfigCommandResponse } from "@api/app-binder/GetConfigCommandTypes";
 import { type ClearSigningType } from "@api/model/ClearSigningType";
+import { type EvmAddressBook } from "@api/model/EvmAddressBook";
 import { type Signature } from "@api/model/Signature";
 import { type TransactionOptions } from "@api/model/TransactionOptions";
 import { type TransactionType } from "@api/model/TransactionType";
@@ -43,6 +44,8 @@ export type SignTransactionDAInput = {
   readonly mapper: TransactionMapperService;
   readonly parser: TransactionParserService;
   readonly contextModule: ContextModule;
+  /** Defaults to `EMPTY_EVM_ADDRESS_BOOK`, which matches no recipient. */
+  readonly addressBook?: EvmAddressBook;
   readonly options: TransactionOptions;
 };
 

--- a/packages/signer/signer-eth/src/api/model/EvmAddressBook.ts
+++ b/packages/signer/signer-eth/src/api/model/EvmAddressBook.ts
@@ -10,8 +10,8 @@
  * carry one.
  */
 export type EvmAddressBook = {
-  contactGroups: EvmContactGroup[];
-  ledgerAccounts: EvmLedgerAccountContact[];
+  contactGroups: readonly EvmContactGroup[];
+  ledgerAccounts: readonly EvmLedgerAccountContact[];
 };
 
 /**
@@ -25,7 +25,7 @@ export type EvmContactGroup = {
   contactName: string;
   groupHandle: Uint8Array;
   hmacProof: Uint8Array;
-  externalAddresses: EvmExternalAddress[];
+  externalAddresses: readonly EvmExternalAddress[];
 };
 
 /**
@@ -51,3 +51,15 @@ export type EvmLedgerAccountContact = {
   chainId: bigint;
   hmacProof: Uint8Array;
 };
+
+/**
+ * The book bound when the host supplies none. Matches nothing.
+ *
+ * Frozen because it is a process-wide singleton: it is the DI binding, the
+ * device-action default and the fixture every test reuses, so a single stray
+ * mutation would leak into every signer at once.
+ */
+export const EMPTY_EVM_ADDRESS_BOOK: EvmAddressBook = Object.freeze({
+  contactGroups: Object.freeze([]),
+  ledgerAccounts: Object.freeze([]),
+});

--- a/packages/signer/signer-eth/src/internal/app-binder/EthAppBinder.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/EthAppBinder.test.ts
@@ -34,8 +34,13 @@ import {
   type SignTypedDataDAIntermediateValue,
   type SignTypedDataDAOutput,
 } from "@api/app-binder/SignTypedDataDeviceActionTypes";
+import {
+  EMPTY_EVM_ADDRESS_BOOK,
+  type EvmAddressBook,
+} from "@api/model/EvmAddressBook";
 import { type Signature } from "@api/model/Signature";
 import { type TypedData } from "@api/model/TypedData";
+import { type SignTransactionDeviceAction } from "@internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction";
 import { type TransactionMapperService } from "@internal/transaction/service/mapper/TransactionMapperService";
 import { type TransactionParserService } from "@internal/transaction/service/parser/TransactionParserService";
 import { type TypedDataParserService } from "@internal/typed-data/service/TypedDataParserService";
@@ -103,6 +108,7 @@ describe("EthAppBinder", () => {
           mockedParser,
           "sessionId",
           mockLoggerFactory,
+          EMPTY_EVM_ADDRESS_BOOK,
         );
         const { observable } = appBinder.getAddress({
           derivationPath: "44'/60'/3'/2/1",
@@ -164,6 +170,7 @@ describe("EthAppBinder", () => {
           mockedParser,
           "sessionId",
           mockLoggerFactory,
+          EMPTY_EVM_ADDRESS_BOOK,
         );
         appBinder.getAddress(params);
 
@@ -199,6 +206,7 @@ describe("EthAppBinder", () => {
           mockedParser,
           "sessionId",
           mockLoggerFactory,
+          EMPTY_EVM_ADDRESS_BOOK,
         );
         appBinder.getAddress(params);
 
@@ -259,6 +267,7 @@ describe("EthAppBinder", () => {
           mockedParser,
           "sessionId",
           mockLoggerFactory,
+          EMPTY_EVM_ADDRESS_BOOK,
         );
         const { observable } = appBinder.signTransaction({
           derivationPath: "44'/60'/3'/2/1",
@@ -332,6 +341,7 @@ describe("EthAppBinder", () => {
           mockedParser,
           "sessionId",
           mockLoggerFactory,
+          EMPTY_EVM_ADDRESS_BOOK,
         );
         const { observable } = appBinder.signTransaction({
           derivationPath: "44'/60'/3'/2/1",
@@ -367,6 +377,51 @@ describe("EthAppBinder", () => {
           },
         });
       }));
+
+    it("passes the injected address book to the sign-transaction device action", () => {
+      // GIVEN
+      const addressBook: EvmAddressBook = {
+        contactGroups: [
+          {
+            contactName: "Alice",
+            groupHandle: new Uint8Array(64).fill(0xaa),
+            hmacProof: new Uint8Array(32).fill(0xbb),
+            externalAddresses: [
+              {
+                scope: "Ethereum",
+                address: "0x1111111111111111111111111111111111111111",
+                chainId: 1n,
+                hmacRest: new Uint8Array(32).fill(0xcc),
+              },
+            ],
+          },
+        ],
+        ledgerAccounts: [],
+      };
+      const executeSpy = vi
+        .spyOn(mockedDmk, "executeDeviceAction")
+        .mockReturnValue({ observable: from([]), cancel: vi.fn() });
+
+      // WHEN
+      new EthAppBinder(
+        mockedDmk,
+        mockedContextModule as unknown as ContextModule,
+        mockedMapper,
+        mockedParser,
+        "sessionId",
+        mockLoggerFactory,
+        addressBook,
+      ).signTransaction({
+        derivationPath: "44'/60'/3'/2/1",
+        transaction: new Uint8Array([0x01]),
+      });
+
+      // THEN
+      const { deviceAction } = executeSpy.mock.calls[0]![0];
+      expect(
+        (deviceAction as SignTransactionDeviceAction).input.addressBook,
+      ).toBe(addressBook);
+    });
   });
 
   describe("signMessage", () => {
@@ -402,6 +457,7 @@ describe("EthAppBinder", () => {
           mockedParser,
           "sessionId",
           mockLoggerFactory,
+          EMPTY_EVM_ADDRESS_BOOK,
         );
         const { observable } = appBinder.signPersonalMessage({
           derivationPath: "44'/60'/3'/2/1",
@@ -474,6 +530,7 @@ describe("EthAppBinder", () => {
           mockedParser,
           "sessionId",
           mockLoggerFactory,
+          EMPTY_EVM_ADDRESS_BOOK,
         );
         const { observable } = appBinder.signDelegationAuthorization({
           derivationPath: "44'/60'/3'/2/1",
@@ -553,6 +610,7 @@ describe("EthAppBinder", () => {
           mockedParser,
           "sessionId",
           mockLoggerFactory,
+          EMPTY_EVM_ADDRESS_BOOK,
         );
         const { observable } = appBinder.signTypedData({
           derivationPath: "44'/60'/3'/2/1",

--- a/packages/signer/signer-eth/src/internal/app-binder/EthAppBinder.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/EthAppBinder.ts
@@ -14,6 +14,7 @@ import { type SignPersonalMessageDAReturnType } from "@api/app-binder/SignPerson
 import { type SignTransactionDAReturnType } from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { type SignTypedDataDAReturnType } from "@api/app-binder/SignTypedDataDeviceActionTypes";
 import { VerifySafeAddressDAReturnType } from "@api/app-binder/VerifySafeAddressDeviceActionTypes";
+import { type EvmAddressBook } from "@api/model/EvmAddressBook";
 import { SafeAddressOptions } from "@api/model/SafeAddressOptions";
 import { type TransactionOptions } from "@api/model/TransactionOptions";
 import { type TypedData } from "@api/model/TypedData";
@@ -43,6 +44,7 @@ export class EthAppBinder {
     @inject(externalTypes.SessionId) private sessionId: DeviceSessionId,
     @inject(externalTypes.DmkLoggerFactory)
     private dmkLoggerFactory: (tag: string) => LoggerPublisherService,
+    @inject(externalTypes.AddressBook) private addressBook: EvmAddressBook,
   ) {}
 
   getAddress(args: {
@@ -132,6 +134,7 @@ export class EthAppBinder {
           mapper: this.mapper,
           parser: this.parser,
           contextModule: this.contextModule,
+          addressBook: this.addressBook,
           options: args.options ?? {},
         },
         loggerFactory: this.dmkLoggerFactory,

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.test.ts
@@ -28,6 +28,7 @@ import {
 } from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { Signature } from "@api/index";
 import { ClearSigningType } from "@api/model/ClearSigningType";
+import { type EvmAddressBook } from "@api/model/EvmAddressBook";
 import { TransactionType } from "@api/model/TransactionType";
 import { makeDeviceActionInternalApiMock } from "@internal/app-binder/device-action/__test-utils__/makeInternalApi";
 import { setupOpenAppDAMock } from "@internal/app-binder/device-action/__test-utils__/setupOpenAppDAMock";
@@ -1260,6 +1261,105 @@ describe("SignTransactionDeviceAction", () => {
           input: expect.objectContaining({
             input: expect.objectContaining({ selectorId: null }),
           }),
+        }),
+      );
+    });
+  });
+
+  describe("with a non-empty address book", () => {
+    const RECIPIENT = "0x1111111111111111111111111111111111111111" as const;
+
+    const addressBook: EvmAddressBook = {
+      contactGroups: [
+        {
+          contactName: "Alice",
+          groupHandle: new Uint8Array(64).fill(0xaa),
+          hmacProof: new Uint8Array(32).fill(0xbb),
+          externalAddresses: [
+            {
+              scope: "Ethereum",
+              address: RECIPIENT,
+              chainId: 1n,
+              hmacRest: new Uint8Array(32).fill(0xcc),
+            },
+          ],
+        },
+      ],
+      ledgerAccounts: [],
+    };
+
+    let observable: ReturnType<
+      SignTransactionDeviceAction["_execute"]
+    >["observable"];
+
+    beforeEach(() => {
+      vi.resetAllMocks();
+      setupOpenAppDAMock();
+      setupAppConfig("1.15.0", false, false);
+      getAddressMock.mockResolvedValueOnce(
+        CommandResultFactory({ data: { address: defaultAddress } }),
+      );
+      parseTransactionMock.mockResolvedValueOnce({
+        subset: { ...defaultSubset, to: RECIPIENT },
+        type: TransactionType.EIP1559,
+      });
+      buildContextsMock.mockResolvedValueOnce({
+        clearSignContexts: [],
+        clearSigningType: ClearSigningType.EIP7730,
+      });
+      provideContextsMock.mockResolvedValueOnce(Right(void 0));
+      signTransactionMock.mockResolvedValueOnce(
+        CommandResultFactory({
+          data: { v: 0x1c, r: "0x8a54", s: "0x64a0" },
+        }),
+      );
+
+      const deviceAction = new SignTransactionDeviceAction({
+        input: {
+          derivationPath: "44'/60'/0'/0/0",
+          transaction: defaultTransaction,
+          options: defaultOptions,
+          contextModule: contextModuleMock as unknown as ContextModule,
+          addressBook,
+          mapper: mapperMock,
+          parser: parserMock,
+        },
+      });
+      vi.spyOn(deviceAction, "extractDependencies").mockReturnValue(
+        extractDependenciesMock(),
+      );
+
+      observable = deviceAction._execute(apiMock).observable;
+    });
+
+    it("hands the book to the provide step untouched", async () => {
+      await executeUntilStep(6, observable);
+
+      // The signer never mutates or re-derives the snapshot: matching a
+      // recipient against it happens downstream, in the provide step.
+      expect(provideContextsMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          input: expect.objectContaining({
+            externalContact: expect.objectContaining({
+              addressBook,
+              subset: expect.objectContaining({ to: RECIPIENT }),
+              appConfig: createAppConfig("1.15.0", false, false),
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("keeps the address book out of the context builder", async () => {
+      await executeUntilStep(5, observable);
+
+      // The context module only serves backend-fetched contexts; the host
+      // address book is not one of them.
+      expect(buildContextsMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          input: expect.not.objectContaining({ addressBook }),
         }),
       );
     });

--- a/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.ts
@@ -29,6 +29,7 @@ import {
   SignTransactionDAStep,
 } from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { ClearSigningType } from "@api/model/ClearSigningType";
+import { EMPTY_EVM_ADDRESS_BOOK } from "@api/model/EvmAddressBook";
 import { type Signature } from "@api/model/Signature";
 import { type TransactionType } from "@api/model/TransactionType";
 import { GetAddressCommand } from "@internal/app-binder/command/GetAddressCommand";
@@ -489,6 +490,12 @@ export class SignTransactionDeviceAction extends XStateDeviceAction<
               contexts: context._internalState.contexts,
               derivationPath: context.input.derivationPath,
               serializedTransaction: context.input.transaction,
+              externalContact: {
+                addressBook:
+                  context.input.addressBook ?? EMPTY_EVM_ADDRESS_BOOK,
+                subset: context._internalState.subset!,
+                appConfig: context._internalState.appConfig!,
+              },
               loggerFactory: this.getLoggerFactory(internalApi),
             }),
             onDone: {

--- a/packages/signer/signer-eth/src/internal/app-binder/task/ProvideTransactionContextsTask.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/ProvideTransactionContextsTask.test.ts
@@ -1,14 +1,25 @@
 import { ClearSignContextType } from "@ledgerhq/context-module";
 import {
+  buildProvideContactPayload,
+  type ContactsErrorCodes,
+  sendProvideContactPayload,
+} from "@ledgerhq/device-contacts-kit";
+import {
   CommandResultFactory,
+  DeviceModelId,
+  DeviceSessionStateType,
+  DeviceStatus,
   type InternalApi,
   type UnknownDeviceExchangeError,
 } from "@ledgerhq/device-management-kit";
 import { Left, Right } from "purify-ts";
 
+import { type GetConfigCommandResponse } from "@api/app-binder/GetConfigCommandTypes";
+import { type EvmAddressBook } from "@api/model/EvmAddressBook";
 import { StoreTransactionCommand } from "@internal/app-binder/command/StoreTransactionCommand";
 import { type EthErrorCodes } from "@internal/app-binder/command/utils/ethAppErrors";
 import { makeDeviceActionInternalApiMock } from "@internal/app-binder/device-action/__test-utils__/makeInternalApi";
+import { type ContextWithSubContexts } from "@internal/app-binder/task/BuildFullContextsTask";
 
 import {
   type ProvideContextTask,
@@ -22,6 +33,17 @@ import {
   type SendCommandInChunksTask,
   type SendCommandInChunksTaskArgs,
 } from "./SendCommandInChunksTask";
+
+vi.mock("@ledgerhq/device-contacts-kit", async (importOriginal) => {
+  const original =
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    await importOriginal<typeof import("@ledgerhq/device-contacts-kit")>();
+  return {
+    ...original,
+    sendProvideContactPayload: vi.fn(),
+  };
+});
+const sendProvideContactPayloadMock = vi.mocked(sendProvideContactPayload);
 
 const mockLogger = {
   debug: vi.fn(),
@@ -736,6 +758,202 @@ describe("ProvideTransactionContextsTask", () => {
         // THEN
         expect(task["_provideContextTaskFactory"]).toBeDefined();
         expect(task["_sendCommandInChunksTaskFactory"]).toBeDefined();
+      });
+    });
+
+    describe("external contact", () => {
+      const RECIPIENT = "0x1111111111111111111111111111111111111111" as const;
+
+      const addressBook: EvmAddressBook = {
+        contactGroups: [
+          {
+            contactName: "Alice",
+            groupHandle: new Uint8Array(64).fill(0xaa),
+            hmacProof: new Uint8Array(32).fill(0xbb),
+            externalAddresses: [
+              {
+                scope: "Ethereum",
+                address: RECIPIENT,
+                chainId: 1n,
+                hmacRest: new Uint8Array(32).fill(0xcc),
+              },
+            ],
+          },
+        ],
+        ledgerAccounts: [],
+      };
+
+      const appConfig: GetConfigCommandResponse = {
+        blindSigningEnabled: false,
+        web3ChecksEnabled: false,
+        web3ChecksOptIn: false,
+        version: "1.15.0",
+      };
+
+      const resolveTrustedName = vi.fn();
+      const trustedName: ContextWithSubContexts = {
+        context: {
+          type: ClearSignContextType.ETHEREUM_TRUSTED_NAME,
+          payload: "trusted name payload",
+        },
+        subcontextCallbacks: [resolveTrustedName],
+      };
+
+      const contactAccepted = CommandResultFactory<void, ContactsErrorCodes>({
+        data: undefined,
+      });
+      const contactRejected = CommandResultFactory<void, ContactsErrorCodes>({
+        data: undefined,
+        error: {} as UnknownDeviceExchangeError,
+      });
+
+      function makeArgs(
+        overrides: Partial<ProvideTransactionContextsTaskArgs> = {},
+      ): ProvideTransactionContextsTaskArgs {
+        return {
+          contexts: [
+            {
+              context: {
+                type: ClearSignContextType.ETHEREUM_TOKEN,
+                payload: "token payload",
+              },
+              subcontextCallbacks: [],
+            },
+          ],
+          derivationPath: "44'/60'/0'/0/0",
+          externalContact: {
+            addressBook,
+            subset: {
+              chainId: 1,
+              to: RECIPIENT,
+              data: "0x",
+              selector: "0x",
+            },
+            appConfig,
+          },
+          loggerFactory: mockLoggerFactory,
+          ...overrides,
+        };
+      }
+
+      function run(args: ProvideTransactionContextsTaskArgs) {
+        return new ProvideTransactionContextsTask(
+          api,
+          args,
+          provideContextTaskMockFactory,
+          sendCommandInChunksTaskMockFactory,
+        ).run();
+      }
+
+      beforeEach(() => {
+        // No `firmwareVersion`: the session refresher drops it once an app is
+        // open, so this is the shape a real signing flow sees.
+        api.getDeviceSessionState.mockReturnValue({
+          sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+          deviceStatus: DeviceStatus.CONNECTED,
+          installedApps: [],
+          currentApp: { name: "Ethereum", version: "1.15.0" },
+          deviceModelId: DeviceModelId.FLEX,
+          isSecureConnectionAllowed: false,
+        });
+        provideContextTaskRunMock.mockResolvedValue(successResult);
+        sendProvideContactPayloadMock.mockResolvedValue(contactAccepted);
+        resolveTrustedName.mockResolvedValue({
+          type: ClearSignContextType.ETHEREUM_TRUSTED_NAME,
+          payload: "resolved trusted name payload",
+        });
+      });
+
+      it("should provide the matching contact before any context", async () => {
+        // WHEN
+        const result = await run(makeArgs());
+
+        // THEN
+        expect(result).toEqual(Right(void 0));
+        expect(sendProvideContactPayloadMock).toHaveBeenCalledWith(api, {
+          payload: buildProvideContactPayload({
+            contactName: "Alice",
+            scope: "Ethereum",
+            identifier: new Uint8Array(20).fill(0x11),
+            groupHandle: new Uint8Array(64).fill(0xaa),
+            hmacProof: new Uint8Array(32).fill(0xbb),
+            hmacRest: new Uint8Array(32).fill(0xcc),
+            blockchainFamily: "ethereum",
+            chainId: 1n,
+          }),
+          logger: mockLogger,
+        });
+        expect(
+          sendProvideContactPayloadMock.mock.invocationCallOrder[0]!,
+        ).toBeLessThan(provideContextTaskRunMock.mock.invocationCallOrder[0]!);
+      });
+
+      it("should skip the trusted name the contact replaces", async () => {
+        // GIVEN
+        const args = makeArgs({ contexts: [trustedName] });
+
+        // WHEN
+        const result = await run(args);
+
+        // THEN
+        // Neither the subcontext nor the main context reaches the device: the
+        // resolved ENS name would overwrite the contact on the review screen.
+        expect(result).toEqual(Right(void 0));
+        expect(resolveTrustedName).not.toHaveBeenCalled();
+        expect(provideContextTaskRunMock).not.toHaveBeenCalled();
+      });
+
+      it("should keep the trusted name when no contact matches the recipient", async () => {
+        // GIVEN
+        const args = makeArgs({
+          contexts: [trustedName],
+          externalContact: {
+            addressBook,
+            subset: {
+              chainId: 8453,
+              to: RECIPIENT,
+              data: "0x",
+              selector: "0x",
+            },
+            appConfig,
+          },
+        });
+
+        // WHEN
+        const result = await run(args);
+
+        // THEN
+        expect(result).toEqual(Right(void 0));
+        expect(sendProvideContactPayloadMock).not.toHaveBeenCalled();
+        expect(provideContextTaskRunMock).toHaveBeenCalledTimes(1);
+      });
+
+      it("should sign anyway when the device rejects the contact", async () => {
+        // GIVEN
+        // A book that is not filtered by seed makes 0x6982 routine; the name is
+        // dropped but the user still gets to sign against the raw address.
+        sendProvideContactPayloadMock.mockResolvedValue(contactRejected);
+        const args = makeArgs({ contexts: [trustedName] });
+
+        // WHEN
+        const result = await run(args);
+
+        // THEN
+        expect(result).toEqual(Right(void 0));
+        expect(mockLogger.warn).toHaveBeenCalled();
+        // Routine, not a fault: it must not reach error-level monitoring.
+        expect(mockLogger.error).not.toHaveBeenCalled();
+        // The contact never made it, so the trusted name is the only name left.
+        expect(provideContextTaskRunMock).toHaveBeenCalledTimes(1);
+      });
+
+      it("should send nothing when no external contact is given", async () => {
+        // WHEN
+        const result = await run(makeArgs({ externalContact: undefined }));
+
+        // THEN
+        expect(result).toEqual(Right(void 0));
+        expect(sendProvideContactPayloadMock).not.toHaveBeenCalled();
       });
     });
   });

--- a/packages/signer/signer-eth/src/internal/app-binder/task/ProvideTransactionContextsTask.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/ProvideTransactionContextsTask.ts
@@ -1,7 +1,9 @@
 import {
   ClearSignContextType,
   isEthereumClearSignContextSuccess,
+  type TransactionSubset,
 } from "@ledgerhq/context-module";
+import { sendProvideContactPayload } from "@ledgerhq/device-contacts-kit";
 import {
   ByteArrayBuilder,
   type CommandErrorResult,
@@ -12,8 +14,11 @@ import {
 import { DerivationPathUtils } from "@ledgerhq/signer-utils";
 import { type Either, Left, Right } from "purify-ts";
 
+import { type GetConfigCommandResponse } from "@api/app-binder/GetConfigCommandTypes";
+import { type EvmAddressBook } from "@api/model/EvmAddressBook";
 import { StoreTransactionCommand } from "@internal/app-binder/command/StoreTransactionCommand";
 import { type EthErrorCodes } from "@internal/app-binder/command/utils/ethAppErrors";
+import { buildExternalContactPayload } from "@internal/shared/utils/buildExternalContactPayload";
 
 import { type ContextWithSubContexts } from "./BuildFullContextsTask";
 import {
@@ -24,6 +29,16 @@ import {
   SendCommandInChunksTask,
   type SendCommandInChunksTaskArgs,
 } from "./SendCommandInChunksTask";
+
+/**
+ * Everything needed to look up the transaction recipient in the host address
+ * book. The three travel together because none of them means anything alone.
+ */
+export type ExternalContactArgs = {
+  readonly addressBook: EvmAddressBook;
+  readonly subset: TransactionSubset;
+  readonly appConfig: GetConfigCommandResponse;
+};
 
 export type ProvideTransactionContextsTaskArgs = {
   /**
@@ -40,6 +55,12 @@ export type ProvideTransactionContextsTaskArgs = {
    * if there is only a standalone calldata embedded in a message.
    */
   serializedTransaction?: Uint8Array;
+  /**
+   * Provide the contact matching the transaction recipient, ahead of the
+   * contexts. Omitted where there is no transaction recipient to match against
+   * — typed-data calldata, or a nested call inside a transaction.
+   */
+  externalContact?: ExternalContactArgs;
   /**
    * Logger factory for creating loggers with custom tags.
    */
@@ -86,8 +107,19 @@ export class ProvideTransactionContextsTask {
     });
 
     let transactionInfoProvided = false;
+    const contactProvided = await this._provideExternalContact();
 
     for (const { context, subcontextCallbacks } of this._args.contexts) {
+      if (
+        contactProvided &&
+        context.type === ClearSignContextType.ETHEREUM_TRUSTED_NAME
+      ) {
+        // The user-chosen name wins: a trusted name (ENS) resolves the same
+        // recipient the contact just decorated, so providing it would overwrite
+        // the contact on the review screen.
+        continue;
+      }
+
       for (const callback of subcontextCallbacks) {
         const subcontext = await callback();
 
@@ -159,5 +191,45 @@ export class ProvideTransactionContextsTask {
       "[run] ProvideTransactionContextsTask completed successfully",
     );
     return Right(void 0);
+  }
+
+  /**
+   * Returns whether the device accepted a contact for the recipient, so the
+   * caller knows to drop the trusted name it replaces.
+   */
+  private async _provideExternalContact(): Promise<boolean> {
+    if (this._args.externalContact === undefined) {
+      return false;
+    }
+
+    const payload = buildExternalContactPayload({
+      ...this._args.externalContact,
+      deviceState: this._api.getDeviceSessionState(),
+    });
+    if (payload === undefined) {
+      return false;
+    }
+
+    const result = await sendProvideContactPayload(this._api, {
+      payload,
+      logger: this._logger,
+    });
+
+    if (!isSuccessCommandResult(result)) {
+      // Warn, not error: a rejection is a routine outcome, not a fault. The
+      // device answers 0x6982 for a proof made by another seed, and the host is
+      // not required to filter its address book by seed, so this fires in normal
+      // use. A contact only decorates the review screen, so the name is dropped
+      // and the user signs against the raw address.
+      this._logger.warn(
+        "[provideExternalContact] Contact rejected, signing without it",
+        {
+          data: { error: result.error },
+        },
+      );
+      return false;
+    }
+
+    return true;
   }
 }

--- a/packages/signer/signer-eth/src/internal/di.ts
+++ b/packages/signer/signer-eth/src/internal/di.ts
@@ -6,7 +6,10 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { Container } from "inversify";
 
-import { type EvmAddressBook } from "@api/model/EvmAddressBook";
+import {
+  EMPTY_EVM_ADDRESS_BOOK,
+  type EvmAddressBook,
+} from "@api/model/EvmAddressBook";
 import { addressModuleFactory } from "@internal/address/di/addressModule";
 import { appBindingModuleFactory } from "@internal/app-binder/di/appBinderModule";
 import { eip7702ModuleFactory } from "@internal/eip7702/di/eip7702Module";
@@ -42,7 +45,7 @@ export const makeContainer = ({
   // matches, so consumers never have to handle `undefined`.
   container
     .bind<EvmAddressBook>(externalTypes.AddressBook)
-    .toConstantValue(addressBook ?? { contactGroups: [], ledgerAccounts: [] });
+    .toConstantValue(addressBook ?? EMPTY_EVM_ADDRESS_BOOK);
 
   container
     .bind<

--- a/packages/signer/signer-eth/src/internal/shared/utils/buildExternalContactPayload.test.ts
+++ b/packages/signer/signer-eth/src/internal/shared/utils/buildExternalContactPayload.test.ts
@@ -1,0 +1,263 @@
+import { type TransactionSubset } from "@ledgerhq/context-module";
+import { buildProvideContactPayload } from "@ledgerhq/device-contacts-kit";
+import {
+  DeviceModelId,
+  type DeviceSessionState,
+  DeviceSessionStateType,
+  DeviceStatus,
+} from "@ledgerhq/device-management-kit";
+
+import { type GetConfigCommandResponse } from "@api/app-binder/GetConfigCommandTypes";
+import {
+  type EvmAddressBook,
+  type EvmExternalAddress,
+} from "@api/model/EvmAddressBook";
+
+import {
+  buildExternalContactPayload,
+  type BuildExternalContactPayloadArgs,
+} from "./buildExternalContactPayload";
+
+const ALICE_MAINNET = "0x1111111111111111111111111111111111111111" as const;
+const ALICE_BASE = "0x2222222222222222222222222222222222222222" as const;
+const UNKNOWN = "0x9999999999999999999999999999999999999999";
+
+const GROUP_HANDLE = new Uint8Array(64).fill(0xaa);
+const HMAC_PROOF = new Uint8Array(32).fill(0xbb);
+const HMAC_REST_MAINNET = new Uint8Array(32).fill(0xcc);
+const HMAC_REST_BASE = new Uint8Array(32).fill(0xdd);
+
+const mainnetAddress: EvmExternalAddress = {
+  scope: "Ethereum",
+  address: ALICE_MAINNET,
+  chainId: 1n,
+  hmacRest: HMAC_REST_MAINNET,
+};
+
+const baseAddress: EvmExternalAddress = {
+  scope: "Base",
+  address: ALICE_BASE,
+  chainId: 8453n,
+  hmacRest: HMAC_REST_BASE,
+};
+
+const addressBook: EvmAddressBook = {
+  contactGroups: [
+    {
+      contactName: "Alice",
+      groupHandle: GROUP_HANDLE,
+      hmacProof: HMAC_PROOF,
+      externalAddresses: [mainnetAddress, baseAddress],
+    },
+  ],
+  ledgerAccounts: [],
+};
+
+const emptyBook: EvmAddressBook = { contactGroups: [], ledgerAccounts: [] };
+
+function subset(overrides: Partial<TransactionSubset> = {}): TransactionSubset {
+  return {
+    chainId: 1,
+    data: "0x",
+    selector: "0x",
+    to: ALICE_MAINNET,
+    ...overrides,
+  };
+}
+
+// No `firmwareVersion`: the session refresher drops it once an app is open, so
+// this is the shape a real signing flow sees.
+function deviceState({
+  appName = "Ethereum",
+  appVersion = "1.15.0",
+  deviceModelId = DeviceModelId.FLEX,
+}: {
+  appName?: string;
+  appVersion?: string;
+  deviceModelId?: DeviceModelId;
+} = {}): DeviceSessionState {
+  return {
+    sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
+    deviceStatus: DeviceStatus.CONNECTED,
+    installedApps: [],
+    currentApp: { name: appName, version: appVersion },
+    deviceModelId,
+    isSecureConnectionAllowed: false,
+  };
+}
+
+function appConfig(version = "1.15.0"): GetConfigCommandResponse {
+  return {
+    blindSigningEnabled: false,
+    web3ChecksEnabled: false,
+    web3ChecksOptIn: false,
+    version,
+  };
+}
+
+function args(
+  overrides: Partial<BuildExternalContactPayloadArgs> = {},
+): BuildExternalContactPayloadArgs {
+  return {
+    addressBook,
+    subset: subset(),
+    deviceState: deviceState(),
+    appConfig: appConfig(),
+    ...overrides,
+  };
+}
+
+describe("buildExternalContactPayload", () => {
+  describe("matching", () => {
+    it("encodes the contact when recipient and chain both match", () => {
+      const payload = buildExternalContactPayload(args());
+
+      expect(payload).toStrictEqual(
+        buildProvideContactPayload({
+          contactName: "Alice",
+          scope: "Ethereum",
+          identifier: new Uint8Array(20).fill(0x11),
+          groupHandle: GROUP_HANDLE,
+          hmacProof: HMAC_PROOF,
+          hmacRest: HMAC_REST_MAINNET,
+          blockchainFamily: "ethereum",
+          chainId: 1n,
+        }),
+      );
+    });
+
+    it("pairs the matched address with the proofs of its own group", () => {
+      const twoGroups: EvmAddressBook = {
+        contactGroups: [
+          {
+            contactName: "Bob",
+            groupHandle: new Uint8Array(64).fill(0x01),
+            hmacProof: new Uint8Array(32).fill(0x02),
+            externalAddresses: [],
+          },
+          ...addressBook.contactGroups,
+        ],
+        ledgerAccounts: [],
+      };
+
+      expect(
+        buildExternalContactPayload(args({ addressBook: twoGroups })),
+      ).toStrictEqual(buildExternalContactPayload(args()));
+    });
+
+    it("selects the address registered for the transaction's chain", () => {
+      const payload = buildExternalContactPayload(
+        args({ subset: subset({ to: ALICE_BASE, chainId: 8453 }) }),
+      );
+
+      expect(payload).toStrictEqual(
+        buildProvideContactPayload({
+          contactName: "Alice",
+          scope: "Base",
+          identifier: new Uint8Array(20).fill(0x22),
+          groupHandle: GROUP_HANDLE,
+          hmacProof: HMAC_PROOF,
+          hmacRest: HMAC_REST_BASE,
+          blockchainFamily: "ethereum",
+          chainId: 8453n,
+        }),
+      );
+    });
+
+    it("does not match a known address on a chain it is not registered for", () => {
+      expect(
+        buildExternalContactPayload(
+          args({ subset: subset({ chainId: 8453 }) }),
+        ),
+      ).toBeUndefined();
+    });
+
+    it("does not match an address absent from the book", () => {
+      expect(
+        buildExternalContactPayload(args({ subset: subset({ to: UNKNOWN }) })),
+      ).toBeUndefined();
+    });
+
+    it("matches regardless of recipient checksum casing", () => {
+      const checksummed = subset({ to: ALICE_MAINNET.toUpperCase() });
+
+      expect(
+        buildExternalContactPayload(args({ subset: checksummed })),
+      ).toStrictEqual(buildExternalContactPayload(args()));
+    });
+
+    it("returns undefined for a transaction with no recipient", () => {
+      expect(
+        buildExternalContactPayload(
+          args({ subset: subset({ to: undefined }) }),
+        ),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined for an empty address book", () => {
+      expect(
+        buildExternalContactPayload(args({ addressBook: emptyBook })),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("device support", () => {
+    it("returns undefined when the app is too old for Contacts", () => {
+      expect(
+        buildExternalContactPayload(
+          args({ deviceState: deviceState({ appVersion: "1.14.0" }) }),
+        ),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined on a device model without Contacts support", () => {
+      expect(
+        buildExternalContactPayload(
+          args({
+            deviceState: deviceState({ deviceModelId: DeviceModelId.NANO_X }),
+          }),
+        ),
+      ).toBeUndefined();
+    });
+
+    it("encodes the contact inside a clone of the Ethereum app", () => {
+      // A clone reports its own name and its own version. The Ethereum minimum
+      // is the one that applies, measured against the version the app config
+      // reports — the clone's `currentApp.version` says nothing about it.
+      const payload = buildExternalContactPayload(
+        args({
+          deviceState: deviceState({ appName: "Polygon", appVersion: "1.0.0" }),
+          appConfig: appConfig("1.15.0"),
+        }),
+      );
+
+      expect(payload).toBeDefined();
+    });
+
+    it("returns undefined in a clone whose underlying app is too old", () => {
+      expect(
+        buildExternalContactPayload(
+          args({
+            deviceState: deviceState({
+              appName: "Polygon",
+              appVersion: "999.0.0",
+            }),
+            appConfig: appConfig("1.14.0"),
+          }),
+        ),
+      ).toBeUndefined();
+    });
+
+    it("encodes the contact even though the session state carries no OS version", () => {
+      // Regression guard: gating on `firmwareVersion` here rejected every
+      // device, because the refresher drops it on the transition out of
+      // Connected and GET OS VERSION is a dashboard-only command.
+      const state = deviceState();
+
+      expect(state).not.toHaveProperty("firmwareVersion");
+      expect(
+        buildExternalContactPayload(args({ deviceState: state })),
+      ).toBeDefined();
+    });
+  });
+});

--- a/packages/signer/signer-eth/src/internal/shared/utils/buildExternalContactPayload.ts
+++ b/packages/signer/signer-eth/src/internal/shared/utils/buildExternalContactPayload.ts
@@ -1,0 +1,120 @@
+import { type TransactionSubset } from "@ledgerhq/context-module";
+import {
+  buildProvideContactPayload,
+  ETHEREUM_APP_NAME,
+  resolveContactsVersionRequirements,
+} from "@ledgerhq/device-contacts-kit";
+import {
+  ApplicationChecker,
+  type DeviceSessionState,
+  hexaStringToBuffer,
+} from "@ledgerhq/device-management-kit";
+
+import { type GetConfigCommandResponse } from "@api/app-binder/GetConfigCommandTypes";
+import { type EvmAddressBook } from "@api/model/EvmAddressBook";
+import { EthereumApplicationResolver } from "@internal/app-binder/EthereumApplicationResolver";
+
+/**
+ * The `BLOCKCHAIN_FAMILY` byte is mandatory on the wire but absent from the
+ * public address-book model: the host has already filtered the snapshot down to
+ * the EVM family, so the signer supplies it as a constant.
+ */
+const BLOCKCHAIN_FAMILY = "ethereum";
+
+export type BuildExternalContactPayloadArgs = {
+  readonly addressBook: EvmAddressBook;
+  readonly subset: TransactionSubset;
+  readonly deviceState: DeviceSessionState;
+  readonly appConfig: GetConfigCommandResponse;
+};
+
+/**
+ * Find the recipient of `subset` in the address book and encode it as the
+ * PROVIDE CONTACT payload, or return `undefined` when the device cannot serve
+ * the Contacts APDUs or the book holds no entry for that address on that chain.
+ *
+ * Matching is on `address` and `chainId` alone. The host resolves the
+ * blockchain family upstream, so no entry of another family can be present;
+ * within EVM, `chainId` is what separates the same address on different chains.
+ *
+ * Scope, deliberately narrow for a first version: the only address considered
+ * is `subset.to`, the transaction's own recipient. A recipient that lives in
+ * calldata — the `to` of an ERC-20 `transfer`, or any address inside a nested
+ * call — is never matched, so those still review as a raw address even when the
+ * book holds a contact for them. Covering them means resolving contacts per
+ * decoded field, alongside the trusted-name references in
+ * `BuildSubcontextsTask`, which is a separate piece of work.
+ */
+export function buildExternalContactPayload({
+  addressBook,
+  subset,
+  deviceState,
+  appConfig,
+}: BuildExternalContactPayloadArgs): Uint8Array | undefined {
+  if (!supportsContacts(deviceState, appConfig)) return undefined;
+
+  const recipient = subset.to?.toLowerCase();
+  if (recipient === undefined) return undefined;
+
+  for (const group of addressBook.contactGroups) {
+    const match = group.externalAddresses.find(
+      (candidate) =>
+        candidate.address.toLowerCase() === recipient &&
+        candidate.chainId === BigInt(subset.chainId),
+    );
+    if (match === undefined) continue;
+
+    const identifier = hexaStringToBuffer(match.address);
+    if (identifier === null) continue;
+
+    return buildProvideContactPayload({
+      contactName: group.contactName,
+      scope: match.scope,
+      identifier,
+      groupHandle: group.groupHandle,
+      hmacProof: group.hmacProof,
+      hmacRest: match.hmacRest,
+      blockchainFamily: BLOCKCHAIN_FAMILY,
+      chainId: match.chainId,
+    });
+  }
+
+  return undefined;
+}
+
+/**
+ * Gated on the device model and the running app, never on the OS version:
+ * `GET OS VERSION` is a dashboard command, and the session refresher drops
+ * `firmwareVersion` from the session state on the transition out of
+ * `Connected` — so an OS check here would reject every device. An app new
+ * enough to serve the Contacts APDUs implies an OS new enough to back it.
+ *
+ * The model minimum comes from the Contacts requirements table; the version
+ * comparison goes through `ApplicationChecker`, as the clear-signing gates do,
+ * so a clone of the Ethereum app is measured by the app version its config
+ * reports rather than the clone's own.
+ */
+function supportsContacts(
+  deviceState: DeviceSessionState,
+  appConfig: GetConfigCommandResponse,
+): boolean {
+  const requirement = resolveContactsVersionRequirements(
+    deviceState.deviceModelId,
+  );
+  if (!requirement.supported) {
+    return false;
+  }
+
+  const minAppVersion = requirement.minAppVersion[ETHEREUM_APP_NAME];
+  if (minAppVersion === undefined) {
+    return false;
+  }
+
+  return new ApplicationChecker(
+    deviceState,
+    appConfig,
+    new EthereumApplicationResolver(),
+  )
+    .withMinVersionInclusive(minAppVersion)
+    .check();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1773,6 +1773,9 @@ importers:
 
   packages/signer/signer-eth:
     dependencies:
+      '@ledgerhq/device-contacts-kit':
+        specifier: workspace:^
+        version: link:../../device-contacts-kit
       '@ledgerhq/signer-utils':
         specifier: workspace:^
         version: link:../signer-utils
@@ -6951,6 +6954,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -8631,6 +8635,7 @@ packages:
   eslint@9.34.0:
     resolution: {integrity: sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -18390,6 +18395,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
+  '@vitest/mocker@3.2.6(vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.3.6(@types/node@24.13.2)(jiti@2.7.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0)
+
   '@vitest/mocker@3.2.6(vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.2.6
@@ -26730,7 +26743,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.7.0))
+      '@vitest/mocker': 3.2.6(vite@7.3.6(@types/node@24.13.2)(jiti@2.7.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))
       '@vitest/pretty-format': 3.2.7
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6


### PR DESCRIPTION
### 📝 Description

When an Ethereum transaction is sent to an address saved in the user's address book, the device now shows the saved contact name instead of the raw recipient address.

The address book already reached the signer via `SignerEthBuilder.withAddressBook()`, but nothing consumed it. This wires it through:

- **`device-contacts-kit`** gains the `PROVIDE CONTACT` sub-command (`B0 10 20`), exposed as `buildProvideContactPayload` — a pure TLV encoder — and `sendProvideContactPayload`, its chunked-framing transport. The command class stays internal; the public surface is only what a signer calls.
- **`context-module`** gains `ETHEREUM_CONTACT_EXTERNAL`. Unlike every other clear-sign context, the signer builds this one locally from the host-supplied snapshot rather than a loader fetching it: contacts are device-issued proofs the host already holds.
- **`signer-eth`** matches the transaction recipient and chain against the book in a pure, device-free step, then provides the match through the existing `ProvideContextTask` before the signing APDU.

**A contact wins over a trusted name (ENS)** for the same recipient. It is ordered ahead of `TRUSTED_NAME` so the device holds the contact name before it renders the recipient field, and the superseded trusted-name context is dropped.

**A rejected contact never breaks signing.** The device answers `0x6982` when a proof was made by another seed, and hosts are not required to filter their address book by seed — so that response is routine, not exceptional. It is reported and the flow signs on against the raw address.

**Matching is on the transaction recipient only**, deliberately, for a first version. A recipient carried in calldata — the `to` of an ERC-20 `transfer`, or an address inside a nested call — is never matched, so those still review as a raw address. Covering them means resolving contacts per decoded field, next to the trusted-name references in `BuildSubcontextsTask`, and is left to a follow-up.

#### Why the support check is app-version only

`GET OS VERSION` is a dashboard command (`E0 01`), and the session refresher rebuilds the session state without `firmwareVersion` on the transition out of `Connected`. So nothing running inside an open app can read the device OS version, and gating on one there rejects every device. The gate reads the model's minimum from the Contacts requirements table, which is already public, and hands the version comparison to DMK's `ApplicationChecker` — the same path the generic-parser and gated-signing gates beside it take.

Going through `EthereumApplicationResolver` also settles the clone apps. It falls back to the app config version when the running app is not literally "Ethereum", because a clone reports its own version, so Polygon and the rest are measured against the Ethereum minimum rather than failing a lookup by app name. If a clone turns out not to carry the feature, the cost is one refused APDU, which the provide task already swallows.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1387](https://ledgerhq.atlassian.net/browse/DSDK-1387)

- **Feature**: Contacts clear signing in the Ethereum signer.

### ✅ Checklist

- [x] **Covered by automatic tests**
  - Payload encoding and response decoding for the new command.
  - The matching step: exact match, no match, same address on a different chain, a group holding several addresses across chains, an empty book, recipient checksum casing.
  - Contact-over-ENS precedence, the version gate, clones of the Ethereum app on both sides of the minimum, and a guard that a contact is still provided when the session state carries no OS version — the shape a real signing flow actually sees.
  - Plumbing from the builder through the device action, and that a contact context reaches the device rather than being skipped.
- [x] **Changeset is provided** — one per affected package.
- [x] **Documentation is up-to-date** — `withAddressBook()` landed with the earlier address-book plumbing but was documented nowhere, and this is the change that makes it visible to a user. Added an "Address book" section to the signer-eth README and to the docs site reference page: a builder example, plus what a caller needs to know about snapshot ownership, EVM-only entries, recipient-only matching, contact-over-ENS precedence, and the fact that nothing here can fail a signature.
- [ ] **Impact of the changes:**
  - Signing is unchanged when the host supplies no address book, when nothing matches, or when the app is too old — the empty book is the default binding, so this is the path most users stay on.
  - Nothing here is a breaking change: `addressBook` is optional on `SignTransactionDAInput`, and the `device-contacts-kit` exports are additive.
  - QA focus: a transaction to a saved contact on the matching chain; the same address on a different chain (should show the raw address); a contact and an ENS name on the same recipient (contact wins); and a proof from a different seed (signature must still succeed, without the name).
  - The wire encoding has not yet run against hardware — the firmware app supporting it is unreleased. Two tag values are ambiguous in the spec (the `PROVIDE CONTACT` section disagrees with the document's own tag registry on `CONTACT_NAME`, and with its struct-type table); the implementation follows the registry. A wrong choice surfaces as `0x6a80`. This is the main thing to validate on device before release.


[DSDK-1387]: https://ledgerhq.atlassian.net/browse/DSDK-1387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


