### PR TITLE
✨ (mock-server) [DSDK-1507]: Ask Speculinho for a 300s route timeout on acquire

### DIFF
--- a/apps/device-mock-server/README.md
+++ b/apps/device-mock-server/README.md
@@ -373,13 +373,13 @@ The standalone server (`src/main.ts`) reads environment variables:
 
 Programmatically, `createMockServer(config)` accepts a `MockServerConfig`:
 
-| Option            | Description                                                                                                             |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `ttlMs`           | Sliding inactivity timeout (refreshed on each authed request).                                                          |
-| `maxLifetimeMs`   | Hard cap on session lifetime regardless of activity.                                                                    |
-| `sweepIntervalMs` | Expired-session sweep interval; `0` disables the sweeper.                                                               |
-| `speculos`        | `{ baseUrl, speculosVersion?, readyTimeoutMs?, pollIntervalMs? }`. When omitted, the server is a pure mock.             |
-| `webUiDir`        | Directory holding the built [configuration UI](#-configuration-ui). When omitted, the server exposes the HTTP API only. |
+| Option            | Description                                                                                                                       |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `ttlMs`           | Sliding inactivity timeout (refreshed on each authed request).                                                                    |
+| `maxLifetimeMs`   | Hard cap on session lifetime regardless of activity.                                                                              |
+| `sweepIntervalMs` | Expired-session sweep interval; `0` disables the sweeper.                                                                         |
+| `speculos`        | `{ baseUrl, speculosVersion?, readyTimeoutMs?, pollIntervalMs?, routeTimeoutSeconds? }`. When omitted, the server is a pure mock. |
+| `webUiDir`        | Directory holding the built [configuration UI](#-configuration-ui). When omitted, the server exposes the HTTP API only.           |
 
 ## 🔹 HTTP API
 

--- a/apps/device-mock-server/src/internal/speculos/data/HttpSpeculosOperatorDataSource.test.ts
+++ b/apps/device-mock-server/src/internal/speculos/data/HttpSpeculosOperatorDataSource.test.ts
@@ -58,6 +58,34 @@ describe("HttpSpeculosOperatorDataSource", () => {
       device: "nanox",
       seed: TEST_SEED,
       run_id: "run-1",
+      route_timeout_seconds: 300,
+    });
+  });
+
+  it("acquires with the configured route timeout", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse({ run_id: "run-1", status: "pending" }));
+
+    await new HttpSpeculosOperatorDataSource({
+      baseUrl: "https://speculinho.test/",
+      routeTimeoutSeconds: 120,
+    })
+      .acquire(
+        {
+          coin_app: "btc",
+          coin_app_version: "2.1.0",
+          device: "nanox",
+          device_os_version: "1.3.0",
+        },
+        "run-1",
+        TEST_SEED,
+      )
+      .run();
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(JSON.parse((init as RequestInit).body as string)).toMatchObject({
+      route_timeout_seconds: 120,
     });
   });
 

--- a/apps/device-mock-server/src/internal/speculos/data/HttpSpeculosOperatorDataSource.ts
+++ b/apps/device-mock-server/src/internal/speculos/data/HttpSpeculosOperatorDataSource.ts
@@ -14,6 +14,7 @@ import {
 
 const DEFAULT_READY_TIMEOUT_MS = 120_000;
 const DEFAULT_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_ROUTE_TIMEOUT_SECONDS = 300;
 /** Liveness probe budget: a gone pod is refused well within this. */
 const LIVENESS_TIMEOUT_MS = 2_000;
 
@@ -49,6 +50,7 @@ export class HttpSpeculosOperatorDataSource
   private readonly speculosVersion?: string;
   private readonly readyTimeoutMs: number;
   private readonly pollIntervalMs: number;
+  private readonly routeTimeoutSeconds: number;
 
   constructor(
     @inject(speculosTypes.OperatorConfig) config: SpeculosOperatorConfig,
@@ -57,6 +59,8 @@ export class HttpSpeculosOperatorDataSource
     this.speculosVersion = config.speculosVersion;
     this.readyTimeoutMs = config.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS;
     this.pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.routeTimeoutSeconds =
+      config.routeTimeoutSeconds ?? DEFAULT_ROUTE_TIMEOUT_SECONDS;
   }
 
   acquire(
@@ -69,6 +73,7 @@ export class HttpSpeculosOperatorDataSource
         ...req,
         seed,
         run_id: runId,
+        route_timeout_seconds: this.routeTimeoutSeconds,
       };
       if (this.speculosVersion) body["speculos_version"] = this.speculosVersion;
       let res: Response;

--- a/apps/device-mock-server/src/internal/speculos/model/SpeculosModels.ts
+++ b/apps/device-mock-server/src/internal/speculos/model/SpeculosModels.ts
@@ -16,6 +16,8 @@ export interface SpeculosOperatorConfig {
   readonly speculosVersion?: string;
   /** Max acquire-to-ready wait before giving up. */
   readonly readyTimeoutMs?: number;
+  /** How long the operator keeps an instance's route alive between requests. */
+  readonly routeTimeoutSeconds?: number;
   /** Status poll cadence while waiting for readiness. */
   readonly pollIntervalMs?: number;
 }


### PR DESCRIPTION
### 📝 Description

`acquire` never sent `route_timeout_seconds`, so a Speculos instance lived on Speculinho's own default and a session left idle lost its emulator mid-flow.



It now sends `route_timeout_seconds: 300`, overridable through the Speculos config.

### ❓ Context

- **JIRA or GitHub link**: [DSDK-1507](https://ledgerhq.atlassian.net/browse/DSDK-1507)
- **Feature**: Speculos instances that outlive a pause.

### ✅ Checklist

- [x] **Covered by automatic tests** — the acquire body carries 300 by default, and the configured value when one is given.
- [ ] **Changeset is provided** — not needed, app-only change.
- [x] **Documentation is up-to-date**
- [ ] **Impact of the changes:**
  - Every Speculos instance the mock server starts now asks for a 5 minute route timeout.
  - Checked against the real Speculinho: acquire, screenshot and finger all still work.


[DSDK-1507]: https://ledgerhq.atlassian.net/browse/DSDK-1507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ