### PR TITLE
🔧 (ci) [NO-ISSUE]: Exclude test files from Sonar duplication detection

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -80,3 +80,15 @@ sonar.coverage.exclusions=\
   **/__tests__/**,\
   **/__mocks__/**,\
   **/*.kt
+
+sonar.cpd.exclusions=\
+  **/*.test.ts,\
+  **/*.test.tsx,\
+  **/*.spec.ts,\
+  **/*.spec.tsx,\
+  **/*.stub.ts,\
+  **/*.stub.tsx,\
+  **/*.mock.ts,\
+  **/*.mock.tsx,\
+  **/__tests__/**,\
+  **/__mocks__/**


### PR DESCRIPTION
### 📝 Description

SonarQube's copy-paste detector was reporting duplicated lines on `.test.ts` files, which inflated the **Duplicated Lines (%) on New Code** metric on pull requests. On PR #1822 for instance, 46 of the duplicated lines came from three test suites:

| File | Duplicated lines on new code |
| ---- | ---------------------------- |
| `packages/signer/signer-eth/src/internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction.test.ts` | 22 (22.0%) |
| `packages/signer/signer-eth/src/internal/app-binder/task/BuildBaseContexts.test.ts` | 22 (10.3%) |
| `packages/signer/signer-eth/src/internal/app-binder/EthAppBinder.test.ts` | 2 (3.4%) |

Test suites legitimately repeat setup, mock wiring and assertion blocks — that repetition is what makes each case readable in isolation, and deduplicating it into shared helpers usually makes tests harder to follow. So the duplication signal is noise here, not debt.

This adds `sonar.cpd.exclusions` to `sonar-project.properties`, mirroring the existing `sonar.coverage.exclusions` list (minus `**/*.kt`, irrelevant to CPD):

```properties
sonar.cpd.exclusions=\
  **/*.test.ts,\
  **/*.test.tsx,\
  **/*.spec.ts,\
  **/*.spec.tsx,\
  **/*.stub.ts,\
  **/*.stub.tsx,\
  **/*.mock.ts,\
  **/*.mock.tsx,\
  **/__tests__/**,\
  **/__mocks__/**
```

`sonar.cpd.exclusions` disables **only** the copy-paste detector for those paths — unlike `sonar.exclusions`, which would drop the files from analysis entirely. Test files therefore keep being scanned for issues, bugs and security hotspots; they simply stop counting towards duplicated lines and duplicated blocks.

Both scan workflows (`.github/workflows/pull_request.yml` and `.github/workflows/develop-sonar.yml`) invoke `sonarsource/sonarqube-scan-action` with no extra `-D` arguments, so this properties file is the single source of configuration — nothing else needed changing.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]

- **Feature**: Sonar configuration only — removes false-positive duplication reports on test files from the PR quality gate.

### ✅ Checklist

- [x] **Covered by automatic tests** — N/A, Sonar scanner configuration. Effect is observable on the next Sonar analysis (duplication density should drop to the non-test contribution).
- [ ] **Changeset is provided** — not needed: no published package is touched, this only changes the root Sonar scanner config.
- [x] **Documentation is up-to-date** — no documentation references duplication exclusions.
- [x] **Impact of the changes:**
  - `sonar-project.properties`: adds a `sonar.cpd.exclusions` block (12 lines, no other property modified).
  - Sonar no longer reports duplicated lines/blocks for test, spec, stub and mock files; all other Sonar rules on those files are unaffected.
  - No runtime, build or published-artifact impact.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
