### PR TITLE
✨ (device-mock-server) [DSDK-1477]: Rename a device from the SetDeviceName APDU

### DIFF
--- a/apps/device-mock-server/README.md
+++ b/apps/device-mock-server/README.md
@@ -132,7 +132,7 @@ flowchart TD
 
 1. **Explicit per-device mock** — an exact-prefix match always wins, **even while a Speculos proxy is active** (multi-response mocks cycle). This lets you override a single app response mid-session — e.g. mock `GetAppAndVersion` to `5515` to simulate a locked device while the app runs on the emulator.
 2. **Active Speculos proxy** — once an app is open, unmatched APDUs are forwarded to the emulator; `Close App` releases it and reverts to mock mode.
-3. **Derived handshake & secure-channel APDUs** — `GetOsVersion` / `GetAppAndVersion` are synthesized from the device's firmware/app metadata, and the [secure-channel](#-secure-channel-websocket) relayed APDUs (`e051` permission, `e052` GetCertificate, `e0f0` install block) derive to sensible defaults (`9000` / a parseable certificate). All of these never need mocking but can be overridden by a mock — which is how secure-channel error paths are injected.
+3. **Derived handshake & secure-channel APDUs** — `GetOsVersion` / `GetAppAndVersion` are synthesized from the device's firmware/app metadata, and the [secure-channel](#-secure-channel-websocket) relayed APDUs (`e051` permission, `e052` GetCertificate, `e0f0` install block) derive to sensible defaults (`9000` / a parseable certificate). All of these never need mocking but can be overridden by a mock — which is how secure-channel error paths are injected. `SetDeviceName` (`e0d4…`) is the one that writes back: it renames the device, so `GetDeviceName`, `GET /devices` and the export all report the new name.
 4. **Unmatched Open App** — when Speculos is configured, provisions a real emulator for the requested app (`6807` if the app is not installed on the device).
 5. **Fallback** — `6d00`.
 

--- a/apps/device-mock-server/src/internal/os/service/OsApduService.test.ts
+++ b/apps/device-mock-server/src/internal/os/service/OsApduService.test.ts
@@ -165,3 +165,45 @@ describe("OsApduService onboarding", () => {
     expect(await os.resolve(record, device, EARLY_CHECK_ENTER)).toBeUndefined();
   });
 });
+
+describe("OsApduService rename", () => {
+  // `e0 d4 00 00 <len> <utf-8 name>` — "Louis Flex" is 10 bytes.
+  const SET_NAME = "e0d400000a4c6f75697320466c6578";
+  const GET_NAME = "e0d2000000";
+
+  it("renames the device and reads the new name back", async () => {
+    const { os, repo, record, device } = setup();
+
+    expect(await os.resolve(record, device, SET_NAME)).toBe("9000");
+
+    const renamed = repo.findDevice(record, device.id).unsafeCoerce();
+    expect(renamed.name).toBe("Louis Flex");
+    expect(await os.resolve(record, renamed, GET_NAME)).toBe(
+      "4c6f75697320466c6578" + "9000",
+    );
+  });
+
+  it("keeps the rest of the device as it was", async () => {
+    const { os, repo, record, device } = setup();
+
+    await os.resolve(record, device, SET_NAME);
+
+    const renamed = repo.findDevice(record, device.id).unsafeCoerce();
+    expect(renamed.id).toBe(device.id);
+    expect(renamed.device_type).toBe(device.device_type);
+    expect(renamed.firmware_version).toBe(device.firmware_version);
+  });
+
+  it("rejects a name the command does not carry in full", async () => {
+    const { os, repo, record, device } = setup();
+
+    // Declares 10 bytes, sends 4.
+    expect(await os.resolve(record, device, "e0d400000a4c6f7569")).toBe("6a80");
+    // Declares no name at all.
+    expect(await os.resolve(record, device, "e0d400000000")).toBe("6a80");
+
+    expect(repo.findDevice(record, device.id).unsafeCoerce().name).toBe(
+      device.name,
+    );
+  });
+});

--- a/apps/device-mock-server/src/internal/os/service/OsApduService.ts
+++ b/apps/device-mock-server/src/internal/os/service/OsApduService.ts
@@ -5,7 +5,9 @@ import {
   deriveGetOsVersion,
   deriveOsApduResponse,
   GET_OS_VERSION_PREFIX,
+  parseSetDeviceName,
   resolveTargetId,
+  SET_DEVICE_NAME_PREFIX,
 } from "@internal/os/service/osApdus";
 import { secureChannelTypes } from "@internal/secure-channel/di/secureChannelTypes";
 import { type FirmwareUpdateResolver } from "@internal/secure-channel/service/FirmwareUpdateResolver";
@@ -23,6 +25,9 @@ const TOGGLE_EARLY_CHECK_ENTER_P2 = "00";
 const TOGGLE_EARLY_CHECK_EXIT_P2 = "01";
 
 const STATUS_OK = "9000";
+
+/** What a device answers a command whose data it cannot use (`6a80`). */
+const INVALID_DATA_SW = "6a80";
 
 /**
  * Synthesizes the OS-handshake APDU responses (GetOsVersion / GetAppAndVersion /
@@ -79,6 +84,17 @@ export class OsApduService {
         );
         return STATUS_OK;
       }
+    }
+
+    // A rename has to stick: the name is what GetDeviceName reads back, and
+    // what every later read of the device reports.
+    if (apdu.startsWith(SET_DEVICE_NAME_PREFIX)) {
+      const name = parseSetDeviceName(apdu);
+      if (name === null) {
+        return INVALID_DATA_SW;
+      }
+      this.repository.editDevice(record, device.id, { name });
+      return STATUS_OK;
     }
 
     return deriveOsApduResponse(device, apdu);

--- a/apps/device-mock-server/src/internal/os/service/osApdus.ts
+++ b/apps/device-mock-server/src/internal/os/service/osApdus.ts
@@ -27,6 +27,11 @@ export const LIST_APPS_CONTINUE_PREFIX = "e0df0000";
  */
 export const GET_DEVICE_NAME_CLEANING_PREFIX = "e0500000";
 export const GET_DEVICE_NAME_PREFIX = "e0d20000";
+/**
+ * SetDeviceName (cla=0xe0, ins=0xd4), sent as `<prefix><len><utf-8 name>` by
+ * live-common's `editDeviceName` when a device is renamed from Ledger Live.
+ */
+export const SET_DEVICE_NAME_PREFIX = "e0d40000";
 
 /**
  * Custom Lock Screen commands (CLA 0xe0), matched on their cla+ins prefix. The
@@ -267,6 +272,22 @@ export function deriveListApps(
  */
 export function deriveGetDeviceName(device: Device): string {
   return asciiHex(device.name ?? "") + STATUS_OK;
+}
+
+/**
+ * The name carried by a SetDeviceName APDU, or `null` when the command is
+ * malformed — no length byte, or fewer name bytes than it declares. A device
+ * also refuses an empty name, which reads as malformed here.
+ */
+export function parseSetDeviceName(apdu: string): string | null {
+  const body = apdu.slice(SET_DEVICE_NAME_PREFIX.length);
+  const declared = parseInt(body.slice(0, 2), 16);
+  const data = body.slice(2);
+  if (!declared || data.length !== declared * 2) {
+    return null;
+  }
+  const bytes = data.match(/../g) ?? [];
+  return String.fromCharCode(...bytes.map((byte) => parseInt(byte, 16)));
 }
 
 const BATTERY_CAPABLE_MODELS = new Set(["stax", "flex", "apex"]);


### PR DESCRIPTION
### 📝 Description

Renaming a mock device from Ledger Live did nothing: the server answers `GetDeviceName` (`e0d2…`) from the device's `name`, but nothing handled `SetDeviceName` (`e0d4 00 00 <len> <utf-8 name>` — what live-common's `editDeviceName` sends), so the APDU fell through to `6d00`.

It now writes the name back, so `GetDeviceName`, `GET /devices`, the export and the configuration UI all report it afterwards. A command that declares more name bytes than it carries, or none at all, answers `6a80` rather than renaming the device to nothing.

Verified against a running server: rename → `9000`, `GetDeviceName` → `4c6f75697320466c6578` ("Louis Flex"), `GET /devices` → `"name": "Louis Flex"`.



> [!NOTE]
> Stacked on #1846 (the configuration UI), which is its base — the diff here is the last commit only.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1477](https://ledgerhq.atlassian.net/browse/DSDK-1477)

### ✅ Checklist

- [x] **Covered by automatic tests** — 3 tests: the rename sticks and reads back, the rest of the device is untouched, and a truncated or empty name is refused
- [x] **No changeset needed** — `apps/device-mock-server` is not published
- [x] **Documentation is up-to-date** — the README's APDU resolution section notes that this is the one that writes back


[DSDK-1477]: https://ledgerhq.atlassian.net/browse/DSDK-1477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ