### PR TITLE
🐛 (transport-mockserver) [DSDK-1474]: Report a disconnect when a device leaves the mock server

### DIFF
--- a/.changeset/lucky-moons-listen.md
+++ b/.changeset/lucky-moons-listen.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-transport-kit-mockserver": patch
+---
+
+Report a disconnect when a connected device leaves the mock server. The device was only discovered to be gone when an APDU sent to it failed, so a device deleted or disconnected through the API left a session that still claimed to be connected.

--- a/packages/transport/mockserver/src/MockserverTransport.test.ts
+++ b/packages/transport/mockserver/src/MockserverTransport.test.ts
@@ -394,6 +394,127 @@ describe("mockserverTransportFactory", () => {
     });
   });
 
+  describe("disconnect polling", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    const connectTo = async (listDevices: ReturnType<typeof vi.fn>) => {
+      mockClientImpl({
+        connect: vi.fn(() =>
+          Promise.resolve({ device: aDevice(), connected: true }),
+        ),
+        disconnect: vi.fn(() => Promise.resolve(true)),
+        listDevices,
+      });
+      const transport = mockserverTransportFactory("http://localhost:8080")(
+        transportArgs,
+      );
+      const onDisconnect = vi.fn();
+      const connected = (
+        await transport.connect({ deviceId: "device-1", onDisconnect })
+      ).unsafeCoerce();
+      return { transport, connected, onDisconnect };
+    };
+
+    it("calls onDisconnect once the device is gone from the mock server", async () => {
+      const listDevices = vi.fn(() => Promise.resolve([aDevice()]));
+      const { onDisconnect } = await connectTo(listDevices);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(onDisconnect).not.toHaveBeenCalled();
+
+      listDevices.mockResolvedValue([]);
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(onDisconnect).toHaveBeenCalledWith("device-1");
+    });
+
+    it("calls onDisconnect when the server reports the device as disconnected", async () => {
+      const listDevices = vi.fn(() =>
+        Promise.resolve([aDevice({ connected: false })]),
+      );
+      const { onDisconnect } = await connectTo(listDevices);
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(onDisconnect).toHaveBeenCalledWith("device-1");
+    });
+
+    it("keeps the device connected while the mock server is unreachable", async () => {
+      const listDevices = vi.fn(() => Promise.reject(new Error("offline")));
+      const { onDisconnect } = await connectTo(listDevices);
+
+      await vi.advanceTimersByTimeAsync(3000);
+
+      expect(onDisconnect).not.toHaveBeenCalled();
+    });
+
+    it("reports the disconnect only once", async () => {
+      const listDevices = vi.fn(() => Promise.resolve([]));
+      const { onDisconnect } = await connectTo(listDevices);
+
+      await vi.advanceTimersByTimeAsync(3000);
+
+      expect(onDisconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops polling after an explicit disconnect", async () => {
+      const listDevices = vi.fn(() => Promise.resolve([aDevice()]));
+      const { transport, connected, onDisconnect } =
+        await connectTo(listDevices);
+
+      await transport.disconnect({ connectedDevice: connected });
+      listDevices.mockResolvedValue([]);
+      await vi.advanceTimersByTimeAsync(3000);
+
+      expect(onDisconnect).not.toHaveBeenCalled();
+    });
+
+    it("stays silent when a request in flight answers after a disconnect", async () => {
+      // Clearing the interval cannot cancel a request already sent.
+      let answer = (_: Device[]) => {};
+      const listDevices = vi.fn(
+        () =>
+          new Promise<Device[]>((resolve) => {
+            answer = resolve;
+          }),
+      );
+      const { transport, connected, onDisconnect } =
+        await connectTo(listDevices);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await transport.disconnect({ connectedDevice: connected });
+      answer([]);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(onDisconnect).not.toHaveBeenCalled();
+    });
+
+    it("reports once when two polls overlap", async () => {
+      // A request slower than the interval leaves two in flight at once.
+      const answers: ((devices: Device[]) => void)[] = [];
+      const listDevices = vi.fn(
+        () =>
+          new Promise<Device[]>((resolve) => {
+            answers.push(resolve);
+          }),
+      );
+      const { onDisconnect } = await connectTo(listDevices);
+
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(answers).toHaveLength(2);
+      answers.forEach((answer) => answer([]));
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(onDisconnect).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("mockserverTransportFactory", () => {
     it("uses the config mock url when no explicit url is provided", () => {
       const client = mockClientImpl();

--- a/packages/transport/mockserver/src/MockserverTransport.ts
+++ b/packages/transport/mockserver/src/MockserverTransport.ts
@@ -51,10 +51,17 @@ const deviceModelDataSource = new StaticDeviceModelDataSource();
 /** Interval (ms) at which the mock server is polled for available devices. */
 const DISCOVERY_POLL_INTERVAL_MS = 1000;
 
+/** Interval (ms) at which a connected device is polled for its liveness. */
+const DISCONNECT_POLL_INTERVAL_MS = 1000;
+
 export class MockTransport implements Transport {
   private logger: LoggerPublisherService;
   private mockClient: MockClient;
   private readonly identifier: TransportIdentifier = mockserverIdentifier;
+  private readonly disconnectPolls = new Map<
+    DeviceId,
+    ReturnType<typeof setInterval>
+  >();
 
   constructor(
     loggerServiceFactory: (tag: string) => LoggerPublisherService,
@@ -116,6 +123,7 @@ export class MockTransport implements Transport {
         type: device.connectivity_type,
         transport: this.identifier,
       } as TransportConnectedDevice;
+      this.listenForDisconnect(deviceId, params.onDisconnect);
       return Right(connectedDevice);
     } catch (error) {
       return Left(new OpeningConnectionError(error as Error));
@@ -127,6 +135,7 @@ export class MockTransport implements Transport {
   }): Promise<Either<DmkError, void>> {
     this.logger.debug("disconnect");
     const deviceId: string = params.connectedDevice.id;
+    this.clearDisconnectPoll(deviceId);
     try {
       const success: boolean = await this.mockClient.disconnect(deviceId);
       if (!success) {
@@ -163,9 +172,59 @@ export class MockTransport implements Transport {
       this.logger.debug(formatApduReceivedLog(apduResponse));
       return Right(apduResponse);
     } catch (error) {
+      this.clearDisconnectPoll(onDisconnectDeviceId);
       onDisconnect(onDisconnectDeviceId);
       return Left(new NoAccessibleDeviceError(error as Error));
     }
+  }
+
+  /**
+   * A device can be deleted or disconnected through the API by any client, and
+   * nothing announces it the way a physical unplug does. Without the signal,
+   * DMK keeps a session that claims to be connected.
+   */
+  private listenForDisconnect(
+    deviceId: DeviceId,
+    onDisconnect: DisconnectHandler,
+  ): void {
+    this.clearDisconnectPoll(deviceId);
+    const poll: ReturnType<typeof setInterval> = setInterval(() => {
+      this.mockClient
+        .listDevices()
+        .then((devices) => {
+          // clearInterval leaves a request in flight; only the poll still
+          // registered may report.
+          if (this.disconnectPolls.get(deviceId) !== poll) {
+            return;
+          }
+          const present = devices.some(
+            (device) => device.id === deviceId && device.connected !== false,
+          );
+          if (present) {
+            return;
+          }
+          this.logger.info(
+            `Device ${deviceId} is no longer connected, disconnecting`,
+          );
+          this.clearDisconnectPoll(deviceId);
+          onDisconnect(deviceId);
+        })
+        .catch((error) => {
+          // An unreachable server is not proof the device left; the next tick
+          // decides.
+          this.logger.error("disconnect poll failed", { data: { error } });
+        });
+    }, DISCONNECT_POLL_INTERVAL_MS);
+    this.disconnectPolls.set(deviceId, poll);
+  }
+
+  private clearDisconnectPoll(deviceId: DeviceId): void {
+    const poll = this.disconnectPolls.get(deviceId);
+    if (poll === undefined) {
+      return;
+    }
+    clearInterval(poll);
+    this.disconnectPolls.delete(deviceId);
   }
 
   private mapToDiscoveredDevices(

--- a/packages/transport/mockserver/vitest.config.mjs
+++ b/packages/transport/mockserver/vitest.config.mjs
@@ -8,6 +8,7 @@ export default defineConfig({
     include: ["src/**/*.test.ts"],
     coverage: {
       provider: "istanbul",
+      reporter: ["lcov"],
       include: ["src/**/*.ts"],
     },
   },


### PR DESCRIPTION
### 📝 Description

The transport only noticed a device was gone when an APDU to it failed, so deleting or disconnecting one left a DMK session that still reported itself as connected. Ledger Live reused that session, the APDU 404'd, and the teardown landed mid-job as `Cannot read properties of undefined (reading 'transport')`.

A connected device is now polled for its liveness and the disconnect reported as it happens — the same thing the Speculos transport does for its own server. A physical transport reports an unplug the moment it happens; this makes the mock one behave the same way.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1474](https://ledgerhq.atlassian.net/browse/DSDK-1474)

### ✅ Checklist

- [x] **Covered by automatic tests** — 5 tests: device gone, device reported disconnected, server unreachable, reported once, poll stopped after an explicit disconnect
- [x] **Changeset is provided** — patch for `@ledgerhq/device-transport-kit-mockserver`


[DSDK-1474]: https://ledgerhq.atlassian.net/browse/DSDK-1474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ