### PR TITLE
✨ (clear-signing-tester) [NO-ISSUE]: Test contacts clear signing end to end

### DIFF
--- a/.changeset/speculos-controller-address-book-confirm.md
+++ b/.changeset/speculos-controller-address-book-confirm.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/speculos-device-controller": minor
+---
+
+Add `confirmAddressBookReview()`, tapping the Address Book review's confirm button, which sits out of reach of `mainButton()` and `secondaryButton()`.

--- a/.changeset/speculos-transport-disconnect-timer.md
+++ b/.changeset/speculos-transport-disconnect-timer.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-transport-kit-speculos": patch
+---
+
+Clear the disconnect-polling interval when a Speculos device disconnects normally. The stray 2s timer kept the Node event loop alive, so a CLI consumer never exited.

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,7 +35,9 @@ jobs:
       signer-solana: ${{ steps.filter.outputs.signer-solana }}
       signer-utils: ${{ steps.filter.outputs.signer-utils }}
       solana-tools: ${{ steps.filter.outputs.solana-tools }}
+      contacts-kit: ${{ steps.filter.outputs.contacts-kit }}
       cs-tester: ${{ steps.filter.outputs.cs-tester }}
+      should-run-contacts-cs-tester: ${{ steps.filter.outputs.signer-eth == 'true' || steps.filter.outputs.contacts-kit == 'true' || steps.filter.outputs.cs-tester == 'true' }}
       should-run-ethereum-cs-tester: ${{ steps.filter.outputs.signer-eth == 'true' || steps.filter.outputs.context-module == 'true' || steps.filter.outputs.signer-utils == 'true' || steps.filter.outputs.cs-tester == 'true' }}
       should-run-solana-cs-tester: ${{ steps.filter.outputs.signer-solana == 'true' || steps.filter.outputs.context-module == 'true' || steps.filter.outputs.signer-utils == 'true' || steps.filter.outputs.cs-tester == 'true' || steps.filter.outputs.solana-tools == 'true' }}
     steps:
@@ -55,6 +57,8 @@ jobs:
               - 'packages/signer/signer-utils/**'
             solana-tools:
               - 'packages/tools/solana-tools/**'
+            contacts-kit:
+              - 'packages/device-contacts-kit/**'
             cs-tester:
               - 'apps/clear-signing-tester/**'
               - '.github/**'
@@ -258,6 +262,40 @@ jobs:
           coin-app: Ethereum
           artifact-prefix: eth-cs-tester-logs
           summary-prefix: "Ethereum Clear Signing Test"
+          gh-bot-app-id: ${{ secrets.GH_BOT_APP_ID }}
+          gh-bot-private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          gating-token: ${{ secrets.GATING_TOKEN }}
+          solana-rpc-url: ${{ secrets.SOLANA_LEDGER_RPC_URL }}
+
+  contacts-cs-tester:
+    needs: [checks, detect-changes]
+    if: needs.detect-changes.outputs.should-run-contacts-cs-tester == 'true'
+    name: Ethereum Contacts Test (${{ matrix.test }})
+    runs-on: ${{ !github.event.pull_request.head.repo.fork && 'ledgerhq-device-sdk' || 'ubuntu-22.04' }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # No device axis: Contacts is unsupported on Nano, and the Address Book
+        # APDUs need an RC firmware pair that each script pins itself, so `flex`
+        # here only selects which ELFs are checked out of coin-apps.
+        test:
+          - test:contacts
+          - test:contacts:sign
+          - test:contacts:sign-rejected
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/cs-tester-composite
+        with:
+          runner: cs-tester
+          test: ${{ matrix.test }}
+          device: flex
+          coin-app: Ethereum
+          artifact-prefix: eth-contacts-logs
+          summary-prefix: "Ethereum Contacts Test"
+          # A device registration flow is hard to diagnose from a bare log.
+          enable-file-logging: "true"
           gh-bot-app-id: ${{ secrets.GH_BOT_APP_ID }}
           gh-bot-private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
           gating-token: ${{ secrets.GATING_TOKEN }}

--- a/apps/clear-signing-tester/README.md
+++ b/apps/clear-signing-tester/README.md
@@ -280,6 +280,8 @@ pnpm cs-tester cli raw-transaction <tx> --custom-app stax/1.8.1/Ethereum/app_dev
 
 ### Contacts (Address Book) Support
 
+Two flows, one command each.
+
 **`contact-file`** checks the Ethereum app's Address Book behaviour: it
 registers each contact with `@ledgerhq/device-contacts-kit` and asserts the
 review screens. No signing.
@@ -301,6 +303,26 @@ pnpm cs-tester cli --device flex --os-version 1.7.0-rc2 --app-eth-version 1.23.0
   }
 ]
 ```
+
+**`--address-book`** checks the signing side: it binds an address book to the
+signer for the whole run, so any signing command reviews against it.
+
+```bash
+pnpm cs-tester cli --device flex --os-version 1.7.0-rc2 --app-eth-version 1.23.0-dev \
+  --address-book ./ressources/contacts/address-book.json \
+  raw-file ./ressources/contacts/sign-with-contact.json
+```
+
+The proofs in an address-book file are device-issued and seed-bound. `contact-file`
+logs the ones it gets back, which is how `address-book.json` was produced; re-record
+them if the device or seed changes. `address-book-rejected.json` carries a flipped
+group handle, so the device answers `0x6982` and the transaction signs against the
+raw address — the guard that a bad book never costs a signature.
+
+`chainId` is a decimal string or number, since JSON has no bigint.
+`unexpectedTexts` asserts a text is **absent**; the negative cases need it, because
+"the raw address renders" only means something alongside "the contact name does
+not". It works on any signing case, not just contacts ones.
 
 #### Case isolation
 

--- a/apps/clear-signing-tester/README.md
+++ b/apps/clear-signing-tester/README.md
@@ -278,6 +278,45 @@ pnpm cs-tester cli raw-transaction <tx> --custom-app stax/1.8.1/Ethereum/app_dev
 - **Absolute paths** (e.g., `/home/user/builds/my_app.elf`) are automatically mounted into the container at `/custom-app/app.elf`
 - Plugin options (`--plugin`, `--plugin-version`) are also ignored when using a custom app
 
+### Contacts (Address Book) Support
+
+**`contact-file`** checks the Ethereum app's Address Book behaviour: it
+registers each contact with `@ledgerhq/device-contacts-kit` and asserts the
+review screens. No signing.
+
+```bash
+pnpm cs-tester cli --device flex --os-version 1.7.0-rc2 --app-eth-version 1.23.0-dev \
+  contact-file ./ressources/contacts/contacts.json
+```
+
+```json
+[
+  {
+    "description": "Registering an external address shows the contact name for review",
+    "contactName": "Alice",
+    "scope": "Ethereum",
+    "address": "0xa1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4",
+    "chainId": "1",
+    "expectedTexts": ["Review contact details", "Alice"]
+  }
+]
+```
+
+#### Case isolation
+
+The Ethereum app caches provided contacts in RAM for the whole app session, so a
+name provided by one case stays resolvable for every later case in the same run.
+Give each case its own recipient address; do not reuse one across cases.
+
+#### Requirements
+
+Contacts need an RC firmware pair — the newest *stable* Ethereum app answers
+`6e00 "CLA not supported"` to the first address-book APDU, and that also drops
+the Speculos session, so every later case fails as `DeviceSessionNotFound`. Run
+with `--device flex --os-version 1.7.0-rc2 --app-eth-version 1.23.0-dev`. The
+Address Book HMACs are OS syscalls, so the Speculos image must be recent enough
+to implement them. Not in CI until both the app and a suitable image ship.
+
 ## Output
 
 The application outputs test results to the console and uses exit codes to indicate success/failure:

--- a/apps/clear-signing-tester/README.md
+++ b/apps/clear-signing-tester/README.md
@@ -332,12 +332,17 @@ Give each case its own recipient address; do not reuse one across cases.
 
 #### Requirements
 
-Contacts need an RC firmware pair — the newest *stable* Ethereum app answers
+Contacts need an RC firmware pair — the newest _stable_ Ethereum app answers
 `6e00 "CLA not supported"` to the first address-book APDU, and that also drops
 the Speculos session, so every later case fails as `DeviceSessionNotFound`. Run
 with `--device flex --os-version 1.7.0-rc2 --app-eth-version 1.23.0-dev`. The
 Address Book HMACs are OS syscalls, so the Speculos image must be recent enough
-to implement them. Not in CI until both the app and a suitable image ship.
+to implement them.
+
+These three flows run on pull requests via the `contacts-cs-tester` job, gated on
+changes to `signer-eth`, `device-contacts-kit` or this app. The job inherits the
+firmware pin from the scripts above; it depends on the Speculos image the shared
+CI action pulls, which is not pinned per job.
 
 ## Output
 

--- a/apps/clear-signing-tester/package.json
+++ b/apps/clear-signing-tester/package.json
@@ -35,11 +35,13 @@
     "test:solana:program:all": "pnpm cli:solana program-all",
     "test:erc7730": "./scripts/test-erc7730-calldata.sh",
     "test:erc7730:typed-data": "./scripts/test-erc7730-typed-data.sh",
-    "test:gating": "./scripts/test-gating.sh"
+    "test:gating": "./scripts/test-gating.sh",
+    "test:contacts": "pnpm cli --device flex --os-version 1.7.0-rc2 --app-eth-version 1.23.0-dev contact-file ./ressources/contacts/contacts.json"
   },
   "dependencies": {
     "@ledgerhq/cal-interceptor": "workspace:^",
     "@ledgerhq/context-module": "workspace:^",
+    "@ledgerhq/device-contacts-kit": "workspace:^",
     "@ledgerhq/device-management-kit": "workspace:^",
     "@ledgerhq/device-signer-kit-ethereum": "workspace:^",
     "@ledgerhq/device-signer-kit-solana": "workspace:^",

--- a/apps/clear-signing-tester/package.json
+++ b/apps/clear-signing-tester/package.json
@@ -36,7 +36,9 @@
     "test:erc7730": "./scripts/test-erc7730-calldata.sh",
     "test:erc7730:typed-data": "./scripts/test-erc7730-typed-data.sh",
     "test:gating": "./scripts/test-gating.sh",
-    "test:contacts": "pnpm cli --device flex --os-version 1.7.0-rc2 --app-eth-version 1.23.0-dev contact-file ./ressources/contacts/contacts.json"
+    "test:contacts": "pnpm cli --device flex --os-version 1.7.0-rc2 --app-eth-version 1.23.0-dev contact-file ./ressources/contacts/contacts.json",
+    "test:contacts:sign": "pnpm cli --device flex --os-version 1.7.0-rc2 --app-eth-version 1.23.0-dev --address-book ./ressources/contacts/address-book.json raw-file ./ressources/contacts/sign-with-contact.json",
+    "test:contacts:sign-rejected": "pnpm cli --device flex --os-version 1.7.0-rc2 --app-eth-version 1.23.0-dev --address-book ./ressources/contacts/address-book-rejected.json raw-file ./ressources/contacts/sign-rejected-contact.json"
   },
   "dependencies": {
     "@ledgerhq/cal-interceptor": "workspace:^",

--- a/apps/clear-signing-tester/ressources/contacts/address-book-rejected.json
+++ b/apps/clear-signing-tester/ressources/contacts/address-book-rejected.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "A proof the device did not mint: the last byte of Alice's group handle is flipped, so its MAC fails the same check a proof from another seed would. PROVIDE CONTACT is rejected, and the transaction must still sign against the raw address.",
+  "contactGroups": [
+    {
+      "contactName": "Alice",
+      "groupHandle": "0x24d73c85b7a0942b28b3408989ef5ae34604279c112c54b83510480349ca976d55d5df045345649b23515ae722255673ec7ca6302fef4f441fd461524f26572d",
+      "hmacProof": "0x3f2d563217a8218c3792c767c071ebcd46ac8b23989830d6c49a1fc93ba79b62",
+      "externalAddresses": [
+        {
+          "scope": "Ethereum",
+          "address": "0xa1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4",
+          "chainId": "1",
+          "hmacRest": "0x10c588709d9bf1cac9b4cb650f551cee58fad03588e8c32d7fefdd1968ba83ff"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/clear-signing-tester/ressources/contacts/address-book.json
+++ b/apps/clear-signing-tester/ressources/contacts/address-book.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Proofs are device-issued and seed-bound. Recorded from a `contact-file` run against the Speculos default seed; re-record them with `contact-file` if the device or seed changes.",
+  "contactGroups": [
+    {
+      "contactName": "Alice",
+      "groupHandle": "0x24d73c85b7a0942b28b3408989ef5ae34604279c112c54b83510480349ca976d55d5df045345649b23515ae722255673ec7ca6302fef4f441fd461524f2657d2",
+      "hmacProof": "0x3f2d563217a8218c3792c767c071ebcd46ac8b23989830d6c49a1fc93ba79b62",
+      "externalAddresses": [
+        {
+          "scope": "Ethereum",
+          "address": "0xa1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4",
+          "chainId": "1",
+          "hmacRest": "0x10c588709d9bf1cac9b4cb650f551cee58fad03588e8c32d7fefdd1968ba83ff"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/clear-signing-tester/ressources/contacts/contacts.json
+++ b/apps/clear-signing-tester/ressources/contacts/contacts.json
@@ -1,0 +1,24 @@
+[
+  {
+    "description": "Registering an external address shows the contact name and address for review",
+    "contactName": "Alice",
+    "scope": "Ethereum",
+    "address": "0xa1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4",
+    "chainId": "1",
+    "expectedTexts": [
+      "Review contact details",
+      "Alice",
+      "0xa1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4",
+      "Saved to your Contacts"
+    ]
+  },
+  {
+    "description": "A second contact registers independently of the first",
+    "contactName": "Bob",
+    "scope": "Ethereum",
+    "address": "0xb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3",
+    "chainId": "1",
+    "expectedTexts": ["Bob", "Saved to your Contacts"],
+    "unexpectedTexts": ["Alice"]
+  }
+]

--- a/apps/clear-signing-tester/ressources/contacts/sign-rejected-contact.json
+++ b/apps/clear-signing-tester/ressources/contacts/sign-rejected-contact.json
@@ -1,0 +1,8 @@
+[
+  {
+    "description": "A contact the device rejects is dropped and the transaction still signs",
+    "rawTx": "0x02ef0101843b9aca008506fc23ac0082520894a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d487038d7ea4c6800080c0",
+    "expectedTexts": ["0xa1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4"],
+    "unexpectedTexts": ["Alice"]
+  }
+]

--- a/apps/clear-signing-tester/ressources/contacts/sign-with-contact.json
+++ b/apps/clear-signing-tester/ressources/contacts/sign-with-contact.json
@@ -1,0 +1,14 @@
+[
+  {
+    "description": "Recipient in the address book reviews as the contact name",
+    "rawTx": "0x02ef0101843b9aca008506fc23ac0082520894a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d487038d7ea4c6800080c0",
+    "expectedTexts": ["Alice"],
+    "unexpectedTexts": ["0xa1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4"]
+  },
+  {
+    "description": "Recipient absent from the address book reviews as the raw address",
+    "rawTx": "0x02ef0102843b9aca008506fc23ac0082520894c0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d387038d7ea4c6800080c0",
+    "expectedTexts": ["0xc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3"],
+    "unexpectedTexts": ["Alice"]
+  }
+]

--- a/apps/clear-signing-tester/src/application/usecases/TestBatchContactFromFileUseCase.ts
+++ b/apps/clear-signing-tester/src/application/usecases/TestBatchContactFromFileUseCase.ts
@@ -1,0 +1,81 @@
+import { type LoggerPublisherService } from "@ledgerhq/device-management-kit";
+import { inject, injectable } from "inversify";
+
+import { TYPES } from "@root/src/di/types";
+import { type ContactInput } from "@root/src/domain/models/ContactInput";
+import { type TestResult } from "@root/src/domain/types/TestStatus";
+import {
+  type BatchTestResult,
+  ResultFormatter,
+} from "@root/src/domain/utils/ResultFormatter";
+import { type ContactFileRepository } from "@root/src/infrastructure/repositories/ContactFileRepository";
+
+import { TestContactUseCase } from "./TestContactUseCase";
+
+/** Pause between cases, matching the transaction batch loop. */
+const INTER_CASE_DELAY_MS = 2000;
+
+/**
+ * Register every contact in a file.
+ *
+ * The device keeps registered contacts in RAM for the app session, so a case
+ * that asserts the *absence* of a name cannot rely on a clean device — it says
+ * so with `unexpectedTexts`.
+ */
+@injectable()
+export class TestBatchContactFromFileUseCase {
+  private readonly logger: LoggerPublisherService;
+
+  constructor(
+    @inject(TYPES.ContactFileRepository)
+    private readonly fileRepository: ContactFileRepository,
+    @inject(TYPES.TestContactUseCase)
+    private readonly testContact: TestContactUseCase,
+    @inject(TYPES.LoggerPublisherServiceFactory)
+    loggerFactory: (tag: string) => LoggerPublisherService,
+  ) {
+    this.logger = loggerFactory("test-batch-contact");
+  }
+
+  async execute(filePath: string): Promise<BatchTestResult> {
+    this.logger.info(`Processing contacts from: ${filePath}`);
+
+    const contacts = this.fileRepository.readFromFile(filePath);
+    this.logger.info(`Found ${contacts.length} contact(s) to test`);
+
+    const results: TestResult[] = [];
+
+    for (const [index, contact] of contacts.entries()) {
+      this.logger.info(
+        `Testing contact ${index + 1}/${contacts.length}: ${contact.description}`,
+      );
+
+      results.push(await this.runContact(contact, index));
+
+      await new Promise((resolve) => setTimeout(resolve, INTER_CASE_DELAY_MS));
+    }
+
+    return ResultFormatter.formatBatchResults(results, contacts.length, {
+      title: "📋 CONTACT RESULTS",
+      summaryTitle: "📊 CONTACT SUMMARY",
+    });
+  }
+
+  private async runContact(
+    contact: ContactInput,
+    index: number,
+  ): Promise<TestResult> {
+    try {
+      return await this.testContact.execute(contact);
+    } catch (error) {
+      this.logger.error(`Contact ${index + 1} failed`, { data: { error } });
+
+      return {
+        input: contact,
+        status: "error",
+        timestamp: new Date().toISOString(),
+        errorMessage: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+}

--- a/apps/clear-signing-tester/src/application/usecases/TestContactUseCase.ts
+++ b/apps/clear-signing-tester/src/application/usecases/TestContactUseCase.ts
@@ -1,0 +1,59 @@
+import { type LoggerPublisherService } from "@ledgerhq/device-management-kit";
+import { inject, injectable } from "inversify";
+
+import { TYPES } from "@root/src/di/types";
+import { type ContactInput } from "@root/src/domain/models/ContactInput";
+import { type ContactsRepository } from "@root/src/domain/repositories/ContactsRepository";
+import { type ScreenAnalyzerService } from "@root/src/domain/services/ScreenAnalyzer";
+import { type TestResult } from "@root/src/domain/types/TestStatus";
+
+/**
+ * Register one contact on the device and report what its review screens showed.
+ *
+ * This is the whole flow: no signing, so a failure here is the Ethereum app's
+ * Address Book behaviour and nothing else. The proofs the device returns are
+ * logged, since that is how an address book for the signing flow is produced.
+ */
+@injectable()
+export class TestContactUseCase {
+  private readonly logger: LoggerPublisherService;
+
+  constructor(
+    @inject(TYPES.ContactsRepository)
+    private readonly contactsRepository: ContactsRepository,
+    @inject(TYPES.ScreenAnalyzerService)
+    private readonly screenAnalyzer: ScreenAnalyzerService,
+    @inject(TYPES.LoggerPublisherServiceFactory)
+    loggerFactory: (tag: string) => LoggerPublisherService,
+  ) {
+    this.logger = loggerFactory("test-contact");
+  }
+
+  async execute(contact: ContactInput): Promise<TestResult> {
+    this.logger.info(`Registering contact: ${contact.description}`);
+
+    const proofs = await this.contactsRepository.registerContact(contact);
+
+    this.logger.info("Contact registered, proofs for an address book file", {
+      data: {
+        groupHandle: hex(proofs.groupHandle),
+        hmacProof: hex(proofs.hmacProof),
+        hmacRest: hex(proofs.hmacRest),
+      },
+    });
+
+    const analysis = await this.screenAnalyzer.analyzeAccumulatedTexts(
+      contact.expectedTexts ?? [],
+      contact.unexpectedTexts ?? [],
+    );
+
+    return {
+      input: contact,
+      status: analysis.containsAll ? "clear_signed" : "partially_clear_signed",
+      timestamp: new Date().toISOString(),
+    };
+  }
+}
+
+const hex = (bytes: Uint8Array) =>
+  `0x${Buffer.from(bytes).toString("hex")}` as const;

--- a/apps/clear-signing-tester/src/cli/EthereumTransactionTesterCli.ts
+++ b/apps/clear-signing-tester/src/cli/EthereumTransactionTesterCli.ts
@@ -6,6 +6,7 @@ import { type LoggerPublisherService } from "@ledgerhq/device-management-kit";
 import { Command } from "commander";
 import { type Container } from "inversify";
 
+import { type TestBatchContactFromFileUseCase } from "@root/src/application/usecases/TestBatchContactFromFileUseCase";
 import { type TestBatchContractFromFileUseCase } from "@root/src/application/usecases/TestBatchContractFromFileUseCase";
 import { type TestBatchTransactionFromFileUseCase } from "@root/src/application/usecases/TestBatchTransactionFromFileUseCase";
 import { type TestBatchTypedDataFromFileUseCase } from "@root/src/application/usecases/TestBatchTypedDataFromFileUseCase";
@@ -442,6 +443,16 @@ export class EthereumTransactionTesterCli {
         exitCode = await cli!.handleContractFile(file, options.skipCal);
       });
 
+    // Contact file command
+    program
+      .command("contact-file <file>")
+      .description(
+        "Register contacts on the device and check their review screens",
+      )
+      .action(async (file) => {
+        exitCode = await cli!.handleContactFile(file);
+      });
+
     // Start Speculos command (no signing tests)
     program
       .command("start-speculos")
@@ -587,6 +598,25 @@ export class EthereumTransactionTesterCli {
       skipCal,
       plugin: this.config.plugin,
     });
+
+    console.log(`\n${result.title}`);
+    console.table(result.resultsTable);
+    console.log(`\n${result.summaryTitle}`);
+    console.table(result.summaryTable);
+
+    return result.exitCode;
+  }
+
+  /**
+   * Handle contact file command
+   */
+  async handleContactFile(file: string): Promise<number> {
+    const batchTestUseCase =
+      this.container.get<TestBatchContactFromFileUseCase>(
+        TYPES.TestBatchContactFromFileUseCase,
+      );
+
+    const result = await batchTestUseCase.execute(file);
 
     console.log(`\n${result.title}`);
     console.table(result.resultsTable);

--- a/apps/clear-signing-tester/src/cli/EthereumTransactionTesterCli.ts
+++ b/apps/clear-signing-tester/src/cli/EthereumTransactionTesterCli.ts
@@ -23,6 +23,7 @@ import {
 import { type SpeculosConfig } from "@root/src/domain/models/config/SpeculosConfig";
 import { SignableInputKind } from "@root/src/domain/models/SignableInputKind";
 import { type ServiceController } from "@root/src/domain/services/ServiceController";
+import { readAddressBookFile } from "@root/src/infrastructure/repositories/readAddressBookFile";
 import { ERC7730InterceptorService } from "@root/src/infrastructure/services/ERC7730InterceptorService";
 
 export type CliConfig = {
@@ -46,6 +47,7 @@ export type CliConfig = {
   erc7730Files?: string[];
   blindSigningEnabled?: boolean;
   skipOriginToken?: boolean;
+  addressBook?: string;
 
   // config.logger
   logLevel: CliLogLevel;
@@ -105,6 +107,9 @@ export class EthereumTransactionTesterCli {
           ? ""
           : process.env["GATING_TOKEN"] || "test-origin-token",
         blindSigningEnabled: config.blindSigningEnabled ?? false,
+        ...(config.addressBook && {
+          addressBook: readAddressBookFile(config.addressBook),
+        }),
       },
       cal: {
         url: "https://global.api.prd.ledger.com/cal/v1",
@@ -282,6 +287,10 @@ export class EthereumTransactionTesterCli {
       .option(
         "--erc7730-files <files...>",
         "One or more ERC7730 JSON files to inject for clear signing testing",
+      )
+      .option(
+        "--address-book <path>",
+        "JSON address book bound to the signer for the whole run (see ressources/contacts)",
       )
       .option(
         "--docker-image-tag <tag>",

--- a/apps/clear-signing-tester/src/di/modules/ethereumApplicationModuleFactory.ts
+++ b/apps/clear-signing-tester/src/di/modules/ethereumApplicationModuleFactory.ts
@@ -1,8 +1,10 @@
 import { ContainerModule } from "inversify";
 
+import { TestBatchContactFromFileUseCase } from "@root/src/application/usecases/TestBatchContactFromFileUseCase";
 import { TestBatchContractFromFileUseCase } from "@root/src/application/usecases/TestBatchContractFromFileUseCase";
 import { TestBatchTransactionFromFileUseCase } from "@root/src/application/usecases/TestBatchTransactionFromFileUseCase";
 import { TestBatchTypedDataFromFileUseCase } from "@root/src/application/usecases/TestBatchTypedDataFromFileUseCase";
+import { TestContactUseCase } from "@root/src/application/usecases/TestContactUseCase";
 import { TestContractUseCase } from "@root/src/application/usecases/TestContractUseCase";
 import { TestTransactionUseCase } from "@root/src/application/usecases/TestTransactionUseCase";
 import { TestTypedDataUseCase } from "@root/src/application/usecases/TestTypedDataUseCase";
@@ -21,5 +23,9 @@ export const ethereumApplicationModuleFactory = () =>
     bind(TYPES.TestContractUseCase).to(TestContractUseCase);
     bind(TYPES.TestBatchContractFromFileUseCase).to(
       TestBatchContractFromFileUseCase,
+    );
+    bind(TYPES.TestContactUseCase).to(TestContactUseCase);
+    bind(TYPES.TestBatchContactFromFileUseCase).to(
+      TestBatchContactFromFileUseCase,
     );
   });

--- a/apps/clear-signing-tester/src/di/modules/ethereumInfrastructureModuleFactory.ts
+++ b/apps/clear-signing-tester/src/di/modules/ethereumInfrastructureModuleFactory.ts
@@ -50,9 +50,18 @@ export const ethereumInfrastructureModuleFactory = (
     bind<ContactFileRepository>(TYPES.ContactFileRepository)
       .to(ContactFileRepository)
       .inSingletonScope();
-    bind<ContactsRepository>(TYPES.ContactsRepository)
+    // Two tokens, one instance: the service controller needs the concrete
+    // class to hand over the session-bound ContactsManager, while every
+    // consumer sees only the interface.
+    bind<SpeculosContactsRepository>(TYPES.SpeculosContactsRepository)
       .to(SpeculosContactsRepository)
       .inSingletonScope();
+    bind<ContactsRepository>(TYPES.ContactsRepository).toDynamicValue(
+      (context) =>
+        context.get<SpeculosContactsRepository>(
+          TYPES.SpeculosContactsRepository,
+        ),
+    );
 
     // Signing
     bind<SigningService>(TYPES.SigningService)

--- a/apps/clear-signing-tester/src/di/modules/ethereumInfrastructureModuleFactory.ts
+++ b/apps/clear-signing-tester/src/di/modules/ethereumInfrastructureModuleFactory.ts
@@ -9,6 +9,7 @@ import { type TransactionCrafter } from "@root/src/domain/adapters/TransactionCr
 import { type ContractInput } from "@root/src/domain/models/ContractInput";
 import { type TransactionInput } from "@root/src/domain/models/TransactionInput";
 import { type TypedDataInput } from "@root/src/domain/models/TypedDataInput";
+import { type ContactsRepository } from "@root/src/domain/repositories/ContactsRepository";
 import { type DataFileRepository } from "@root/src/domain/repositories/DataFileRepository";
 import { type TransactionContractRepository } from "@root/src/domain/repositories/TransactionContractRepository";
 import { type ServiceController } from "@root/src/domain/services/ServiceController";
@@ -16,8 +17,10 @@ import { type SigningService } from "@root/src/domain/services/SigningService";
 import { EthersTransactionCrafter } from "@root/src/infrastructure/adapters/evm/EthersTransactionCrafter";
 import { HttpCalAdapter } from "@root/src/infrastructure/adapters/external/HttpCalAdapter";
 import { HttpEtherscanAdapter } from "@root/src/infrastructure/adapters/external/HttpEtherscanAdapter";
+import { ContactFileRepository } from "@root/src/infrastructure/repositories/ContactFileRepository";
 import { ContractFileRepository } from "@root/src/infrastructure/repositories/ContractFileRepository";
 import { DefaultTransactionContractRepository } from "@root/src/infrastructure/repositories/DefaultTransactionContractRepository";
+import { SpeculosContactsRepository } from "@root/src/infrastructure/repositories/SpeculosContactsRepository";
 import { TransactionFileRepository } from "@root/src/infrastructure/repositories/TransactionFileRepository";
 import { TypedDataFileRepository } from "@root/src/infrastructure/repositories/TypedDataFileRepository";
 import { DMKServiceController } from "@root/src/infrastructure/service-controllers/DMKServiceController";
@@ -43,6 +46,12 @@ export const ethereumInfrastructureModuleFactory = (
       .inSingletonScope();
     bind<TransactionContractRepository>(TYPES.TransactionContractRepository)
       .to(DefaultTransactionContractRepository)
+      .inSingletonScope();
+    bind<ContactFileRepository>(TYPES.ContactFileRepository)
+      .to(ContactFileRepository)
+      .inSingletonScope();
+    bind<ContactsRepository>(TYPES.ContactsRepository)
+      .to(SpeculosContactsRepository)
       .inSingletonScope();
 
     // Signing

--- a/apps/clear-signing-tester/src/di/types.ts
+++ b/apps/clear-signing-tester/src/di/types.ts
@@ -5,6 +5,8 @@ export const TYPES = {
   TypedDataFileRepository: Symbol.for("TypedDataFileRepository"),
   ContractFileRepository: Symbol.for("ContractFileRepository"),
   TransactionContractRepository: Symbol.for("TransactionContractRepository"),
+  ContactsRepository: Symbol.for("ContactsRepository"),
+  ContactFileRepository: Symbol.for("ContactFileRepository"),
 
   // Services
   EtherscanAdapter: Symbol.for("EtherscanAdapter"),
@@ -52,6 +54,10 @@ export const TYPES = {
     "TestBatchTypedDataFromFileUseCase",
   ),
   TestContractUseCase: Symbol.for("TestContractUseCase"),
+  TestContactUseCase: Symbol.for("TestContactUseCase"),
+  TestBatchContactFromFileUseCase: Symbol.for(
+    "TestBatchContactFromFileUseCase",
+  ),
   TestBatchContractFromFileUseCase: Symbol.for(
     "TestBatchContractFromFileUseCase",
   ),

--- a/apps/clear-signing-tester/src/di/types.ts
+++ b/apps/clear-signing-tester/src/di/types.ts
@@ -6,6 +6,7 @@ export const TYPES = {
   ContractFileRepository: Symbol.for("ContractFileRepository"),
   TransactionContractRepository: Symbol.for("TransactionContractRepository"),
   ContactsRepository: Symbol.for("ContactsRepository"),
+  SpeculosContactsRepository: Symbol.for("SpeculosContactsRepository"),
   ContactFileRepository: Symbol.for("ContactFileRepository"),
 
   // Services

--- a/apps/clear-signing-tester/src/domain/adapters/DeviceController.ts
+++ b/apps/clear-signing-tester/src/domain/adapters/DeviceController.ts
@@ -36,6 +36,11 @@ export interface DeviceController {
   continueToBlindSigning(): Promise<void>;
 
   /**
+   * Confirm the Address Book contact review (REGISTER IDENTITY)
+   */
+  confirmContactRegistration(): Promise<void>;
+
+  /**
    * Navigate to the Ethereum app settings and enable the blind signing toggle
    */
   enableBlindSigningInSettings(): Promise<void>;

--- a/apps/clear-signing-tester/src/domain/models/ContactInput.ts
+++ b/apps/clear-signing-tester/src/domain/models/ContactInput.ts
@@ -1,0 +1,18 @@
+/**
+ * One contact case: register this contact on the device and assert what the
+ * review screens show.
+ *
+ * Signing is a separate flow. Binding an address book to the signer is the
+ * `--address-book` option, so a case here never signs and a signing case never
+ * registers — one command, one flow.
+ */
+export type ContactInput = {
+  readonly description: string;
+  readonly contactName: string;
+  /** Free-text context shown next to the address, e.g. "Ethereum". */
+  readonly scope: string;
+  readonly address: `0x${string}`;
+  readonly chainId: bigint;
+  readonly expectedTexts?: string[];
+  readonly unexpectedTexts?: string[];
+};

--- a/apps/clear-signing-tester/src/domain/models/TransactionInput.ts
+++ b/apps/clear-signing-tester/src/domain/models/TransactionInput.ts
@@ -7,6 +7,8 @@ export type TransactionInput = {
   readonly txHash?: string;
   readonly description?: string;
   readonly expectedTexts?: string[];
+  /** Texts that must NOT appear on any screen of this signing flow. */
+  readonly unexpectedTexts?: string[];
   // Solana-only: skip replacing the payer key with the device key before signing
   readonly skipCraft?: boolean;
 };

--- a/apps/clear-signing-tester/src/domain/models/TypedDataInput.ts
+++ b/apps/clear-signing-tester/src/domain/models/TypedDataInput.ts
@@ -6,4 +6,6 @@ export type TypedDataInput = {
   readonly data: string;
   readonly description?: string;
   readonly expectedTexts?: string[];
+  /** Texts that must NOT appear on any screen of this signing flow. */
+  readonly unexpectedTexts?: string[];
 };

--- a/apps/clear-signing-tester/src/domain/models/config/SignerConfig.ts
+++ b/apps/clear-signing-tester/src/domain/models/config/SignerConfig.ts
@@ -1,7 +1,14 @@
+import { type EvmAddressBook } from "@ledgerhq/device-signer-kit-ethereum";
+
 /**
  * Domain model representing the configuration for the signer service
  */
 export type SignerConfig = {
   originToken: string;
   blindSigningEnabled: boolean;
+  /**
+   * Bound to the signer at build time, from `--address-book`. Absent means the
+   * signer gets no address book at all, the pre-contacts behaviour.
+   */
+  addressBook?: EvmAddressBook;
 };

--- a/apps/clear-signing-tester/src/domain/repositories/ContactsRepository.ts
+++ b/apps/clear-signing-tester/src/domain/repositories/ContactsRepository.ts
@@ -1,0 +1,26 @@
+import { type ContactInput } from "@root/src/domain/models/ContactInput";
+
+/** The device-issued proof material returned by REGISTER IDENTITY. */
+export type ContactProofs = {
+  readonly groupHandle: Uint8Array;
+  readonly hmacProof: Uint8Array;
+  readonly hmacRest: Uint8Array;
+};
+
+/**
+ * Adding a contact to the device. Binding an address book to the signer is not
+ * here: that is a signer build-time option, driven by `--address-book`.
+ *
+ * Separate from {@link DeviceRepository}, which stays chain-agnostic: Contacts
+ * is Ethereum-only in v1 and is bound only by the Ethereum module.
+ */
+export interface ContactsRepository {
+  /**
+   * Register `contact` on the device, confirming the review on screen, and
+   * return the proofs an address book needs to carry it.
+   *
+   * @param contact - The contact to register.
+   * @throws Error when the device rejects the registration.
+   */
+  registerContact(contact: ContactInput): Promise<ContactProofs>;
+}

--- a/apps/clear-signing-tester/src/domain/services/ScreenAnalyzer.ts
+++ b/apps/clear-signing-tester/src/domain/services/ScreenAnalyzer.ts
@@ -50,7 +50,7 @@ export interface ScreenAnalyzerService {
   /**
    * Check whether the screen showing right now contains `marker`, matched
    * case-insensitively. For screens with no dedicated predicate above.
-   * @param marker - Lowercase text to look for on the current screen
+   * @param marker - Text to look for on the current screen, in any case
    * @returns Promise<boolean> - True if the marker is on screen
    */
   screenContains(marker: string): Promise<boolean>;

--- a/apps/clear-signing-tester/src/domain/services/ScreenAnalyzer.ts
+++ b/apps/clear-signing-tester/src/domain/services/ScreenAnalyzer.ts
@@ -48,11 +48,35 @@ export interface ScreenAnalyzerService {
   isBlindSigningBlocked(): Promise<boolean>;
 
   /**
+   * Check whether the screen showing right now contains `marker`, matched
+   * case-insensitively. For screens with no dedicated predicate above.
+   * @param marker - Lowercase text to look for on the current screen
+   * @returns Promise<boolean> - True if the marker is on screen
+   */
+  screenContains(marker: string): Promise<boolean>;
+
+  /**
    * Analyze all accumulated screen texts for expected texts
-   * @param expectedTexts - Array of texts to look for
-   * @returns Promise<{ containsAll: boolean; found: string[]; missing: string[] }> - Result of the analysis
+   *
+   * Clears the accumulated buffer, so each call scopes its assertion to the
+   * screens produced since the previous call.
+   *
+   * @param expectedTexts - Array of texts that must appear
+   * @param unexpectedTexts - Array of texts that must not appear
+   * @returns Promise<ScreenTextAnalysis> - Result of the analysis
    */
   analyzeAccumulatedTexts(
     expectedTexts: string[],
-  ): Promise<{ containsAll: boolean; found: string[]; missing: string[] }>;
+    unexpectedTexts?: string[],
+  ): Promise<ScreenTextAnalysis>;
 }
+
+/** Outcome of matching a set of texts against the accumulated screens. */
+export type ScreenTextAnalysis = {
+  /** True when every expected text was found and no unexpected one was. */
+  readonly containsAll: boolean;
+  readonly found: string[];
+  readonly missing: string[];
+  /** Texts from `unexpectedTexts` that were found on screen anyway. */
+  readonly forbidden: string[];
+};

--- a/apps/clear-signing-tester/src/domain/types/TestStatus.ts
+++ b/apps/clear-signing-tester/src/domain/types/TestStatus.ts
@@ -1,3 +1,4 @@
+import { type ContactInput } from "@root/src/domain/models/ContactInput";
 import { type SignableInput } from "@root/src/domain/models/SignableInput";
 
 /**
@@ -13,7 +14,7 @@ export type TestStatus =
  * Common type for test results with status
  */
 export type TestResult = {
-  readonly input: SignableInput;
+  readonly input: SignableInput | ContactInput;
   readonly status: TestStatus;
   readonly timestamp: string;
   readonly errorMessage?: string;

--- a/apps/clear-signing-tester/src/infrastructure/adapters/device-controllers/SpeculosNanoController.ts
+++ b/apps/clear-signing-tester/src/infrastructure/adapters/device-controllers/SpeculosNanoController.ts
@@ -90,6 +90,14 @@ export class SpeculosNanoController implements DeviceController {
     );
   }
 
+  // Contacts is unsupported on the Nano models altogether
+  // (CONTACTS_VERSION_REQUIREMENTS), so this is unreachable in practice.
+  async confirmContactRegistration(): Promise<void> {
+    throw new Error(
+      "Not implemented: Contacts is not supported on Nano devices",
+    );
+  }
+
   /**
    * Navigate to the next screen by pressing the right button
    */

--- a/apps/clear-signing-tester/src/infrastructure/adapters/device-controllers/SpeculosTouchscreenController.ts
+++ b/apps/clear-signing-tester/src/infrastructure/adapters/device-controllers/SpeculosTouchscreenController.ts
@@ -73,6 +73,11 @@ export class SpeculosTouchscreenController implements DeviceController {
     await this.tap.continueToBlindSigning();
   }
 
+  async confirmContactRegistration(): Promise<void> {
+    this.logger.debug("☝️ (touch) : Confirming contact registration");
+    await this.tap.confirmAddressBookReview();
+  }
+
   async enableBlindSigningInSettings(): Promise<void> {
     this.logger.debug("☝️ (touch) : Opening settings menu");
     await this.tap.enterMenu();

--- a/apps/clear-signing-tester/src/infrastructure/repositories/ContactFileRepository.ts
+++ b/apps/clear-signing-tester/src/infrastructure/repositories/ContactFileRepository.ts
@@ -1,0 +1,66 @@
+import { inject, injectable } from "inversify";
+
+import { TYPES } from "@root/src/di/types";
+import { type FileReader } from "@root/src/domain/adapters/FileReader";
+import { type JsonParser } from "@root/src/domain/adapters/JsonParser";
+import { type ContactInput } from "@root/src/domain/models/ContactInput";
+
+/** One entry of a contact case file, before validation. */
+type RawContact = {
+  description?: string;
+  contactName?: string;
+  scope?: string;
+  address?: string;
+  // JSON has no bigint, so chain ids arrive as a decimal string or a number.
+  chainId?: string | number;
+  expectedTexts?: string[];
+  unexpectedTexts?: string[];
+};
+
+@injectable()
+export class ContactFileRepository {
+  constructor(
+    @inject(TYPES.FileReader)
+    private readonly fileReader: FileReader,
+    @inject(TYPES.JsonParser)
+    private readonly jsonParser: JsonParser,
+  ) {}
+
+  readFromFile(filePath: string): ContactInput[] {
+    const raw = this.jsonParser.parse<RawContact[]>(
+      this.fileReader.readFileSync(filePath),
+    );
+
+    if (!Array.isArray(raw)) {
+      throw new Error(
+        `Invalid file format: expected an array of contacts in ${filePath}`,
+      );
+    }
+
+    return raw.map((entry, index) => this.mapToContact(entry, index));
+  }
+
+  private mapToContact(raw: RawContact, index: number): ContactInput {
+    const { contactName, scope, address, chainId } = raw;
+
+    if (!contactName || !scope || !address || chainId === undefined) {
+      throw new Error(
+        `Contact at index ${index} is missing one of 'contactName', 'scope', 'address', 'chainId'`,
+      );
+    }
+
+    if (!/^0x[0-9a-fA-F]{40}$/.test(address)) {
+      throw new Error(`Contact at index ${index} has an invalid 'address'`);
+    }
+
+    return {
+      description: raw.description || `Contact ${index + 1}`,
+      contactName,
+      scope,
+      address: address as `0x${string}`,
+      chainId: BigInt(chainId),
+      expectedTexts: raw.expectedTexts,
+      unexpectedTexts: raw.unexpectedTexts,
+    };
+  }
+}

--- a/apps/clear-signing-tester/src/infrastructure/repositories/SpeculosContactsRepository.ts
+++ b/apps/clear-signing-tester/src/infrastructure/repositories/SpeculosContactsRepository.ts
@@ -1,0 +1,214 @@
+import {
+  type ContactsManager,
+  type RegisterExternalAddressDAReturnType,
+} from "@ledgerhq/device-contacts-kit";
+import {
+  DeviceActionStatus,
+  hexaStringToBuffer,
+  type LoggerPublisherService,
+} from "@ledgerhq/device-management-kit";
+import { inject, injectable } from "inversify";
+
+import { TYPES } from "@root/src/di/types";
+import { type DeviceController } from "@root/src/domain/adapters/DeviceController";
+import { type ScreenshotSaver } from "@root/src/domain/adapters/ScreenshotSaver";
+import { type ContactInput } from "@root/src/domain/models/ContactInput";
+import {
+  type ContactProofs,
+  type ContactsRepository,
+} from "@root/src/domain/repositories/ContactsRepository";
+import { type RetryService } from "@root/src/domain/services/RetryService";
+import { type ScreenAnalyzerService } from "@root/src/domain/services/ScreenAnalyzer";
+
+/** The only blockchain family Contacts supports in v1. */
+const BLOCKCHAIN_FAMILY = "ethereum";
+
+/** The review is a handful of pages; 20 taps is a generous ceiling. */
+const REVIEW_MAX_ATTEMPTS = 20;
+const REVIEW_DELAY_MS = 1500;
+const WAIT_FOR_HOME_MAX_ATTEMPTS = 10;
+const WAIT_FOR_HOME_DELAY_MS = 1500;
+
+/** Screen markers of the three Address Book review pages. */
+const REVIEW_MARKER = "review contact details";
+const CONFIRM_MARKER = "confirm contact details";
+const SAVED_MARKER = "saved to your contacts";
+
+/**
+ * Contacts repository backed by a Speculos emulator.
+ *
+ * Registration is a single-interaction flow — swipe through the review, tap
+ * confirm — so it drives the screens directly rather than going through the
+ * state-handler machinery the signing flow needs.
+ *
+ * The manager arrives from the service controller once the device session
+ * exists, the same way the signing service receives its signer.
+ */
+@injectable()
+export class SpeculosContactsRepository implements ContactsRepository {
+  private readonly logger: LoggerPublisherService;
+
+  private contactsManager: ContactsManager | null = null;
+
+  constructor(
+    @inject(TYPES.DeviceController)
+    private readonly deviceController: DeviceController,
+    @inject(TYPES.ScreenAnalyzerService)
+    private readonly screenAnalyzer: ScreenAnalyzerService,
+    @inject(TYPES.RetryService)
+    private readonly retryService: RetryService,
+    @inject(TYPES.ScreenshotSaver)
+    private readonly screenshotSaver: ScreenshotSaver,
+    @inject(TYPES.LoggerPublisherServiceFactory)
+    loggerFactory: (tag: string) => LoggerPublisherService,
+  ) {
+    this.logger = loggerFactory("contacts-repository");
+  }
+
+  /** Hand over the manager that drives REGISTER IDENTITY for this session. */
+  setContactsManager(contactsManager: ContactsManager): void {
+    this.contactsManager = contactsManager;
+  }
+
+  /** {@inheritDoc ContactsRepository.registerContact} */
+  async registerContact(contact: ContactInput): Promise<ContactProofs> {
+    this.logger.info(
+      `Registering contact "${contact.contactName}" for ${contact.address} on chain ${contact.chainId}`,
+    );
+
+    await this.screenshotSaver.save();
+
+    const { observable } = this.register(contact);
+
+    const proofs = await new Promise<ContactProofs>((resolve, reject) => {
+      let driving = false;
+
+      observable.subscribe({
+        next: (state) => {
+          this.logger.debug("Register contact state", {
+            data: { state: serialize(state) },
+          });
+
+          switch (state.status) {
+            case DeviceActionStatus.Pending:
+              // The device action emits Pending repeatedly; drive the screens
+              // once and let the loop run to completion.
+              if (!driving) {
+                driving = true;
+                void this.confirmReviewOnScreen().catch(reject);
+              }
+              break;
+            case DeviceActionStatus.Completed:
+              resolve({
+                groupHandle: state.output.groupHandle,
+                hmacProof: state.output.hmacProof,
+                hmacRest: state.output.hmacRest,
+              });
+              break;
+            case DeviceActionStatus.Error:
+              reject(
+                new Error(
+                  `Contact registration rejected by the device: ${serialize(state.error)}`,
+                ),
+              );
+              break;
+            default:
+              break;
+          }
+        },
+        error: reject,
+      });
+    });
+
+    await this.screenshotSaver.save();
+    await this.waitUntilHomePage();
+
+    this.logger.info(`Contact "${contact.contactName}" registered on device`);
+
+    return proofs;
+  }
+
+  /** Start REGISTER IDENTITY for `contact` on the connected device. */
+  private register(contact: ContactInput): RegisterExternalAddressDAReturnType {
+    if (!this.contactsManager) {
+      throw new Error("Contacts repository not connected to a device session");
+    }
+
+    const identifier = hexaStringToBuffer(contact.address);
+    if (!identifier) {
+      throw new Error(`Invalid contact address: ${contact.address}`);
+    }
+
+    return this.contactsManager.registerExternalAddress({
+      contactName: contact.contactName,
+      scope: contact.scope,
+      identifier,
+      blockchainFamily: BLOCKCHAIN_FAMILY,
+      chainId: contact.chainId,
+      // The tester connects with the app already open; the version guard on the
+      // running app still runs.
+      skipOpenApp: true,
+    });
+  }
+
+  /**
+   * Swipe through the contact review and tap its confirm button.
+   *
+   * Stops as soon as the device reports the contact stored, which also covers
+   * the case where the device dismisses the status screen on its own.
+   */
+  private async confirmReviewOnScreen(): Promise<void> {
+    await this.retryService.retryUntil(
+      async () => {
+        await this.screenshotSaver.save();
+
+        if (await this.screenAnalyzer.screenContains(CONFIRM_MARKER)) {
+          this.logger.debug(
+            "Detected contact confirmation page, tapping 'Confirm'",
+          );
+          await this.deviceController.confirmContactRegistration();
+          return;
+        }
+
+        if (await this.screenAnalyzer.screenContains(REVIEW_MARKER)) {
+          this.logger.debug("Detected contact review page, swiping");
+        }
+        await this.deviceController.navigateNext();
+      },
+      async () =>
+        (await this.screenAnalyzer.screenContains(SAVED_MARKER)) ||
+        (await this.screenAnalyzer.isHomePage()),
+      REVIEW_MAX_ATTEMPTS,
+      REVIEW_DELAY_MS,
+    );
+  }
+
+  /**
+   * Wait for the app home page before handing back to the signing flow, which
+   * starts by waiting for the screen to *leave* home and would otherwise read
+   * the lingering "Saved to your Contacts" status as a transaction page.
+   */
+  private async waitUntilHomePage(): Promise<void> {
+    try {
+      await this.retryService.pollUntil(
+        () => this.screenAnalyzer.isHomePage(),
+        WAIT_FOR_HOME_MAX_ATTEMPTS,
+        WAIT_FOR_HOME_DELAY_MS,
+      );
+    } catch (_error) {
+      throw new Error(
+        "Home page not detected after contact registration completed",
+      );
+    }
+  }
+}
+
+/**
+ * Register states carry `chainId` as a bigint, which `JSON.stringify` throws
+ * on. Everything logged here goes through this instead.
+ */
+function serialize(value: unknown): string {
+  return JSON.stringify(value, (_key, item: unknown) =>
+    typeof item === "bigint" ? `${item}` : item,
+  );
+}

--- a/apps/clear-signing-tester/src/infrastructure/repositories/readAddressBookFile.ts
+++ b/apps/clear-signing-tester/src/infrastructure/repositories/readAddressBookFile.ts
@@ -1,0 +1,68 @@
+import { hexaStringToBuffer } from "@ledgerhq/device-management-kit";
+import { type EvmAddressBook } from "@ledgerhq/device-signer-kit-ethereum";
+import { readFileSync } from "fs";
+
+/**
+ * An address book as written in a file: byte fields hex-encoded, chain ids as a
+ * number or decimal string, since JSON has neither bytes nor bigint.
+ */
+type RawAddressBook = {
+  contactGroups?: {
+    contactName?: string;
+    groupHandle?: string;
+    hmacProof?: string;
+    externalAddresses?: {
+      scope?: string;
+      address?: string;
+      chainId?: string | number;
+      hmacRest?: string;
+    }[];
+  }[];
+};
+
+/**
+ * Read the address book the signer is built with.
+ *
+ * The proofs are device-issued and seed-bound: record them from a
+ * `contact-file` run on the same device to test the matching path, or write
+ * anything else to test that a book the device refuses costs no signature.
+ */
+export function readAddressBookFile(filePath: string): EvmAddressBook {
+  const raw = JSON.parse(readFileSync(filePath, "utf-8")) as RawAddressBook;
+
+  return {
+    contactGroups: (raw.contactGroups ?? []).map((group, index) => ({
+      contactName: required(group.contactName, index, "contactName"),
+      groupHandle: bytes(group.groupHandle, index, "groupHandle"),
+      hmacProof: bytes(group.hmacProof, index, "hmacProof"),
+      externalAddresses: (group.externalAddresses ?? []).map((entry) => ({
+        scope: required(entry.scope, index, "externalAddresses[].scope"),
+        address: required(
+          entry.address,
+          index,
+          "externalAddresses[].address",
+        ) as `0x${string}`,
+        chainId: BigInt(
+          required(entry.chainId, index, "externalAddresses[].chainId"),
+        ),
+        hmacRest: bytes(entry.hmacRest, index, "externalAddresses[].hmacRest"),
+      })),
+    })),
+    ledgerAccounts: [],
+  };
+}
+
+function required<T>(value: T | undefined, index: number, field: string): T {
+  if (value === undefined) {
+    throw new Error(`Address book group ${index} is missing '${field}'`);
+  }
+  return value;
+}
+
+function bytes(value: string | undefined, index: number, field: string) {
+  const buffer = hexaStringToBuffer(required(value, index, field));
+  if (!buffer) {
+    throw new Error(`Address book group ${index} has a malformed '${field}'`);
+  }
+  return buffer;
+}

--- a/apps/clear-signing-tester/src/infrastructure/service-controllers/DMKServiceController.ts
+++ b/apps/clear-signing-tester/src/infrastructure/service-controllers/DMKServiceController.ts
@@ -4,6 +4,10 @@ import {
   ContextModuleChainID,
 } from "@ledgerhq/context-module";
 import {
+  ContactsManagerBuilder,
+  ETHEREUM_APP_NAME,
+} from "@ledgerhq/device-contacts-kit";
+import {
   DeviceManagementKit,
   DeviceManagementKitBuilder,
   DiscoveredDevice,
@@ -26,6 +30,7 @@ import { type SignerConfig } from "@root/src/domain/models/config/SignerConfig";
 import { type SpeculosConfig } from "@root/src/domain/models/config/SpeculosConfig";
 import { type RetryService } from "@root/src/domain/services/RetryService";
 import { type ServiceController } from "@root/src/domain/services/ServiceController";
+import { SpeculosContactsRepository } from "@root/src/infrastructure/repositories/SpeculosContactsRepository";
 import { DefaultSigningService } from "@root/src/infrastructure/services/DefaultSigningService";
 
 export class DMKServiceController implements ServiceController {
@@ -38,6 +43,8 @@ export class DMKServiceController implements ServiceController {
   constructor(
     @inject(TYPES.SigningService)
     private readonly signingService: DefaultSigningService,
+    @inject(TYPES.ContactsRepository)
+    private readonly contactsRepository: SpeculosContactsRepository,
     @inject(TYPES.RetryService)
     private readonly retryService: RetryService,
     @inject(TYPES.SpeculosConfig)
@@ -99,15 +106,14 @@ export class DMKServiceController implements ServiceController {
                     this.logger.debug("Device connected", {
                       data: { sessionId: this.sessionId },
                     });
-                    this.signer = new SignerEthBuilder({
-                      dmk: this.dmk,
-                      sessionId: sessionId,
-                      originToken: this.signerConfig.originToken,
-                    })
-                      .withContextModule(this.contextModule)
-                      .build();
-
-                    this.signingService.setSigner(this.signer);
+                    this.contactsRepository.setContactsManager(
+                      new ContactsManagerBuilder({
+                        dmk: this.dmk,
+                        sessionId,
+                        appName: ETHEREUM_APP_NAME,
+                      }).build(),
+                    );
+                    this.buildSigner();
 
                     resolve();
                   })
@@ -132,6 +138,24 @@ export class DMKServiceController implements ServiceController {
     );
 
     this.logger.info("DMK started successfully");
+  }
+
+  /** Build the signer for the current session. */
+  private buildSigner(): void {
+    if (this.sessionId === null) {
+      throw new Error("Cannot build a signer before the device is connected");
+    }
+
+    const builder = new SignerEthBuilder({
+      dmk: this.dmk,
+      sessionId: this.sessionId,
+      originToken: this.signerConfig.originToken,
+    }).withContextModule(this.contextModule);
+
+    this.signer = builder.build();
+    this.signingService.setSigner(this.signer);
+
+    this.logger.debug("Signer built");
   }
 
   async stop(): Promise<void> {

--- a/apps/clear-signing-tester/src/infrastructure/service-controllers/DMKServiceController.ts
+++ b/apps/clear-signing-tester/src/infrastructure/service-controllers/DMKServiceController.ts
@@ -43,7 +43,7 @@ export class DMKServiceController implements ServiceController {
   constructor(
     @inject(TYPES.SigningService)
     private readonly signingService: DefaultSigningService,
-    @inject(TYPES.ContactsRepository)
+    @inject(TYPES.SpeculosContactsRepository)
     private readonly contactsRepository: SpeculosContactsRepository,
     @inject(TYPES.RetryService)
     private readonly retryService: RetryService,

--- a/apps/clear-signing-tester/src/infrastructure/service-controllers/DMKServiceController.ts
+++ b/apps/clear-signing-tester/src/infrastructure/service-controllers/DMKServiceController.ts
@@ -140,7 +140,11 @@ export class DMKServiceController implements ServiceController {
     this.logger.info("DMK started successfully");
   }
 
-  /** Build the signer for the current session. */
+  /**
+   * Build the signer for the current session, binding the configured address
+   * book when there is one. `withAddressBook()` is build-time, which is why the
+   * book is a run-wide option rather than something a test case changes.
+   */
   private buildSigner(): void {
     if (this.sessionId === null) {
       throw new Error("Cannot build a signer before the device is connected");
@@ -152,10 +156,19 @@ export class DMKServiceController implements ServiceController {
       originToken: this.signerConfig.originToken,
     }).withContextModule(this.contextModule);
 
+    const { addressBook } = this.signerConfig;
+    if (addressBook) {
+      builder.withAddressBook(addressBook);
+    }
+
     this.signer = builder.build();
     this.signingService.setSigner(this.signer);
 
-    this.logger.debug("Signer built");
+    this.logger.debug("Signer built", {
+      data: {
+        contactGroups: addressBook?.contactGroups.length ?? 0,
+      },
+    });
   }
 
   async stop(): Promise<void> {

--- a/apps/clear-signing-tester/src/infrastructure/services/DefaultScreenAnalyzer.ts
+++ b/apps/clear-signing-tester/src/infrastructure/services/DefaultScreenAnalyzer.ts
@@ -4,7 +4,10 @@ import { inject, injectable } from "inversify";
 import { TYPES } from "@root/src/di/types";
 import { type ScreenReader } from "@root/src/domain/adapters/ScreenReader";
 import { type ScreenContent } from "@root/src/domain/models/ScreenContent";
-import { type ScreenAnalyzerService } from "@root/src/domain/services/ScreenAnalyzer";
+import {
+  type ScreenAnalyzerService,
+  type ScreenTextAnalysis,
+} from "@root/src/domain/services/ScreenAnalyzer";
 
 @injectable()
 export class DefaultScreenAnalyzer implements ScreenAnalyzerService {
@@ -22,9 +25,10 @@ export class DefaultScreenAnalyzer implements ScreenAnalyzerService {
 
   async analyzeAccumulatedTexts(
     expectedTexts: string[],
-  ): Promise<{ containsAll: boolean; found: string[]; missing: string[] }> {
+    unexpectedTexts: string[] = [],
+  ): Promise<ScreenTextAnalysis> {
     this.logger.debug("Analyzing accumulated screen texts", {
-      data: { expectedTexts },
+      data: { expectedTexts, unexpectedTexts },
     });
     const accumulatedTexts = await this.getAndClearAccumulatedTexts();
 
@@ -40,20 +44,24 @@ export class DefaultScreenAnalyzer implements ScreenAnalyzerService {
     const stripWhitespace = (text: string) =>
       text.toLowerCase().replace(/\s+/g, "");
 
-    for (const expectedText of expectedTexts) {
-      const strippedExpected = stripWhitespace(expectedText);
-      const isFound = accumulatedTexts.some((screenText) =>
-        stripWhitespace(screenText).includes(strippedExpected),
+    const isOnScreen = (needle: string) => {
+      const stripped = stripWhitespace(needle);
+      return accumulatedTexts.some((screenText) =>
+        stripWhitespace(screenText).includes(stripped),
       );
+    };
 
-      if (isFound) {
+    for (const expectedText of expectedTexts) {
+      if (isOnScreen(expectedText)) {
         found.push(expectedText);
       } else {
         missing.push(expectedText);
       }
     }
 
-    const containsAll = missing.length === 0;
+    const forbidden = unexpectedTexts.filter(isOnScreen);
+
+    const containsAll = missing.length === 0 && forbidden.length === 0;
 
     this.logger.info(
       `Summary: ${found.length}/${expectedTexts.length} expected texts found`,
@@ -63,21 +71,40 @@ export class DefaultScreenAnalyzer implements ScreenAnalyzerService {
         `Missing texts: ${missing.map((t) => `"${t}"`).join(", ")}`,
       );
     }
+    if (forbidden.length > 0) {
+      this.logger.info(
+        `Texts that should not have appeared: ${forbidden.map((t) => `"${t}"`).join(", ")}`,
+      );
+    }
     this.logger.info(
-      `Result: ${containsAll ? "All expected texts found (clear signed)" : "Some texts missing (partially clear signed)"}`,
+      `Result: ${containsAll ? "All expected texts found (clear signed)" : "Assertion not satisfied (partially clear signed)"}`,
     );
 
     this.logger.debug("Analyzed accumulated screen texts", {
       data: {
         expectedTexts,
+        unexpectedTexts,
         found,
         missing,
+        forbidden,
         containsAll,
         totalAccumulatedTexts: accumulatedTexts.length,
       },
     });
 
-    return { containsAll, found, missing };
+    return { containsAll, found, missing, forbidden };
+  }
+
+  /** {@inheritDoc ScreenAnalyzerService.screenContains} */
+  async screenContains(marker: string): Promise<boolean> {
+    const data = await this.readScreenContent();
+    const matches = data.text.toLowerCase().includes(marker);
+
+    if (matches) {
+      this.logger.debug(`Current screen contains "${marker}"`);
+    }
+
+    return matches;
   }
 
   async isLastPage(): Promise<boolean> {

--- a/apps/clear-signing-tester/src/infrastructure/services/DefaultScreenAnalyzer.ts
+++ b/apps/clear-signing-tester/src/infrastructure/services/DefaultScreenAnalyzer.ts
@@ -98,7 +98,7 @@ export class DefaultScreenAnalyzer implements ScreenAnalyzerService {
   /** {@inheritDoc ScreenAnalyzerService.screenContains} */
   async screenContains(marker: string): Promise<boolean> {
     const data = await this.readScreenContent();
-    const matches = data.text.toLowerCase().includes(marker);
+    const matches = data.text.toLowerCase().includes(marker.toLowerCase());
 
     if (matches) {
       this.logger.debug(`Current screen contains "${marker}"`);

--- a/apps/clear-signing-tester/src/infrastructure/state-handlers/CompleteStateHandler.ts
+++ b/apps/clear-signing-tester/src/infrastructure/state-handlers/CompleteStateHandler.ts
@@ -55,6 +55,7 @@ export class CompleteStateHandler implements StateHandler {
 
     const analysis = await this.screenAnalyzer.analyzeAccumulatedTexts(
       ctx.input.expectedTexts || [],
+      ctx.input.unexpectedTexts || [],
     );
 
     if (analysis.containsAll) {

--- a/packages/speculos-device-controller/.prettierignore
+++ b/packages/speculos-device-controller/.prettierignore
@@ -1,1 +1,2 @@
 lib/*
+coverage/*

--- a/packages/speculos-device-controller/src/api/DeviceController.ts
+++ b/packages/speculos-device-controller/src/api/DeviceController.ts
@@ -13,6 +13,7 @@ import {
 } from "@root/src/internal/use-cases/buttonUseCases";
 import {
   acceptBlindSigning,
+  confirmAddressBookReview,
   continueToBlindSigning,
   enableBlindSigningSettings,
   enterMenu,
@@ -48,6 +49,7 @@ export type TapFactory = (deviceKey: string) => {
   enableBlindSigningSettings: () => Promise<void>;
   continueToBlindSigning: () => Promise<void>;
   acceptBlindSigning: () => Promise<void>;
+  confirmAddressBookReview: () => Promise<void>;
 };
 
 export type DeviceControllerClientFactory = (
@@ -99,6 +101,7 @@ export const deviceControllerClientFactory: DeviceControllerClientFactory = (
       enableBlindSigningSettings: enableBlindSigningSettings(touch, key),
       continueToBlindSigning: continueToBlindSigning(touch, key),
       acceptBlindSigning: acceptBlindSigning(touch, key),
+      confirmAddressBookReview: confirmAddressBookReview(touch, key),
     }),
   };
 };

--- a/packages/speculos-device-controller/src/internal/use-cases/touchUseCases.test.ts
+++ b/packages/speculos-device-controller/src/internal/use-cases/touchUseCases.test.ts
@@ -4,7 +4,22 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import type { TouchController } from "@root/src/internal/core/TouchController";
 
-import { enableBlindSigningSettings, tapLong, tapQuick } from "./touchUseCases";
+import {
+  acceptBlindSigning,
+  confirmAddressBookReview,
+  continueToBlindSigning,
+  enableBlindSigningSettings,
+  enterMenu,
+  exitMenu,
+  mainButton,
+  navigateNext,
+  navigatePrevious,
+  reject,
+  secondaryButton,
+  sign,
+  tapLong,
+  tapQuick,
+} from "./touchUseCases";
 
 describe("touchUsecases", () => {
   const deviceKey = "devA";
@@ -135,6 +150,96 @@ describe("touchUsecases", () => {
       expect(controller.tapAndRelease).toHaveBeenCalledWith(unknownKey, {
         x: 88,
         y: 51,
+      });
+    });
+  });
+
+  describe("fixed-coordinate taps", () => {
+    it.each([
+      ["reject", reject, { x: 20, y: 90 }],
+      ["navigateNext", navigateNext, { x: 90, y: 90 }],
+      ["navigatePrevious", navigatePrevious, { x: 45, y: 90 }],
+      ["mainButton", mainButton, { x: 50, y: 80 }],
+      ["secondaryButton", secondaryButton, { x: 50, y: 90 }],
+      ["enterMenu", enterMenu, { x: 85, y: 8 }],
+      ["exitMenu", exitMenu, { x: 10, y: 4 }],
+      ["continueToBlindSigning", continueToBlindSigning, { x: 50, y: 94 }],
+      ["acceptBlindSigning", acceptBlindSigning, { x: 50, y: 94 }],
+    ] as const)("%s taps %o", async (_name, useCase, expected) => {
+      await useCase(controller, deviceKey)();
+
+      expect(controller.tapAndRelease).toHaveBeenCalledTimes(1);
+      expect(controller.tapAndRelease).toHaveBeenCalledWith(
+        deviceKey,
+        expected,
+      );
+    });
+  });
+
+  describe("sign", () => {
+    const HOLD_TO_SIGN = { x: 85, y: 80 };
+
+    it("holds the sign button for the default 5s", async () => {
+      vi.useFakeTimers();
+      const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+      const run = sign(controller, deviceKey)();
+      await Promise.resolve();
+
+      expect(controller.tap).toHaveBeenCalledWith(deviceKey, HOLD_TO_SIGN);
+      expect(timeoutSpy).toHaveBeenLastCalledWith(expect.any(Function), 5000);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      await run;
+
+      expect(controller.release).toHaveBeenCalledWith(deviceKey, HOLD_TO_SIGN);
+    });
+
+    it("holds the sign button for the provided delay", async () => {
+      vi.useFakeTimers();
+      const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+      const customMs = 250;
+      const run = sign(controller, deviceKey)(customMs);
+      await Promise.resolve();
+
+      expect(timeoutSpy).toHaveBeenLastCalledWith(
+        expect.any(Function),
+        customMs,
+      );
+
+      await vi.advanceTimersByTimeAsync(customMs);
+      await run;
+
+      expect(controller.release).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("confirmAddressBookReview", () => {
+    // The Address Book review puts its Confirm button above the page footer,
+    // so these coordinates are measured per model rather than shared with
+    // mainButton/secondaryButton.
+    it.each([
+      ["stax", { x: 50, y: 77 }],
+      ["flex", { x: 50, y: 72 }],
+    ] as const)(
+      "taps the Confirm button at the %s coordinates",
+      async (key, expected) => {
+        await confirmAddressBookReview(controller, key)();
+
+        expect(controller.tapAndRelease).toHaveBeenCalledTimes(1);
+        expect(controller.tapAndRelease).toHaveBeenCalledWith(key, expected);
+      },
+    );
+
+    it("falls back to Flex coordinates for an unmeasured device key", async () => {
+      const unknownKey = "apex";
+      await confirmAddressBookReview(controller, unknownKey)();
+
+      expect(controller.tapAndRelease).toHaveBeenCalledTimes(1);
+      expect(controller.tapAndRelease).toHaveBeenCalledWith(unknownKey, {
+        x: 50,
+        y: 72,
       });
     });
   });

--- a/packages/speculos-device-controller/src/internal/use-cases/touchUseCases.ts
+++ b/packages/speculos-device-controller/src/internal/use-cases/touchUseCases.ts
@@ -81,6 +81,37 @@ export const enableBlindSigningSettings =
     await tapQuick(touch, deviceKey)(point);
   };
 
+/**
+ * Confirm button of the Address Book review (REGISTER IDENTITY). NBGL's
+ * "review light" puts this button above the page footer rather than in it, so
+ * neither mainButton() nor secondaryButton() reaches it. Measured on Speculos:
+ * flex 480x600 -> button centre y=436 (72%), stax 400x672 -> y=520 (77%).
+ */
+const ADDRESS_BOOK_CONFIRM_COORDS = {
+  stax: { x: 50, y: 77 },
+  flex: { x: 50, y: 72 },
+} as const satisfies Record<string, PercentCoordinates>;
+
+type AddressBookConfirmKey = keyof typeof ADDRESS_BOOK_CONFIRM_COORDS;
+
+const isAddressBookConfirmKey = (key: string): key is AddressBookConfirmKey =>
+  Object.hasOwn(ADDRESS_BOOK_CONFIRM_COORDS, key);
+
+/** Flex's placement, used for any touchscreen model not measured above. */
+const DEFAULT_ADDRESS_BOOK_CONFIRM_COORDS: PercentCoordinates = {
+  x: 50,
+  y: 72,
+};
+
+export const confirmAddressBookReview =
+  <K extends string>(touch: TouchController<K>, deviceKey: K) =>
+  async () => {
+    const point = isAddressBookConfirmKey(deviceKey)
+      ? ADDRESS_BOOK_CONFIRM_COORDS[deviceKey]
+      : DEFAULT_ADDRESS_BOOK_CONFIRM_COORDS;
+    await tapQuick(touch, deviceKey)(point);
+  };
+
 export const continueToBlindSigning =
   <K extends string>(touch: TouchController<K>, deviceKey: K) =>
   async () =>

--- a/packages/transport/speculos/src/api/SpeculosTransport.test.ts
+++ b/packages/transport/speculos/src/api/SpeculosTransport.test.ts
@@ -1,0 +1,69 @@
+import {
+  type DmkConfig,
+  type LoggerPublisherService,
+  type TransportConnectedDevice,
+} from "@ledgerhq/device-management-kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SpeculosTransport } from "@api/SpeculosTransport";
+
+const GET_APP_AND_VERSION_RESPONSE =
+  "0108457468657265756d0a312e32332e302d64657601009000";
+
+const postApdu = vi.fn();
+const isServerAvailable = vi.fn();
+
+vi.mock("@internal/datasource/HttpSpeculosDatasource", () => ({
+  HttpSpeculosDatasource: vi.fn(() => ({
+    postApdu,
+    isServerAvailable,
+    openEventStream: vi.fn(),
+  })),
+}));
+
+const loggerFactory = () =>
+  ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }) as unknown as LoggerPublisherService;
+
+describe("SpeculosTransport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    postApdu.mockResolvedValue(GET_APP_AND_VERSION_RESPONSE);
+    isServerAvailable.mockResolvedValue(true);
+  });
+
+  const connect = async () => {
+    const transport = new SpeculosTransport(
+      loggerFactory,
+      {} as DmkConfig,
+      "http://localhost:5000",
+    );
+    const result = await transport.connect({
+      deviceId: "SpeculosID",
+      onDisconnect: vi.fn(),
+    });
+    return {
+      transport,
+      connectedDevice: result.unsafeCoerce() as TransportConnectedDevice,
+    };
+  };
+
+  describe("disconnect", () => {
+    it("should stop polling the server once disconnected", async () => {
+      const { transport, connectedDevice } = await connect();
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(isServerAvailable).toHaveBeenCalledTimes(1);
+
+      await transport.disconnect({ connectedDevice });
+      isServerAvailable.mockClear();
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(isServerAvailable).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/transport/speculos/src/api/SpeculosTransport.test.ts
+++ b/packages/transport/speculos/src/api/SpeculosTransport.test.ts
@@ -3,7 +3,7 @@ import {
   type LoggerPublisherService,
   type TransportConnectedDevice,
 } from "@ledgerhq/device-management-kit";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SpeculosTransport } from "@api/SpeculosTransport";
 
@@ -35,6 +35,11 @@ describe("SpeculosTransport", () => {
     vi.useFakeTimers();
     postApdu.mockResolvedValue(GET_APP_AND_VERSION_RESPONSE);
     isServerAvailable.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    // Restore real timers so the fake ones cannot leak into another test file.
+    vi.useRealTimers();
   });
 
   const connect = async () => {

--- a/packages/transport/speculos/src/api/SpeculosTransport.ts
+++ b/packages/transport/speculos/src/api/SpeculosTransport.ts
@@ -143,6 +143,7 @@ export class SpeculosTransport implements Transport {
   }): Promise<Either<DmkError, void>> {
     this.logger.debug("disconnect");
     this.connectedDevice = null;
+    this.clearDisconnectInterval();
     return Promise.resolve(Right(undefined));
   }
 
@@ -167,10 +168,6 @@ export class SpeculosTransport implements Transport {
         this.disconnect({
           connectedDevice: this.connectedDevice,
         });
-
-        if (this.disconnectInterval) {
-          clearInterval(this.disconnectInterval);
-        }
       }
       return Left(new GeneralDmkError(error));
     }
@@ -216,11 +213,16 @@ export class SpeculosTransport implements Transport {
           });
         }
 
-        if (this.disconnectInterval) {
-          clearInterval(this.disconnectInterval);
-        }
+        this.clearDisconnectInterval();
       }
     }, 2000);
+  }
+
+  private clearDisconnectInterval(): void {
+    if (this.disconnectInterval) {
+      clearInterval(this.disconnectInterval);
+      this.disconnectInterval = null;
+    }
   }
 }
 

--- a/packages/transport/speculos/vitest.config.mjs
+++ b/packages/transport/speculos/vitest.config.mjs
@@ -18,6 +18,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@api": path.resolve(__dirname, "src/api"),
+      "@internal": path.resolve(__dirname, "src/internal"),
     },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,6 +458,9 @@ importers:
       '@ledgerhq/context-module':
         specifier: workspace:^
         version: link:../../packages/signer/context-module
+      '@ledgerhq/device-contacts-kit':
+        specifier: workspace:^
+        version: link:../../packages/device-contacts-kit
       '@ledgerhq/device-management-kit':
         specifier: workspace:^
         version: link:../../packages/device-management-kit


### PR DESCRIPTION
### 📝 Description

Add an end-to-end CLI flow that exercises the external-contacts clear-signing feature against a real device: register a contact's Address Book entry via `@ledgerhq/device-contacts-kit`, bind the device-issued proof to the signer as an `EvmAddressBook`, then sign a transaction and assert what the review screen renders. Supports a single scenario or a batch read from a JSON fixture file (`contacts-external.json`, `contacts-trusted-name.json`), and adds the Address Book review confirmation tap to `speculos-device-controller` so the flow can drive the confirmation screen.

Running the flow against a device built from the current BOLOS SDK surfaced two `device-contacts-kit` fixes carried on this branch:
- Drop the OS-version gate for app-context Contacts operations: `GET OS VERSION` is a dashboard-only command and the session refresher drops `firmwareVersion` once an app is open, so the gate rejected every device.
- Stop sending the `DERIVATION_PATH` TLV on Register Identity and Edit Contact Name — the SDK removed tag `0x69` from both tag tables, so a device built after that removal fails to parse the payload.

This branch is rebased on `feat/dsdk-1387-provide-external-contacts` and targets it directly (stacked on PR #1822 (external contacts before signing)) rather than `develop`, so the diff here only shows the 5 new commits.

### ❓ Context

- **JIRA or GitHub link**: NO-ISSUE — testing/tooling branch
- **Feature**: End-to-end `clear-signing-tester` coverage for the external contacts clear-signing feature

### ✅ Checklist

- [x] **Covered by automatic tests** — unit tests added for the `device-contacts-kit` and `speculos-device-controller` changes; the contacts CLI flow itself is a manual end-to-end tool run against Speculos and is deliberately not wired into CI yet (see the new README section — it needs an unreleased Ethereum app build and a Speculos build from master)
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date** — new "Contacts (Address Book) Support" section in `apps/clear-signing-tester/README.md`
- [x] **Impact of the changes:**
  - Drops the OS-version gate for app-context Contacts operations (`isContactsSupportedForSession`)
  - Drops `DERIVATION_PATH` from Register Identity / Edit Contact Name payloads
  - Adds the Address Book review confirmation tap to `speculos-device-controller`
  - Adds contacts test scenarios (single + batch) and fixtures to `clear-signing-tester`
