### PR TITLE
🐛 (signer-zcash) [LIVE-36833]: Name the status words that surface as UnknownError

### DIFF
--- a/.changeset/zcash-map-precondition-status-word.md
+++ b/.changeset/zcash-map-precondition-status-word.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-zcash": patch
+---
+
+Map the status words the Zcash app returns for an unmet signing precondition, a version parsing failure and an RNG failure, so they surface as named errors instead of UnknownError

--- a/.changeset/zcash-name-6985-a-user-rejection.md
+++ b/.changeset/zcash-name-6985-a-user-rejection.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-zcash": patch
+---
+
+Rename the 0x6985 error to UserRejectedError, the condition the Zcash app actually reports on that status word

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetAppConfigCommand.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetAppConfigCommand.test.ts
@@ -102,6 +102,25 @@ describe("GetAppConfigCommand", () => {
       }
     });
 
+    it("should name the status word the app returns when it cannot parse its own version", () => {
+      const command = new GetAppConfigCommand();
+      const response = new ApduResponse({
+        statusCode: new Uint8Array([0x6f, 0x01]),
+        data: new Uint8Array(0),
+      });
+
+      const result = command.parseResponse(response);
+
+      expect(isSuccessCommandResult(result)).toBe(false);
+      if (!isSuccessCommandResult(result)) {
+        const err = result.error as ZcashAppCommandError;
+        expect(err.errorCode).toBe("6f01");
+        // An unmapped word also carries its errorCode, so the message is what
+        // tells a named error apart from the UnknownError fallback.
+        expect(err.message).toBe("VersionParsingFailError");
+      }
+    });
+
     it("should return InvalidStatusWordError when response is empty", () => {
       const command = new GetAppConfigCommand();
       const response = new ApduResponse({

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetTrustedInputCommand.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetTrustedInputCommand.test.ts
@@ -98,5 +98,23 @@ describe("GetTrustedInputCommand", () => {
         expect(error.message).toBe("ConditionOfUseNotSatisfiedError");
       }
     });
+
+    it("should name the status word the app returns when its nonce draw fails", () => {
+      const apduResponse = new ApduResponse({
+        statusCode: new Uint8Array([0x6f, 0x03]),
+        data: new Uint8Array([]),
+      });
+
+      const response = command.parseResponse(apduResponse);
+
+      expect(isSuccessCommandResult(response)).toBe(false);
+      if (!isSuccessCommandResult(response)) {
+        const error = response.error as { errorCode?: string; message: string };
+        expect(error.errorCode).toBe("6f03");
+        // An unmapped word also carries its errorCode, so the message is what
+        // tells a named error apart from the UnknownError fallback.
+        expect(error.message).toBe("RngFailureError");
+      }
+    });
   });
 });

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/GetTrustedInputCommand.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/GetTrustedInputCommand.test.ts
@@ -95,7 +95,7 @@ describe("GetTrustedInputCommand", () => {
       if (!isSuccessCommandResult(response)) {
         const error = response.error as { errorCode?: string; message: string };
         expect(error.errorCode).toBe("6985");
-        expect(error.message).toBe("ConditionOfUseNotSatisfiedError");
+        expect(error.message).toBe("UserRejectedError");
       }
     });
 

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/PcztBundleCommands.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/PcztBundleCommands.test.ts
@@ -23,7 +23,7 @@ const success = new ApduResponse({
   data: new Uint8Array(),
 });
 const rejected = new ApduResponse({
-  statusCode: Uint8Array.of(0x69, 0x85), // ConditionOfUseNotSatisfied
+  statusCode: Uint8Array.of(0x69, 0x85), // the user declined on device
   data: new Uint8Array(),
 });
 

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/SignPcztCommands.test.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/SignPcztCommands.test.ts
@@ -7,13 +7,17 @@ import { describe, expect, it } from "vitest";
 import { SignPcztIronwoodCommand } from "@internal/app-binder/command/SignPcztIronwoodCommand";
 import { SignPcztOrchardCommand } from "@internal/app-binder/command/SignPcztOrchardCommand";
 import { SignPcztTransparentCommand } from "@internal/app-binder/command/SignPcztTransparentCommand";
+import { ZcashAppCommandError } from "@internal/app-binder/command/utils/zcashApplicationErrors";
 
 const apduHex = (raw: Uint8Array): string => Buffer.from(raw).toString("hex");
 const response = (statusCode: number[], data: Uint8Array): ApduResponse =>
   new ApduResponse({ statusCode: Uint8Array.from(statusCode), data });
 
 const OK = [0x90, 0x00];
-const REJECTED = [0x69, 0x85]; // ConditionOfUseNotSatisfied (signed before finalize)
+const REJECTED = [0x69, 0x85]; // the user declined on device
+// Preconditions the app refuses a signature on: a derivation path that is not the
+// account the change returns to, and a command issued before the PCZT is finalized.
+const PRECONDITION_UNMET = [0x69, 0x86];
 
 describe("SignPcztOrchardCommand", () => {
   it("builds INS 0x57 with empty data and the action index in P2", () => {
@@ -46,6 +50,17 @@ describe("SignPcztOrchardCommand", () => {
       response(REJECTED, new Uint8Array()),
     );
     expect(isSuccessCommandResult(result)).toBe(false);
+  });
+
+  it("names the unmet-precondition status word", () => {
+    const result = new SignPcztOrchardCommand({ actionIndex: 0 }).parseResponse(
+      response(PRECONDITION_UNMET, new Uint8Array()),
+    );
+    expect(isSuccessCommandResult(result)).toBe(false);
+    if (!isSuccessCommandResult(result)) {
+      expect(result.error).toBeInstanceOf(ZcashAppCommandError);
+      expect((result.error as ZcashAppCommandError).errorCode).toBe("6986");
+    }
   });
 });
 
@@ -81,6 +96,17 @@ describe("SignPcztIronwoodCommand", () => {
       actionIndex: 0,
     }).parseResponse(response(REJECTED, new Uint8Array()));
     expect(isSuccessCommandResult(result)).toBe(false);
+  });
+
+  it("names the unmet-precondition status word", () => {
+    const result = new SignPcztIronwoodCommand({
+      actionIndex: 0,
+    }).parseResponse(response(PRECONDITION_UNMET, new Uint8Array()));
+    expect(isSuccessCommandResult(result)).toBe(false);
+    if (!isSuccessCommandResult(result)) {
+      expect(result.error).toBeInstanceOf(ZcashAppCommandError);
+      expect((result.error as ZcashAppCommandError).errorCode).toBe("6986");
+    }
   });
 });
 
@@ -127,5 +153,16 @@ describe("SignPcztTransparentCommand", () => {
       inputIndex: 0,
     }).parseResponse(response(REJECTED, new Uint8Array()));
     expect(isSuccessCommandResult(result)).toBe(false);
+  });
+
+  it("names the unmet-precondition status word", () => {
+    const result = new SignPcztTransparentCommand({
+      inputIndex: 0,
+    }).parseResponse(response(PRECONDITION_UNMET, new Uint8Array()));
+    expect(isSuccessCommandResult(result)).toBe(false);
+    if (!isSuccessCommandResult(result)) {
+      expect(result.error).toBeInstanceOf(ZcashAppCommandError);
+      expect((result.error as ZcashAppCommandError).errorCode).toBe("6986");
+    }
   });
 });

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/utils/zcashApplicationErrors.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/utils/zcashApplicationErrors.ts
@@ -12,6 +12,7 @@ export type ZcashErrorCodes =
   | "6981"
   | "6982"
   | "6985"
+  | "6986"
   | "6a80"
   | "6a84"
   | "6a88"
@@ -21,6 +22,8 @@ export type ZcashErrorCodes =
   | "6d00"
   | "6e00"
   | "6f00"
+  | "6f01"
+  | "6f03"
   | "6f42"
   | "6faa"
   | "9240"
@@ -48,6 +51,11 @@ export const ZCASH_APP_ERRORS: CommandErrors<ZcashErrorCodes> = {
   "6981": { message: "CommandIncompatibleFileStructureError" },
   "6982": { message: "SecurityStatusNotSatisfiedError" },
   "6985": { message: "ConditionOfUseNotSatisfiedError" },
+  // The app keeps 6985 for a user denial, so this adjacent word carries the
+  // preconditions it refuses on: a signing command whose derivation path does not
+  // match the account the change returns to, and one issued before the PCZT is
+  // finalized.
+  "6986": { message: "ConditionsOfUseNotSatisfiedError" },
   "6a80": { message: "IncorrectDataError" },
   "6a84": { message: "NotEnoughMemorySpaceError" },
   "6a88": { message: "ReferencedDataNotFoundError" },
@@ -57,6 +65,8 @@ export const ZCASH_APP_ERRORS: CommandErrors<ZcashErrorCodes> = {
   "6d00": { message: "InsNotSupportedError" },
   "6e00": { message: "ClaNotSupportedError" },
   "6f00": { message: "TechnicalProblemError" },
+  "6f01": { message: "VersionParsingFailError" },
+  "6f03": { message: "RngFailureError" },
   "6f42": { message: "LicensingError" },
   "6faa": { message: "HaltedError" },
   "9240": { message: "MemoryProblemError" },

--- a/packages/signer/signer-zcash/src/internal/app-binder/command/utils/zcashApplicationErrors.ts
+++ b/packages/signer/signer-zcash/src/internal/app-binder/command/utils/zcashApplicationErrors.ts
@@ -50,7 +50,7 @@ export const ZCASH_APP_ERRORS: CommandErrors<ZcashErrorCodes> = {
   "6700": { message: "IncorrectLengthError" },
   "6981": { message: "CommandIncompatibleFileStructureError" },
   "6982": { message: "SecurityStatusNotSatisfiedError" },
-  "6985": { message: "ConditionOfUseNotSatisfiedError" },
+  "6985": { message: "UserRejectedError" },
   // The app keeps 6985 for a user denial, so this adjacent word carries the
   // preconditions it refuses on: a signing command whose derivation path does not
   // match the account the change returns to, and one issued before the PCZT is


### PR DESCRIPTION
### 📝 Description

`ZCASH_APP_ERRORS` did not carry `0x6986`. That status word therefore fell through `CommandErrorHelper` to `GlobalCommandErrorHandler`, whose own table holds none of the Zcash app's words either, and reached the host as an `UnknownDeviceExchangeError` whose message is `UnknownError`.

The app returns `0x6986` on two conditions, both on the paths that release a signature: a signing command whose derivation path is not the account the change returns to, and a signature requested before the PCZT is finalized. The status code was preserved on the error object, so logs stayed diagnosable, but there was no named error to key on.

Two further words the app returns were absent as well — `0x6f01` (version parsing) and `0x6f03` (RNG failure).

**Second commit, self-contained.** `0x6985` was mapped as `ConditionOfUseNotSatisfiedError`, but the app uses that word for a user denial and deliberately keeps the adjacent one for the unmet preconditions:

```rust
Deny = StatusWords::UserCancelled as u16,
// 0x6986, not the 0x6985 an ISO reading would suggest: the legacy protocol uses 0x6985 for a
// user denial (see `Deny`), so this condition takes the adjacent word.
ConditionsOfUseNotSatisfied = 0x6986,
```

The two were effectively swapped, and the misnomer had already propagated into test comments. `0x6985` becomes `UserRejectedError`, the wording the other signers in this monorepo already use for that word. This commit changes a published error string, which is why it is kept separate — it can be dropped without losing the mapping. If it is dropped, `0x6986` needs a message that does not sit one letter away from the `0x6985` one.

This is a diagnosability fix, not a defect on a live path: the refusal is not reachable from `coin-zcash` today, which carries one account index per transaction.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-36833
- **Feature**: Zcash shielded signing — error surfacing

### ✅ Checklist

- [x] **Covered by automatic tests** — each added word is asserted where the app can actually raise it: `6986` on the three signature-release commands (`SignPcztCommands.test.ts`), `6f01` on the command that reads the firmware version (`GetAppConfigCommand.test.ts`), `6f03` on the trusted-input nonce draw (`GetTrustedInputCommand.test.ts`). Every one was checked against a table with its entry removed — it fails there and passes with it, so it measures the mapping rather than the absence of a crash. Note that `UnknownDeviceExchangeError` carries an `errorCode` too, so these assert the message: the code alone passes even when the word is unmapped.
- [x] **Changeset is provided** — one per commit, both `patch` on `@ledgerhq/device-signer-kit-zcash`, one package each.
- [x] **Documentation is up-to-date** — the new `0x6986` entry documents the two device conditions it stands for; two stale `// ConditionOfUseNotSatisfied` comments on `0x6985` are corrected.
- [x] **Impact of the changes:**
  - `0x6986`, `0x6f01` and `0x6f03` now produce a `ZcashAppCommandError` instead of an `UnknownDeviceExchangeError`.
  - The message for `0x6985` changes from `ConditionOfUseNotSatisfiedError` to `UserRejectedError`. One in-repo consumer asserted the old string and is updated; a consumer outside this repo keying on it would need the same change. The `errorCode` is untouched.
  - No change to any APDU, wire format or device interaction.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
