### PR TITLE
✨ (mock-server-ui) [DSDK-1502]: Add a device screen tab with touch and buttons

### DIFF
--- a/apps/device-mock-server-ui/src/api/client.ts
+++ b/apps/device-mock-server-ui/src/api/client.ts
@@ -5,6 +5,8 @@ import {
   type MockConfig,
   type Session,
   type SessionExport,
+  type SpeculosAction,
+  type SpeculosButton,
 } from "@ledgerhq/device-mockserver-client";
 
 export interface Health {
@@ -70,6 +72,28 @@ async function errorMessage(response: Response): Promise<string> {
 }
 
 const body = (payload: unknown) => JSON.stringify(payload);
+
+/**
+ * Drive the Speculos instance behind a device. What comes back through the
+ * passthrough is the emulator's own answer, not the server's JSON envelope.
+ */
+async function speculos(
+  path: string,
+  token: string,
+  payload: unknown,
+): Promise<void> {
+  const response = await fetch(path, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: body(payload),
+  });
+  if (!response.ok) {
+    throw new MockServerError(response.status, await errorMessage(response));
+  }
+}
 
 export const api = {
   health: () => request<Health>("/health"),
@@ -145,6 +169,38 @@ export const api = {
 
   clearMocks: (token: string, deviceId: string) =>
     request<void>(`/devices/${deviceId}/mocks`, { method: "DELETE", token }),
+
+  /** Null when the device has no Speculos instance, which is any time no app runs. */
+  screenshot: async (token: string, deviceId: string): Promise<Blob | null> => {
+    const response = await fetch(`/devices/${deviceId}/speculos/screenshot`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (response.status === 409) return null;
+    if (!response.ok) {
+      throw new MockServerError(response.status, await errorMessage(response));
+    }
+    return response.blob();
+  },
+
+  pressButton: (
+    token: string,
+    deviceId: string,
+    button: SpeculosButton,
+    action: SpeculosAction,
+  ) =>
+    speculos(`/devices/${deviceId}/speculos/button/${button}`, token, {
+      action,
+    }),
+
+  /** Coordinates in device screen pixels. */
+  touchScreen: (
+    token: string,
+    deviceId: string,
+    x: number,
+    y: number,
+    action: SpeculosAction,
+  ) =>
+    speculos(`/devices/${deviceId}/speculos/finger`, token, { action, x, y }),
 
   exportSession: (token: string) =>
     request<SessionExport>("/export", { token }),

--- a/apps/device-mock-server-ui/src/components/DeviceCard.tsx
+++ b/apps/device-mock-server-ui/src/components/DeviceCard.tsx
@@ -20,16 +20,18 @@ import {
 import { api } from "@/api/client";
 import { ConsolePanel } from "@/components/ConsolePanel";
 import { CopyButton } from "@/components/CopyButton";
+import { DeviceScreenPanel } from "@/components/DeviceScreenPanel";
 import { LabeledRow } from "@/components/LabeledRow";
 import { MocksPanel } from "@/components/MocksPanel";
 import { findModel } from "@/domain/devices";
 
-type Tab = "overview" | "mocks" | "console";
+type Tab = "overview" | "mocks" | "console" | "screen";
 
 const TABS: { value: Tab; label: string }[] = [
   { value: "overview", label: "Overview" },
   { value: "mocks", label: "Mocks" },
   { value: "console", label: "APDU console" },
+  { value: "screen", label: "Screen" },
 ];
 
 interface DeviceCardProps {
@@ -277,6 +279,15 @@ export function DeviceCard({
               token={token}
               device={device}
               onDeviceMayHaveChanged={onChanged}
+              onError={onError}
+            />
+          ) : null}
+
+          {tab === "screen" ? (
+            <DeviceScreenPanel
+              token={token}
+              deviceId={device.id}
+              model={model}
               onError={onError}
             />
           ) : null}

--- a/apps/device-mock-server-ui/src/components/DeviceScreenPanel.tsx
+++ b/apps/device-mock-server-ui/src/components/DeviceScreenPanel.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  type PointerEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   type SpeculosAction,
   type SpeculosButton,
@@ -45,6 +51,7 @@ export function DeviceScreenPanel({
   const imageRef = useRef<HTMLImageElement>(null);
   /** Where the finger went down, so the release lands on the same spot. */
   const held = useRef<Point | null>(null);
+  const unmounted = useRef(false);
 
   const releaseObjectUrl = useCallback(() => {
     if (objectUrl.current) {
@@ -58,6 +65,8 @@ export function DeviceScreenPanel({
     inFlight.current = true;
     try {
       const blob = await api.screenshot(token, deviceId);
+      // A frame that arrives after unmount has no cleanup left to revoke it.
+      if (unmounted.current) return;
       releaseObjectUrl();
       objectUrl.current = blob ? URL.createObjectURL(blob) : null;
       setSrc(objectUrl.current);
@@ -88,7 +97,13 @@ export function DeviceScreenPanel({
     };
   }, [refresh]);
 
-  useEffect(() => releaseObjectUrl, [releaseObjectUrl]);
+  useEffect(
+    () => () => {
+      unmounted.current = true;
+      releaseObjectUrl();
+    },
+    [releaseObjectUrl],
+  );
 
   const send = (call: Promise<void>) =>
     void call
@@ -104,22 +119,29 @@ export function DeviceScreenPanel({
   );
 
   const toDevicePoint = (
-    event: React.PointerEvent<HTMLImageElement>,
+    event: PointerEvent<HTMLImageElement>,
   ): Point | null => {
     const image = imageRef.current;
     if (!image?.naturalWidth || !image.naturalHeight) return null;
     const rect = image.getBoundingClientRect();
+    if (!rect.width || !rect.height) return null;
+    // The far edge maps to the pixel count itself, which is one past the last
+    // pixel the emulator has.
+    const clamp = (value: number, size: number) =>
+      Math.min(Math.max(Math.round(value), 0), size - 1);
     return {
-      x: Math.round(
+      x: clamp(
         ((event.clientX - rect.left) / rect.width) * image.naturalWidth,
+        image.naturalWidth,
       ),
-      y: Math.round(
+      y: clamp(
         ((event.clientY - rect.top) / rect.height) * image.naturalHeight,
+        image.naturalHeight,
       ),
     };
   };
 
-  const onPointerDown = (event: React.PointerEvent<HTMLImageElement>) => {
+  const onPointerDown = (event: PointerEvent<HTMLImageElement>) => {
     if (!model?.touch || held.current) return;
     const point = toDevicePoint(event);
     if (!point) return;
@@ -130,7 +152,7 @@ export function DeviceScreenPanel({
     send(touch(point.x, point.y, "press"));
   };
 
-  const onPointerUp = (event: React.PointerEvent<HTMLImageElement>) => {
+  const onPointerUp = (event: PointerEvent<HTMLImageElement>) => {
     const point = held.current;
     if (!model?.touch || !point) return;
     held.current = null;
@@ -182,10 +204,16 @@ export function DeviceScreenPanel({
                   key={button}
                   type="button"
                   aria-label={`${label} button`}
-                  onPointerDown={() =>
-                    send(api.pressButton(token, deviceId, button, "press"))
-                  }
+                  onPointerDown={(event) => {
+                    // Capture, so a pointer released off the button still
+                    // releases it here rather than leaving it held down.
+                    event.currentTarget.setPointerCapture(event.pointerId);
+                    send(api.pressButton(token, deviceId, button, "press"));
+                  }}
                   onPointerUp={() =>
+                    send(api.pressButton(token, deviceId, button, "release"))
+                  }
+                  onPointerCancel={() =>
                     send(api.pressButton(token, deviceId, button, "release"))
                   }
                   className="border-muted body-3 text-base bg-muted hover:bg-muted-pressed active:bg-active flex-1 rounded-md border py-8 select-none"

--- a/apps/device-mock-server-ui/src/components/DeviceScreenPanel.tsx
+++ b/apps/device-mock-server-ui/src/components/DeviceScreenPanel.tsx
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  type SpeculosAction,
+  type SpeculosButton,
+} from "@ledgerhq/device-mockserver-client";
+import { Banner } from "@ledgerhq/lumen-ui-react";
+
+import { api } from "@/api/client";
+import { type DeviceModel } from "@/domain/devices";
+
+const SCREEN_POLL_MS = 500;
+const IDLE_POLL_MS = 2000;
+
+const BUTTONS: { button: SpeculosButton; label: string }[] = [
+  { button: "left", label: "Left" },
+  { button: "both", label: "Both" },
+  { button: "right", label: "Right" },
+];
+
+interface Point {
+  readonly x: number;
+  readonly y: number;
+}
+
+interface DeviceScreenPanelProps {
+  readonly token: string;
+  readonly deviceId: string;
+  readonly model: DeviceModel | undefined;
+  readonly onError: (message: string) => void;
+}
+
+export function DeviceScreenPanel({
+  token,
+  deviceId,
+  model,
+  onError,
+}: DeviceScreenPanelProps) {
+  const [src, setSrc] = useState<string | null>(null);
+  const objectUrl = useRef<string | null>(null);
+  const inFlight = useRef(false);
+  /** Read by the poll loop to pick its delay. */
+  const isLive = useRef(false);
+  isLive.current = src !== null;
+
+  const imageRef = useRef<HTMLImageElement>(null);
+  /** Where the finger went down, so the release lands on the same spot. */
+  const held = useRef<Point | null>(null);
+
+  const releaseObjectUrl = useCallback(() => {
+    if (objectUrl.current) {
+      URL.revokeObjectURL(objectUrl.current);
+      objectUrl.current = null;
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (inFlight.current) return;
+    inFlight.current = true;
+    try {
+      const blob = await api.screenshot(token, deviceId);
+      releaseObjectUrl();
+      objectUrl.current = blob ? URL.createObjectURL(blob) : null;
+      setSrc(objectUrl.current);
+    } catch (cause) {
+      onError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      inFlight.current = false;
+    }
+  }, [token, deviceId, releaseObjectUrl, onError]);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    let cancelled = false;
+
+    const tick = async () => {
+      if (!document.hidden) await refresh();
+      if (cancelled) return;
+      timer = setTimeout(
+        () => void tick(),
+        isLive.current ? SCREEN_POLL_MS : IDLE_POLL_MS,
+      );
+    };
+    void tick();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [refresh]);
+
+  useEffect(() => releaseObjectUrl, [releaseObjectUrl]);
+
+  const send = (call: Promise<void>) =>
+    void call
+      .then(() => refresh())
+      .catch((cause: unknown) =>
+        onError(cause instanceof Error ? cause.message : String(cause)),
+      );
+
+  const touch = useCallback(
+    (x: number, y: number, action: SpeculosAction) =>
+      api.touchScreen(token, deviceId, x, y, action),
+    [token, deviceId],
+  );
+
+  const toDevicePoint = (
+    event: React.PointerEvent<HTMLImageElement>,
+  ): Point | null => {
+    const image = imageRef.current;
+    if (!image?.naturalWidth || !image.naturalHeight) return null;
+    const rect = image.getBoundingClientRect();
+    return {
+      x: Math.round(
+        ((event.clientX - rect.left) / rect.width) * image.naturalWidth,
+      ),
+      y: Math.round(
+        ((event.clientY - rect.top) / rect.height) * image.naturalHeight,
+      ),
+    };
+  };
+
+  const onPointerDown = (event: React.PointerEvent<HTMLImageElement>) => {
+    if (!model?.touch || held.current) return;
+    const point = toDevicePoint(event);
+    if (!point) return;
+    // Capture so the release still arrives if the pointer wanders off the
+    // image mid-hold, which would leave the device pressed forever.
+    imageRef.current?.setPointerCapture(event.pointerId);
+    held.current = point;
+    send(touch(point.x, point.y, "press"));
+  };
+
+  const onPointerUp = (event: React.PointerEvent<HTMLImageElement>) => {
+    const point = held.current;
+    if (!model?.touch || !point) return;
+    held.current = null;
+    imageRef.current?.releasePointerCapture(event.pointerId);
+    send(touch(point.x, point.y, "release"));
+  };
+
+  // Leaving the tab mid-hold would otherwise leave the emulator with a finger
+  // down.
+  useEffect(
+    () => () => {
+      const point = held.current;
+      if (!point) return;
+      held.current = null;
+      void touch(point.x, point.y, "release");
+    },
+    [touch],
+  );
+
+  return (
+    <div className="flex flex-col gap-16">
+      <p className="body-3 text-muted">
+        The screen of the Speculos instance backing this device, refreshed while
+        this tab is open. Press and release are sent separately, so holding the
+        pointer holds the finger — which is how Stax and Flex confirm.
+      </p>
+
+      {src ? (
+        <>
+          <img
+            ref={imageRef}
+            src={src}
+            alt="Device screen"
+            draggable={false}
+            onPointerDown={onPointerDown}
+            onPointerUp={onPointerUp}
+            onPointerCancel={onPointerUp}
+            className={`border-muted mx-auto max-w-[420px] min-w-0 rounded-md border bg-black select-none ${
+              model?.touch ? "cursor-pointer" : ""
+            }`}
+            // Device screens are tiny; smoothing them turns text to mush, and a
+            // hold must not start a native image drag.
+            style={{ imageRendering: "pixelated", touchAction: "none" }}
+          />
+          {model && !model.touch ? (
+            <div className="mx-auto flex w-full max-w-[420px] gap-8">
+              {BUTTONS.map(({ button, label }) => (
+                <button
+                  key={button}
+                  type="button"
+                  aria-label={`${label} button`}
+                  onPointerDown={() =>
+                    send(api.pressButton(token, deviceId, button, "press"))
+                  }
+                  onPointerUp={() =>
+                    send(api.pressButton(token, deviceId, button, "release"))
+                  }
+                  className="border-muted body-3 text-base bg-muted hover:bg-muted-pressed active:bg-active flex-1 rounded-md border py-8 select-none"
+                  style={{ touchAction: "none" }}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </>
+      ) : (
+        <Banner
+          appearance="info"
+          title="No screen to capture"
+          description={
+            model && !model.speculos
+              ? `Speculos has no emulator for the ${model.label}, so this device is mocked all the way through and has no screen.`
+              : "A Speculos instance only exists while an app is open. Open one from the APDU console, and its screen appears here."
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/device-mock-server-ui/src/domain/devices.ts
+++ b/apps/device-mock-server-ui/src/domain/devices.ts
@@ -15,6 +15,8 @@ export interface DeviceModel {
   readonly icon: typeof Nano;
   /** Whether Speculinho can start a real Speculos emulator for this model. */
   readonly speculos: boolean;
+  /** How the device is driven: a touchscreen, or left/right/both buttons. */
+  readonly touch: boolean;
 }
 
 export const DEVICE_MODELS: DeviceModel[] = [
@@ -26,6 +28,7 @@ export const DEVICE_MODELS: DeviceModel[] = [
     mask: 0x31100000,
     icon: Nano,
     speculos: true,
+    touch: false,
   },
   {
     value: "nanoSP",
@@ -35,6 +38,7 @@ export const DEVICE_MODELS: DeviceModel[] = [
     mask: 0x33100000,
     icon: Nano,
     speculos: true,
+    touch: false,
   },
   {
     value: "nanoX",
@@ -44,6 +48,7 @@ export const DEVICE_MODELS: DeviceModel[] = [
     mask: 0x33000000,
     icon: Nano,
     speculos: true,
+    touch: false,
   },
   {
     value: "stax",
@@ -53,6 +58,7 @@ export const DEVICE_MODELS: DeviceModel[] = [
     mask: 0x33200000,
     icon: Stax,
     speculos: true,
+    touch: true,
   },
   {
     value: "flex",
@@ -62,6 +68,7 @@ export const DEVICE_MODELS: DeviceModel[] = [
     mask: 0x33300000,
     icon: Flex,
     speculos: true,
+    touch: true,
   },
   {
     value: "apexp",
@@ -71,6 +78,7 @@ export const DEVICE_MODELS: DeviceModel[] = [
     mask: 0x33400000,
     icon: Apex,
     speculos: false,
+    touch: true,
   },
 ];
 


### PR DESCRIPTION
### 📝 Description

The configuration UI can build a device and open an app on it, but not see it: watching a Speculos screen or pressing a button meant the sample app, or curl against `/devices/:id/speculos/*`.

A **Screen** tab now sits next to Overview / Mocks / APDU console on each device card:

- The screenshot is polled while the tab is open — 500 ms with a screen live, 2 s without — and the request is skipped while the browser tab is hidden.
- Touch for Stax, Flex and Apex; left / both / right buttons for the Nanos, from a new `touch` flag on `DEVICE_MODELS`.
- Press and release are sent separately, so holding the pointer holds the finger — which is how Stax and Flex confirm. Pointer capture keeps a hold from sticking if the pointer leaves the image, and leaving the tab mid-hold releases it.
- Touches map to device screen pixels off the PNG's own dimensions, so no per-model size table is needed.
- With no instance the tab explains itself instead of showing a broken frame: a Speculos instance only exists while an app is open, and Apex has no emulator at all.

The server is untouched: this goes through the existing Speculos passthrough, and `/devices` is already proxied in dev. The approach is the sample app's `DeviceScreen`, kept as a single component here rather than its `sources/` hierarchy — this UI has only one transport to feed it.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1502](https://ledgerhq.atlassian.net/browse/DSDK-1502)
- **Feature**: seeing and driving a device's screen from the mock server UI.

### ✅ Checklist

- [ ] **Covered by automatic tests** — this app has no test suite. Verified by hand end to end: a mock Flex on 1.6.1 with Ethereum opened, `GET /speculos/screenshot` returning a live PNG, and a finger press/release changing the frame.
- [ ] **Changeset is provided** — not needed, the change only touches an app (`device-mock-server-ui`), no published package.
- [x] **Documentation is up-to-date**
- [ ] **Impact of the changes:**
  - New tab on every device card; the other tabs and the server are unchanged.
  - While the tab is open it polls the screenshot endpoint, which reaches Speculinho through the mock server — one request per 500 ms with a screen live, per 2 s without.
  - Worth a look on a Nano (buttons) and on a Stax or Flex (hold-to-sign), since press and release travel separately.


[DSDK-1502]: https://ledgerhq.atlassian.net/browse/DSDK-1502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ