### PR TITLE
🐛 (transport-mockserver) [DSDK-1473]: Keep polling for devices after a failed request

### DIFF
--- a/.changeset/breezy-ideas-warn.md
+++ b/.changeset/breezy-ideas-warn.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-transport-kit-mockserver": patch
+---
+
+Keep polling for available devices after a failed request. A `catchError` on the outer pipeline replaced the poll timer along with the failed request, so one unreachable moment ended discovery for the rest of the subscription and a device added later was never found.

--- a/packages/transport/mockserver/src/MockserverTransport.test.ts
+++ b/packages/transport/mockserver/src/MockserverTransport.test.ts
@@ -32,6 +32,9 @@ const transportArgs = {
   loggerServiceFactory,
 } as unknown as TransportArgs;
 
+/** Mirrors the transport's own discovery interval. */
+const POLL_INTERVAL_MS = 1000;
+
 const aDevice = (overrides: Partial<Device> = {}): Device => ({
   id: "device-1",
   name: "Ledger Nano X",
@@ -68,6 +71,10 @@ describe("mockserverTransportFactory", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockListDevices(() => Promise.resolve([]));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("builds a supported transport with the mockserver identifier", () => {
@@ -114,15 +121,18 @@ describe("mockserverTransportFactory", () => {
     });
 
     it("keeps polling so newly added devices appear", async () => {
+      vi.useFakeTimers();
       const listDevices = mockListDevices(() => Promise.resolve([]));
       listDevices.mockResolvedValueOnce([]).mockResolvedValueOnce([aDevice()]);
       const transport = mockserverTransportFactory("http://localhost:8080")(
         transportArgs,
       );
 
-      const emissions = await firstValueFrom(
+      const polled = firstValueFrom(
         transport.listenToAvailableDevices().pipe(take(2), toArray()),
       );
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      const emissions = await polled;
 
       expect(emissions[0]).toEqual([]);
       expect(emissions[1]).toEqual([
@@ -141,6 +151,28 @@ describe("mockserverTransportFactory", () => {
       );
 
       expect(devices).toEqual([]);
+    });
+
+    it("keeps polling after a failed request", async () => {
+      vi.useFakeTimers();
+      const listDevices = mockListDevices(() => Promise.resolve([]));
+      listDevices
+        .mockRejectedValueOnce(new Error("offline"))
+        .mockResolvedValueOnce([aDevice()]);
+      const transport = mockserverTransportFactory("http://localhost:8080")(
+        transportArgs,
+      );
+
+      const polled = firstValueFrom(
+        transport.listenToAvailableDevices().pipe(take(2), toArray()),
+      );
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+      const emissions = await polled;
+
+      expect(emissions[0]).toEqual([]);
+      expect(emissions[1]).toEqual([
+        expect.objectContaining({ id: "device-1" }),
+      ]);
     });
   });
 

--- a/packages/transport/mockserver/src/MockserverTransport.ts
+++ b/packages/transport/mockserver/src/MockserverTransport.ts
@@ -76,14 +76,21 @@ export class MockTransport implements Transport {
   listenToAvailableDevices(): Observable<TransportDiscoveredDevice[]> {
     this.logger.debug("listenToAvailableDevices");
     return timer(0, DISCOVERY_POLL_INTERVAL_MS).pipe(
-      switchMap(() => from(this.mockClient.listDevices())),
-      map((devices) => this.mapToDiscoveredDevices(devices)),
-      catchError((error) => {
-        this.logger.error("listenToAvailableDevices failed", {
-          data: { error },
-        });
-        return of([]);
-      }),
+      switchMap(() =>
+        // Recovery belongs to the request, not to the pipeline: a catchError
+        // on the outer chain replaces the timer along with the failed poll, so
+        // one unreachable moment would end discovery for the rest of the
+        // subscription and no device added later could ever be found.
+        from(this.mockClient.listDevices()).pipe(
+          map((devices) => this.mapToDiscoveredDevices(devices)),
+          catchError((error) => {
+            this.logger.error("listenToAvailableDevices failed", {
+              data: { error },
+            });
+            return of<TransportDiscoveredDevice[]>([]);
+          }),
+        ),
+      ),
     );
   }
 

--- a/packages/transport/mockserver/vitest.config.mjs
+++ b/packages/transport/mockserver/vitest.config.mjs
@@ -8,6 +8,7 @@ export default defineConfig({
     include: ["src/**/*.test.ts"],
     coverage: {
       provider: "istanbul",
+      reporter: ["lcov"],
       include: ["src/**/*.ts"],
     },
   },


### PR DESCRIPTION
### 📝 Description

One failed request to the mock server ended device discovery for the rest of the subscription, so a device added afterwards was never found. A `catchError` on the outer pipeline replaced the poll timer along with the failed request — recovery now belongs to the request.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1473](https://ledgerhq.atlassian.net/browse/DSDK-1473)

### ✅ Checklist

- [x] **Covered by automatic tests** — regression test: discovery keeps polling after a failed request
- [x] **Changeset is provided** — patch for `@ledgerhq/device-transport-kit-mockserver`


[DSDK-1473]: https://ledgerhq.atlassian.net/browse/DSDK-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ