### PR TITLE
🔖 (mock-server) [NO-ISSUE]: Bump version to 0.1.2

### DIFF
--- a/apps/device-mock-server/package.json
+++ b/apps/device-mock-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/device-mock-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
### 📝 Description

Bumps `@ledgerhq/device-mock-server` from `0.1.1` to `0.1.2` so the Docker image publish workflow (`release_mock_server.yml`) tags a fresh image on JFrog.

Mock server changes on `develop` since `0.1.1` was tagged:

- ✨ [DSDK-1460] Opt-in device onboarding simulation (#1817)
- ✨ [DSDK-1462] Erase installed apps on OS update (#1818)
- 🐛 Revert to mock mode when an app is quit on the device (#1815)

Once merged, the image can be published with `gh workflow run release_mock_server.yml -f ref=develop`, producing `jfrog.ledgerlabs.net/bcs-oci-prod-green/device-mock-server:0.1.2`.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]

- **Feature**: Mock server Docker image release

### ✅ Checklist

- [x] **Covered by automatic tests** <!-- Version-only change, no behavior to test -->
- [x] **Changeset is provided** <!-- Not applicable: `apps/device-mock-server` is a private app, not a published package -->
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - `apps/device-mock-server/package.json` version only — no source or behavior change
  - QA focus: none; the next mock server Docker image will be tagged `0.1.2`

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[DSDK-1460]: https://ledgerhq.atlassian.net/browse/DSDK-1460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSDK-1462]: https://ledgerhq.atlassian.net/browse/DSDK-1462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ