### PR TITLE
🔧 (contacts-kit) [DSDK-1469]: Update Contacts minimum version requirements, add Nano X / Nano SP

### DIFF
--- a/.changeset/dmk-min-version-accepting-prerelease.md
+++ b/.changeset/dmk-min-version-accepting-prerelease.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": minor
+---
+
+Add ApplicationChecker.withMinVersionInclusiveAcceptingPrerelease, a variant of withMinVersionInclusive that strips prerelease and build tags before comparing, so an app reporting a release candidate of the minimum still passes the check

--- a/.changeset/dsdk-1469-contacts-nano-support.md
+++ b/.changeset/dsdk-1469-contacts-nano-support.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-contacts-kit": minor
+---
+
+Update the Contacts version requirements: raise the minimum OS versions for Stax, Flex and Apex, raise the minimum Ethereum app version, and add Nano X and Nano SP as supported models (Nano S stays unsupported). Version comparison now ignores prerelease and build tags, so a device on a release candidate of a minimum counts as meeting it. Removes `isContactsSupported`: the OS and app minimums gate different operations and are checked independently, so compose them from `resolveContactsVersionRequirements` and `isVersionAtLeast` instead

--- a/.changeset/eth-contacts-accept-prerelease.md
+++ b/.changeset/eth-contacts-accept-prerelease.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": minor
+---
+
+Provide matching external contacts before signing on prerelease builds of the Ethereum app: the Contacts support check now compares only the release core, so an app reporting e.g. 1.23.0-rc2 against a 1.23.0 minimum is no longer treated as too old

--- a/apps/docs/content/docs/references/signers/eth.mdx
+++ b/apps/docs/content/docs/references/signers/eth.mdx
@@ -109,8 +109,8 @@ Points to know:
   contact the device rejects all leave the transaction signing as before,
   against the raw address.
 
-> **Note:** Contacts are supported on Stax, Flex and Apex, and need a recent
-> enough Ethereum app. Register contacts on the device with
+> **Note:** Contacts are supported on every device model except Nano S, and
+> need a recent enough Ethereum app. Register contacts on the device with
 > [`@ledgerhq/device-contacts-kit`](https://github.com/LedgerHQ/device-sdk-ts/tree/develop/packages/device-contacts-kit).
 
 ## 🔹 Use Cases

--- a/packages/device-contacts-kit/README.md
+++ b/packages/device-contacts-kit/README.md
@@ -94,7 +94,8 @@ consume them without duplicating the values:
 ```ts
 import {
   CONTACTS_VERSION_REQUIREMENTS,
-  isContactsSupported,
+  ETHEREUM_APP_NAME,
+  isVersionAtLeast,
   resolveContactsVersionRequirements,
 } from "@ledgerhq/device-contacts-kit";
 
@@ -102,17 +103,25 @@ import {
 const requirement = resolveContactsVersionRequirements(deviceModelId);
 // { supported: true, minOsVersion, minAppVersion: { Ethereum } } | { supported: false }
 
-// Or evaluate support directly.
-const supported = isContactsSupported({
-  deviceModelId,
-  osVersion,
-  appName,
-  appVersion,
-});
+if (requirement.supported) {
+  // OS-owned operations, e.g. renaming a contact from the dashboard.
+  const osReady = isVersionAtLeast(osVersion, requirement.minOsVersion);
+
+  // App-owned operations, e.g. registering an external address.
+  const minAppVersion = requirement.minAppVersion[ETHEREUM_APP_NAME];
+  const appReady =
+    minAppVersion !== undefined && isVersionAtLeast(appVersion, minAppVersion);
+}
 ```
 
-There are two independent axes: `minOsVersion` gates OS-owned operations (served by the device OS,
-e.g. renaming a contact from the dashboard) and `minAppVersion` gates app-owned operations (served
-by the embedded app, keyed by app name — v1 ships Ethereum only). The `isContactsSupported` helper
-and the raw `CONTACTS_VERSION_REQUIREMENTS` table are pure and dependency-light, so a host such as
-Ledger Wallet can import either to compose its own app-readiness checks.
+The two axes are checked independently, never as one combined verdict: `minOsVersion` gates
+OS-owned operations (served by the device OS, e.g. renaming a contact from the dashboard) and
+`minAppVersion` gates app-owned operations (served by the embedded app, keyed by app name — v1
+ships Ethereum only). A device can satisfy one and not the other, and each Contacts operation
+depends on exactly one of them, so collapsing them into a single "is Contacts supported" answer
+would reject devices that can serve the operation the host actually wants.
+
+`isVersionAtLeast` and the raw `CONTACTS_VERSION_REQUIREMENTS` table are pure and
+dependency-light, so a host such as Ledger Wallet can import either to compose its own
+app-readiness checks. Version comparison ignores prerelease and build tags, so a device on a
+release candidate of a minimum (`1.7.0-rc2` against a `1.7.0` minimum) counts as meeting it.

--- a/packages/device-contacts-kit/src/api/index.ts
+++ b/packages/device-contacts-kit/src/api/index.ts
@@ -41,10 +41,8 @@ export {
   type ContactsModelRequirement,
   type ContactsModelSupport,
   type ContactsModelUnsupported,
-  type ContactsSupportQuery,
   type ContactsVersionRequirements,
   ETHEREUM_APP_NAME,
-  isContactsSupported,
   isVersionAtLeast,
   resolveContactsVersionRequirements,
 } from "@api/model/ContactsVersionRequirements";

--- a/packages/device-contacts-kit/src/api/model/ContactsVersionRequirements.test.ts
+++ b/packages/device-contacts-kit/src/api/model/ContactsVersionRequirements.test.ts
@@ -2,31 +2,10 @@ import { DeviceModelId } from "@ledgerhq/device-management-kit";
 
 import {
   CONTACTS_VERSION_REQUIREMENTS,
-  type ContactsModelSupport,
   ETHEREUM_APP_NAME,
-  isContactsSupported,
   isVersionAtLeast,
   resolveContactsVersionRequirements,
 } from "./ContactsVersionRequirements";
-
-const BELOW_ANY_VERSION = "0.0.1";
-const ABOVE_ANY_VERSION = "999.0.0";
-
-function supportOf(modelId: DeviceModelId): ContactsModelSupport {
-  const requirement = resolveContactsVersionRequirements(modelId);
-  if (!requirement.supported) {
-    throw new Error(`expected ${modelId} to be supported in the test fixture`);
-  }
-  return requirement;
-}
-
-function ethAppVersionOf(support: ContactsModelSupport): string {
-  const version = support.minAppVersion[ETHEREUM_APP_NAME];
-  if (version === undefined) {
-    throw new Error("expected an Ethereum minimum app version in the fixture");
-  }
-  return version;
-}
 
 describe("ContactsVersionRequirements", () => {
   describe("resolveContactsVersionRequirements", () => {
@@ -36,83 +15,46 @@ describe("ContactsVersionRequirements", () => {
       }
     });
 
-    it("reports Nano models as unsupported", () => {
+    it("reports Nano S as unsupported", () => {
       expect(resolveContactsVersionRequirements(DeviceModelId.NANO_S)).toEqual({
         supported: false,
       });
-      expect(resolveContactsVersionRequirements(DeviceModelId.NANO_X)).toEqual({
-        supported: false,
+    });
+
+    // Pins the minimums themselves, not just their shape: each OS version is
+    // the release whose changelog introduces the Address Book feature, so a
+    // change here has to be a deliberate one, reviewed against that release.
+    it("pins the minimum OS and app versions of every supported model", () => {
+      const ethereum = { [ETHEREUM_APP_NAME]: "1.23.0" };
+
+      expect(CONTACTS_VERSION_REQUIREMENTS).toEqual({
+        [DeviceModelId.NANO_S]: { supported: false },
+        [DeviceModelId.NANO_SP]: {
+          supported: true,
+          minOsVersion: "1.7.0",
+          minAppVersion: ethereum,
+        },
+        [DeviceModelId.NANO_X]: {
+          supported: true,
+          minOsVersion: "2.8.0",
+          minAppVersion: ethereum,
+        },
+        [DeviceModelId.STAX]: {
+          supported: true,
+          minOsVersion: "1.11.0",
+          minAppVersion: ethereum,
+        },
+        [DeviceModelId.FLEX]: {
+          supported: true,
+          minOsVersion: "1.7.0",
+          minAppVersion: ethereum,
+        },
+        [DeviceModelId.APEX]: {
+          supported: true,
+          minOsVersion: "1.2.0",
+          minAppVersion: ethereum,
+        },
       });
-    });
-
-    it("reports touchscreen models as supported with OS and app minimums", () => {
-      const flex = supportOf(DeviceModelId.FLEX);
-      expect(flex.minOsVersion).toEqual(expect.any(String));
-      expect(ethAppVersionOf(flex)).toEqual(expect.any(String));
-    });
-  });
-
-  describe("isContactsSupported", () => {
-    it("returns false for an unsupported device model", () => {
-      const flex = supportOf(DeviceModelId.FLEX);
-      expect(
-        isContactsSupported({
-          deviceModelId: DeviceModelId.NANO_S,
-          osVersion: ABOVE_ANY_VERSION,
-          appName: ETHEREUM_APP_NAME,
-          appVersion: ethAppVersionOf(flex),
-        }),
-      ).toBe(false);
-    });
-
-    // App-version requirement.
-    it("gates on the minimum app version", () => {
-      const flex = supportOf(DeviceModelId.FLEX);
-      const minAppVersion = ethAppVersionOf(flex);
-      const base = {
-        deviceModelId: DeviceModelId.FLEX,
-        osVersion: flex.minOsVersion,
-        appName: ETHEREUM_APP_NAME,
-      };
-
-      expect(
-        isContactsSupported({ ...base, appVersion: BELOW_ANY_VERSION }),
-      ).toBe(false);
-      expect(isContactsSupported({ ...base, appVersion: minAppVersion })).toBe(
-        true,
-      );
-      expect(
-        isContactsSupported({ ...base, appVersion: ABOVE_ANY_VERSION }),
-      ).toBe(true);
-    });
-
-    it("returns false for an app that is unknown to Contacts", () => {
-      const flex = supportOf(DeviceModelId.FLEX);
-      expect(
-        isContactsSupported({
-          deviceModelId: DeviceModelId.FLEX,
-          osVersion: flex.minOsVersion,
-          appName: "Bitcoin",
-          appVersion: ABOVE_ANY_VERSION,
-        }),
-      ).toBe(false);
-    });
-
-    // OS-version requirement.
-    it("gates on the minimum OS version", () => {
-      const flex = supportOf(DeviceModelId.FLEX);
-      const base = {
-        deviceModelId: DeviceModelId.FLEX,
-        appName: ETHEREUM_APP_NAME,
-        appVersion: ethAppVersionOf(flex),
-      };
-
-      expect(
-        isContactsSupported({ ...base, osVersion: BELOW_ANY_VERSION }),
-      ).toBe(false);
-      expect(
-        isContactsSupported({ ...base, osVersion: flex.minOsVersion }),
-      ).toBe(true);
     });
   });
 
@@ -130,6 +72,15 @@ describe("ContactsVersionRequirements", () => {
     it("returns false when a version cannot be parsed", () => {
       expect(isVersionAtLeast("not-a-version", "1.2.0")).toBe(false);
       expect(isVersionAtLeast("1.2.0", "not-a-version")).toBe(false);
+    });
+
+    it("ignores prerelease and build tags when comparing to the minimum", () => {
+      expect(isVersionAtLeast("1.7.0-rc2", "1.7.0")).toBe(true);
+      expect(isVersionAtLeast("1.23.0-dev", "1.23.0")).toBe(true);
+    });
+
+    it("still fails a minimum strictly above the tagged version's core", () => {
+      expect(isVersionAtLeast("1.6.9-rc5", "1.7.0")).toBe(false);
     });
   });
 });

--- a/packages/device-contacts-kit/src/api/model/ContactsVersionRequirements.ts
+++ b/packages/device-contacts-kit/src/api/model/ContactsVersionRequirements.ts
@@ -43,22 +43,30 @@ export const ETHEREUM_APP_NAME = "Ethereum";
 
 const UNSUPPORTED: ContactsModelUnsupported = { supported: false };
 
-// TODO(DSDK-1376): replace these placeholder versions with the real minimums
-// confirmed by the firmware and Ethereum-app owners. The shape and consumers
-// are final; only the version strings below are provisional.
-const MIN_OS_VERSION_STAX = "1.5.0";
-const MIN_OS_VERSION_FLEX = "1.2.0";
-const MIN_OS_VERSION_APEX = "0.9.0";
-const MIN_ETHEREUM_APP_VERSION = "1.15.0";
+const MIN_OS_VERSION_STAX = "1.11.0";
+const MIN_OS_VERSION_FLEX = "1.7.0";
+const MIN_OS_VERSION_APEX = "1.2.0";
+const MIN_OS_VERSION_NANO_X = "2.8.0";
+const MIN_OS_VERSION_NANO_SP = "1.7.0";
+
+const MIN_ETHEREUM_APP_VERSION = "1.23.0";
 
 /**
- * Contacts APDUs are supported only on the touchscreen device models (Stax,
- * Flex, Apex). The Nano models do not support Contacts at all.
+ * Contacts APDUs are supported on the touchscreen device models (Stax, Flex,
+ * Apex) and on Nano X / Nano SP. Nano S does not support Contacts at all.
  */
 export const CONTACTS_VERSION_REQUIREMENTS: ContactsVersionRequirements = {
   [DeviceModelId.NANO_S]: UNSUPPORTED,
-  [DeviceModelId.NANO_SP]: UNSUPPORTED,
-  [DeviceModelId.NANO_X]: UNSUPPORTED,
+  [DeviceModelId.NANO_SP]: {
+    supported: true,
+    minOsVersion: MIN_OS_VERSION_NANO_SP,
+    minAppVersion: { [ETHEREUM_APP_NAME]: MIN_ETHEREUM_APP_VERSION },
+  },
+  [DeviceModelId.NANO_X]: {
+    supported: true,
+    minOsVersion: MIN_OS_VERSION_NANO_X,
+    minAppVersion: { [ETHEREUM_APP_NAME]: MIN_ETHEREUM_APP_VERSION },
+  },
   [DeviceModelId.STAX]: {
     supported: true,
     minOsVersion: MIN_OS_VERSION_STAX,
@@ -88,48 +96,15 @@ export function resolveContactsVersionRequirements(
 
 /**
  * Whether `actual` is greater than or equal to `minimum`, comparing as semver.
- * Tolerant of non-strict version strings (coerces where possible) and returns
- * `false` (i.e. requirement not met) when either version cannot be parsed, so
- * an unknown version never passes a check.
+ * Tolerant of non-strict version strings and prerelease/build tags (coerces
+ * both sides, which drops them) so a release candidate such as `1.7.0-rc2`
+ * counts as meeting a `1.7.0` minimum. Returns `false` (i.e. requirement not
+ * met) when either version cannot be parsed, so an unknown version never
+ * passes a check.
  */
 export function isVersionAtLeast(actual: string, minimum: string): boolean {
-  const a = valid(actual) ?? valid(coerce(actual));
-  const b = valid(minimum) ?? valid(coerce(minimum));
+  const a = valid(coerce(actual));
+  const b = valid(coerce(minimum));
   if (a === null || b === null) return false;
   return gte(a, b);
-}
-
-/** Inputs for {@link isContactsSupported}. */
-export type ContactsSupportQuery = {
-  readonly deviceModelId: DeviceModelId;
-  /** The device OS (firmware) version. */
-  readonly osVersion: string;
-  /** The name of the currently running embedded app. */
-  readonly appName: string;
-  /** The version of the currently running embedded app. */
-  readonly appVersion: string;
-};
-
-/**
- * Whether Contacts app-owned operations are supported for the given device
- * model, OS version, and running app — checking the model is supported, the OS
- * meets its minimum, the app is known to Contacts, and the app meets its
- * minimum.
- *
- * Pure and dependency-light: hosts can call this directly, or read
- * {@link CONTACTS_VERSION_REQUIREMENTS} to build their own checks.
- */
-export function isContactsSupported({
-  deviceModelId,
-  osVersion,
-  appName,
-  appVersion,
-}: ContactsSupportQuery): boolean {
-  const requirement = resolveContactsVersionRequirements(deviceModelId);
-  if (!requirement.supported) return false;
-  if (!isVersionAtLeast(osVersion, requirement.minOsVersion)) return false;
-
-  const minAppVersion = requirement.minAppVersion[appName];
-  if (minAppVersion === undefined) return false;
-  return isVersionAtLeast(appVersion, minAppVersion);
 }

--- a/packages/device-contacts-kit/src/internal/app-binder/contactsVersionGuards.test.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/contactsVersionGuards.test.ts
@@ -84,7 +84,7 @@ describe("isContactsAppVersionSupportedForSession", () => {
 
   it("returns false on an unsupported device model", () => {
     const api = createInternalApi(
-      createReadyState({ modelId: DeviceModelId.NANO_X }),
+      createReadyState({ modelId: DeviceModelId.NANO_S }),
     );
     expect(isContactsAppVersionSupportedForSession(api, runningApp())).toBe(
       false,
@@ -108,6 +108,16 @@ describe("isContactsAppVersionSupportedForSession", () => {
     ).toBe(false);
   });
 
+  it("returns true for a prerelease build of the minimum app version", () => {
+    const api = createInternalApi(createReadyState());
+    expect(
+      isContactsAppVersionSupportedForSession(
+        api,
+        runningApp(ETHEREUM_APP_NAME, `${MIN_APP_VERSION}-rc2`),
+      ),
+    ).toBe(true);
+  });
+
   it("returns false when the device session has no running app", () => {
     const api = createInternalApi({
       sessionStateType: DeviceSessionStateType.Connected,
@@ -128,7 +138,7 @@ describe("isContactsOsSupportedForSession", () => {
 
   it("returns false on an unsupported device model", () => {
     const api = createInternalApi(
-      createReadyState({ modelId: DeviceModelId.NANO_X }),
+      createReadyState({ modelId: DeviceModelId.NANO_S }),
     );
     expect(isContactsOsSupportedForSession(api)).toBe(false);
   });
@@ -136,6 +146,20 @@ describe("isContactsOsSupportedForSession", () => {
   it("returns false when the OS version is below the minimum", () => {
     const api = createInternalApi(
       createReadyState({ osVersion: BELOW_ANY_VERSION }),
+    );
+    expect(isContactsOsSupportedForSession(api)).toBe(false);
+  });
+
+  it("returns true for a release candidate of the minimum OS version", () => {
+    const api = createInternalApi(
+      createReadyState({ osVersion: `${MIN_OS_VERSION}-rc2` }),
+    );
+    expect(isContactsOsSupportedForSession(api)).toBe(true);
+  });
+
+  it("returns false for a release candidate below the minimum OS version", () => {
+    const api = createInternalApi(
+      createReadyState({ osVersion: `${BELOW_ANY_VERSION}-rc2` }),
     );
     expect(isContactsOsSupportedForSession(api)).toBe(false);
   });

--- a/packages/device-contacts-kit/src/internal/app-binder/contactsVersionGuards.ts
+++ b/packages/device-contacts-kit/src/internal/app-binder/contactsVersionGuards.ts
@@ -90,6 +90,6 @@ export function isContactsAppVersionSupportedForSession(
     { version: app.version },
     new ContactsApplicationResolver(),
   )
-    .withMinVersionInclusive(minAppVersion)
+    .withMinVersionInclusiveAcceptingPrerelease(minAppVersion)
     .check();
 }

--- a/packages/device-management-kit/src/api/utils/ApplicationChecker.test.ts
+++ b/packages/device-management-kit/src/api/utils/ApplicationChecker.test.ts
@@ -176,6 +176,143 @@ describe("ApplicationChecker", () => {
     expect(result).toStrictEqual(false);
   });
 
+  describe("withMinVersionInclusiveAcceptingPrerelease", () => {
+    it("should accept a release candidate of the minimum", () => {
+      const resolver = createMockResolver({
+        isCompatible: true,
+        version: "1.23.0-rc2",
+      });
+      const result = new ApplicationChecker(
+        createReadyState(),
+        appConfig,
+        resolver,
+      )
+        .withMinVersionInclusiveAcceptingPrerelease("1.23.0")
+        .check();
+      expect(result).toStrictEqual(true);
+    });
+
+    it("should accept a dev build of the minimum", () => {
+      const resolver = createMockResolver({
+        isCompatible: true,
+        version: "1.23.0-dev",
+      });
+      const result = new ApplicationChecker(
+        createReadyState(),
+        appConfig,
+        resolver,
+      )
+        .withMinVersionInclusiveAcceptingPrerelease("1.23.0")
+        .check();
+      expect(result).toStrictEqual(true);
+    });
+
+    it("should accept a plain version equal to the minimum", () => {
+      const resolver = createMockResolver({
+        isCompatible: true,
+        version: "1.23.0",
+      });
+      const result = new ApplicationChecker(
+        createReadyState(),
+        appConfig,
+        resolver,
+      )
+        .withMinVersionInclusiveAcceptingPrerelease("1.23.0")
+        .check();
+      expect(result).toStrictEqual(true);
+    });
+
+    it("should accept a plain version above the minimum", () => {
+      const resolver = createMockResolver({
+        isCompatible: true,
+        version: "1.24.0",
+      });
+      const result = new ApplicationChecker(
+        createReadyState(),
+        appConfig,
+        resolver,
+      )
+        .withMinVersionInclusiveAcceptingPrerelease("1.23.0")
+        .check();
+      expect(result).toStrictEqual(true);
+    });
+
+    it("should reject a plain version below the minimum", () => {
+      const resolver = createMockResolver({
+        isCompatible: true,
+        version: "1.22.9",
+      });
+      const result = new ApplicationChecker(
+        createReadyState(),
+        appConfig,
+        resolver,
+      )
+        .withMinVersionInclusiveAcceptingPrerelease("1.23.0")
+        .check();
+      expect(result).toStrictEqual(false);
+    });
+
+    it("should reject a prerelease whose release core is below the minimum", () => {
+      const resolver = createMockResolver({
+        isCompatible: true,
+        version: "1.22.9-rc5",
+      });
+      const result = new ApplicationChecker(
+        createReadyState(),
+        appConfig,
+        resolver,
+      )
+        .withMinVersionInclusiveAcceptingPrerelease("1.23.0")
+        .check();
+      expect(result).toStrictEqual(false);
+    });
+
+    it("should reject a version that cannot be parsed", () => {
+      const resolver = createMockResolver({
+        isCompatible: true,
+        version: "not-a-version",
+      });
+      const result = new ApplicationChecker(
+        createReadyState(),
+        appConfig,
+        resolver,
+      )
+        .withMinVersionInclusiveAcceptingPrerelease("1.23.0")
+        .check();
+      expect(result).toStrictEqual(false);
+    });
+
+    it("should reject a minimum that cannot be parsed", () => {
+      const resolver = createMockResolver({
+        isCompatible: true,
+        version: "1.23.0",
+      });
+      const result = new ApplicationChecker(
+        createReadyState(),
+        appConfig,
+        resolver,
+      )
+        .withMinVersionInclusiveAcceptingPrerelease("not-a-version")
+        .check();
+      expect(result).toStrictEqual(false);
+    });
+
+    it("should not override incompatible resolution", () => {
+      const resolver = createMockResolver({
+        isCompatible: false,
+        version: "1.23.0-rc2",
+      });
+      const result = new ApplicationChecker(
+        createReadyState(),
+        appConfig,
+        resolver,
+      )
+        .withMinVersionInclusiveAcceptingPrerelease("1.23.0")
+        .check();
+      expect(result).toStrictEqual(false);
+    });
+  });
+
   it("should not override incompatible resolution even if constraints pass", () => {
     const resolver = createMockResolver({
       isCompatible: false,

--- a/packages/device-management-kit/src/api/utils/ApplicationChecker.ts
+++ b/packages/device-management-kit/src/api/utils/ApplicationChecker.ts
@@ -1,4 +1,4 @@
-import { gt, gte } from "semver";
+import { coerce, gt, gte, valid } from "semver";
 
 import { type DeviceModelId } from "@api/device/DeviceModel";
 import { type DeviceSessionState } from "@api/device-session/DeviceSessionState";
@@ -34,6 +34,33 @@ export class ApplicationChecker {
 
   withMinVersionExclusive(version: string): ApplicationChecker {
     if (!gt(this.version, version)) this.isCompatible = false;
+    return this;
+  }
+
+  /**
+   * Like {@link withMinVersionInclusive}, but compares only the release core:
+   * prerelease and build tags are stripped from both sides first, so an app
+   * reporting `1.23.0-rc2` or `1.23.0-dev` satisfies a `1.23.0` minimum.
+   *
+   * This accepts a prerelease *of* the minimum, not any prerelease: the core
+   * still has to clear the bar, so `1.22.9-rc5` fails a `1.23.0` minimum just
+   * as `1.22.9` does. A version neither side can parse fails the check, so an
+   * unknown version never passes.
+   *
+   * Use this when a feature lands in a given release and devices running its
+   * release candidates must not be locked out — device versions reach the SDK
+   * verbatim, tags included (`GET APP AND VERSION` yields strings such as
+   * `1.4.0-rc2`). Prefer the strict {@link withMinVersionInclusive} when a
+   * prerelease genuinely cannot be trusted to carry the feature.
+   */
+  withMinVersionInclusiveAcceptingPrerelease(
+    version: string,
+  ): ApplicationChecker {
+    const actual = valid(coerce(this.version));
+    const minimum = valid(coerce(version));
+    if (actual === null || minimum === null || !gte(actual, minimum)) {
+      this.isCompatible = false;
+    }
     return this;
   }
 

--- a/packages/signer/signer-eth/src/internal/app-binder/task/ProvideTransactionContextsTask.test.ts
+++ b/packages/signer/signer-eth/src/internal/app-binder/task/ProvideTransactionContextsTask.test.ts
@@ -2,6 +2,8 @@ import { ClearSignContextType } from "@ledgerhq/context-module";
 import {
   buildProvideContactPayload,
   type ContactsErrorCodes,
+  ETHEREUM_APP_NAME,
+  resolveContactsVersionRequirements,
   sendProvideContactPayload,
 } from "@ledgerhq/device-contacts-kit";
 import {
@@ -54,6 +56,14 @@ const mockLogger = {
 };
 
 const mockLoggerFactory = (_tag: string) => mockLogger;
+
+const minContactsAppVersion = (() => {
+  const requirement = resolveContactsVersionRequirements(DeviceModelId.FLEX);
+  if (!requirement.supported) throw new Error("Flex must be supported");
+  const version = requirement.minAppVersion[ETHEREUM_APP_NAME];
+  if (version === undefined) throw new Error("Ethereum min version required");
+  return version;
+})();
 
 describe("ProvideTransactionContextsTask", () => {
   const api = makeDeviceActionInternalApiMock();
@@ -787,7 +797,7 @@ describe("ProvideTransactionContextsTask", () => {
         blindSigningEnabled: false,
         web3ChecksEnabled: false,
         web3ChecksOptIn: false,
-        version: "1.15.0",
+        version: minContactsAppVersion,
       };
 
       const resolveTrustedName = vi.fn();
@@ -852,7 +862,7 @@ describe("ProvideTransactionContextsTask", () => {
           sessionStateType: DeviceSessionStateType.ReadyWithoutSecureChannel,
           deviceStatus: DeviceStatus.CONNECTED,
           installedApps: [],
-          currentApp: { name: "Ethereum", version: "1.15.0" },
+          currentApp: { name: "Ethereum", version: minContactsAppVersion },
           deviceModelId: DeviceModelId.FLEX,
           isSecureConnectionAllowed: false,
         });

--- a/packages/signer/signer-eth/src/internal/shared/utils/buildExternalContactPayload.test.ts
+++ b/packages/signer/signer-eth/src/internal/shared/utils/buildExternalContactPayload.test.ts
@@ -1,5 +1,9 @@
 import { type TransactionSubset } from "@ledgerhq/context-module";
-import { buildProvideContactPayload } from "@ledgerhq/device-contacts-kit";
+import {
+  buildProvideContactPayload,
+  ETHEREUM_APP_NAME,
+  resolveContactsVersionRequirements,
+} from "@ledgerhq/device-contacts-kit";
 import {
   DeviceModelId,
   type DeviceSessionState,
@@ -55,6 +59,14 @@ const addressBook: EvmAddressBook = {
 
 const emptyBook: EvmAddressBook = { contactGroups: [], ledgerAccounts: [] };
 
+const minContactsAppVersion = (() => {
+  const requirement = resolveContactsVersionRequirements(DeviceModelId.FLEX);
+  if (!requirement.supported) throw new Error("Flex must be supported");
+  const version = requirement.minAppVersion[ETHEREUM_APP_NAME];
+  if (version === undefined) throw new Error("Ethereum min version required");
+  return version;
+})();
+
 function subset(overrides: Partial<TransactionSubset> = {}): TransactionSubset {
   return {
     chainId: 1,
@@ -69,7 +81,7 @@ function subset(overrides: Partial<TransactionSubset> = {}): TransactionSubset {
 // this is the shape a real signing flow sees.
 function deviceState({
   appName = "Ethereum",
-  appVersion = "1.15.0",
+  appVersion = minContactsAppVersion,
   deviceModelId = DeviceModelId.FLEX,
 }: {
   appName?: string;
@@ -86,7 +98,7 @@ function deviceState({
   };
 }
 
-function appConfig(version = "1.15.0"): GetConfigCommandResponse {
+function appConfig(version = minContactsAppVersion): GetConfigCommandResponse {
   return {
     blindSigningEnabled: false,
     web3ChecksEnabled: false,
@@ -210,11 +222,26 @@ describe("buildExternalContactPayload", () => {
       ).toBeUndefined();
     });
 
+    // The version compared is the one on `currentApp`, not `appConfig`:
+    // EthereumApplicationResolver only falls back to the config version for a
+    // clone. Setting it here would leave the prerelease string uncompared.
+    it("encodes the contact on a prerelease build of the minimum app version", () => {
+      expect(
+        buildExternalContactPayload(
+          args({
+            deviceState: deviceState({
+              appVersion: `${minContactsAppVersion}-rc2`,
+            }),
+          }),
+        ),
+      ).toBeDefined();
+    });
+
     it("returns undefined on a device model without Contacts support", () => {
       expect(
         buildExternalContactPayload(
           args({
-            deviceState: deviceState({ deviceModelId: DeviceModelId.NANO_X }),
+            deviceState: deviceState({ deviceModelId: DeviceModelId.NANO_S }),
           }),
         ),
       ).toBeUndefined();
@@ -227,7 +254,7 @@ describe("buildExternalContactPayload", () => {
       const payload = buildExternalContactPayload(
         args({
           deviceState: deviceState({ appName: "Polygon", appVersion: "1.0.0" }),
-          appConfig: appConfig("1.15.0"),
+          appConfig: appConfig(minContactsAppVersion),
         }),
       );
 

--- a/packages/signer/signer-eth/src/internal/shared/utils/buildExternalContactPayload.ts
+++ b/packages/signer/signer-eth/src/internal/shared/utils/buildExternalContactPayload.ts
@@ -115,6 +115,6 @@ function supportsContacts(
     appConfig,
     new EthereumApplicationResolver(),
   )
-    .withMinVersionInclusive(minAppVersion)
+    .withMinVersionInclusiveAcceptingPrerelease(minAppVersion)
     .check();
 }


### PR DESCRIPTION
### 📝 Description

Three changes to how Contacts decides a device is supported.

**1. Real version minimums (`ContactsVersionRequirements.ts`)**

- Set the minimum OS versions for Stax, Flex and Apex, and raised the shared Ethereum-app minimum to 1.23.0. The placeholders and their `TODO` are gone.
- Added Nano X and Nano SP as supported models, using the shape already in place for the touchscreen models. Nano S is now the only unsupported model.

Each OS minimum is the release whose changelog introduces the Address Book feature, per the Ledger OS release pages: Stax 1.11.0, Flex 1.7.0, Nano Gen5 1.2.0, LNS Plus 1.7.0, LNX 2.8.0. Those releases are still in RC with no release date set, which is what makes the next point matter.

**2. Prerelease builds no longer read as unsupported**

Device versions reach the SDK verbatim, tags included — `GET APP AND VERSION` yields strings such as `1.4.0-rc2`. Both gates compared with semver prerelease precedence, under which `1.23.0-rc2` sorts *below* `1.23.0`, so a device on a release candidate of the minimum was reported unsupported. Since the OS releases above are exactly the RCs rolling out now, this would have hit real devices.

- `isVersionAtLeast` (the OS gate) coerces before comparing, dropping prerelease and build tags.
- `ApplicationChecker` gains `withMinVersionInclusiveAcceptingPrerelease`, which the two Contacts call sites adopt. The existing strict methods are untouched — every other version gate in the monorepo relies on that behaviour.

This accepts a prerelease *of* the minimum, not any prerelease: `1.22.9-rc5` still fails a `1.23.0` minimum.

**3. `isContactsSupported` removed**

It had no caller outside its own test and the README, and it collapsed the two axes into one verdict. That is the wrong shape: the OS minimum gates dashboard operations, the app minimum gates app-owned ones, and each Contacts operation depends on exactly one of them — so a combined answer rejects devices that can serve the operation the host wants. Hosts compose the axis they need from `resolveContactsVersionRequirements` and `isVersionAtLeast`, as the README now shows.

**Not addressed here:** the same strict comparison is used by ~10 other gates (signer-solana, signer-zcash, signer-concordium, and signer-eth's web3-checks / gated-signing / generic-parser / EIP-712 gates). Same latent issue, their own ticket.

**Test coverage**

- The five minimums are pinned by value, so a typo in any of them fails the suite.
- Prerelease acceptance is covered at both gates and at each call site. The signer-eth case sets `currentApp.version`, the field `EthereumApplicationResolver` reads for the Ethereum app.
- `ApplicationChecker.test.ts` covers the new method, including that it does not override an incompatible resolution.

### ❓ Context

- **JIRA or GitHub link**: DSDK-1469 (contacts Nano support)

### ✅ Checklist

- [x] **Covered by automatic tests**
- [x] **Changeset is provided**
- [x] **Documentation is up-to-date**
- [x] **Impact of the changes:**
  - `@ledgerhq/device-contacts-kit` requires higher minimum OS/app versions for Stax, Flex and Apex, and now reports Nano X and Nano SP as Contacts-capable. **Breaking:** `isContactsSupported` is removed — hosts read `CONTACTS_VERSION_REQUIREMENTS` or `resolveContactsVersionRequirements` and check the axis they need.
  - Devices on prerelease firmware or app builds of the minimum are now reported as supported — worth a QA pass against an RC build, since that is the path that previously failed.
  - `@ledgerhq/device-management-kit` gains one additive `ApplicationChecker` method; no existing gate changes behaviour.
