### PR TITLE
🔥 (contacts-kit) [DSDK-1465]: Remove derivation path from external-address ops

### DIFF
--- a/.changeset/dsdk-1465-remove-derivation-path.md
+++ b/.changeset/dsdk-1465-remove-derivation-path.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-contacts-kit": patch
+---
+
+Stop sending the `DERIVATION_PATH` TLV (tag `0x69`) on the external-address operations — Register External Address, Edit External Address Identifier, and Edit External Address Scope. The current Ethereum app rejects the tag on these ops (`0x6a80`) and no longer requires it; the path was a temporary coin-app requirement and is Ledger-Account only. The path was kit-internal (never part of the public input), so this is not a breaking API change. Note: this requires an Ethereum app build that has dropped the requirement — older apps that still mandate the path will fail these ops.

--- a/packages/device-contacts-kit/src/internal/app-binder/model/contactsConstants.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/model/contactsConstants.ts
@@ -28,15 +28,6 @@ export const SUB_CMD_EDIT_IDENTIFIER = 0x03;
 export const SUB_CMD_EDIT_SCOPE = 0x04;
 
 /**
- * BIP32 segments (`m/44'/60'/0'/0/0`) sent with EDIT IDENTIFIER. Temporary: the
- * coin app currently requires a DERIVATION_PATH TLV, so the kit sends one fixed,
- * unexposed path; it will be removed once firmware stops requiring it.
- */
-export const EXTERNAL_ADDRESS_DERIVATION_PATH_SEGMENTS: readonly number[] = [
-  0x8000002c, 0x8000003c, 0x80000000, 0x00000000, 0x00000000,
-];
-
-/**
  * EDIT CONTACT NAME (rename) is a blockchain-agnostic OS/dashboard command with
  * its own CLA/INS — NOT a sub-command of the address-book app APDU (0xB0/0x10).
  * The OS serves it directly, so it must run on the dashboard. P1 is a fixed

--- a/packages/device-contacts-kit/src/internal/app-binder/task/SendEditExternalAddressIdentifierTask.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/task/SendEditExternalAddressIdentifierTask.test.ts
@@ -18,9 +18,10 @@ function hexToBytes(hex: string): Uint8Array {
   return out;
 }
 
-// Framed chunk = "00 ec" (2-byte BE total TLV length = 236) + TLV.
+// Framed chunk = "00 d5" (2-byte BE total TLV length = 213) + TLV. No
+// DERIVATION_PATH TLV (external-address ops carry no path).
 const FRAMED_CHUNK = hexToBytes(
-  "00ec" +
+  "00d5" +
     "010131" +
     "020101" +
     "81f005416c696365" +
@@ -29,7 +30,6 @@ const FRAMED_CHUNK = hexToBytes(
     "81f41400000000000000000000000000000000deadbeef" +
     "81f640" +
     "cc".repeat(64) +
-    "6915058000002c8000003c800000000000000000000000" +
     "230101" +
     "2920" +
     "dd".repeat(32) +

--- a/packages/device-contacts-kit/src/internal/app-binder/task/SendEditExternalAddressIdentifierTask.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/task/SendEditExternalAddressIdentifierTask.ts
@@ -2,9 +2,9 @@
 // chunked framing; the device returns struct_type + hmac_rest on the final
 // chunk. Tag order: STRUCT_TYPE, STRUCT_VERSION, CONTACT_NAME, SCOPE,
 // ACCOUNT_IDENTIFIER (new), PREVIOUS_IDENTIFIER (old), GROUP_HANDLE,
-// DERIVATION_PATH, CHAIN_ID (Ethereum only), HMAC_PROOF, HMAC_REST (old),
-// BLOCKCHAIN_FAMILY. DERIVATION_PATH is a temporary coin-app requirement: the
-// kit sends one fixed, unexposed path and will drop it once firmware does.
+// CHAIN_ID (Ethereum only), HMAC_PROOF, HMAC_REST (old), BLOCKCHAIN_FAMILY.
+// No DERIVATION_PATH: external-address ops carry no path — the current Ethereum
+// app rejects the tag (0x6a80); it is Ledger-Account only (DSDK-1465).
 // Reference: Address Book Final Specifications — Edit Identifier.
 import {
   ByteArrayBuilder,
@@ -19,7 +19,6 @@ import {
 import { EditExternalAddressIdentifierCommand } from "@internal/app-binder/command/EditExternalAddressIdentifierCommand";
 import {
   BLOCKCHAIN_FAMILY_BY_NAME,
-  EXTERNAL_ADDRESS_DERIVATION_PATH_SEGMENTS,
   SUB_CMD_EDIT_IDENTIFIER,
 } from "@internal/app-binder/model/contactsConstants";
 import { type ContactsErrorCodes } from "@internal/app-binder/model/contactsErrors";
@@ -29,7 +28,6 @@ import {
   encodeTlvBuffer,
   encodeTlvChainId,
   encodeTlvUInt8,
-  packDerivationPath,
   STRUCT_TYPE_EDIT_IDENTIFIER,
   STRUCT_VERSION_VALUE,
 } from "@internal/app-binder/services/contactsTlvSerializer";
@@ -99,10 +97,6 @@ export class SendEditExternalAddressIdentifierTask {
       );
     }
 
-    const pathBytes = packDerivationPath([
-      ...EXTERNAL_ADDRESS_DERIVATION_PATH_SEGMENTS,
-    ]);
-
     const builder = new ByteArrayBuilder();
     encodeTlvUInt8(
       builder,
@@ -127,7 +121,6 @@ export class SendEditExternalAddressIdentifierTask {
       args.previousIdentifier,
     );
     encodeTlvBuffer(builder, CONTACTS_TLV_TAG.GROUP_HANDLE, args.groupHandle);
-    encodeTlvBuffer(builder, CONTACTS_TLV_TAG.DERIVATION_PATH, pathBytes);
     if (args.chainId !== undefined) {
       encodeTlvChainId(builder, CONTACTS_TLV_TAG.CHAIN_ID, args.chainId);
     }

--- a/packages/device-contacts-kit/src/internal/app-binder/task/SendEditExternalAddressScopeTask.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/task/SendEditExternalAddressScopeTask.test.ts
@@ -18,12 +18,12 @@ function hexToBytes(hex: string): Uint8Array {
   return out;
 }
 
-// Framed chunk = "00 e0" (2-byte BE total TLV length = 224) + TLV.
+// Framed chunk = "00 c9" (2-byte BE total TLV length = 201) + TLV.
 // Tag order: STRUCT_TYPE(0x32), STRUCT_VERSION, CONTACT_NAME, SCOPE(new),
-// ACCOUNT_IDENTIFIER, PREVIOUS_SCOPE, GROUP_HANDLE, DERIVATION_PATH, CHAIN_ID,
-// HMAC_PROOF, HMAC_REST(old), BLOCKCHAIN_FAMILY.
+// ACCOUNT_IDENTIFIER, PREVIOUS_SCOPE, GROUP_HANDLE, CHAIN_ID, HMAC_PROOF,
+// HMAC_REST(old), BLOCKCHAIN_FAMILY. No DERIVATION_PATH TLV.
 const FRAMED_CHUNK = hexToBytes(
-  "00e0" +
+  "00c9" +
     "010132" +
     "020101" +
     "81f005416c696365" + // CONTACT_NAME "Alice"
@@ -33,7 +33,6 @@ const FRAMED_CHUNK = hexToBytes(
     "81f508457468206d61696e" + // PREVIOUS_SCOPE "Eth main"
     "81f640" +
     "cc".repeat(64) +
-    "6915058000002c8000003c800000000000000000000000" +
     "230101" +
     "2920" +
     "dd".repeat(32) +

--- a/packages/device-contacts-kit/src/internal/app-binder/task/SendEditExternalAddressScopeTask.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/task/SendEditExternalAddressScopeTask.ts
@@ -1,10 +1,10 @@
 // Builds the op-4 (Edit Scope) TLV and dispatches it via the shared chunked
 // framing; the device returns struct_type + hmac_rest on the final chunk. Tag
 // order: STRUCT_TYPE, STRUCT_VERSION, CONTACT_NAME, SCOPE (new), ACCOUNT_IDENTIFIER
-// (unchanged), PREVIOUS_SCOPE (old), GROUP_HANDLE, DERIVATION_PATH, CHAIN_ID
-// (Ethereum only), HMAC_PROOF, HMAC_REST (old), BLOCKCHAIN_FAMILY. DERIVATION_PATH
-// is a temporary coin-app requirement: the kit sends one fixed, unexposed path
-// and will drop it once firmware does.
+// (unchanged), PREVIOUS_SCOPE (old), GROUP_HANDLE, CHAIN_ID (Ethereum only),
+// HMAC_PROOF, HMAC_REST (old), BLOCKCHAIN_FAMILY.
+// No DERIVATION_PATH: external-address ops carry no path — the current Ethereum
+// app rejects the tag (0x6a80); it is Ledger-Account only (DSDK-1465).
 // Reference: Address Book Final Specifications — Edit Scope.
 import {
   ByteArrayBuilder,
@@ -19,7 +19,6 @@ import {
 import { EditExternalAddressScopeCommand } from "@internal/app-binder/command/EditExternalAddressScopeCommand";
 import {
   BLOCKCHAIN_FAMILY_BY_NAME,
-  EXTERNAL_ADDRESS_DERIVATION_PATH_SEGMENTS,
   SUB_CMD_EDIT_SCOPE,
 } from "@internal/app-binder/model/contactsConstants";
 import { type ContactsErrorCodes } from "@internal/app-binder/model/contactsErrors";
@@ -29,7 +28,6 @@ import {
   encodeTlvBuffer,
   encodeTlvChainId,
   encodeTlvUInt8,
-  packDerivationPath,
   STRUCT_TYPE_EDIT_SCOPE,
   STRUCT_VERSION_VALUE,
 } from "@internal/app-binder/services/contactsTlvSerializer";
@@ -97,10 +95,6 @@ export class SendEditExternalAddressScopeTask {
       );
     }
 
-    const pathBytes = packDerivationPath([
-      ...EXTERNAL_ADDRESS_DERIVATION_PATH_SEGMENTS,
-    ]);
-
     const builder = new ByteArrayBuilder();
     encodeTlvUInt8(
       builder,
@@ -125,7 +119,6 @@ export class SendEditExternalAddressScopeTask {
       args.previousScope,
     );
     encodeTlvBuffer(builder, CONTACTS_TLV_TAG.GROUP_HANDLE, args.groupHandle);
-    encodeTlvBuffer(builder, CONTACTS_TLV_TAG.DERIVATION_PATH, pathBytes);
     if (args.chainId !== undefined) {
       encodeTlvChainId(builder, CONTACTS_TLV_TAG.CHAIN_ID, args.chainId);
     }

--- a/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterIdentityTask.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterIdentityTask.test.ts
@@ -1,8 +1,8 @@
 // Validates that the TLV serializer + tag ordering + chunk framing produce the
 // expected wire bytes for op 1 (Register Identity): tags >= 0x80 use the 2-byte
-// DER form [0x81, tag], and Register Identity carries DERIVATION_PATH (tag 0x69,
-// m/44'/60'/0'/0/0) which the Ethereum app requires. The framed chunk = 2-byte
-// BE total length + TLV.
+// DER form [0x81, tag], and Register Identity carries NO DERIVATION_PATH (the
+// Ethereum app rejects the tag on external-address ops). The framed chunk =
+// 2-byte BE total length + TLV.
 import {
   CommandResultFactory,
   type InternalApi,
@@ -23,24 +23,21 @@ function hexToBytes(hex: string): Uint8Array {
 
 // Framed chunk = "00 <Lc>" (2-byte BE total TLV length) + TLV. Tag order:
 // STRUCT_TYPE, STRUCT_VERSION, CONTACT_NAME, SCOPE, ACCOUNT_IDENTIFIER,
-// DERIVATION_PATH, CHAIN_ID, BLOCKCHAIN_FAMILY, then optional GROUP_HANDLE +
-// HMAC_PROOF. Tags >= 0x80 are encoded as [0x81, tag]; DERIVATION_PATH (0x69)
-// packs m/44'/60'/0'/0/0 as "05 8000002c 8000003c 80000000 00000000 00000000".
+// CHAIN_ID, BLOCKCHAIN_FAMILY, then optional GROUP_HANDLE + HMAC_PROOF. Tags
+// >= 0x80 are encoded as [0x81, tag]. No DERIVATION_PATH TLV.
 const FRESH_FRAMED_CHUNK = hexToBytes(
-  "004d01012d020101" +
+  "003601012d020101" +
     "81f005416c696365" +
     "81f108457468206d61696e" +
     "81f21400000000000000000000000000000000deadbeef" +
-    "6915058000002c8000003c800000000000000000000000" +
     "230101510101",
 );
 
 const EXTENSION_FRAMED_CHUNK = hexToBytes(
-  "00b301012d020101" +
+  "009c01012d020101" +
     "81f005416c696365" +
     "81f108417262206d61696e" +
     "81f2144444444444444444444444444444444444444444" +
-    "6915058000002c8000003c800000000000000000000000" +
     "2302a4b1510101" +
     "81f640cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" +
     "2920dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",

--- a/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterIdentityTask.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/task/SendRegisterIdentityTask.ts
@@ -5,12 +5,12 @@
 //
 // Reference: Address Book Final Specifications — Register Identity. Tag order:
 //   STRUCT_TYPE, STRUCT_VERSION, CONTACT_NAME, SCOPE, ACCOUNT_IDENTIFIER,
-//   DERIVATION_PATH, CHAIN_ID (Ethereum only), BLOCKCHAIN_FAMILY, then optional
+//   CHAIN_ID (Ethereum only), BLOCKCHAIN_FAMILY, then optional
 //   GROUP_HANDLE + HMAC_PROOF when extending an existing group.
 //
-// DERIVATION_PATH (tag 0x69, default m/44'/60'/0'/0/0): the Ethereum app
-// requires it on Register Identity and rejects the payload with 0x6a80 when it
-// is absent (verified on-device against the deployed dev app).
+// No DERIVATION_PATH: external-address ops carry no path. The current Ethereum
+// app rejects the tag when present (0x6a80) and no longer requires it; the tag
+// is Ledger-Account only (verified on-device, DSDK-1465).
 import {
   ByteArrayBuilder,
   type CommandResult,
@@ -34,7 +34,6 @@ import {
   encodeTlvBuffer,
   encodeTlvChainId,
   encodeTlvUInt8,
-  packDerivationPath,
   STRUCT_TYPE_REGISTER_IDENTITY,
   STRUCT_VERSION_VALUE,
 } from "@internal/app-binder/services/contactsTlvSerializer";
@@ -124,13 +123,6 @@ export class SendRegisterIdentityTask {
       builder,
       CONTACTS_TLV_TAG.ACCOUNT_IDENTIFIER,
       args.identifier,
-    );
-    // The Ethereum app requires DERIVATION_PATH on Register Identity (0x6a80
-    // without it). Default m/44'/60'/0'/0/0.
-    encodeTlvBuffer(
-      builder,
-      CONTACTS_TLV_TAG.DERIVATION_PATH,
-      packDerivationPath([0x8000002c, 0x8000003c, 0x80000000, 0, 0]),
     );
     if (args.chainId !== undefined) {
       encodeTlvChainId(builder, CONTACTS_TLV_TAG.CHAIN_ID, args.chainId);


### PR DESCRIPTION
### 📝 Description

The external-address Contacts operations were sending a fixed, kit-internal `DERIVATION_PATH` TLV (tag `0x69`, `m/44'/60'/0'/0/0`). This was a temporary workaround for an older dev Ethereum app that rejected the payload with `0x6a80` when the tag was absent.

The requirement has since flipped: the current Ethereum app **rejects** `DERIVATION_PATH` on external-address ops (returns `0x6a80` when it is present) and no longer requires it. This was confirmed on-device (real Flex) with a clean toggle matrix, the payload only registers when the path is **omitted** and 2-byte DER tags are kept.

### ❓ Context

- **JIRA or GitHub link**: DSDK-1465

- **Feature**: Contacts / Address Book external-address operations wire format

### ✅ Checklist

Pull Requests must pass CI checks and undergo code review. Set the PR as Draft if it is not yet ready for review.

- [X] **Covered by automatic tests** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [X] **Changeset is provided** <!-- Please provide a changeset -->
- [X] **Documentation is up-to-date** <!-- Please ensure all relevant documentation (README, API docs, etc.) has been updated -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - _list of the changes_

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
