### PR TITLE
✨ (signer-concordium) [LIVE-36749]: Map the PLT unsupported-decimals status word

### DIFF
--- a/.changeset/concordium-plt-unsupported-decimals.md
+++ b/.changeset/concordium-plt-unsupported-decimals.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-concordium": minor
+---
+
+Register the `0x6B11` status word the Concordium app returns when a PLT amount carries more than the 18 decimal places the app can display. It previously fell through to `UnknownDeviceExchangeError`; it now resolves to `ConcordiumErrorCodes.PLT_UNSUPPORTED_DECIMALS`, so consumers can match on it.

--- a/packages/signer/signer-concordium/src/internal/app-binder/command/utils/ConcordiumApplicationErrors.ts
+++ b/packages/signer/signer-concordium/src/internal/app-binder/command/utils/ConcordiumApplicationErrors.ts
@@ -23,6 +23,7 @@ export enum ConcordiumErrorCodes {
   PLT_BUFFER_ERROR = "6b0e",
   PLT_DATA_ERROR = "6b0f",
   PLT_MULTI_OP = "6b10",
+  PLT_UNSUPPORTED_DECIMALS = "6b11",
   UNSUPPORTED_TRANSACTION_TYPE = "unsupported_transaction_type",
   UNSUPPORTED_APP_VERSION = "unsupported_app_version",
   INVALID_PLT_TRANSACTION = "invalid_plt_transaction",
@@ -50,6 +51,10 @@ export const CONCORDIUM_APP_ERRORS: CommandErrors<ConcordiumErrorCodes> = {
   "6b0e": { message: "PLT buffer error" },
   "6b0f": { message: "PLT data error" },
   "6b10": { message: "PLT payload has more than one operation" },
+  "6b11": {
+    message:
+      "PLT amount has more than the 18 decimal places the app can display",
+  },
   unsupported_transaction_type: { message: "Unsupported transaction type" },
   unsupported_app_version: { message: "Unsupported app version" },
   invalid_plt_transaction: { message: "Invalid PLT transaction" },


### PR DESCRIPTION
### 📝 Description

Registers the `0x6B11` status word the Concordium app returns when a PLT amount carries more decimal places than the app can display.

The app rejects an amount whose exponent magnitude exceeds 18 at CBOR parse time and answers `0x6B11` `ERROR_PLT_UNSUPPORTED_DECIMALS`. This is an app display constraint, documented in the app's `doc/ins_sign_plt.md`; the chain itself permits 0 to 255 decimals.

`CONCORDIUM_APP_ERRORS` stopped at `6b10`, so `0x6B11` fell through to `GlobalCommandErrorHandler` and surfaced as `UnknownDeviceExchangeError` with the message `"UnknownError"`.

| Before | After |
| ------ | ----- |
| `UnknownDeviceExchangeError`, message `"UnknownError"` | `ConcordiumErrorCodes.PLT_UNSUPPORTED_DECIMALS`, message naming the 18-decimal limit |

Two additions, no behavioural change beyond error typing — the signer already streams whatever payload it is given and the device decides:

- `PLT_UNSUPPORTED_DECIMALS = "6b11"` on `ConcordiumErrorCodes`, after `PLT_MULTI_OP`.
- The matching `"6b11"` entry in `CONCORDIUM_APP_ERRORS`.

**This has to land here before the consumer side can be written.** `ConcordiumErrorCodes` reaches the public type surface through `api/app-binder/*DeviceActionTypes.ts`, and consumers switch on `errorCode` against that union. Adding the case in `live-signer-concordium` first does not compile:

```
TS2678: Type '"6b11"' is not comparable to type '... | ConcordiumErrorCodes'
```

So the sequence is this PR, then a published snapshot, then the wallet-side mapping in `ledger-live`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-36749](https://ledgerhq.atlassian.net/browse/LIVE-36749)

- **Feature**: PLT (Protocol Level Token) signing for Concordium, epic [LIVE-32855](https://ledgerhq.atlassian.net/browse/LIVE-32855). Follows [LIVE-33617](https://ledgerhq.atlassian.net/browse/LIVE-33617) (PLT signing) and [LIVE-36566](https://ledgerhq.atlassian.net/browse/LIVE-36566) (max fee on device display).

### ✅ Checklist

- [ ] **Covered by automatic tests** — no new test. The change is two data entries in an error table with no branching logic; there is no existing test over `CONCORDIUM_APP_ERRORS` contents to extend. Happy to add one asserting the code resolves rather than falling through, if you would prefer that shape.
- [x] **Changeset is provided** — `minor` on `@ledgerhq/device-signer-kit-concordium`, since the enum member is an additive change to a type consumers match on.
- [x] **Documentation is up-to-date** — the status word is documented on the app side (`app-concordium` `doc/ins_sign_plt.md`); nothing in this package documents the error table.
- [ ] **Impact of the changes:**
  - One new recognised status word for `INS 0x27`. No existing code is rerouted; `0x6B11` was previously unrecognised.
  - Nothing to exercise manually: reaching `0x6B11` needs a PLT with more than 18 decimals, and none exists on Concordium mainnet or testnet. Every deployed PLT uses 6 decimals, with one testnet token at 2.
  - QA focus: none. The path is not reachable with any real token.

---

### 🧐 Checklist for the PR Reviewers

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.


[LIVE-36749]: https://ledgerhq.atlassian.net/browse/LIVE-36749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ