### PR TITLE
🐛 (device-management-kit): Map the 0x6901 status word to a typed error

### DIFF
--- a/.changeset/wild-donkeys-report.md
+++ b/.changeset/wild-donkeys-report.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-management-kit": patch
+---
+
+Map the 0x6901 status word so a device whose own interface is in the foreground surfaces as a typed error instead of an unknown one

--- a/packages/device-management-kit/src/api/command/utils/GlobalCommandError.test.ts
+++ b/packages/device-management-kit/src/api/command/utils/GlobalCommandError.test.ts
@@ -16,6 +16,11 @@ const GLOBAL_ERRORS_LIST: [Uint8Array, string, string][] = [
     "DeviceInternalError",
     "device internal error",
   ],
+  [
+    Uint8Array.from([0x69, 0x01]),
+    "DeviceNotReadyError",
+    "device not ready error",
+  ],
 ];
 
 describe("GlobalCommandError", () => {

--- a/packages/device-management-kit/src/api/command/utils/GlobalCommandError.ts
+++ b/packages/device-management-kit/src/api/command/utils/GlobalCommandError.ts
@@ -17,7 +17,8 @@ export type GlobalCommandErrorStatusCode =
   | "5502"
   | "5223"
   | "6e00"
-  | "6d00";
+  | "6d00"
+  | "6901";
 
 /**
  * Global command error class
@@ -38,6 +39,10 @@ export const GLOBAL_ERRORS: CommandErrors<GlobalCommandErrorStatusCode> = {
   "5223": { message: "Device internal error", tag: "DeviceInternalError" },
   "6e00": { message: "CLA not supported", tag: "DeviceInternalError" },
   "6d00": { message: "INS not supported", tag: "DeviceInternalError" },
+  "6901": {
+    message: "Device is busy, its own interface is in the foreground.",
+    tag: "DeviceNotReadyError",
+  },
 };
 
 /**


### PR DESCRIPTION
Fixes #1773.

The bug
While the device's own interface is in the foreground, BOLOS answers every APDU with 0x6901, under the 0xb0 CLA as much as 0xe0. That code is not in GLOBAL_ERRORS, which maps only 5515 / 5501 / 5502 / 5223 / 6e00 / 6d00, so it falls through to UnknownDeviceExchangeError.

The consequence is worse than an unhelpful message. OpenAppDeviceAction begins at GetDeviceStatus, which goes through GetAppAndVersionCommand. That result is an error, the machine transitions straight to Error, and 0xe0d8 is never sent. The device displays no prompt, so from the user's point of view tapping connect does nothing at all.

The locked-device path is the useful comparison. 0x5515 is mapped, so WaitForAppAndVersionDeviceAction recognises it, requests UserInteractionRequired.UnlockDevice, and keeps polling until unlockTimeout. Same shape of problem, graceful recovery. The only difference is whether the status word is in the table.

The change
Adds 6901 to GlobalCommandErrorStatusCode and to GLOBAL_ERRORS, plus a row in the existing table-driven test.

One naming question for you
The natural tag here is DeviceBusyError, but that name is already taken by a class in api/Error.ts. It appears to be unused — I could not find anywhere it is constructed — but two error types sharing a _tag would break discrimination for consumers matching on it.

So I used DeviceNotReadyError and put the precision in the message. Happy to switch to DeviceBusyError if you would rather reuse it, or to any name you prefer.

Deliberately not addressed
The issue raises two further points that read as design decisions rather than missing entries, so I have left them alone:

DeviceSession.sendApdu classifies anything that is not a locked-device response as CONNECTED, so a session refusing every command still reports deviceStatus: CONNECTED with currentApp: undefined.
The status word survives only on originalError.errorCode and is not part of the public typed surface.
Happy to follow up on either, together or separately, if you would like them handled.

Verification
pnpm test        # device-management-kit: 1056 passed, 109 files
pnpm typecheck   # 77 of 77 tasks successful
pnpm lint        # 0 errors; the 53 warnings are pre-existing and in other files
prettier --check # both changed files conform

Changeset included, patch bump.

Context
Found while building a pre-signing risk check for AI agents that routes high-risk verdicts to a Ledger for physical confirmation: https://github.com/ritiklakhwani/preflight

We hit the same class of problem in our own code: unmapped device states turning into unreadable errors for whoever is standing at the device. A locked Ledger surfaced to our users as truncated JSON, and a disconnect as DeviceDisconnectedBeforeSendingApdu, until we built a translation layer. This is that lesson applied one level down.