### PR TITLE
✨ (signer-eth) [LBD-298]: Update type for SignTransaction/TypedData factories

### DIFF
--- a/.changeset/late-jeans-glow.md
+++ b/.changeset/late-jeans-glow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-signer-kit-ethereum": patch
+---
+
+Update type for SignTransaction/TypedData factories

--- a/packages/signer/signer-eth/src/api/app-binder/SignTransactionDeviceActionFactory.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignTransactionDeviceActionFactory.ts
@@ -1,5 +1,7 @@
 import { type ContextModule } from "@ledgerhq/context-module";
 import {
+  type DeviceActionStateMachine,
+  type InternalApi,
   type LoggerPublisherService,
   type XStateDeviceAction,
 } from "@ledgerhq/device-management-kit";
@@ -17,6 +19,24 @@ import { SignTransactionDeviceAction } from "@internal/app-binder/device-action/
 import { EthersTransactionMapperService } from "@internal/transaction/service/mapper/EthersTransactionMapperService";
 import { TransactionParserService } from "@internal/transaction/service/parser/TransactionParserService";
 
+type SignTransactionDA = XStateDeviceAction<
+  SignTransactionDAOutput,
+  SignTransactionDAInput,
+  SignTransactionDAError,
+  SignTransactionDAIntermediateValue,
+  SignTransactionDAInternalState
+> & {
+  makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    SignTransactionDAOutput,
+    SignTransactionDAInput,
+    SignTransactionDAError,
+    SignTransactionDAIntermediateValue,
+    SignTransactionDAInternalState
+  >;
+};
+
 export const SignTransactionDeviceActionFactory = (args: {
   derivationPath: string;
   transaction: Uint8Array;
@@ -25,13 +45,7 @@ export const SignTransactionDeviceActionFactory = (args: {
   options?: TransactionOptions;
   inspect?: boolean;
   loggerFactory?: (tag: string) => LoggerPublisherService;
-}): XStateDeviceAction<
-  SignTransactionDAOutput,
-  SignTransactionDAInput,
-  SignTransactionDAError,
-  SignTransactionDAIntermediateValue,
-  SignTransactionDAInternalState
-> =>
+}): SignTransactionDA =>
   new SignTransactionDeviceAction({
     input: {
       derivationPath: args.derivationPath,

--- a/packages/signer/signer-eth/src/api/app-binder/SignTransactionDeviceActionFactory.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignTransactionDeviceActionFactory.ts
@@ -1,41 +1,11 @@
 import { type ContextModule } from "@ledgerhq/context-module";
-import {
-  type DeviceActionStateMachine,
-  type InternalApi,
-  type LoggerPublisherService,
-  type XStateDeviceAction,
-} from "@ledgerhq/device-management-kit";
+import { type LoggerPublisherService } from "@ledgerhq/device-management-kit";
 
-import {
-  type SignTransactionDAError,
-  type SignTransactionDAInput,
-  type SignTransactionDAIntermediateValue,
-  type SignTransactionDAInternalState,
-  type SignTransactionDAOutput,
-} from "@api/app-binder/SignTransactionDeviceActionTypes";
 import { type EvmAddressBook } from "@api/model/EvmAddressBook";
 import { type TransactionOptions } from "@api/model/TransactionOptions";
 import { SignTransactionDeviceAction } from "@internal/app-binder/device-action/SignTransaction/SignTransactionDeviceAction";
 import { EthersTransactionMapperService } from "@internal/transaction/service/mapper/EthersTransactionMapperService";
 import { TransactionParserService } from "@internal/transaction/service/parser/TransactionParserService";
-
-type SignTransactionDA = XStateDeviceAction<
-  SignTransactionDAOutput,
-  SignTransactionDAInput,
-  SignTransactionDAError,
-  SignTransactionDAIntermediateValue,
-  SignTransactionDAInternalState
-> & {
-  makeStateMachine(
-    internalApi: InternalApi,
-  ): DeviceActionStateMachine<
-    SignTransactionDAOutput,
-    SignTransactionDAInput,
-    SignTransactionDAError,
-    SignTransactionDAIntermediateValue,
-    SignTransactionDAInternalState
-  >;
-};
 
 export const SignTransactionDeviceActionFactory = (args: {
   derivationPath: string;
@@ -45,7 +15,7 @@ export const SignTransactionDeviceActionFactory = (args: {
   options?: TransactionOptions;
   inspect?: boolean;
   loggerFactory?: (tag: string) => LoggerPublisherService;
-}): SignTransactionDA =>
+}) =>
   new SignTransactionDeviceAction({
     input: {
       derivationPath: args.derivationPath,

--- a/packages/signer/signer-eth/src/api/app-binder/SignTypedDataDeviceActionFactory.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignTypedDataDeviceActionFactory.ts
@@ -1,41 +1,11 @@
 import { type ContextModule } from "@ledgerhq/context-module";
-import {
-  type DeviceActionStateMachine,
-  type InternalApi,
-  type LoggerPublisherService,
-  type XStateDeviceAction,
-} from "@ledgerhq/device-management-kit";
+import { type LoggerPublisherService } from "@ledgerhq/device-management-kit";
 
-import {
-  type SignTypedDataDAError,
-  type SignTypedDataDAInput,
-  type SignTypedDataDAIntermediateValue,
-  type SignTypedDataDAInternalState,
-  type SignTypedDataDAOutput,
-} from "@api/app-binder/SignTypedDataDeviceActionTypes";
 import { type TypedData } from "@api/model/TypedData";
 import { SignTypedDataDeviceAction } from "@internal/app-binder/device-action/SignTypedData/SignTypedDataDeviceAction";
 import { EthersTransactionMapperService } from "@internal/transaction/service/mapper/EthersTransactionMapperService";
 import { TransactionParserService } from "@internal/transaction/service/parser/TransactionParserService";
 import { DefaultTypedDataParserService } from "@internal/typed-data/service/DefaultTypedDataParserService";
-
-type SignTypedDataDA = XStateDeviceAction<
-  SignTypedDataDAOutput,
-  SignTypedDataDAInput,
-  SignTypedDataDAError,
-  SignTypedDataDAIntermediateValue,
-  SignTypedDataDAInternalState
-> & {
-  makeStateMachine(
-    internalApi: InternalApi,
-  ): DeviceActionStateMachine<
-    SignTypedDataDAOutput,
-    SignTypedDataDAInput,
-    SignTypedDataDAError,
-    SignTypedDataDAIntermediateValue,
-    SignTypedDataDAInternalState
-  >;
-};
 
 export const SignTypedDataDeviceActionFactory = (args: {
   derivationPath: string;
@@ -44,7 +14,7 @@ export const SignTypedDataDeviceActionFactory = (args: {
   skipOpenApp: boolean;
   inspect?: boolean;
   loggerFactory?: (tag: string) => LoggerPublisherService;
-}): SignTypedDataDA =>
+}) =>
   new SignTypedDataDeviceAction({
     input: {
       derivationPath: args.derivationPath,

--- a/packages/signer/signer-eth/src/api/app-binder/SignTypedDataDeviceActionFactory.ts
+++ b/packages/signer/signer-eth/src/api/app-binder/SignTypedDataDeviceActionFactory.ts
@@ -1,5 +1,7 @@
 import { type ContextModule } from "@ledgerhq/context-module";
 import {
+  type DeviceActionStateMachine,
+  type InternalApi,
   type LoggerPublisherService,
   type XStateDeviceAction,
 } from "@ledgerhq/device-management-kit";
@@ -17,6 +19,24 @@ import { EthersTransactionMapperService } from "@internal/transaction/service/ma
 import { TransactionParserService } from "@internal/transaction/service/parser/TransactionParserService";
 import { DefaultTypedDataParserService } from "@internal/typed-data/service/DefaultTypedDataParserService";
 
+type SignTypedDataDA = XStateDeviceAction<
+  SignTypedDataDAOutput,
+  SignTypedDataDAInput,
+  SignTypedDataDAError,
+  SignTypedDataDAIntermediateValue,
+  SignTypedDataDAInternalState
+> & {
+  makeStateMachine(
+    internalApi: InternalApi,
+  ): DeviceActionStateMachine<
+    SignTypedDataDAOutput,
+    SignTypedDataDAInput,
+    SignTypedDataDAError,
+    SignTypedDataDAIntermediateValue,
+    SignTypedDataDAInternalState
+  >;
+};
+
 export const SignTypedDataDeviceActionFactory = (args: {
   derivationPath: string;
   data: TypedData;
@@ -24,13 +44,7 @@ export const SignTypedDataDeviceActionFactory = (args: {
   skipOpenApp: boolean;
   inspect?: boolean;
   loggerFactory?: (tag: string) => LoggerPublisherService;
-}): XStateDeviceAction<
-  SignTypedDataDAOutput,
-  SignTypedDataDAInput,
-  SignTypedDataDAError,
-  SignTypedDataDAIntermediateValue,
-  SignTypedDataDAInternalState
-> =>
+}): SignTypedDataDA =>
   new SignTypedDataDeviceAction({
     input: {
       derivationPath: args.derivationPath,


### PR DESCRIPTION
> [!NOTE]
> 
>
> This PR fixes [#1775](https://github.com/LedgerHQ/device-sdk-ts/pull/1775).

### Why the type update?

`XStateDeviceAction` declares `makeStateMachine` as a `protected abstract`.
Subclasses need to make it public otherwise it's not callable from consumer code. 

```ts
export class SignTypedDataDeviceAction extends XStateDeviceAction<
  SignTypedDataDAOutput,
  SignTypedDataDAInput,
  SignTypedDataDAError,
  SignTypedDataDAIntermediateValue,
  SignTypedDataDAInternalState
> {
  makeStateMachine(internalApi: InternalApi): ... { // ← public
```

The intersection type is the middle ground — no `@internal/` leak, `makeStateMachine` stays callable:
```ts
type SignTypedDataDA = XStateDeviceAction<...> & {
  makeStateMachine(internalApi: InternalApi): DeviceActionStateMachine<...>;
};
```

### Why a factory? (reminder)

It hides internal dependencies from the consumer:

```ts
import { EthersTransactionMapperService } from "@internal/transaction...";
import { TransactionParserService } from "@internal/transaction....";
import { DefaultTypedDataParserService } from "@internal/typed-data...";
```

and embeds them directly in the Factory:

```ts
  new SignTypedDataDeviceAction({
    input: {
      derivationPath: args.derivationPath,
      data: args.data,
      contextModule: args.contextModule,
      skipOpenApp: args.skipOpenApp,
      parser: new DefaultTypedDataParserService(), // ← embedded
      transactionMapper: new EthersTransactionMapperService(),  // ← embedded
      transactionParser: new TransactionParserService(), // ← embedded
    },
    ....
  });
```

### Remark 

cs-tests might be failing on this branch but a fix @aussedatlo is incoming - tested [here](https://github.com/LedgerHQ/device-sdk-ts/actions/runs/34486029269/job/102901895136) with his changes ]