### PR TITLE
🔖 (mock-server) [NO-ISSUE]: Bump version to 0.1.4

### DIFF
--- a/apps/device-mock-server/package.json
+++ b/apps/device-mock-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/device-mock-server",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
### 📝 Description

Bumps `@ledgerhq/device-mock-server` from `0.1.3` to `0.1.4` (patch) to prepare the next Docker image release.

The `release_mock_server.yml` workflow reads the version from `apps/device-mock-server/package.json` at the pushed ref and tags the image with it, so this bump has to land before the image can be published as `jfrog.ledgerlabs.net/bcs-oci-prod-green/device-mock-server:0.1.4`.

Notable mock server changes shipping in this image since `0.1.3`:

- Release-candidate firmwares are resolved on their model's provider (#1869), so a device on e.g. Flex `1.7.0-rc2` answers GetOsVersion instead of falling through to `6d00`.
- A device screen tab with touch and buttons in the configuration UI (#1870).
- Speculinho acquires ask for a 300s route timeout (#1872).

Single-line change, no functional impact.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Mock server Docker image release

### ✅ Checklist

- [x] **Covered by automatic tests** — version-only change, no behaviour to test; the existing mock server suite is unaffected.
- [x] **Changeset is provided** — not required: `@ledgerhq/device-mock-server` is `private: true` (an app, not a published package). Per CONTRIBUTING.md changesets are only needed for published packages.
- [x] **Documentation is up-to-date** — no docs reference the version explicitly.
- [x] **Impact of the changes:**
  - Version metadata only; QA should simply confirm the published image is tagged `0.1.4` and boots as before.

---

### 🧐 Checklist for the PR Reviewers

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
