### PR TITLE
🐛 (device-mock-server) [DSDK-1475]: Report no code data for an app without an install hash

### DIFF
--- a/apps/device-mock-server/src/internal/secure-channel/service/scripts.ts
+++ b/apps/device-mock-server/src/internal/secure-channel/service/scripts.ts
@@ -56,8 +56,20 @@ const HANDSHAKE: readonly SecureChannelStep[] = [
 ];
 
 /**
+ * What a real device reports for an entry that carries no code data, and what
+ * Ledger Live skips on sight. An empty string does not read that way to it: a
+ * hash-less app is taken for an installed one and its empty hash looked up,
+ * which the Manager API answers with an unrelated app.
+ */
+const NO_CODE_DATA = "0".repeat(64);
+
+/**
  * Map a device's `apps` metadata to the installed-app list shape DMK expects,
  * excluding the BOLOS dashboard (which is not a regular installed app).
+ *
+ * The code-data hash is derived per app, not fixed: an app carrying an install
+ * hash is reported as installed, one without as having no code data, so it is
+ * skipped rather than misidentified.
  */
 export function deriveInstalledApps(device: Device): InstalledAppEntry[] {
   return (device.apps ?? [])
@@ -65,7 +77,7 @@ export function deriveInstalledApps(device: Device): InstalledAppEntry[] {
     .map((app) => ({
       flags: 0,
       hash: app.hash ?? "",
-      hash_code_data: "",
+      hash_code_data: app.hash ?? NO_CODE_DATA,
       name: app.name,
     }));
 }

--- a/apps/device-mock-server/src/internal/secure-channel/ws/SecureChannelWebSocket.test.ts
+++ b/apps/device-mock-server/src/internal/secure-channel/ws/SecureChannelWebSocket.test.ts
@@ -189,8 +189,8 @@ describe("secure channel WebSocket", () => {
     const terminal = await drive(token, id, "apps/list");
     expect(terminal.type).toBe("success");
     expect(terminal.data).toEqual([
-      { flags: 0, hash: "", hash_code_data: "", name: "Bitcoin" },
-      { flags: 0, hash: "", hash_code_data: "", name: "Ethereum" },
+      { flags: 0, hash: "", hash_code_data: "0".repeat(64), name: "Bitcoin" },
+      { flags: 0, hash: "", hash_code_data: "0".repeat(64), name: "Ethereum" },
     ]);
   });
 
@@ -253,7 +253,7 @@ describe("secure channel WebSocket: install commits the app to the device contex
     // The device context now reflects Bitcoin, with its install hash.
     const after = await drive(token, id, "apps/list");
     expect(after.data).toEqual([
-      { flags: 0, hash: BTC.hash, hash_code_data: "", name: "Bitcoin" },
+      { flags: 0, hash: BTC.hash, hash_code_data: BTC.hash, name: "Bitcoin" },
     ]);
   });
 
@@ -292,7 +292,7 @@ describe("secure channel WebSocket: install commits the app to the device contex
 
     const before = await drive(token, id, "apps/list");
     expect(before.data).toEqual([
-      { flags: 0, hash: BTC.hash, hash_code_data: "", name: "Bitcoin" },
+      { flags: 0, hash: BTC.hash, hash_code_data: BTC.hash, name: "Bitcoin" },
     ]);
 
     const uninstall = await drive(token, id, `install?hash=${BTC.hash}`);
@@ -433,7 +433,7 @@ describe("secure channel WebSocket: firmware install erases the app storage", ()
     ]);
     const before = await drive(token, id, "apps/list");
     expect(before.data).toEqual([
-      { flags: 0, hash: "abc123", hash_code_data: "", name: "Bitcoin" },
+      { flags: 0, hash: "abc123", hash_code_data: "abc123", name: "Bitcoin" },
     ]);
 
     const install = await drive(


### PR DESCRIPTION
### 📝 Description

Every installed app was reported with an empty code-data hash. Ledger Live does not read that as "no code data", so it looked the empty hash up instead — and the Manager API answers `[""]` with **Vault**, a Ledger Blue app with `bytes: 0` that is in no current catalog. My Ledger then crashed on `Cannot read properties of undefined (reading 'bytes')`.

The code-data hash is now derived per app: an app carrying an install hash is reported as installed, one without is reported as having no code data, so Ledger Live skips it instead of misidentifying it. Per app, not a flat constant — reporting no code data for every app would drop the apps installed through Ledger Live too.

The other half, sending the real install hash from the app catalog so an app added in the UI shows up as installed, is in #1846.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1475](https://ledgerhq.atlassian.net/browse/DSDK-1475)

### ✅ Checklist

- [x] **Covered by automatic tests** — the secure-channel `apps/list` expectations cover an app with a hash and one without
- [x] **No changeset needed** — `apps/device-mock-server` is not published

> [!NOTE]
> **Correction to an earlier note here:** this PR previously claimed 2 `createMockServer.test.ts` tests fail on `develop`. That was wrong. Those tests reach the Manager API (GetOsVersion synthesis resolves the MCU version from it), and they only failed because the sandbox they ran in blocked outbound network. With network access the suite is green.


[DSDK-1475]: https://ledgerhq.atlassian.net/browse/DSDK-1475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
