### PR TITLE
📝 (mock-server) [NO-ISSUE]: Document the Speculinho route timeout range

### DIFF
--- a/apps/device-mock-server/README.md
+++ b/apps/device-mock-server/README.md
@@ -373,13 +373,13 @@ The standalone server (`src/main.ts`) reads environment variables:
 
 Programmatically, `createMockServer(config)` accepts a `MockServerConfig`:
 
-| Option            | Description                                                                                                                       |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `ttlMs`           | Sliding inactivity timeout (refreshed on each authed request).                                                                    |
-| `maxLifetimeMs`   | Hard cap on session lifetime regardless of activity.                                                                              |
-| `sweepIntervalMs` | Expired-session sweep interval; `0` disables the sweeper.                                                                         |
-| `speculos`        | `{ baseUrl, speculosVersion?, readyTimeoutMs?, pollIntervalMs?, routeTimeoutSeconds? }`. When omitted, the server is a pure mock. |
-| `webUiDir`        | Directory holding the built [configuration UI](#-configuration-ui). When omitted, the server exposes the HTTP API only.           |
+| Option            | Description                                                                                                                                                                                                                                  |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ttlMs`           | Sliding inactivity timeout (refreshed on each authed request).                                                                                                                                                                               |
+| `maxLifetimeMs`   | Hard cap on session lifetime regardless of activity.                                                                                                                                                                                         |
+| `sweepIntervalMs` | Expired-session sweep interval; `0` disables the sweeper.                                                                                                                                                                                    |
+| `speculos`        | `{ baseUrl, speculosVersion?, readyTimeoutMs?, pollIntervalMs?, routeTimeoutSeconds? }`. `routeTimeoutSeconds` is the per-pod route timeout Speculinho stamps on acquire: 1-300, defaulting to 300. When omitted, the server is a pure mock. |
+| `webUiDir`        | Directory holding the built [configuration UI](#-configuration-ui). When omitted, the server exposes the HTTP API only.                                                                                                                      |
 
 ## 🔹 HTTP API
 


### PR DESCRIPTION
### 📝 Description

**Temporary — do not merge.** Stands up a mock server preview environment built from `develop`, to verify that `web-app` chart 0.1.4 raises the request timeout on the route in front of the mock server.

The diff is a one-line README clarification (`routeTimeoutSeconds` is 1-300, default 300), because the preview workflow only triggers on changes under `apps/device-mock-server/**`. It is accurate, but it is not the point of the PR.

**What this environment should show.** Measured before chart 0.1.4, an APDU waiting on an on-device confirmation was cut at ~30s with `504 upstream request timeout`, even though the Speculos pod behind it held the connection for the full 300s the mock server asks Speculinho for on `/acquire`. On chart 0.1.4 that request should now survive to 300s.

Repro script is in the first comment.

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: Mock server preview environment

### ✅ Checklist

- [x] **Covered by automatic tests** — documentation only, no behaviour to test.
- [x] **Changeset is provided** — not required: `@ledgerhq/device-mock-server` is `private: true` (an app, not a published package).
- [x] **Documentation is up-to-date** — this PR is the documentation change.
- [x] **Impact of the changes:**
  - None on the product. Close and delete the branch once the environment has served its purpose.

---

### 🧐 Checklist for the PR Reviewers

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
