### PR TITLE
✨ (mock-server) [DSDK-1501]: Resolve release-candidate firmwares on their model's provider

### DIFF
--- a/apps/device-mock-server-ui/src/api/managerApi.ts
+++ b/apps/device-mock-server-ui/src/api/managerApi.ts
@@ -5,7 +5,13 @@
  */
 const MANAGER_API_URL = "https://manager.api.live.ledger.com/api";
 
-const PROVIDER = "1";
+const DEFAULT_PROVIDER = 1;
+
+/** A release candidate is published to its model's own provider only. */
+const providersFor = (rcProvider?: number): number[] =>
+  rcProvider === undefined || rcProvider === DEFAULT_PROVIDER
+    ? [DEFAULT_PROVIDER]
+    : [DEFAULT_PROVIDER, rcProvider];
 
 export interface CatalogApp {
   readonly name: string;
@@ -53,25 +59,29 @@ const get = async (path: string, params: Record<string, string>) => {
 export async function listCatalogApps(
   mask: number,
   firmwareVersion: string,
+  rcProvider?: number,
 ): Promise<CatalogApp[]> {
   const targetId = targetIdForMask(mask);
   const key = `${targetId}:${firmwareVersion}`;
   const cached = appsCache.get(key);
   if (cached) return cached;
 
-  const response = await get("v2/apps/by-target", {
-    target_id: String(targetId),
-    provider: PROVIDER,
-    firmware_version_name: firmwareVersion,
-  });
-  if (!response.ok) {
-    throw new ManagerApiError(
-      `The Manager API answered ${response.status} for the app list`,
-    );
+  let entries: CatalogApp[] = [];
+  for (const provider of providersFor(rcProvider)) {
+    const response = await get("v2/apps/by-target", {
+      target_id: String(targetId),
+      provider: String(provider),
+      firmware_version_name: firmwareVersion,
+    });
+    if (!response.ok) {
+      throw new ManagerApiError(
+        `The Manager API answered ${response.status} for the app list`,
+      );
+    }
+    entries = toEntries((await response.json()) as ApplicationDto[]);
+    if (entries.length > 0) break;
   }
 
-  const apps = (await response.json()) as ApplicationDto[];
-  const entries = toEntries(apps);
   appsCache.set(key, entries);
   return entries;
 }
@@ -84,6 +94,7 @@ export async function listCatalogApps(
 export async function firmwareExists(
   mask: number,
   firmwareVersion: string,
+  rcProvider?: number,
 ): Promise<boolean> {
   const targetId = targetIdForMask(mask);
   const key = `${targetId}:${firmwareVersion}`;
@@ -91,20 +102,27 @@ export async function firmwareExists(
   if (cached !== undefined) return cached;
 
   const deviceVersion = await resolveDeviceVersion(targetId);
-  const response = await get("get_firmware_version", {
-    device_version: String(deviceVersion),
-    version_name: firmwareVersion,
-    provider: PROVIDER,
-  });
-  // 404 is the answer "no such OS version", not a failure.
-  if (!response.ok && response.status !== 404) {
-    throw new ManagerApiError(
-      `The Manager API answered ${response.status} for the OS version`,
-    );
+  let exists = false;
+  for (const provider of providersFor(rcProvider)) {
+    const response = await get("get_firmware_version", {
+      device_version: String(deviceVersion),
+      version_name: firmwareVersion,
+      provider: String(provider),
+    });
+    // 404 is the answer "no such OS version", not a failure.
+    if (!response.ok && response.status !== 404) {
+      throw new ManagerApiError(
+        `The Manager API answered ${response.status} for the OS version`,
+      );
+    }
+    if (response.ok) {
+      exists = true;
+      break;
+    }
   }
 
-  firmwareCache.set(key, response.ok);
-  return response.ok;
+  firmwareCache.set(key, exists);
+  return exists;
 }
 
 async function resolveDeviceVersion(targetId: number): Promise<number> {
@@ -113,7 +131,7 @@ async function resolveDeviceVersion(targetId: number): Promise<number> {
 
   const response = await get("get_device_version", {
     target_id: String(targetId),
-    provider: PROVIDER,
+    provider: String(DEFAULT_PROVIDER),
   });
   if (!response.ok) {
     throw new ManagerApiError("The Manager API does not know this model");

--- a/apps/device-mock-server-ui/src/api/useDeviceCatalog.ts
+++ b/apps/device-mock-server-ui/src/api/useDeviceCatalog.ts
@@ -42,8 +42,8 @@ export function useDeviceCatalog(
     setState({ status: "loading" });
     const timer = setTimeout(() => {
       Promise.all([
-        firmwareExists(model.mask, version),
-        listCatalogApps(model.mask, version),
+        firmwareExists(model.mask, version, model.rcProvider),
+        listCatalogApps(model.mask, version, model.rcProvider),
       ])
         .then(([exists, apps]) => {
           if (cancelled) return;

--- a/apps/device-mock-server-ui/src/domain/devices.ts
+++ b/apps/device-mock-server-ui/src/domain/devices.ts
@@ -17,6 +17,11 @@ export interface DeviceModel {
   readonly speculos: boolean;
   /** How the device is driven: a touchscreen, or left/right/both buttons. */
   readonly touch: boolean;
+  /**
+   * Provider carrying this model's release-candidate firmwares, absent for a
+   * model that no longer gets any.
+   */
+  readonly rcProvider?: number;
 }
 
 export const DEVICE_MODELS: DeviceModel[] = [
@@ -39,6 +44,7 @@ export const DEVICE_MODELS: DeviceModel[] = [
     icon: Nano,
     speculos: true,
     touch: false,
+    rcProvider: 81,
   },
   {
     value: "nanoX",
@@ -49,6 +55,7 @@ export const DEVICE_MODELS: DeviceModel[] = [
     icon: Nano,
     speculos: true,
     touch: false,
+    rcProvider: 80,
   },
   {
     value: "stax",
@@ -59,6 +66,7 @@ export const DEVICE_MODELS: DeviceModel[] = [
     icon: Stax,
     speculos: true,
     touch: true,
+    rcProvider: 83,
   },
   {
     value: "flex",
@@ -69,6 +77,7 @@ export const DEVICE_MODELS: DeviceModel[] = [
     icon: Flex,
     speculos: true,
     touch: true,
+    rcProvider: 82,
   },
   {
     value: "apexp",
@@ -79,6 +88,7 @@ export const DEVICE_MODELS: DeviceModel[] = [
     icon: Apex,
     speculos: false,
     touch: true,
+    rcProvider: 84,
   },
 ];
 

--- a/apps/device-mock-server/src/internal/secure-channel/service/FirmwareUpdateResolver.test.ts
+++ b/apps/device-mock-server/src/internal/secure-channel/service/FirmwareUpdateResolver.test.ts
@@ -238,5 +238,69 @@ describe("FirmwareUpdateResolver", () => {
       });
       expect(fetchSpy.mock.calls.length).toBe(callsAfterFirst);
     });
+
+    it("falls back to the model's provider for a release-candidate firmware", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation((input) => {
+          const url = String(input);
+          if (url.includes("/get_device_version")) return json({ id: 135 });
+          if (url.includes("/get_firmware_version")) {
+            // Flex 1.7.0-rc2 is published to provider 82 only.
+            return url.includes("provider=82")
+              ? json({ id: 593 })
+              : Promise.resolve({ ok: false, status: 404 } as Response);
+          }
+          if (url.includes("/get_latest_firmware")) {
+            return json({ result: "null" });
+          }
+          if (url.includes("/firmware_final_versions/593")) {
+            return json({ id: 593, name: "1.7.0-rc2", mcu_versions: [55] });
+          }
+          if (url.includes("/mcu_versions")) {
+            return json([{ id: 55, name: "5.32.3" }]);
+          }
+          throw new Error(`unexpected fetch ${url}`);
+        });
+
+      const resolved = await resolver().resolveCurrentMcuVersion({
+        targetId: 0x33300004,
+        currentVersion: "1.7.0-rc2",
+      });
+
+      expect(resolved.extract()).toBe("5.32.3");
+      const askedLatestOnRcProvider = fetchSpy.mock.calls.some(([input]) => {
+        const url = String(input);
+        return (
+          url.includes("/get_latest_firmware") && url.includes("provider=82")
+        );
+      });
+      expect(askedLatestOnRcProvider).toBe(true);
+    });
+
+    it("keeps the default provider for a released firmware", async () => {
+      const fetchSpy = mockFetch({
+        "/get_device_version": { id: 135 },
+        "/get_firmware_version": { id: 588 },
+        "/get_latest_firmware": { result: "null" },
+        "/firmware_final_versions/588": {
+          id: 588,
+          name: "1.6.1",
+          mcu_versions: [55],
+        },
+        "/mcu_versions": [{ id: 55, name: "5.32.3" }],
+      });
+
+      const resolved = await resolver().resolveCurrentMcuVersion({
+        targetId: 0x33300004,
+        currentVersion: "1.6.1",
+      });
+
+      expect(resolved.extract()).toBe("5.32.3");
+      const askedRcProvider = fetchSpy.mock.calls.some(([input]) =>
+        String(input).includes("provider=82"),
+      );
+      expect(askedRcProvider).toBe(false);
+    });
   });
 });

--- a/apps/device-mock-server/src/internal/secure-channel/service/FirmwareUpdateResolver.ts
+++ b/apps/device-mock-server/src/internal/secure-channel/service/FirmwareUpdateResolver.ts
@@ -447,7 +447,12 @@ export class FirmwareUpdateResolver {
       if (response.status >= 500) {
         throw new Error(`Manager API /${path} returned ${response.status}`);
       }
-      logger.warn(`Manager API /${path} returned ${response.status}`);
+      // A 404 is how a provider says it does not carry this firmware, which is
+      // the fallback's normal path. Callers log their own message once every
+      // provider has answered that.
+      if (response.status !== 404) {
+        logger.warn(`Manager API /${path} returned ${response.status}`);
+      }
       return undefined;
     }
     return (await response.json()) as T;

--- a/apps/device-mock-server/src/internal/secure-channel/service/FirmwareUpdateResolver.ts
+++ b/apps/device-mock-server/src/internal/secure-channel/service/FirmwareUpdateResolver.ts
@@ -13,9 +13,22 @@ const LIVE_COMMON_VERSION = "36.2.0";
 
 /**
  * Default provider (1 = Ledger). Mirrors `FORCE_PROVIDER`'s default in
- * ledger-live; the mock does not model alternative firmware providers.
+ * ledger-live.
  */
 const DEFAULT_PROVIDER = 1;
+
+/**
+ * Provider carrying a model's release-candidate firmwares, by target id: an RC
+ * is published there only. Ledger Live needs `FORCE_PROVIDER` set to the same
+ * value to see such a device.
+ */
+const RC_PROVIDER_BY_TARGET_ID: Record<number, number> = {
+  0x33000004: 80, // Nano X
+  0x33100004: 81, // Nano S Plus
+  0x33200004: 83, // Stax
+  0x33300004: 82, // Flex
+  0x33400004: 84, // Apex
+};
 
 /**
  * Rollout salt the Manager API uses to gate staged firmware releases. In
@@ -164,26 +177,16 @@ export class FirmwareUpdateResolver {
     currentVersion: string;
     providerId: number;
   }): Promise<LanguagePackageDto[]> {
-    const deviceVersion = await this.get<DeviceVersionDto>(
-      "get_device_version",
-      { provider: providerId, target_id: targetId },
-    );
-    if (deviceVersion?.id === undefined) {
-      logger.warn(`Manager API: unknown target_id ${targetId}`);
-      return [];
-    }
-    const firmware = await this.get<FinalFirmwareDto>("get_firmware_version", {
-      device_version: deviceVersion.id,
-      version_name: currentVersion,
-      provider: providerId,
+    const current = await this.fetchCurrentFirmware({
+      targetId,
+      currentVersion,
+      providerId,
     });
-    if (firmware?.id === undefined) {
-      logger.warn(`Manager API: unknown firmware ${currentVersion}`);
-      return [];
-    }
+    if (!current) return [];
+
     const packs = await this.get<LanguagePackageDto[]>("language-packages", {
-      device_version: deviceVersion.id,
-      current_se_firmware_final_version: firmware.id,
+      device_version: current.deviceVersionId,
+      current_se_firmware_final_version: current.firmwareId,
     });
     return packs ?? [];
   }
@@ -239,33 +242,18 @@ export class FirmwareUpdateResolver {
     // Transient errors (network failure, 5xx) are left to propagate so the
     // caching layer can evict them; only deterministic outcomes reach the
     // `Maybe.empty()` returns below and are safe to cache.
-    const deviceVersion = await this.get<DeviceVersionDto>(
-      "get_device_version",
-      { provider: providerId, target_id: targetId },
-    );
-    if (deviceVersion?.id === undefined) {
-      logger.warn(`Manager API: unknown target_id ${targetId}`);
-      return Maybe.empty();
-    }
-
-    const currentFirmware = await this.get<FinalFirmwareDto>(
-      "get_firmware_version",
-      {
-        device_version: deviceVersion.id,
-        version_name: currentVersion,
-        provider: providerId,
-      },
-    );
-    if (currentFirmware?.id === undefined) {
-      logger.warn(`Manager API: unknown firmware ${currentVersion}`);
-      return Maybe.empty();
-    }
+    const current = await this.fetchCurrentFirmware({
+      targetId,
+      currentVersion,
+      providerId,
+    });
+    if (!current) return Maybe.empty();
 
     const latest = await this.get<LatestFirmwareDto>("get_latest_firmware", {
       salt: ROLLOUT_SALT,
-      current_se_firmware_final_version: currentFirmware.id,
-      device_version: deviceVersion.id,
-      provider: providerId,
+      current_se_firmware_final_version: current.firmwareId,
+      device_version: current.deviceVersionId,
+      provider: current.provider,
     });
     const osu = latest?.se_firmware_osu_version;
     // When an update is available use the next firmware's MCU list so LLD's
@@ -277,7 +265,7 @@ export class FirmwareUpdateResolver {
       latest?.result !== "null" &&
       osu?.next_se_firmware_final_version !== undefined
         ? osu.next_se_firmware_final_version
-        : currentFirmware.id;
+        : current.firmwareId;
 
     const firmware = await this.get<FinalFirmwareDto>(
       `firmware_final_versions/${firmwareId}`,
@@ -339,33 +327,18 @@ export class FirmwareUpdateResolver {
     // Transient errors (network failure, 5xx) are left to propagate so the
     // caching layer can evict them; only deterministic outcomes reach the
     // `Maybe.empty()` returns below and are safe to cache.
-    const deviceVersion = await this.get<DeviceVersionDto>(
-      "get_device_version",
-      { provider: providerId, target_id: targetId },
-    );
-    if (deviceVersion?.id === undefined) {
-      logger.warn(`Manager API: unknown target_id ${targetId}`);
-      return Maybe.empty();
-    }
-
-    const currentFirmware = await this.get<FinalFirmwareDto>(
-      "get_firmware_version",
-      {
-        device_version: deviceVersion.id,
-        version_name: currentVersion,
-        provider: providerId,
-      },
-    );
-    if (currentFirmware?.id === undefined) {
-      logger.warn(`Manager API: unknown firmware ${currentVersion}`);
-      return Maybe.empty();
-    }
+    const current = await this.fetchCurrentFirmware({
+      targetId,
+      currentVersion,
+      providerId,
+    });
+    if (!current) return Maybe.empty();
 
     const latest = await this.get<LatestFirmwareDto>("get_latest_firmware", {
       salt: ROLLOUT_SALT,
-      current_se_firmware_final_version: currentFirmware.id,
-      device_version: deviceVersion.id,
-      provider: providerId,
+      current_se_firmware_final_version: current.firmwareId,
+      device_version: current.deviceVersionId,
+      provider: current.provider,
     });
     const osu = latest?.se_firmware_osu_version;
     if (
@@ -388,6 +361,72 @@ export class FirmwareUpdateResolver {
     }
 
     return Maybe.of(final);
+  }
+
+  private providersFor(
+    targetId: string | number,
+    providerId: number,
+  ): number[] {
+    const rcProvider = RC_PROVIDER_BY_TARGET_ID[Number(targetId)];
+    return rcProvider === undefined || rcProvider === providerId
+      ? [providerId]
+      : [providerId, rcProvider];
+  }
+
+  /**
+   * `get_device_version` -> `get_firmware_version` over each provider in turn.
+   * Resolves the provider that answered so the rest of a chain stays on it: the
+   * update and language packs of an RC firmware live on its provider too.
+   */
+  private async fetchCurrentFirmware({
+    targetId,
+    currentVersion,
+    providerId,
+  }: {
+    targetId: string | number;
+    currentVersion: string;
+    providerId: number;
+  }): Promise<
+    | {
+        provider: number;
+        deviceVersionId: number;
+        firmwareId: number;
+        firmware: FinalFirmwareDto;
+      }
+    | undefined
+  > {
+    let targetKnown = false;
+    for (const provider of this.providersFor(targetId, providerId)) {
+      const deviceVersion = await this.get<DeviceVersionDto>(
+        "get_device_version",
+        { provider, target_id: targetId },
+      );
+      if (deviceVersion?.id === undefined) continue;
+      targetKnown = true;
+
+      const firmware = await this.get<FinalFirmwareDto>(
+        "get_firmware_version",
+        {
+          device_version: deviceVersion.id,
+          version_name: currentVersion,
+          provider,
+        },
+      );
+      if (firmware?.id !== undefined) {
+        return {
+          provider,
+          deviceVersionId: deviceVersion.id,
+          firmwareId: firmware.id,
+          firmware,
+        };
+      }
+    }
+    logger.warn(
+      targetKnown
+        ? `Manager API: unknown firmware ${currentVersion}`
+        : `Manager API: unknown target_id ${targetId}`,
+    );
+    return undefined;
   }
 
   private async get<T>(


### PR DESCRIPTION
### 📝 Description

A mock device on a release-candidate firmware was not recognised by Ledger Live: My Ledger showed nothing, and the server answered `6d00` to GetOsVersion.

```
b001000000 -> 0105424f4c4f5309312e372e302d7263329000   (GetAppAndVersion → BOLOS 1.7.0-rc2)  ✅
e001000000 -> 6d00 (no matching mock)                  (GetOsVersion)                        ❌
```

GetOsVersion is only synthesized once the MCU version resolves from the Manager API, and every lookup went to provider 1 — where an RC firmware does not exist. The lookup 404'd, `resolveCurrentMcuVersion` returned `Nothing`, and the APDU fell through.

An RC is published to its model's own provider instead. Verified against the Manager API:

| model | version | provider 1 | model's provider |
| --- | --- | --- | --- |
| Flex | `1.7.0-rc2` | 404 | **82** — 200, 24 apps |
| Stax | `1.11.0-rc2` | 404 | **83** — 200, 23 apps |
| Apex | `1.2.0-rc2` | 404 | **84** — 200, 23 apps |
| Nano X | `2.8.0-rc2` | 404 | **80** — 200, 24 apps |
| Nano S Plus | `1.7.0-rc2` | 404 | **81** — 200, 24 apps |

So the firmware lookup now falls back to the model's provider when the default one does not know the version, and the rest of the chain (`get_latest_firmware`, language packs) stays on whichever provider answered. A released firmware still resolves on provider 1 and never asks the second one.

The configuration UI does the same, so an RC version validates instead of reading as "no such OS version" and its apps are listed.

**Ledger Live must run with `FORCE_PROVIDER` set to the same value** (e.g. `FORCE_PROVIDER=82` for a Flex on `1.7.0-rc2`) — `getProviderIdUseCase` defaults to provider 1, so My Ledger would otherwise still find nothing for that device. Nothing on the mock server side can change that.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1501](https://ledgerhq.atlassian.net/browse/DSDK-1501)
- **Feature**: mock server support for release-candidate firmwares.

### ✅ Checklist

- [x] **Covered by automatic tests** — two tests on `FirmwareUpdateResolver`: the fallback for an RC firmware (and that the rest of the chain follows the provider that answered), and that a released firmware never leaves the default provider.
- [ ] **Changeset is provided** — not needed, the change only touches apps (`device-mock-server`, `device-mock-server-ui`), no published package.
- [x] **Documentation is up-to-date**
- [ ] **Impact of the changes:**
  - A device on an RC firmware now completes the handshake and is recognised by Ledger Live (with `FORCE_PROVIDER` set to the model's provider).
  - One extra Manager API round-trip per device/version, only when the default provider does not know the version; the result is memoized as before.
  - Released firmwares are unaffected — same single-provider chain as today.


[DSDK-1501]: https://ledgerhq.atlassian.net/browse/DSDK-1501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ