### PR TITLE
🐛 (mock-server) [NO-ISSUE]: Stop revalidating API responses so polling clients never see a 304

### DIFF
--- a/apps/device-mock-server/src/api/createMockServer.test.ts
+++ b/apps/device-mock-server/src/api/createMockServer.test.ts
@@ -96,6 +96,22 @@ describe("createMockServer (HTTP contract)", () => {
   });
 
   describe("devices", () => {
+    it("never revalidates GET /devices, so a polling client keeps its list", async () => {
+      const token = await authenticate();
+      await addDevice(token);
+
+      const first = await api("/devices", {}, token);
+      expect(first.headers.get("etag")).toBeNull();
+
+      const again = await api(
+        "/devices",
+        { headers: { "If-None-Match": 'W/"anything"' } },
+        token,
+      );
+      expect(again.status).toBe(200);
+      expect((await again.json()) as unknown[]).toHaveLength(1);
+    });
+
     it("creates, lists, fetches, edits and deletes a device", async () => {
       const token = await authenticate();
 

--- a/apps/device-mock-server/src/internal/server/HttpAppFactory.ts
+++ b/apps/device-mock-server/src/internal/server/HttpAppFactory.ts
@@ -30,6 +30,10 @@ export class HttpAppFactory {
   build(): Express {
     const app = express();
 
+    // Clients poll this API; a 304 on an unchanged device list reads as an
+    // error to them, so never let a response be revalidated.
+    app.set("etag", false);
+
     app.use(requestLogger());
     app.use(express.json());
 


### PR DESCRIPTION
### 📝 Description

Express enables ETags by default, so `GET /devices` carried one and answered a conditional poll with `304 Not Modified` and an empty body. `DmkNetworkClient` rejects anything outside 2xx, so `MockClient.listDevices()` throws on that 304, and `MockserverTransport.listenToAvailableDevices` turns the throw into an empty device list.

The result on a client: the first poll after any change to the list is a `200`, every later poll is a `304`, so discovery goes permanently empty and `DeviceManagementKitTransport.open()` — which waits for a non-empty list — never connects. Importing a session is the reliable way to hit it: the import deletes the device the client was connected to, and by the time it rediscovers, the list is stable and every poll 304s. The server log shows `GET /devices -> 304` once a second with no `/connect` and no `/apdu` following it.

`app.set("etag", false)` turns revalidation off for the API. Static UI assets are unaffected — `express.static` does its own ETag handling — so they keep caching as before.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Mock server

### ✅ Checklist

- [x] **Covered by automatic tests** — new HTTP-contract test asserts `GET /devices` sends no ETag and answers `200` with the list to a request carrying `If-None-Match`. It fails on `develop` and passes here.
- [x] **Changeset is provided** — not required: `@ledgerhq/device-mock-server` is `private: true` (an app, not a published package).
- [x] **Documentation is up-to-date** — no docs describe the caching behaviour.
- [x] **Impact of the changes:**
  - Every mock server API response loses its `ETag`; responses get slightly larger on unchanged polls, which is the point.
  - QA: connect Ledger Live to a mock session, import a snapshot, and check the device reconnects instead of staying stuck.

---

### 🧐 Checklist for the PR Reviewers

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
